### PR TITLE
M3.1: team-abstraction §B audit P0 fixes

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -94,14 +94,20 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
     Ok(out)
 }
 
-/// `ccteam new "request"`. Bootstraps a project on disk and returns
-/// the chosen slug. Side effects: creates `~/projects/<slug>/...`.
-pub fn run_new(paths: &CcteamPaths, request: &str) -> Result<String> {
+/// `ccteam new "request" --team <name>`. Bootstraps a project on disk
+/// and returns the chosen slug. Side effects: creates
+/// `~/projects/<slug>/...`. `team` is recorded in state.json so the
+/// orchestrator can route this project through the matching phase set
+/// (M3.1 F12/F13 — non-dev teams land in M3.4).
+pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String> {
     if request.trim().is_empty() {
         bail!("ccteam new: request must be non-empty");
     }
+    if team.trim().is_empty() {
+        bail!("ccteam new: --team must be non-empty");
+    }
     let slug = pick_unused_slug(paths, request)?;
-    bootstrap_project(paths, &slug, request)?;
+    bootstrap_project(paths, &slug, request, team)?;
     Ok(slug)
 }
 
@@ -738,7 +744,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "Build a bookmark manager").unwrap();
+        let slug = run_new(&paths, "Build a bookmark manager", "dev").unwrap();
         assert!(slug.starts_with("build-a-bookmark-manager"));
         let project = paths.project_dir(&slug);
         assert!(project.join(".ccteam/spec.md").exists());
@@ -751,8 +757,63 @@ mod tests {
     fn run_new_rejects_empty_request() {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let err = run_new(&paths, "   \n\t").unwrap_err();
+        let err = run_new(&paths, "   \n\t", "dev").unwrap_err();
         assert!(format!("{err:#}").contains("non-empty"));
+    }
+
+    #[test]
+    fn run_new_rejects_empty_team() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let err = run_new(&paths, "build something", "  ").unwrap_err();
+        assert!(format!("{err:#}").contains("--team"));
+    }
+
+    #[test]
+    fn run_new_records_team_in_state_json() {
+        // M3.1 F12/F13: --team must persist into state.json so the
+        // orchestrator can route this project's phase set.
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let slug = run_new(&paths, "research project", "research").unwrap();
+        let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+        assert_eq!(state.team, "research");
+    }
+
+    #[test]
+    fn legacy_state_json_without_team_field_loads_as_dev() {
+        // F13 backwards-compat: state.json files written by pre-M3.1
+        // ccteam don't have a `team` field; serde default kicks in.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.json");
+        // Hand-rolled JSON missing the `team` key:
+        let body = r#"{
+            "slug": "legacy",
+            "created_at": "2026-05-01T00:00:00Z",
+            "tmux_session": "ccteam-legacy",
+            "claude_session_id": null,
+            "claude_pid": null,
+            "phase_state": "idle",
+            "current_phase": "",
+            "parallelism": "solo",
+            "phase_history": [],
+            "fix_cycle_count": 0,
+            "cost_used_usd": 0.0,
+            "soft_warn_threshold_usd": 20.0,
+            "hard_kill_threshold_usd": 200.0,
+            "context_tokens_used": 0,
+            "context_reset_threshold_tokens": 600000,
+            "context_reset_count": 0,
+            "last_progress_event_at": null,
+            "last_event_type": null,
+            "last_user_interaction_at": "2026-05-01T00:00:00Z",
+            "user_attached": false,
+            "user_pause_pending": false
+        }"#;
+        std::fs::write(&path, body).unwrap();
+        let s = ProjectState::load(&path).unwrap();
+        assert_eq!(s.team, "dev");
     }
 
     #[test]
@@ -768,8 +829,8 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        run_new(&paths, "demo one").unwrap();
-        run_new(&paths, "demo two").unwrap();
+        run_new(&paths, "demo one", "dev").unwrap();
+        run_new(&paths, "demo two", "dev").unwrap();
 
         let body = run_ls(&paths, OutputFormat::Json).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
@@ -783,7 +844,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo").unwrap();
+        let slug = run_new(&paths, "demo", "dev").unwrap();
         let body = run_show(&paths, &slug, OutputFormat::Json).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["state"]["slug"], slug);
@@ -803,7 +864,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo").unwrap();
+        let slug = run_new(&paths, "demo", "dev").unwrap();
         // simulate an escalated state
         let state_path = paths.project_state(&slug);
         let mut state = ProjectState::load(&state_path).unwrap();
@@ -856,7 +917,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo").unwrap();
+        let slug = run_new(&paths, "demo", "dev").unwrap();
         progress::append_event(
             &paths.progress_jsonl(&slug),
             &json!({"event": "session_start", "ts": "2026-05-05T00:00:00Z"}),

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -62,6 +62,11 @@ enum Command {
         /// Read the request from a file instead of the positional arg.
         #[arg(short, long, value_name = "PATH")]
         file: Option<PathBuf>,
+        /// Team to run this project under. Default `dev` keeps the
+        /// shipped pipeline (plan-eng → implement → … → ship). Other
+        /// teams (research, design, ...) land in M3.4.
+        #[arg(long, default_value = "dev")]
+        team: String,
     },
     /// List all known projects.
     Ls {
@@ -149,7 +154,7 @@ fn main() -> Result<()> {
             tick_seconds,
             skip_tool_check,
         } => run_start(tick_seconds, skip_tool_check),
-        Command::New { request, file } => run_new(request, file),
+        Command::New { request, file, team } => run_new(request, file, team),
         Command::Ls { format } => run_ls(format),
         Command::Show { slug, format } => run_show(&slug, format),
         Command::Attach { slug } => commands::run_attach(&slug),
@@ -249,7 +254,7 @@ fn run_start(tick_seconds: u64, skip_tool_check: bool) -> Result<()> {
     })
 }
 
-fn run_new(request: Option<String>, file: Option<PathBuf>) -> Result<()> {
+fn run_new(request: Option<String>, file: Option<PathBuf>, team: String) -> Result<()> {
     let paths = CcteamPaths::from_env()?;
     let body = match (file, request) {
         (Some(path), _) => std::fs::read_to_string(&path)
@@ -259,8 +264,8 @@ fn run_new(request: Option<String>, file: Option<PathBuf>) -> Result<()> {
             anyhow::bail!("ccteam new: provide a request as a positional arg or --file PATH")
         }
     };
-    let slug = commands::run_new(&paths, body.trim())?;
-    println!("created project {slug}");
+    let slug = commands::run_new(&paths, body.trim(), &team)?;
+    println!("created project {slug} (team: {team})");
     println!("  spec   : {}", paths.project_ccteam_dir(&slug).join("spec.md").display());
     println!("  state  : {}", paths.project_state(&slug).display());
     println!("  config : {}", paths.project_dir(&slug).join(".claude/settings.json").display());

--- a/crates/ccteam-core/src/cost.rs
+++ b/crates/ccteam-core/src/cost.rs
@@ -42,6 +42,7 @@ mod tests {
         let now = Utc::now();
         ProjectState {
             slug: "demo".into(),
+            team: "dev".into(),
             created_at: now,
             tmux_session: "ccteam-demo".into(),
             claude_session_id: None,

--- a/crates/ccteam-core/src/dag.rs
+++ b/crates/ccteam-core/src/dag.rs
@@ -1,0 +1,202 @@
+//! Phase DAG inferred from a topologically-ordered slice of
+//! `PhaseTemplate`s. Replaces the M0 `M0_PHASE_DAG` / `FIRST_PHASE`
+//! constants so ccteam-core can drive non-dev teams.
+//!
+//! Two edges per phase:
+//!
+//! - `next_on_done`: the phase to dispatch after `phase_done`. When
+//!   omitted in YAML, defaults to the next phase in the topological
+//!   list (file-order). Last phase's default is `None` — that's how
+//!   the DAG terminal node is recognized.
+//! - `next_on_escalate`: explicit revert target on `escalate`. When
+//!   omitted, the project is marked terminally escalated. The M0.5.4
+//!   `REVERT_TO_PHASE` ESCALATE grammar still routes via the event's
+//!   `target_phase` field — that's hot-routed by the orchestrator
+//!   and independent of this static fallback.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use crate::phases::PhaseTemplate;
+use crate::state::ProjectState;
+
+#[derive(Debug, Clone)]
+pub struct Dag {
+    /// First phase to dispatch on a fresh project (idle, current_phase
+    /// empty). Derived from the input slice's order — i.e. the first
+    /// template in topological filename order.
+    entry: String,
+    /// phase name → next phase on `phase_done`. `None` marks a DAG
+    /// endpoint (terminal node).
+    next_on_done: HashMap<String, Option<String>>,
+    /// phase name → static revert target on `escalate`. `None` means
+    /// "no automatic revert; project is terminally escalated".
+    next_on_escalate: HashMap<String, Option<String>>,
+}
+
+impl Dag {
+    /// Build a DAG from a topologically-ordered slice of phase
+    /// templates (typically loaded by `Orchestrator::new` from
+    /// `~/.ccteam/phases/` after sort-by-filename).
+    ///
+    /// Defaults: `phases[i].next_on_done = phases[i+1].name` unless
+    /// the YAML overrides; the last phase's default is `None`. So the
+    /// shipped dev pipeline gets a working DAG without any phase
+    /// markdown declaring `next_on_done` — only forks need explicit
+    /// edges.
+    ///
+    /// An empty template slice is allowed (matches the pre-M3.1
+    /// behavior where `Orchestrator::new` succeeded with no phases on
+    /// disk). The resulting DAG has an empty entry node and dispatches
+    /// nothing — `decide_tick` short-circuits to NoOp until phases
+    /// are written and the orchestrator restarts.
+    pub fn from_templates(templates: &[PhaseTemplate]) -> Result<Self> {
+        if templates.is_empty() {
+            return Ok(Self {
+                entry: String::new(),
+                next_on_done: HashMap::new(),
+                next_on_escalate: HashMap::new(),
+            });
+        }
+        let mut next_on_done: HashMap<String, Option<String>> = HashMap::new();
+        let mut next_on_escalate: HashMap<String, Option<String>> = HashMap::new();
+        for (i, t) in templates.iter().enumerate() {
+            let topo_default = templates.get(i + 1).map(|n| n.name.clone());
+            let done = t.next_on_done.clone().or(topo_default);
+            next_on_done.insert(t.name.clone(), done);
+            next_on_escalate.insert(t.name.clone(), t.next_on_escalate.clone());
+        }
+        Ok(Self {
+            entry: templates[0].name.clone(),
+            next_on_done,
+            next_on_escalate,
+        })
+    }
+
+    /// True when the DAG has no phases (orchestrator started without a
+    /// populated `~/.ccteam/phases/` dir). `decide_tick` returns NoOp
+    /// in this state — there's nothing to dispatch.
+    pub fn is_empty(&self) -> bool {
+        self.entry.is_empty()
+    }
+
+    /// First phase a fresh project should dispatch.
+    pub fn entry(&self) -> &str {
+        &self.entry
+    }
+
+    /// Phase to dispatch after `phase_done` from `name`. `None` when
+    /// `name` is a DAG endpoint or unknown.
+    pub fn next_on_done(&self, name: &str) -> Option<&str> {
+        self.next_on_done.get(name).and_then(|o| o.as_deref())
+    }
+
+    /// Static revert target on `escalate` from `name`. `None` for
+    /// "terminally escalate" (M0/M1 default for every phase).
+    pub fn next_on_escalate(&self, name: &str) -> Option<&str> {
+        self.next_on_escalate.get(name).and_then(|o| o.as_deref())
+    }
+
+    /// True when `name` is a DAG endpoint — declared without a
+    /// `next_on_done` edge and last in topological order.
+    pub fn is_terminal_phase(&self, name: &str) -> bool {
+        matches!(self.next_on_done.get(name), Some(None))
+    }
+
+    /// True when the project has reached a terminal state: any
+    /// history entry escalated, or the last passed history entry
+    /// landed on a DAG endpoint.
+    pub fn is_terminal_state(&self, state: &ProjectState) -> bool {
+        for h in &state.phase_history {
+            if h.status == "escalated" {
+                return true;
+            }
+            if h.status == "passed" && self.is_terminal_phase(&h.phase) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// Build a `Dag` from the shipped dev phase templates (`PHASE_TEMPLATES`).
+/// Convenience for tests that exercise the orchestrator state machine
+/// without bootstrapping a project on disk first. Production code
+/// gets its DAG from `Orchestrator::new` after loading templates from
+/// `~/.ccteam/phases/`.
+pub fn dev_dag() -> Dag {
+    let templates: Vec<PhaseTemplate> = crate::templates::PHASE_TEMPLATES
+        .iter()
+        .map(|(_, body)| {
+            PhaseTemplate::parse(body)
+                .expect("shipped phase template must parse")
+        })
+        .collect();
+    Dag::from_templates(&templates).expect("shipped phase templates must form a valid DAG")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::Parallelism;
+    use crate::tool_surface::ToolsRequired;
+
+    fn t(name: &str, next_on_done: Option<&str>) -> PhaseTemplate {
+        PhaseTemplate {
+            name: name.into(),
+            required_inputs: Vec::new(),
+            required_outputs: Vec::new(),
+            soft_cost_warn_usd: None,
+            stall_warn_minutes: None,
+            parallelism: Parallelism::Solo,
+            agent_team: Vec::new(),
+            sub_skills: Vec::new(),
+            tools_required: ToolsRequired::default(),
+            hooks: Default::default(),
+            auto_loop: false,
+            auto_loop_max_iterations: 3,
+            completion_signal: String::new(),
+            next_on_done: next_on_done.map(String::from),
+            next_on_escalate: None,
+        }
+    }
+
+    #[test]
+    fn topological_order_provides_default_edges() {
+        let templates = vec![t("a", None), t("b", None), t("c", None)];
+        let dag = Dag::from_templates(&templates).unwrap();
+        assert_eq!(dag.entry(), "a");
+        assert_eq!(dag.next_on_done("a"), Some("b"));
+        assert_eq!(dag.next_on_done("b"), Some("c"));
+        assert_eq!(dag.next_on_done("c"), None);
+        assert!(dag.is_terminal_phase("c"));
+        assert!(!dag.is_terminal_phase("a"));
+    }
+
+    #[test]
+    fn explicit_next_on_done_overrides_topological_default() {
+        // `a → c` skips `b`; `b` falls back to its topo neighbor `c`.
+        let templates = vec![t("a", Some("c")), t("b", None), t("c", None)];
+        let dag = Dag::from_templates(&templates).unwrap();
+        assert_eq!(dag.next_on_done("a"), Some("c"));
+        assert_eq!(dag.next_on_done("b"), Some("c"));
+        assert_eq!(dag.next_on_done("c"), None);
+    }
+
+    #[test]
+    fn empty_template_list_yields_inert_dag() {
+        let dag = Dag::from_templates(&[]).unwrap();
+        assert!(dag.is_empty());
+        assert_eq!(dag.entry(), "");
+        assert_eq!(dag.next_on_done("anything"), None);
+    }
+
+    #[test]
+    fn unknown_phase_returns_none_not_panic() {
+        let templates = vec![t("a", None)];
+        let dag = Dag::from_templates(&templates).unwrap();
+        assert_eq!(dag.next_on_done("ghost"), None);
+        assert!(!dag.is_terminal_phase("ghost"));
+    }
+}

--- a/crates/ccteam-core/src/fix_loop.rs
+++ b/crates/ccteam-core/src/fix_loop.rs
@@ -32,14 +32,19 @@ pub struct FixLoopState {
 }
 
 impl FixLoopState {
-    pub fn new(slug: String, prompt: String, max_iterations: u32) -> Self {
+    pub fn new(
+        slug: String,
+        prompt: String,
+        max_iterations: u32,
+        completion_signal: String,
+    ) -> Self {
         let now = Utc::now();
         Self {
             front: FixLoopFrontMatter {
                 slug,
                 iteration: 1,
                 max_iterations,
-                completion_signal: "TESTS_GREEN".into(),
+                completion_signal,
                 created_at: now,
                 updated_at: now,
             },
@@ -132,6 +137,7 @@ mod tests {
             "demo".into(),
             "fix the broken tests in src/db.rs".into(),
             3,
+            "TESTS_GREEN".into(),
         );
         s.front.iteration = iter;
         s

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod progress;
 pub mod projects;
 pub mod stall;
 pub mod state;
+pub mod team;
 pub mod templates;
 pub mod tmux;
 pub mod tool_surface;
@@ -33,6 +34,7 @@ pub use phases::{
     AgentTeamRole, PhaseHooks, PhaseTemplate, SubSkillSpec, SubSkillTrigger,
 };
 pub use state::{Parallelism, PhaseHistoryEntry, PhaseState, ProjectState};
+pub use team::{RetroFieldKind, RetroFieldSpec, TeamSpec};
 pub use templates::{
     current_ccteam_bin, project_phase_filename, render_project_settings,
     write_global_phase_templates, write_project_phase_templates, write_project_settings,

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! `ccteam-hooks` (hook handlers invoked via `ccteam hook ...`).
 
 pub mod cost;
+pub mod dag;
 pub mod fix_loop;
 pub mod orchestrator;
 pub mod paths;
@@ -15,11 +16,11 @@ pub mod templates;
 pub mod tmux;
 pub mod tool_surface;
 
+pub use dag::{dev_dag, Dag};
 pub use fix_loop::{FixLoopDecision, FixLoopFrontMatter, FixLoopState};
 pub use orchestrator::{
     append_progress_summary, build_progress_summary, check_phase_tools, decide_tick,
-    decide_tick_from_events, is_terminal, next_phase, Orchestrator, OrchestratorConfig,
-    TickAction, FIRST_PHASE, M0_PHASE_DAG,
+    decide_tick_from_events, Orchestrator, OrchestratorConfig, TickAction,
 };
 pub use projects::{bootstrap_project, pick_unused_slug, pre_trust_project, slugify};
 pub use cost::{classify as classify_cost, CostLevel, COST_MID_WARN_USD};

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -21,6 +21,7 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use serde_json::{json, Value};
 
 use crate::cost::{self, CostLevel};
+use crate::dag::Dag;
 use crate::fix_loop::{self, FixLoopState};
 use crate::paths::CcteamPaths;
 use crate::phases::PhaseTemplate;
@@ -29,37 +30,6 @@ use crate::stall::{self, StallLevel, StallThresholds};
 use crate::state::{PhaseHistoryEntry, PhaseState, ProjectState};
 use crate::tmux::TmuxSession;
 use crate::tool_surface::{user_claude_dir, ToolSurfaceSnapshot};
-
-/// M0 linear phase DAG. M2+ widens to fork on test results, sub-skill
-/// scheduling, and (M3) multi-session fan-out / fan-in.
-pub const M0_PHASE_DAG: &[(&str, Option<&str>)] = &[
-    ("plan-eng", Some("implement")),
-    ("implement", Some("test-author")),
-    ("test-author", Some("test-run")),
-    ("test-run", Some("fix")),
-    ("fix", Some("ship")),
-    ("ship", None),
-];
-
-pub const FIRST_PHASE: &str = "plan-eng";
-
-/// Next phase per M0 DAG, or `None` if `current` is terminal / unknown.
-pub fn next_phase(current: &str) -> Option<&'static str> {
-    M0_PHASE_DAG
-        .iter()
-        .find(|(p, _)| *p == current)
-        .and_then(|(_, n)| *n)
-}
-
-/// True if the project has reached a terminal state — `ship` passed or
-/// any phase escalated. Both block automatic advance until the user
-/// (M0: manual; M1: telegram) decides what to do next.
-pub fn is_terminal(state: &ProjectState) -> bool {
-    state
-        .phase_history
-        .iter()
-        .any(|h| (h.phase == "ship" && h.status == "passed") || h.status == "escalated")
-}
 
 /// Pure decision function: given the current `state` and the last
 /// progress.jsonl event, what should the orchestrator do next?
@@ -84,8 +54,8 @@ pub enum TickAction {
     },
 }
 
-pub fn decide_tick(state: &ProjectState, last_event: Option<&Value>) -> TickAction {
-    decide_tick_from_events(state, last_event.map(std::slice::from_ref).unwrap_or(&[]))
+pub fn decide_tick(dag: &Dag, state: &ProjectState, last_event: Option<&Value>) -> TickAction {
+    decide_tick_from_events(dag, state, last_event.map(std::slice::from_ref).unwrap_or(&[]))
 }
 
 /// Like `decide_tick` but considers recent events as a slice rather
@@ -96,8 +66,16 @@ pub fn decide_tick(state: &ProjectState, last_event: Option<&Value>) -> TickActi
 ///
 /// `events` should be ordered oldest→newest. `decide_tick` continues
 /// to forward a single event for backwards-compat with old call sites.
-pub fn decide_tick_from_events(state: &ProjectState, events: &[Value]) -> TickAction {
-    if is_terminal(state) {
+pub fn decide_tick_from_events(
+    dag: &Dag,
+    state: &ProjectState,
+    events: &[Value],
+) -> TickAction {
+    if dag.is_empty() {
+        // No phases loaded — orchestrator is inert until templates land.
+        return TickAction::NoOp;
+    }
+    if dag.is_terminal_state(state) {
         return TickAction::NoOp;
     }
 
@@ -118,7 +96,7 @@ pub fn decide_tick_from_events(state: &ProjectState, events: &[Value]) -> TickAc
             return match kind {
                 "phase_done" => TickAction::AdvancePhase {
                     from: state.current_phase.clone(),
-                    to: next_phase(&state.current_phase).map(String::from),
+                    to: dag.next_on_done(&state.current_phase).map(String::from),
                 },
                 "escalate" => {
                     let reason = terminal
@@ -136,9 +114,10 @@ pub fn decide_tick_from_events(state: &ProjectState, events: &[Value]) -> TickAc
         }
         TickAction::NoOp
     } else {
-        // Idle: dispatch the current phase, defaulting to FIRST_PHASE.
+        // Idle: dispatch the current phase, defaulting to the DAG's
+        // entry node (e.g. dev's `plan-eng`, research's `00-topic`).
         let phase = if state.current_phase.is_empty() {
-            FIRST_PHASE.to_string()
+            dag.entry().to_string()
         } else {
             state.current_phase.clone()
         };
@@ -189,6 +168,7 @@ pub struct Orchestrator {
     paths: CcteamPaths,
     config: OrchestratorConfig,
     templates: Vec<PhaseTemplate>,
+    dag: Dag,
 }
 
 impl Orchestrator {
@@ -207,20 +187,28 @@ impl Orchestrator {
         } else {
             tracing::warn!("skip_tool_check=true: phase tools_required not validated");
         }
+        let dag = Dag::from_templates(&templates)
+            .context("build phase DAG from loaded templates")?;
         tracing::info!(
             templates = templates.len(),
             phases_dir = %paths.phases_dir().display(),
+            entry_phase = %dag.entry(),
             "orchestrator initialized",
         );
         Ok(Self {
             paths,
             config,
             templates,
+            dag,
         })
     }
 
     pub fn templates(&self) -> &[PhaseTemplate] {
         &self.templates
+    }
+
+    pub fn dag(&self) -> &Dag {
+        &self.dag
     }
 
     pub fn paths(&self) -> &CcteamPaths {
@@ -358,7 +346,7 @@ impl Orchestrator {
     /// Mutates + persists `state.claude_pid` whenever a new session is
     /// born. Skipped silently for terminal projects.
     pub fn ensure_session(&self, slug: &str, state: &mut ProjectState) -> Result<()> {
-        if is_terminal(state) {
+        if self.dag.is_terminal_state(state) {
             return Ok(());
         }
         let session = TmuxSession::for_slug(slug);
@@ -416,7 +404,7 @@ impl Orchestrator {
 
         for _ in 0..MAX_ITERS {
             let events = progress::read_all_events(&progress_path)?;
-            let action = decide_tick_from_events(&state, &events);
+            let action = decide_tick_from_events(&self.dag, &state, &events);
             match action {
                 TickAction::NoOp => return Ok(state),
                 TickAction::AdvancePhase { from, to } => {
@@ -440,7 +428,7 @@ impl Orchestrator {
 
                     // Phase boundary: maybe reset context if the
                     // 60%-of-1M threshold has been crossed.
-                    if !is_terminal(&state)
+                    if !self.dag.is_terminal_state(&state)
                         && state.context_tokens_used > state.context_reset_threshold_tokens
                     {
                         if let Err(err) = self.reset_context(slug, &mut state) {
@@ -607,7 +595,7 @@ impl Orchestrator {
         slug: &str,
         mut state: ProjectState,
     ) -> Result<Option<ProjectState>> {
-        if is_terminal(&state) {
+        if self.dag.is_terminal_state(&state) {
             return Ok(Some(state));
         }
         match cost::classify(&state) {
@@ -672,7 +660,7 @@ impl Orchestrator {
     }
 
     fn warn_if_stalled(&self, slug: &str, state: &ProjectState, now: chrono::DateTime<Utc>) {
-        if is_terminal(state) {
+        if self.dag.is_terminal_state(state) {
             return;
         }
         let silent = stall::silent_seconds(state, now);

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -30,9 +30,6 @@ use crate::state::{PhaseHistoryEntry, PhaseState, ProjectState};
 use crate::tmux::TmuxSession;
 use crate::tool_surface::{user_claude_dir, ToolSurfaceSnapshot};
 
-const FIX_PHASE_NAME: &str = "fix";
-const FIX_LOOP_MAX_ITERATIONS: u32 = 3;
-
 /// M0 linear phase DAG. M2+ widens to fork on test results, sub-skill
 /// scheduling, and (M3) multi-session fan-out / fan-in.
 pub const M0_PHASE_DAG: &[(&str, Option<&str>)] = &[
@@ -490,15 +487,18 @@ impl Orchestrator {
                     // session simply wouldn't exist.
                     self.ensure_session(slug, &mut state)?;
                     self.dispatch_phase(slug, &phase)?;
-                    let target_state = if phase == FIX_PHASE_NAME {
+                    let template = self.templates.iter().find(|t| t.name == phase);
+                    let target_state = if template.is_some_and(|t| t.auto_loop) {
                         // Stop hook (M0.12) drives the loop; orchestrator
                         // only re-enters on phase_done/escalate.
+                        let t = template.expect("auto_loop branch implies template present");
                         let project_dir = self.paths.project_dir(slug);
                         let prompt = progress::build_phase_prompt(&phase);
                         let fl = FixLoopState::new(
                             slug.to_string(),
                             prompt,
-                            FIX_LOOP_MAX_ITERATIONS,
+                            t.auto_loop_max_iterations,
+                            t.completion_signal.clone(),
                         );
                         fix_loop::write(&fix_loop::path_in(&project_dir), &fl)?;
                         PhaseState::FixLocked

--- a/crates/ccteam-core/src/phases.rs
+++ b/crates/ccteam-core/src/phases.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 use crate::state::Parallelism;
 use crate::tool_surface::ToolsRequired;
 
+const DEFAULT_AUTO_LOOP_MAX_ITERATIONS: u32 = 3;
+
 /// Phase-internal multi-role agent (M2+; M0 ignores).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentTeamRole {
@@ -79,6 +81,32 @@ pub struct PhaseTemplate {
 
     #[serde(default)]
     pub hooks: PhaseHooks,
+
+    /// When true, the orchestrator hands the loop to the Stop hook on
+    /// dispatch (ralph-loop pattern, tech-design §3.5). The hook
+    /// re-feeds `prompt` until either the assistant prints
+    /// `completion_signal` or `auto_loop_max_iterations` is reached.
+    /// Mechanism is phase-name-agnostic — dev's `fix` phase sets it
+    /// true, research's `04-primary` data-collection phase will also
+    /// set it true.
+    #[serde(default)]
+    pub auto_loop: bool,
+
+    /// Iteration cap when `auto_loop = true`. Defaults to 3 so existing
+    /// dev `fix` phase markdown keeps the same semantics without
+    /// declaring it.
+    #[serde(default = "default_auto_loop_max_iterations")]
+    pub auto_loop_max_iterations: u32,
+
+    /// Substring the assistant must print to break out of the auto-loop.
+    /// Required (non-empty) when `auto_loop = true`; ignored otherwise.
+    /// Validated by `validate_m0`.
+    #[serde(default)]
+    pub completion_signal: String,
+}
+
+fn default_auto_loop_max_iterations() -> u32 {
+    DEFAULT_AUTO_LOOP_MAX_ITERATIONS
 }
 
 impl PhaseTemplate {
@@ -110,6 +138,18 @@ impl PhaseTemplate {
                 "phase `{}` declares parallelism `{:?}`; M0 only supports `solo` (development-plan §2.1)",
                 self.name,
                 self.parallelism,
+            );
+        }
+        if self.auto_loop && self.completion_signal.trim().is_empty() {
+            bail!(
+                "phase `{}` declares `auto_loop: true` but no `completion_signal` — orchestrator can't tell when the loop is done",
+                self.name,
+            );
+        }
+        if self.auto_loop && self.auto_loop_max_iterations == 0 {
+            bail!(
+                "phase `{}` declares `auto_loop: true` with `auto_loop_max_iterations: 0` — that would never enter the loop",
+                self.name,
             );
         }
         Ok(())
@@ -232,5 +272,79 @@ mod tests {
         );
         let t = PhaseTemplate::parse(src).unwrap();
         assert!(t.tools_required.is_empty());
+    }
+
+    #[test]
+    fn auto_loop_defaults_to_false_when_omitted() {
+        let src = concat!(
+            "---\n",
+            "name: implement\n",
+            "parallelism: solo\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        assert!(!t.auto_loop);
+        assert_eq!(t.auto_loop_max_iterations, 3);
+        assert!(t.completion_signal.is_empty());
+        // M0 validation passes — auto_loop=false ignores the empty signal.
+        t.validate_m0().unwrap();
+    }
+
+    #[test]
+    fn auto_loop_explicit_fields_parse_correctly() {
+        let src = concat!(
+            "---\n",
+            "name: fix\n",
+            "parallelism: solo\n",
+            "auto_loop: true\n",
+            "auto_loop_max_iterations: 5\n",
+            "completion_signal: TESTS_GREEN\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        assert!(t.auto_loop);
+        assert_eq!(t.auto_loop_max_iterations, 5);
+        assert_eq!(t.completion_signal, "TESTS_GREEN");
+        t.validate_m0().unwrap();
+    }
+
+    #[test]
+    fn auto_loop_true_without_completion_signal_fails_validation() {
+        let src = concat!(
+            "---\n",
+            "name: fix\n",
+            "parallelism: solo\n",
+            "auto_loop: true\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("completion_signal"),
+            "got: {err:#}",
+        );
+    }
+
+    #[test]
+    fn auto_loop_true_with_zero_max_iterations_fails_validation() {
+        let src = concat!(
+            "---\n",
+            "name: fix\n",
+            "parallelism: solo\n",
+            "auto_loop: true\n",
+            "auto_loop_max_iterations: 0\n",
+            "completion_signal: TESTS_GREEN\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("auto_loop_max_iterations"),
+            "got: {err:#}",
+        );
     }
 }

--- a/crates/ccteam-core/src/phases.rs
+++ b/crates/ccteam-core/src/phases.rs
@@ -103,6 +103,22 @@ pub struct PhaseTemplate {
     /// Validated by `validate_m0`.
     #[serde(default)]
     pub completion_signal: String,
+
+    /// Explicit DAG edge for the "phase passed" branch. When `None`
+    /// (the YAML field is omitted), `Dag::from_templates` falls back
+    /// to the next phase in topological filename order, or treats the
+    /// phase as terminal when it's the last in the list. M3.2 widens
+    /// this to fork on test results.
+    #[serde(default)]
+    pub next_on_done: Option<String>,
+
+    /// Explicit DAG edge for the "phase escalated" branch. When
+    /// `None`, the orchestrator marks the project terminally
+    /// escalated (M0/M1 behavior). The M0.5.4 `REVERT_TO_PHASE`
+    /// ESCALATE grammar continues to route via the event's
+    /// `target_phase` field, independent of this static fallback.
+    #[serde(default)]
+    pub next_on_escalate: Option<String>,
 }
 
 fn default_auto_loop_max_iterations() -> u32 {

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -81,15 +81,19 @@ pub fn pick_unused_slug(paths: &CcteamPaths, base: &str) -> Result<String> {
 
 /// Write the bootstrap files for a fresh project:
 /// - `<project>/.ccteam/spec.md` ← `request`
-/// - `<project>/.ccteam/state.json` ← `ProjectState::initial`
+/// - `<project>/.ccteam/state.json` ← `ProjectState::initial_for_team(slug, team)`
 /// - `<project>/.claude/settings.json` ← M0.4 template
 /// - `<project>/CLAUDE.md` ← header + spec link
+///
+/// `team` lands in state.json so the orchestrator can route this
+/// project through the matching phase set (M3.1 F12/F13).
 ///
 /// Returns the full project directory path.
 pub fn bootstrap_project(
     paths: &CcteamPaths,
     slug: &str,
     request: &str,
+    team: &str,
 ) -> Result<PathBuf> {
     let project_dir = paths.project_dir(slug);
     let ccteam_dir = paths.project_ccteam_dir(slug);
@@ -99,12 +103,12 @@ pub fn bootstrap_project(
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
     let spec_path = ccteam_dir.join("spec.md");
     let spec_body = format!(
-        "---\nslug: {slug}\ncreated_at: {now}\n---\n\n# 用户需求\n\n{request}\n",
+        "---\nslug: {slug}\ncreated_at: {now}\nteam: {team}\n---\n\n# 用户需求\n\n{request}\n",
     );
     std::fs::write(&spec_path, spec_body)
         .with_context(|| format!("write {}", spec_path.display()))?;
 
-    let state = ProjectState::initial(slug.to_string());
+    let state = ProjectState::initial_for_team(slug.to_string(), team.to_string());
     state.save(&paths.project_state(slug))?;
 
     write_project_settings(&project_dir)?;
@@ -427,7 +431,7 @@ mod tests {
             projects_root: tmp.path().join("projects"),
         };
         let slug = "demo";
-        bootstrap_project(&paths, slug, "demo request").unwrap();
+        bootstrap_project(&paths, slug, "demo request", "dev").unwrap();
         let phases_dir = paths.project_dir(slug).join(".ccteam/phases");
         assert!(phases_dir.join("plan-eng.md").exists());
         assert!(phases_dir.join("implement.md").exists());
@@ -450,7 +454,7 @@ mod tests {
             root: tmp.path().join("home"),
             projects_root: tmp.path().join("projects"),
         };
-        bootstrap_project(&paths, "demo", "demo request").unwrap();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
         let skills = paths.project_dir("demo").join(".claude/skills");
         assert!(
             skills.is_dir(),
@@ -466,7 +470,7 @@ mod tests {
             root: tmp.path().join("home"),
             projects_root: tmp.path().join("projects"),
         };
-        bootstrap_project(&paths, "demo", "demo request").unwrap();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
         let settings = paths.project_dir("demo").join(".claude/settings.json");
         let body = std::fs::read_to_string(&settings).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();

--- a/crates/ccteam-core/src/state.rs
+++ b/crates/ccteam-core/src/state.rs
@@ -54,6 +54,12 @@ pub struct PhaseHistoryEntry {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ProjectState {
     pub slug: String,
+    /// Team this project runs under — selects which phase template
+    /// set the orchestrator uses (M3.1 F13). serde-default `"dev"`
+    /// keeps state.json files written before M3.1 loadable as the
+    /// dev team, no migration script needed.
+    #[serde(default = "default_team")]
+    pub team: String,
     pub created_at: DateTime<Utc>,
     pub tmux_session: String,
     pub claude_session_id: Option<String>,
@@ -76,15 +82,27 @@ pub struct ProjectState {
     pub user_pause_pending: bool,
 }
 
+fn default_team() -> String {
+    "dev".into()
+}
+
 impl ProjectState {
     /// Default initial state for a freshly-created project. `current_phase`
     /// is left empty so the orchestrator's first tick reads it as
-    /// "no phase yet" and dispatches `FIRST_PHASE`.
+    /// "no phase yet" and dispatches the DAG entry node.
     pub fn initial(slug: String) -> Self {
+        Self::initial_for_team(slug, default_team())
+    }
+
+    /// Like `initial` but lets the caller pin the team. Used by
+    /// `bootstrap_project` so `ccteam new --team <name>` carries
+    /// through to state.json.
+    pub fn initial_for_team(slug: String, team: String) -> Self {
         let now = Utc::now();
         Self {
             tmux_session: format!("ccteam-{slug}"),
             slug,
+            team,
             created_at: now,
             claude_session_id: None,
             claude_pid: None,

--- a/crates/ccteam-core/src/team.rs
+++ b/crates/ccteam-core/src/team.rs
@@ -1,0 +1,229 @@
+//! `team.yaml` schema — team-level configuration that lives next to a
+//! team's phase template directory (M3.4 lays out the on-disk layout).
+//!
+//! M3.1 scope: **data form + parsing only.** No call sites yet — M4.1
+//! retro phase implementation will read `retro_schema` so retro reports
+//! pick up the right fields per team from day one.
+//!
+//! Why this lands in M3.1 (and not M4.1): cross-project memory was
+//! reordered after team-abstraction in development-plan §5. Without
+//! `retro_schema` shipped first, M4.1 retro would freeze dev-only fields
+//! (tech stack / pitfalls / …) into the RAG index, forcing a rebuild
+//! when research team retro lands later. F20 was upgraded P1→P0 for
+//! exactly this reason — see `dev-coupling-audit.md §F20` for context.
+
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// One field in a team's retro schema. M4.1 retro phase emits a
+/// markdown section per entry; the cross-project memory RAG indexes
+/// each field as a tagged document so future projects can pull only
+/// the field types relevant to their own team.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetroFieldSpec {
+    /// snake_case field name. Used as the markdown subsection slug
+    /// AND the RAG index tag, so keep it stable per team — renaming
+    /// invalidates indexed history.
+    pub field: String,
+    /// Free-text description shown to the assistant in the retro
+    /// phase prompt — explains what to put in this field.
+    pub description: String,
+    /// `list` for bulleted text, `text` for a single paragraph. M4.1
+    /// retro phase formats accordingly.
+    #[serde(default = "default_field_kind")]
+    pub kind: RetroFieldKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetroFieldKind {
+    /// Bulleted list of short items (tech stack, pitfalls, …).
+    List,
+    /// Single paragraph (overall summary, narrative).
+    Text,
+}
+
+fn default_field_kind() -> RetroFieldKind {
+    RetroFieldKind::List
+}
+
+/// `team.yaml` — the team-level config. M3.1 ships only the fields
+/// loadable by the orchestrator at startup; M3.4 adds artifact lists,
+/// danger-command patterns, claude_md_template, etc.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamSpec {
+    /// Team identifier. Must match the `--team` arg / `state.json.team`
+    /// field. snake-case lowercase — gets used as a directory name.
+    pub name: String,
+
+    /// Human-readable one-liner; surfaced by `ccteam ls --teams`
+    /// (M3.4) and in error messages.
+    #[serde(default)]
+    pub description: String,
+
+    /// Field schema for the retro phase (M4.1). Empty list = no
+    /// retro phase for this team. Order is preserved — the retro
+    /// markdown emits sections in this order.
+    #[serde(default)]
+    pub retro_schema: Vec<RetroFieldSpec>,
+}
+
+impl TeamSpec {
+    /// Parse `team.yaml` from raw YAML source.
+    pub fn parse(source: &str) -> Result<Self> {
+        let spec: TeamSpec = serde_yaml::from_str(source)
+            .context("team.yaml does not match schema")?;
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    /// Load + parse `team.yaml` from disk.
+    pub fn load(path: &Path) -> Result<Self> {
+        let source = std::fs::read_to_string(path)
+            .with_context(|| format!("read team.yaml at {}", path.display()))?;
+        Self::parse(&source)
+            .with_context(|| format!("parse team.yaml at {}", path.display()))
+    }
+
+    /// Sanity checks at parse time. The orchestrator never wants to
+    /// hold an "almost OK" TeamSpec — better to fail loud at load
+    /// than to discover a duplicate retro field name during M4.1
+    /// retro execution.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.trim().is_empty() {
+            bail!("team.yaml: `name` must be non-empty");
+        }
+        if self
+            .name
+            .chars()
+            .any(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_'))
+        {
+            bail!(
+                "team.yaml: `name` must be ascii lower / digit / `-` / `_`; got `{}`",
+                self.name,
+            );
+        }
+
+        let mut seen = std::collections::HashSet::new();
+        for f in &self.retro_schema {
+            if f.field.trim().is_empty() {
+                bail!("team.yaml: retro_schema entry has empty `field`");
+            }
+            if !seen.insert(f.field.as_str()) {
+                return Err(anyhow!(
+                    "team.yaml: retro_schema duplicates field `{}`",
+                    f.field,
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_team_yaml() {
+        let src = "name: dev\n";
+        let spec = TeamSpec::parse(src).unwrap();
+        assert_eq!(spec.name, "dev");
+        assert!(spec.description.is_empty());
+        assert!(spec.retro_schema.is_empty());
+    }
+
+    #[test]
+    fn parses_dev_team_retro_schema() {
+        let src = concat!(
+            "name: dev\n",
+            "description: Software development team\n",
+            "retro_schema:\n",
+            "  - field: tech_stack\n",
+            "    description: Languages, frameworks, key libraries\n",
+            "  - field: pitfalls\n",
+            "    description: Mistakes to avoid next time\n",
+            "  - field: successful_designs\n",
+            "    description: Design choices that paid off\n",
+            "  - field: do_not_do_again\n",
+            "    description: Anti-patterns observed\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert_eq!(spec.name, "dev");
+        assert_eq!(spec.retro_schema.len(), 4);
+        assert_eq!(spec.retro_schema[0].field, "tech_stack");
+        // default kind = list
+        assert_eq!(spec.retro_schema[0].kind, RetroFieldKind::List);
+    }
+
+    #[test]
+    fn parses_research_team_with_text_field() {
+        let src = concat!(
+            "name: research\n",
+            "retro_schema:\n",
+            "  - field: methodology\n",
+            "    description: Methods used\n",
+            "  - field: summary\n",
+            "    description: Narrative recap\n",
+            "    kind: text\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert_eq!(spec.retro_schema[1].kind, RetroFieldKind::Text);
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let err = TeamSpec::parse("name: ''\n").unwrap_err();
+        assert!(format!("{err:#}").contains("non-empty"));
+    }
+
+    #[test]
+    fn rejects_invalid_chars_in_name() {
+        let err = TeamSpec::parse("name: Dev Team\n").unwrap_err();
+        assert!(format!("{err:#}").contains("ascii"));
+    }
+
+    #[test]
+    fn rejects_duplicate_retro_field() {
+        let src = concat!(
+            "name: dev\n",
+            "retro_schema:\n",
+            "  - field: tech_stack\n",
+            "    description: First\n",
+            "  - field: tech_stack\n",
+            "    description: Duplicate\n",
+        );
+        let err = TeamSpec::parse(src).unwrap_err();
+        assert!(format!("{err:#}").contains("duplicates"));
+    }
+
+    #[test]
+    fn rejects_empty_field_name() {
+        let src = concat!(
+            "name: dev\n",
+            "retro_schema:\n",
+            "  - field: ''\n",
+            "    description: empty\n",
+        );
+        let err = TeamSpec::parse(src).unwrap_err();
+        assert!(format!("{err:#}").contains("empty"));
+    }
+
+    #[test]
+    fn round_trip_through_yaml_preserves_fields() {
+        let original = TeamSpec {
+            name: "dev".into(),
+            description: "Software dev".into(),
+            retro_schema: vec![RetroFieldSpec {
+                field: "tech_stack".into(),
+                description: "List of techs".into(),
+                kind: RetroFieldKind::List,
+            }],
+        };
+        let yaml = serde_yaml::to_string(&original).unwrap();
+        let parsed = TeamSpec::parse(&yaml).unwrap();
+        assert_eq!(parsed, original);
+    }
+}

--- a/crates/ccteam-core/tests/context_reset_test.rs
+++ b/crates/ccteam-core/tests/context_reset_test.rs
@@ -9,8 +9,9 @@ use tempfile::TempDir;
 
 use ccteam_core::tmux::{tmux_available, TmuxSession};
 use ccteam_core::{
-    append_progress_summary, build_progress_summary, CcteamPaths, Orchestrator,
-    OrchestratorConfig, Parallelism, PhaseHistoryEntry, PhaseState, ProjectState,
+    append_progress_summary, build_progress_summary, write_global_phase_templates,
+    CcteamPaths, Orchestrator, OrchestratorConfig, Parallelism, PhaseHistoryEntry,
+    PhaseState, ProjectState,
 };
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -114,6 +115,9 @@ fn reset_context_recycles_tmux_and_resets_counter() {
     let slug = unique_slug("recycle");
     let project_dir = paths.project_dir(&slug);
     std::fs::create_dir_all(project_dir.join(".ccteam")).unwrap();
+    // Orchestrator::new now requires a non-empty phase template list
+    // (M3.1 F2: DAG inference replaces M0_PHASE_DAG constant).
+    write_global_phase_templates(&paths.root, false).unwrap();
 
     // Persist initial state with tokens above threshold.
     let mut state = fresh_state(&slug, "test-author");
@@ -133,6 +137,7 @@ fn reset_context_recycles_tmux_and_resets_counter() {
     let config = OrchestratorConfig {
         claude_argv: vec!["sh".into(), "-c".into(), ready_cmd],
         ready_timeout: Duration::from_secs(5),
+        skip_tool_check: true,
         ..OrchestratorConfig::default()
     };
     let orch = Orchestrator::new(paths.clone(), config).unwrap();
@@ -167,6 +172,7 @@ fn reset_context_times_out_when_ready_marker_never_appears() {
     let slug = unique_slug("timeout");
     let project_dir = paths.project_dir(&slug);
     std::fs::create_dir_all(project_dir.join(".ccteam")).unwrap();
+    write_global_phase_templates(&paths.root, false).unwrap();
 
     let mut state = fresh_state(&slug, "implement");
     state.save(&paths.project_state(&slug)).unwrap();
@@ -175,6 +181,7 @@ fn reset_context_times_out_when_ready_marker_never_appears() {
         // pane process does NOT touch ready
         claude_argv: vec!["sh".into(), "-c".into(), "sleep 60".into()],
         ready_timeout: Duration::from_millis(400),
+        skip_tool_check: true,
         ..OrchestratorConfig::default()
     };
     let orch = Orchestrator::new(paths.clone(), config).unwrap();

--- a/crates/ccteam-core/tests/context_reset_test.rs
+++ b/crates/ccteam-core/tests/context_reset_test.rs
@@ -26,6 +26,7 @@ fn fresh_state(slug: &str, current_phase: &str) -> ProjectState {
     let now = Utc::now();
     ProjectState {
         slug: slug.into(),
+        team: "dev".into(),
         created_at: now,
         tmux_session: TmuxSession::for_slug(slug).name().into(),
         claude_session_id: None,

--- a/crates/ccteam-core/tests/dispatch_test.rs
+++ b/crates/ccteam-core/tests/dispatch_test.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 
 use ccteam_core::tmux::{tmux_available, TmuxSession};
 use ccteam_core::{
-    progress, CcteamPaths, Orchestrator, OrchestratorConfig, Parallelism, PhaseState, ProjectState,
+    progress, write_global_phase_templates, CcteamPaths, Orchestrator, OrchestratorConfig,
+    Parallelism, PhaseState, ProjectState,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -55,6 +56,10 @@ fn fixture(test_name: &str) -> Option<(TempDir, CcteamPaths, String, ScopedSessi
     let project = paths.project_dir(&slug);
     std::fs::create_dir_all(&project).unwrap();
     std::fs::create_dir_all(paths.project_state(&slug).parent().unwrap()).unwrap();
+    // M3.1 F2: Orchestrator::new now requires phase templates to build
+    // a DAG. Tests that previously got away with empty `~/.ccteam/phases/`
+    // must populate it via the shipped dev templates.
+    write_global_phase_templates(&paths.root, false).unwrap();
     let now = chrono::Utc::now();
     ProjectState {
         slug: slug.clone(),
@@ -100,7 +105,14 @@ fn dispatch_phase_sends_idle_prompt_and_appends_event_when_no_history() {
     else {
         return;
     };
-    let orch = Orchestrator::new(paths.clone(), OrchestratorConfig::default()).unwrap();
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
 
     orch.dispatch_phase(&slug, "implement").unwrap();
 
@@ -124,7 +136,14 @@ fn dispatch_phase_uses_btw_when_busy() {
     )
     .unwrap();
 
-    let orch = Orchestrator::new(paths.clone(), OrchestratorConfig::default()).unwrap();
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
     orch.dispatch_phase(&slug, "implement").unwrap();
 
     let last = progress::last_event(&paths.progress_jsonl(&slug))
@@ -139,7 +158,14 @@ fn dispatch_phase_payload_lands_in_tmux_pane() {
     let Some((_tmp, paths, slug, scoped)) = fixture("payload-in-pane") else {
         return;
     };
-    let orch = Orchestrator::new(paths, OrchestratorConfig::default()).unwrap();
+    let orch = Orchestrator::new(
+        paths,
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
     let session = TmuxSession::for_slug(&slug);
     assert!(
         session.exists(),

--- a/crates/ccteam-core/tests/dispatch_test.rs
+++ b/crates/ccteam-core/tests/dispatch_test.rs
@@ -63,6 +63,7 @@ fn fixture(test_name: &str) -> Option<(TempDir, CcteamPaths, String, ScopedSessi
     let now = chrono::Utc::now();
     ProjectState {
         slug: slug.clone(),
+        team: "dev".into(),
         created_at: now,
         tmux_session: TmuxSession::for_slug(&slug).name().to_string(),
         claude_session_id: None,

--- a/crates/ccteam-core/tests/e2e_happy_path_test.rs
+++ b/crates/ccteam-core/tests/e2e_happy_path_test.rs
@@ -75,7 +75,7 @@ fn full_pipeline_advances_through_every_m0_phase() {
 
     let slug = slugify(request);
     ensure_isolation();
-    bootstrap_project(&paths, &slug, request).unwrap();
+    bootstrap_project(&paths, &slug, request, "dev").unwrap();
 
     let dag = dev_dag();
 
@@ -164,7 +164,7 @@ fn full_pipeline_runs_three_times_without_leaking_state() {
         let paths = fresh(&tmp);
         let slug = slugify(&format!("smoke {run}"));
         ensure_isolation();
-        bootstrap_project(&paths, &slug, "smoke").unwrap();
+        bootstrap_project(&paths, &slug, "smoke", "dev").unwrap();
         let state_path = paths.project_state(&slug);
 
         for phase in M0_DAG {
@@ -218,7 +218,7 @@ fn pipeline_halts_on_escalate_event_mid_dag() {
     let paths = fresh(&tmp);
     let slug = slugify("escalate-test");
     ensure_isolation();
-    bootstrap_project(&paths, &slug, "escalate test").unwrap();
+    bootstrap_project(&paths, &slug, "escalate test", "dev").unwrap();
     let state_path = paths.project_state(&slug);
 
     let dag = dev_dag();

--- a/crates/ccteam-core/tests/e2e_happy_path_test.rs
+++ b/crates/ccteam-core/tests/e2e_happy_path_test.rs
@@ -14,9 +14,8 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use ccteam_core::{
-    bootstrap_project, decide_tick, disable_tool_surface_bootstrap_for_tests,
-    is_terminal, next_phase, progress, slugify, CcteamPaths, PhaseHistoryEntry,
-    PhaseState, ProjectState, TickAction, FIRST_PHASE,
+    bootstrap_project, decide_tick, dev_dag, disable_tool_surface_bootstrap_for_tests,
+    progress, slugify, CcteamPaths, PhaseHistoryEntry, PhaseState, ProjectState, TickAction,
 };
 
 /// These tests don't care about the tool-surface side effects of
@@ -45,13 +44,15 @@ fn fresh(paths: &TempDir) -> CcteamPaths {
     }
 }
 
+/// Pretend the orchestrator dispatched `phase`. `decide_tick` treats
+/// InFlight and FixLocked identically (both block AdvancePhase until
+/// a `phase_done` event lands), so this fixture uses InFlight
+/// uniformly — the FixLocked branch's actual transition is covered
+/// by the orchestrator tests in `state_machine_test.rs` and the
+/// hooks integration tests.
 fn fake_dispatch(state: &mut ProjectState, phase: &str) {
     state.current_phase = phase.into();
-    state.phase_state = if phase == "fix" {
-        PhaseState::FixLocked
-    } else {
-        PhaseState::InFlight
-    };
+    state.phase_state = PhaseState::InFlight;
 }
 
 fn fake_phase_done(paths: &CcteamPaths, slug: &str, phase: &str) {
@@ -76,17 +77,19 @@ fn full_pipeline_advances_through_every_m0_phase() {
     ensure_isolation();
     bootstrap_project(&paths, &slug, request).unwrap();
 
+    let dag = dev_dag();
+
     let state_path = paths.project_state(&slug);
     let state = ProjectState::load(&state_path).unwrap();
     assert!(state.current_phase.is_empty());
     assert_eq!(state.phase_state, PhaseState::Idle);
 
-    // First decision on a fresh project: dispatch FIRST_PHASE.
-    let action = decide_tick(&state, None);
+    // First decision on a fresh project: dispatch the DAG entry node.
+    let action = decide_tick(&dag, &state, None);
     assert_eq!(
         action,
         TickAction::DispatchPhase {
-            phase: FIRST_PHASE.into()
+            phase: dag.entry().into(),
         },
     );
 
@@ -107,8 +110,8 @@ fn full_pipeline_advances_through_every_m0_phase() {
         let last = progress::last_event(&paths.progress_jsonl(&slug))
             .unwrap()
             .unwrap();
-        let action = decide_tick(&s, Some(&last));
-        let expected_to = next_phase(phase).map(String::from);
+        let action = decide_tick(&dag, &s, Some(&last));
+        let expected_to = dag.next_on_done(phase).map(String::from);
         assert_eq!(
             action,
             TickAction::AdvancePhase {
@@ -132,16 +135,17 @@ fn full_pipeline_advances_through_every_m0_phase() {
     }
 
     let final_state = ProjectState::load(&state_path).unwrap();
-    assert!(is_terminal(&final_state), "project must be terminal after ship");
-    assert_eq!(
-        final_state.phase_history.last().unwrap().phase,
-        "ship",
-        "last history entry must be ship",
+    assert!(
+        dag.is_terminal_state(&final_state),
+        "project must be terminal after the DAG endpoint",
     );
-    assert_eq!(
-        final_state.phase_history.last().unwrap().status,
-        "passed",
+    let last_history = final_state.phase_history.last().unwrap();
+    assert!(
+        dag.is_terminal_phase(&last_history.phase),
+        "last history phase must be a DAG endpoint, got {}",
+        last_history.phase,
     );
+    assert_eq!(last_history.status, "passed");
     assert_eq!(
         final_state.phase_history.len(),
         M0_DAG.len(),
@@ -154,6 +158,7 @@ fn full_pipeline_runs_three_times_without_leaking_state() {
     // Per dev-plan, M0 closure requires three e2e passes. Run the
     // walk thrice in fresh tempdirs to confirm reproducibility — no
     // global state leak should produce divergent histories.
+    let dag = dev_dag();
     for run in 1..=3 {
         let tmp = TempDir::new().unwrap();
         let paths = fresh(&tmp);
@@ -172,8 +177,8 @@ fn full_pipeline_runs_three_times_without_leaking_state() {
             let last = progress::last_event(&paths.progress_jsonl(&slug))
                 .unwrap()
                 .unwrap();
-            let action = decide_tick(&s, Some(&last));
-            let expected_to = next_phase(phase).map(String::from);
+            let action = decide_tick(&dag, &s, Some(&last));
+            let expected_to = dag.next_on_done(phase).map(String::from);
             assert_eq!(
                 action,
                 TickAction::AdvancePhase {
@@ -196,8 +201,8 @@ fn full_pipeline_runs_three_times_without_leaking_state() {
 
         let final_state = ProjectState::load(&state_path).unwrap();
         assert!(
-            is_terminal(&final_state),
-            "run {run}: project must terminate at ship",
+            dag.is_terminal_state(&final_state),
+            "run {run}: project must terminate at the DAG endpoint",
         );
         assert_eq!(
             final_state.phase_history.len(),
@@ -216,6 +221,8 @@ fn pipeline_halts_on_escalate_event_mid_dag() {
     bootstrap_project(&paths, &slug, "escalate test").unwrap();
     let state_path = paths.project_state(&slug);
 
+    let dag = dev_dag();
+
     // Advance to test-run, then claude escalates.
     for phase in &M0_DAG[..3] {
         let mut s = ProjectState::load(&state_path).unwrap();
@@ -231,7 +238,7 @@ fn pipeline_halts_on_escalate_event_mid_dag() {
             cost_usd: 0.0,
         });
         s.phase_state = PhaseState::Idle;
-        s.current_phase = next_phase(phase).unwrap_or("").into();
+        s.current_phase = dag.next_on_done(phase).unwrap_or("").into();
         s.save(&state_path).unwrap();
     }
 
@@ -253,7 +260,7 @@ fn pipeline_halts_on_escalate_event_mid_dag() {
     let last = progress::last_event(&paths.progress_jsonl(&slug))
         .unwrap()
         .unwrap();
-    let action = decide_tick(&s, Some(&last));
+    let action = decide_tick(&dag, &s, Some(&last));
     assert_eq!(
         action,
         TickAction::Escalated {

--- a/crates/ccteam-core/tests/orchestrator_test.rs
+++ b/crates/ccteam-core/tests/orchestrator_test.rs
@@ -235,7 +235,7 @@ fn ensure_session_starts_a_missing_session() {
     let paths = fresh_paths(&tmp);
     let slug = format!("ensure-test-{}", std::process::id());
     ensure_isolation();
-    bootstrap_project(&paths, &slug, "test request").unwrap();
+    bootstrap_project(&paths, &slug, "test request", "dev").unwrap();
 
     let project_dir = paths.project_dir(&slug);
     let ready = project_dir.join(".ccteam/ready");
@@ -286,7 +286,7 @@ fn ensure_session_is_no_op_when_session_alive() {
     let paths = fresh_paths(&tmp);
     let slug = format!("ensure-noop-{}", std::process::id());
     ensure_isolation();
-    bootstrap_project(&paths, &slug, "test request").unwrap();
+    bootstrap_project(&paths, &slug, "test request", "dev").unwrap();
 
     let project_dir = paths.project_dir(&slug);
     let ready = project_dir.join(".ccteam/ready");

--- a/crates/ccteam-core/tests/state_machine_test.rs
+++ b/crates/ccteam-core/tests/state_machine_test.rs
@@ -13,6 +13,7 @@ fn fresh_state(current_phase: &str, phase_state: PhaseState) -> ProjectState {
     let now = Utc::now();
     ProjectState {
         slug: "demo".into(),
+        team: "dev".into(),
         created_at: now,
         tmux_session: "ccteam-demo".into(),
         claude_session_id: None,

--- a/crates/ccteam-core/tests/state_machine_test.rs
+++ b/crates/ccteam-core/tests/state_machine_test.rs
@@ -5,9 +5,8 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use ccteam_core::{
-    decide_tick, is_terminal, next_phase, progress, CcteamPaths, Orchestrator,
+    decide_tick, dev_dag, progress, write_global_phase_templates, CcteamPaths, Orchestrator,
     OrchestratorConfig, Parallelism, PhaseHistoryEntry, PhaseState, ProjectState, TickAction,
-    FIRST_PHASE,
 };
 
 fn fresh_state(current_phase: &str, phase_state: PhaseState) -> ProjectState {
@@ -38,32 +37,37 @@ fn fresh_state(current_phase: &str, phase_state: PhaseState) -> ProjectState {
 }
 
 #[test]
-fn next_phase_walks_the_m0_dag() {
+fn dev_dag_walks_through_every_phase() {
+    let dag = dev_dag();
     let chain = ["plan-eng", "implement", "test-author", "test-run", "fix", "ship"];
     for w in chain.windows(2) {
-        assert_eq!(next_phase(w[0]), Some(w[1]));
+        assert_eq!(dag.next_on_done(w[0]), Some(w[1]));
     }
-    assert_eq!(next_phase("ship"), None);
-    assert_eq!(next_phase("not-a-real-phase"), None);
+    assert_eq!(dag.next_on_done("ship"), None);
+    assert_eq!(dag.next_on_done("not-a-real-phase"), None);
+    assert_eq!(dag.entry(), "plan-eng");
+    assert!(dag.is_terminal_phase("ship"));
 }
 
 #[test]
 fn decide_tick_dispatches_first_phase_for_fresh_project() {
+    let dag = dev_dag();
     let state = fresh_state("", PhaseState::Idle);
     assert_eq!(
-        decide_tick(&state, None),
+        decide_tick(&dag, &state, None),
         TickAction::DispatchPhase {
-            phase: FIRST_PHASE.into()
+            phase: dag.entry().into(),
         },
     );
 }
 
 #[test]
 fn decide_tick_advances_when_phase_done_matches() {
+    let dag = dev_dag();
     let state = fresh_state("implement", PhaseState::InFlight);
     let event = json!({"event": "phase_done", "phase": "implement"});
     assert_eq!(
-        decide_tick(&state, Some(&event)),
+        decide_tick(&dag, &state, Some(&event)),
         TickAction::AdvancePhase {
             from: "implement".into(),
             to: Some("test-author".into()),
@@ -73,10 +77,11 @@ fn decide_tick_advances_when_phase_done_matches() {
 
 #[test]
 fn decide_tick_advances_to_none_after_ship() {
+    let dag = dev_dag();
     let state = fresh_state("ship", PhaseState::InFlight);
     let event = json!({"event": "phase_done", "phase": "ship"});
     assert_eq!(
-        decide_tick(&state, Some(&event)),
+        decide_tick(&dag, &state, Some(&event)),
         TickAction::AdvancePhase {
             from: "ship".into(),
             to: None,
@@ -86,18 +91,20 @@ fn decide_tick_advances_to_none_after_ship() {
 
 #[test]
 fn decide_tick_ignores_phase_done_for_a_different_phase() {
+    let dag = dev_dag();
     let state = fresh_state("implement", PhaseState::InFlight);
     let stale = json!({"event": "phase_done", "phase": "plan-eng"});
-    assert_eq!(decide_tick(&state, Some(&stale)), TickAction::NoOp);
+    assert_eq!(decide_tick(&dag, &state, Some(&stale)), TickAction::NoOp);
 }
 
 #[test]
 fn decide_tick_classifies_busy_events_as_noop() {
+    let dag = dev_dag();
     let state = fresh_state("implement", PhaseState::InFlight);
     for kind in ["PreToolUse", "PostToolUse", "phase_inject", "SubagentStop"] {
         let e = json!({"event": kind});
         assert_eq!(
-            decide_tick(&state, Some(&e)),
+            decide_tick(&dag, &state, Some(&e)),
             TickAction::NoOp,
             "{kind} must be NoOp",
         );
@@ -106,10 +113,11 @@ fn decide_tick_classifies_busy_events_as_noop() {
 
 #[test]
 fn decide_tick_emits_escalated_on_escalate_event() {
+    let dag = dev_dag();
     let state = fresh_state("fix", PhaseState::InFlight);
     let e = json!({"event": "escalate", "reason": "fix-cycle 撞 3 顶"});
     assert_eq!(
-        decide_tick(&state, Some(&e)),
+        decide_tick(&dag, &state, Some(&e)),
         TickAction::Escalated {
             phase: "fix".into(),
             reason: "fix-cycle 撞 3 顶".into(),
@@ -118,7 +126,8 @@ fn decide_tick_emits_escalated_on_escalate_event() {
 }
 
 #[test]
-fn is_terminal_true_after_ship_passes() {
+fn is_terminal_state_true_after_dag_endpoint_passes() {
+    let dag = dev_dag();
     let mut state = fresh_state("ship", PhaseState::Idle);
     state.phase_history.push(PhaseHistoryEntry {
         phase: "ship".into(),
@@ -126,11 +135,12 @@ fn is_terminal_true_after_ship_passes() {
         duration_s: 0,
         cost_usd: 0.0,
     });
-    assert!(is_terminal(&state));
+    assert!(dag.is_terminal_state(&state));
 }
 
 #[test]
-fn is_terminal_true_after_any_escalation() {
+fn is_terminal_state_true_after_any_escalation() {
+    let dag = dev_dag();
     let mut state = fresh_state("implement", PhaseState::Idle);
     state.phase_history.push(PhaseHistoryEntry {
         phase: "implement".into(),
@@ -138,7 +148,23 @@ fn is_terminal_true_after_any_escalation() {
         duration_s: 0,
         cost_usd: 0.0,
     });
-    assert!(is_terminal(&state));
+    assert!(dag.is_terminal_state(&state));
+}
+
+#[test]
+fn is_terminal_state_false_when_non_endpoint_passes() {
+    // After F4: "passed" on a non-endpoint phase is NOT terminal.
+    // Old logic only checked for "ship" string match — this test
+    // guards against regression.
+    let dag = dev_dag();
+    let mut state = fresh_state("implement", PhaseState::Idle);
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "implement".into(),
+        status: "passed".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    assert!(!dag.is_terminal_state(&state));
 }
 
 #[test]
@@ -162,8 +188,15 @@ fn process_project_writes_escalation_md_and_marks_history() {
     )
     .unwrap();
 
-    let orch =
-        Orchestrator::new(paths.clone(), OrchestratorConfig::default()).unwrap();
+    write_global_phase_templates(&paths.root, false).unwrap();
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
     let new_state = orch
         .process_project(slug, ProjectState::load(&paths.project_state(slug)).unwrap())
         .unwrap();
@@ -210,8 +243,15 @@ fn process_project_advances_history_when_phase_done_observed_without_tmux_dispat
     )
     .unwrap();
 
-    let orch =
-        Orchestrator::new(paths.clone(), OrchestratorConfig::default()).unwrap();
+    write_global_phase_templates(&paths.root, false).unwrap();
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
     let new_state = orch
         .process_project(slug, ProjectState::load(&paths.project_state(slug)).unwrap())
         .unwrap();

--- a/crates/ccteam-core/tests/state_test.rs
+++ b/crates/ccteam-core/tests/state_test.rs
@@ -12,6 +12,7 @@ fn sample_state() -> ProjectState {
     let t0 = Utc.with_ymd_and_hms(2026, 5, 4, 10, 23, 0).unwrap();
     ProjectState {
         slug: "bookmark-mgr-a3f9".into(),
+        team: "dev".into(),
         created_at: t0,
         tmux_session: "ccteam-bookmark-mgr-a3f9".into(),
         claude_session_id: Some("abc123-def-456".into()),

--- a/crates/ccteam-core/tests/tool_surface_e2e_test.rs
+++ b/crates/ccteam-core/tests/tool_surface_e2e_test.rs
@@ -125,7 +125,7 @@ fn fresh_project_passes_tool_surface_validator_for_shipped_implement() {
     write_global_phases_with_implement(&paths.phases_dir());
 
     let slug = slugify("review smoke");
-    bootstrap_project(&paths, &slug, "review smoke").unwrap();
+    bootstrap_project(&paths, &slug, "review smoke", "dev").unwrap();
 
     // Confirm bootstrap actually placed the symlink — this is the
     // M0.5.1 + M0.5.3 contract.
@@ -227,7 +227,7 @@ fn missing_code_reviewer_fails_orchestrator_construction_with_fix_hint() {
     // Bootstrap will warn (source missing) but not fail. The
     // orchestrator validator is what we expect to fail loudly.
     let slug = slugify("missing reviewer");
-    bootstrap_project(&paths, &slug, "missing reviewer").unwrap();
+    bootstrap_project(&paths, &slug, "missing reviewer", "dev").unwrap();
 
     let err = Orchestrator::new(paths, OrchestratorConfig::default()).unwrap_err();
     let msg = format!("{err:#}");

--- a/crates/ccteam-core/tests/tool_surface_e2e_test.rs
+++ b/crates/ccteam-core/tests/tool_surface_e2e_test.rs
@@ -20,7 +20,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use ccteam_core::{
-    bootstrap_project, decide_tick_from_events, next_phase, progress, slugify,
+    bootstrap_project, decide_tick_from_events, dev_dag, progress, slugify,
     CcteamPaths, Orchestrator, OrchestratorConfig, PhaseState, PhaseTemplate,
     ProjectState, TickAction, RECOMMENDED_AGENTS,
 };
@@ -193,12 +193,13 @@ fn implement_phase_advances_when_subagent_done_lands_after_phase_done() {
     }
 
     let read = progress::read_all_events(&progress_path).unwrap();
-    let action = decide_tick_from_events(&state, &read);
+    let dag = dev_dag();
+    let action = decide_tick_from_events(&dag, &state, &read);
     assert_eq!(
         action,
         TickAction::AdvancePhase {
             from: "implement".into(),
-            to: next_phase("implement").map(String::from),
+            to: dag.next_on_done("implement").map(String::from),
         },
         "SubagentStop tail must NOT mask phase_done — orchestrator should still advance",
     );

--- a/crates/ccteam-hooks/tests/fix_loop_test.rs
+++ b/crates/ccteam-hooks/tests/fix_loop_test.rs
@@ -33,6 +33,7 @@ impl Fixture {
         let now = Utc::now();
         ProjectState {
             slug: slug.into(),
+            team: "dev".into(),
             created_at: now,
             tmux_session: format!("ccteam-{slug}"),
             claude_session_id: None,

--- a/crates/ccteam-hooks/tests/fix_loop_test.rs
+++ b/crates/ccteam-hooks/tests/fix_loop_test.rs
@@ -80,6 +80,7 @@ impl Fixture {
             self.slug.clone(),
             "请按 @.ccteam/phases/06-fix.md 完成本阶段...".into(),
             3,
+            "TESTS_GREEN".into(),
         );
         state.front.iteration = iter;
         fix_loop::write(&fix_loop::path_in(&self.project_dir), &state).unwrap();

--- a/crates/ccteam-hooks/tests/hooks_test.rs
+++ b/crates/ccteam-hooks/tests/hooks_test.rs
@@ -40,6 +40,7 @@ impl Fixture {
         let now = Utc::now();
         let state = ProjectState {
             slug: slug.into(),
+            team: "dev".into(),
             created_at: now,
             tmux_session: format!("ccteam-{slug}"),
             claude_session_id: None,

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -311,6 +311,11 @@ auto_loop: false                  # 默认 false。true 时 orchestrator 派发�
 auto_loop_max_iterations: 3       # 自循环硬上限,默认 3。auto_loop=false 时忽略
 completion_signal: TESTS_GREEN    # 自循环退出信号(子串匹配)。auto_loop=true 时必填且非空,
                                   # auto_loop=false 时可省略
+next_on_done: implement           # 可选。`phase_done` 后跳转目标。省略 → 走拓扑序下一相
+                                  # (M3.1 F2:从 PhaseTemplate 列表的文件名顺序推 DAG;
+                                  # 末尾相省略 next_on_done = 终点节点 = is_terminal_phase)
+next_on_escalate: null            # 可选。`escalate` 后静态 revert 目标。省略(null)= 项目终态 escalated
+                                  # (M0.5.4 ESCALATE: REVERT_TO_PHASE 语法在事件 target_phase 字段独立路由)
 hooks:                            # phase 级 hook(项目级 hook 在 settings.json,详见 §6)
   before: scripts/snapshot-git.sh
   after: scripts/run-golden-rules.sh

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -387,6 +387,52 @@ confidence: 0.0-1.0
 
 ---
 
+### 5.5 `team.yaml` 团队配置(M3.1+)
+
+每个团队一份 `team.yaml`,M3.4 落到 `~/.ccteam/teams/<name>/team.yaml`。**M3.1 只交付数据形式 + 解析,无运行时调用**——`retro_schema` 字段供 M4.1 retro phase 实现读取,从 day 1 就能写出团队特定字段(避免 RAG 索引重建,详见 dev-coupling-audit.md F20)。
+
+```yaml
+# ~/.ccteam/teams/dev/team.yaml(M3.4 路径)
+name: dev                              # 必填。snake-case [a-z0-9_-]+,与 --team / state.json.team 对齐
+description: Software development team  # 可选。`ccteam ls --teams`(M3.4)显示
+retro_schema:                           # 可选。retro phase 字段定义。空 = 该团队无 retro
+  - field: tech_stack                   # 必填。snake_case;markdown 子节标题 + RAG tag(改名 = 索引失效)
+    description: Languages, frameworks, key libraries used
+    kind: list                          # 默认 list。可选 text(单段叙述)
+  - field: pitfalls
+    description: Mistakes / surprises to avoid next time
+  - field: successful_designs
+    description: Design choices that paid off
+  - field: do_not_do_again
+    description: Anti-patterns observed
+```
+
+**research 团队示例**(对比 dev 字段差异):
+
+```yaml
+name: research
+retro_schema:
+  - field: methodology
+    description: Methods used for data collection / analysis
+  - field: data_sources
+    description: Sources consulted (URLs, papers, datasets)
+  - field: findings
+    description: Top-N conclusions
+  - field: open_questions
+    description: Things needing follow-up
+  - field: summary
+    description: Narrative recap of the research
+    kind: text
+```
+
+**校验**(`TeamSpec::validate` 在 parse 时执行):
+- `name` 非空,只允许 ascii 小写 / 数字 / `-` / `_`
+- `retro_schema[*].field` 非空,**不允许重复**(防 RAG 索引冲突)
+
+**M3.1 实现位置**:`crates/ccteam-core/src/team.rs`(`TeamSpec` / `RetroFieldSpec` / `RetroFieldKind`),通过 `ccteam_core::TeamSpec::load(path)` 暴露。当前 ccteam binary 不读这个文件——**M3.4 加载逻辑、M4.1 retro phase 读 schema**。
+
+---
+
 ## 6. Hooks 配置 schema
 
 ### 6.1 项目 `.claude/settings.json` 完整模板

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -305,6 +305,12 @@ tools_required:                   # M0.5+:phase 内会调用的工具,orchestrat
     - some-skill
   mcp:                            # `mcp__<server>__<tool>` 引用的 MCP server 名
     - playwright
+auto_loop: false                  # 默认 false。true 时 orchestrator 派发后交棒给 Stop hook,
+                                  # 由 hook 反复重喂 prompt 直到 `completion_signal` 出现或撞 `auto_loop_max_iterations`
+                                  # (M3.1:dev 的 fix phase 设 true,research 的 04-primary 也会设 true;mechanism 与 phase 名无关)
+auto_loop_max_iterations: 3       # 自循环硬上限,默认 3。auto_loop=false 时忽略
+completion_signal: TESTS_GREEN    # 自循环退出信号(子串匹配)。auto_loop=true 时必填且非空,
+                                  # auto_loop=false 时可省略
 hooks:                            # phase 级 hook(项目级 hook 在 settings.json,详见 §6)
   before: scripts/snapshot-git.sh
   after: scripts/run-golden-rules.sh

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -108,6 +108,7 @@
 ```json
 {
   "slug": "bookmark-mgr-a3f9",
+  "team": "dev",
   "created_at": "2026-05-04T10:23:00Z",
   "tmux_session": "ccteam-bookmark-mgr-a3f9",
   "claude_session_id": "abc123-def-456",
@@ -138,6 +139,8 @@
 **`phase_state` 枚举**:`in_flight` / `idle` / `fix_locked`(详见 tech-design §3.2)。
 
 **`parallelism` 枚举**:`solo` / `agent_team` / `multi_session`(详见 §5.1 phase schema)。
+
+**`team` 字段**(M3.1 F13):指定项目跑哪个团队的 phase 集合(默认 `dev`,M3.4 加 `research` 等)。serde 默认值 `"dev"`,所以 M3.1 之前写出的 state.json 自动以 dev 团队加载,无需迁移脚本。
 
 **原子写入**:`.tmp` + `rename`;启动校验 schema,损坏走 backup。
 

--- a/phases/06-fix.md
+++ b/phases/06-fix.md
@@ -8,6 +8,9 @@ soft_cost_warn_usd: 8.0
 stall_warn_minutes: 5
 parallelism: solo
 sub_skills: []
+auto_loop: true
+auto_loop_max_iterations: 3
+completion_signal: TESTS_GREEN
 ---
 
 # 任务:修 bug(fix-cycle)


### PR DESCRIPTION
## Summary

M3.1 §B audit P0 fixes — ccteam-core can now run a non-dev team. All 7 P0 items from `docs/dev-coupling-audit.md` closed across 4 commits:

- **F1** `auto_loop` field on PhaseTemplate replaces FIX_PHASE_NAME string coupling — `309d235`
- **F2** DAG inferred from PhaseTemplate.next_on_done / next_on_escalate, M0_PHASE_DAG deleted — `b28618d`
- **F3** FIRST_PHASE constant deleted, derived from DAG entry node — `b28618d`
- **F4** `is_terminal()` reads DAG terminal nodes (no more "ship" string match) — `b28618d`
- **F12** `ccteam new --team` CLI parameter, default `"dev"` — `969e7c5`
- **F13** state.json `team` field, serde default `"dev"` for legacy files — `969e7c5`
- **F20** team.yaml schema with `retro_schema[]` data form — `4ccdb9a`

## Lib API breaking changes

Per CLAUDE.md §五.3 (no backwards-compat shim):

- `pub use ... M0_PHASE_DAG, FIRST_PHASE, is_terminal, next_phase` removed from `crates/ccteam-core/src/lib.rs`
- `decide_tick` / `decide_tick_from_events` now take `&Dag` as their first argument
- `bootstrap_project(...)` and `commands::run_new(...)` take a `team: &str` parameter
- `FixLoopState::new(...)` takes a `completion_signal: String` parameter (was hardcoded `"TESTS_GREEN"`)

New public surface:
- `ccteam_core::Dag` + `ccteam_core::dev_dag()` test helper
- `ccteam_core::TeamSpec` / `RetroFieldSpec` / `RetroFieldKind`
- `ProjectState::initial_for_team(slug, team)`

## 验收

- [x] `cargo test --workspace` 全绿(190 passing, was 174 — 16 new tests for the four PRs combined)
- [x] dev pipeline happy path 回归通过 (`cargo test --test e2e_happy_path_test`, `cargo test --test tool_surface_e2e_test`)
- [x] interfaces.md §2.1 (state.json `team` field) / §5.1 (phase YAML `auto_loop` / `next_on_done` / `next_on_escalate`) / §5.5 (new — team.yaml schema) 同步
- [x] dev pipeline phase 模板 (`phases/06-fix.md`) 补 `auto_loop: true` / `completion_signal: TESTS_GREEN`,语义不变

## 实施中发现的 doc / 设计漏洞

无。审计的解耦方案与代码现实匹配良好,执行过程没有需要回头修订 strategic doc / dev-coupling-audit 的位置。

## 下游影响

- **M3.2** (team.yaml 完整 schema + 加载逻辑) 现在可以基于 `TeamSpec` 起。
- **M3.4** (phases-research/ 入仓 + per-team phase template loading) 现在可以基于 DAG 推断 + `--team` flag 起。
- **M4.1** (retro phase 实现) 直接读 `retro_schema` 写出每团队特定字段,跨项目记忆 RAG 索引从 day 1 就携带正确 field tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)