### PR TITLE
M1 phase 1: meta-agent dispatch end-to-end

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -10,10 +10,11 @@ use chrono::Utc;
 use serde_json::{json, Map, Value};
 
 use ccteam_core::{
-    bootstrap_project, current_ccteam_bin, link_recommended_agents, pick_unused_slug,
-    user_claude_dir, write_global_phase_templates, AgentLinkAction, AgentLinkReport,
-    CcteamPaths, LinkOptions, PhaseState, PhaseTemplate, ProjectState, ToolSurfaceSnapshot,
-    BUILTIN_SUBAGENTS, PHASE_TEMPLATES,
+    bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
+    link_recommended_agents, pick_unused_slug, user_claude_dir, write_global_phase_templates,
+    AgentLinkAction, AgentLinkReport, CcteamPaths, InstallSkillOptions, LinkOptions,
+    MetaBootstrapReport, PhaseState, PhaseTemplate, ProjectState, SkillInstallAction,
+    ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, PHASE_TEMPLATES,
 };
 use ccteam_core::tmux::TmuxSession;
 
@@ -234,22 +235,31 @@ pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
     Ok(())
 }
 
-/// `ccteam doctor` flags. M0.5 ships two subcommands gated by flags
-/// rather than a `doctor <subcommand>` because both are read-only or
-/// effectively idempotent — making them top-level keeps the surface
-/// small. M1+ may add `doctor --install-skill` etc.
-#[derive(Debug, Clone, Copy, Default)]
+/// `ccteam doctor` flags. Each mode is a separate boolean / option so
+/// they can be combined (e.g. `--install-meta-agent rob` implies
+/// `--install-skill` automatically).
+#[derive(Debug, Clone, Default)]
 pub struct DoctorOptions {
     pub install_recommended_agents: bool,
     pub dry_run: bool,
     pub force: bool,
     pub tool_surface: bool,
+    /// M1.8: install ~/.claude/skills/ccteam-control/SKILL.md.
+    pub install_skill: bool,
+    /// M1.0: bootstrap a meta-agent project for the given user handle.
+    /// `Some("rob")` ⇒ creates `~/projects/rob-meta/` and triggers
+    /// `install_skill` regardless of its standalone flag.
+    pub install_meta_agent: Option<String>,
 }
 
 /// `ccteam doctor` dispatch. Returns a human-readable report so unit
 /// tests don't need to capture stdout.
 pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
-    if !opts.install_recommended_agents && !opts.tool_surface {
+    let any_mode = opts.install_recommended_agents
+        || opts.tool_surface
+        || opts.install_skill
+        || opts.install_meta_agent.is_some();
+    if !any_mode {
         return Ok(String::from(
             "ccteam doctor: pass at least one mode flag.\n\
              \n\
@@ -257,20 +267,80 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
              --install-recommended-agents [--dry-run] [--force]\n      \
              ln -sf 8 plugin agents into ~/.claude/agents/ (M0.5.5).\n  \
              --tool-surface\n      \
-             cross-check phase templates' tools_required against current reachability (M0.5.6).\n",
+             cross-check phase templates' tools_required against current reachability (M0.5.6).\n  \
+             --install-skill [--force]\n      \
+             write ~/.claude/skills/ccteam-control/SKILL.md (M1.8).\n  \
+             --install-meta-agent <user-handle>\n      \
+             bootstrap a meta-agent project for the given user (M1.0). Implies --install-skill.\n",
         ));
     }
     let mut out = String::new();
     if opts.install_recommended_agents {
-        out.push_str(&render_install_recommended_agents_report(opts)?);
+        out.push_str(&render_install_recommended_agents_report(&opts)?);
     }
     if opts.tool_surface {
         out.push_str(&render_tool_surface_report(paths)?);
     }
+    // --install-meta-agent implies --install-skill so a fresh meta
+    // session has the dispatcher tool list immediately.
+    let install_skill_now = opts.install_skill || opts.install_meta_agent.is_some();
+    if install_skill_now {
+        out.push_str(&render_install_skill_report(&opts)?);
+    }
+    if let Some(handle) = &opts.install_meta_agent {
+        out.push_str(&render_install_meta_agent_report(paths, handle)?);
+    }
     Ok(out)
 }
 
-fn render_install_recommended_agents_report(opts: DoctorOptions) -> Result<String> {
+fn render_install_skill_report(opts: &DoctorOptions) -> Result<String> {
+    let report = install_ccteam_control_skill(InstallSkillOptions {
+        force: opts.force,
+        dry_run: opts.dry_run,
+    })?;
+    let mut out = String::from("ccteam doctor --install-skill\n\n");
+    let label: String = match &report.action {
+        SkillInstallAction::Wrote => "wrote".into(),
+        SkillInstallAction::AlreadyPresent => "already-present (use --force to overwrite)".into(),
+        SkillInstallAction::Replaced => "replaced".into(),
+        SkillInstallAction::DryRun { would_write } => {
+            if *would_write {
+                "would write".into()
+            } else {
+                "no-op (already present)".into()
+            }
+        }
+    };
+    out.push_str(&format!("  ccteam-control  {label}  {}\n", report.target.display()));
+    out.push('\n');
+    Ok(out)
+}
+
+fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> Result<String> {
+    let report: MetaBootstrapReport = bootstrap_meta_project(paths, user_handle)?;
+    let mut out = String::from("ccteam doctor --install-meta-agent\n\n");
+    out.push_str(&format!("  user handle      {user_handle}\n"));
+    out.push_str(&format!("  project slug     {}\n", report.slug));
+    out.push_str(&format!("  project dir      {}\n", report.project_dir.display()));
+    out.push_str(&format!("  role prompt      {}\n", report.claude_md.display()));
+    out.push_str(&format!(
+        "  status           {}\n",
+        if report.already_existed { "refreshed" } else { "created" },
+    ));
+    out.push('\n');
+    out.push_str(&format!(
+        "tmux session     ccteam-meta-{}\n",
+        ccteam_core::meta_slug(user_handle)?.trim_end_matches("-meta"),
+    ));
+    out.push_str(&format!(
+        "attach with      tmux attach -t ccteam-meta-{}\n",
+        ccteam_core::meta_slug(user_handle)?.trim_end_matches("-meta"),
+    ));
+    out.push_str("\nrun `ccteam start --foreground` (in another terminal) to wake the meta session.\n");
+    Ok(out)
+}
+
+fn render_install_recommended_agents_report(opts: &DoctorOptions) -> Result<String> {
     let reports = link_recommended_agents(LinkOptions {
         force: opts.force,
         dry_run: opts.dry_run,
@@ -281,7 +351,7 @@ fn render_install_recommended_agents_report(opts: DoctorOptions) -> Result<Strin
     } else {
         "ccteam doctor --install-recommended-agents\n"
     });
-    out.push_str("\n");
+    out.push('\n');
     let mut all_ok = true;
     for r in &reports {
         out.push_str(&render_agent_link_line(r));
@@ -289,7 +359,7 @@ fn render_install_recommended_agents_report(opts: DoctorOptions) -> Result<Strin
             all_ok = false;
         }
     }
-    out.push_str("\n");
+    out.push('\n');
     if !all_ok {
         out.push_str(
             "some agents skipped — pass --force to overwrite user files, or install \
@@ -355,7 +425,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
     ));
     out.push_str(&format!("skills seen      : {}\n", snap.skills.len()));
     out.push_str(&format!("mcp servers seen : {}\n", snap.mcp.len()));
-    out.push_str("\n");
+    out.push('\n');
 
     if templates.is_empty() {
         out.push_str(
@@ -406,7 +476,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
         }
     }
 
-    out.push_str("\n");
+    out.push('\n');
     if any_missing {
         out.push_str(
             "**Verdict:** at least one phase has a missing tool. \
@@ -937,6 +1007,62 @@ mod tests {
         let body = run_doctor(&paths, DoctorOptions::default()).unwrap();
         assert!(body.contains("install-recommended-agents"));
         assert!(body.contains("tool-surface"));
+        assert!(body.contains("install-skill"));
+        assert!(body.contains("install-meta-agent"));
+    }
+
+    #[test]
+    fn run_doctor_install_meta_agent_creates_project_and_skill() {
+        // M1.0 + M1.8 combo: --install-meta-agent <handle> implies
+        // --install-skill, so a single invocation gets the user a
+        // ready-to-attach session.
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        // Redirect ~/.claude/ to the tempdir so the skill install
+        // doesn't touch the developer's real ~/.claude/.
+        std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
+
+        let opts = DoctorOptions {
+            install_meta_agent: Some("rob".into()),
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(report.contains("install-skill"), "skill install report missing");
+        assert!(report.contains("install-meta-agent"), "meta install report missing");
+        assert!(report.contains("rob-meta"), "meta slug should be reported");
+
+        // Project directory exists.
+        assert!(paths.project_dir("rob-meta").is_dir());
+        let state = ProjectState::load(&paths.project_state("rob-meta")).unwrap();
+        assert_eq!(state.team, "meta-agent");
+        assert_eq!(state.tmux_session, "ccteam-meta-rob");
+
+        // Skill landed under the redirected ~/.claude/.
+        let skill_path = tmp.path().join("skills/ccteam-control/SKILL.md");
+        assert!(skill_path.is_file(), "skill SKILL.md not written: {}", skill_path.display());
+
+        std::env::remove_var("CLAUDE_CONFIG_HOME");
+    }
+
+    #[test]
+    fn run_doctor_install_skill_only_lays_down_skill_md() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
+
+        let opts = DoctorOptions {
+            install_skill: true,
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(report.contains("install-skill"));
+        assert!(!report.contains("install-meta-agent"));
+
+        let skill_path = tmp.path().join("skills/ccteam-control/SKILL.md");
+        assert!(skill_path.is_file());
+        std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
 
     #[test]

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -91,6 +91,11 @@ enum Command {
     },
     /// Resume a paused / escalated project (re-arm phase_state=idle).
     Resume { slug: String },
+    /// Stop the running orchestrator daemon. Sends SIGTERM via the
+    /// pidfile so the loop drains gracefully. Does **not** kill any
+    /// tmux sessions — `ccteam start` reattaches to them on next launch
+    /// (M1.5).
+    Stop,
     /// Health checks + tool-surface maintenance.
     Doctor {
         /// Backfill ~/.claude/agents/<name>.md symlinks for the eight
@@ -111,6 +116,17 @@ enum Command {
         /// (M0.5.6).
         #[arg(long, default_value_t = false)]
         tool_surface: bool,
+        /// Install the `ccteam-control` skill at
+        /// `~/.claude/skills/ccteam-control/SKILL.md` (M1.8). Idempotent.
+        #[arg(long, default_value_t = false)]
+        install_skill: bool,
+        /// Bootstrap a meta-agent project (M1.0) for the given user
+        /// handle. Creates `~/projects/<handle>-meta/` with the
+        /// dispatcher role prompt + inbox/outbox dirs and (always)
+        /// installs the `ccteam-control` skill. Pass the user handle as
+        /// the value (e.g. `--install-meta-agent rob`).
+        #[arg(long, value_name = "HANDLE")]
+        install_meta_agent: Option<String>,
     },
 }
 
@@ -167,17 +183,39 @@ fn main() -> Result<()> {
             let paths = CcteamPaths::from_env()?;
             commands::run_resume(&paths, &slug)
         }
+        Command::Stop => run_stop(),
         Command::Doctor {
             install_recommended_agents,
             dry_run,
             force,
             tool_surface,
+            install_skill,
+            install_meta_agent,
         } => run_doctor(commands::DoctorOptions {
             install_recommended_agents,
             dry_run,
             force,
             tool_surface,
+            install_skill,
+            install_meta_agent,
         }),
+    }
+}
+
+fn run_stop() -> Result<()> {
+    let paths = CcteamPaths::from_env()?;
+    match ccteam_core::send_sigterm_to_pidfile(&paths)? {
+        Some(pid) => {
+            println!("ccteam stop: SIGTERM sent to orchestrator pid {pid}");
+            println!(
+                "tmux sessions are NOT killed — `ccteam start` will reattach to them.",
+            );
+            Ok(())
+        }
+        None => {
+            println!("ccteam stop: no running orchestrator (pidfile absent or stale).");
+            Ok(())
+        }
     }
 }
 
@@ -239,19 +277,51 @@ fn run_start(tick_seconds: u64, skip_tool_check: bool) -> Result<()> {
         skip_tool_check,
         ..OrchestratorConfig::default()
     };
-    let orchestrator = Orchestrator::new(paths, config)?;
+    // Write the pidfile *before* constructing the orchestrator so a
+    // second `ccteam start` against the same root errors out cleanly
+    // before either side has touched tmux.
+    let pidfile = ccteam_core::write_pidfile(&paths)?;
+    tracing::info!(pidfile = %pidfile.display(), "orchestrator pidfile written");
 
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("build tokio runtime")?;
-    runtime.block_on(async move {
-        let shutdown = async {
-            let _ = tokio::signal::ctrl_c().await;
-            tracing::info!("ctrl+c received");
-        };
-        orchestrator.run(shutdown).await
-    })
+    // We need the paths twice (for orchestrator construction + final
+    // pidfile cleanup), so clone before the move into Orchestrator::new.
+    let cleanup_paths = paths.clone();
+    let result = (|| -> Result<()> {
+        let orchestrator = Orchestrator::new(paths, config)?;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("build tokio runtime")?;
+        runtime.block_on(async move {
+            let shutdown = async {
+                #[cfg(unix)]
+                {
+                    use tokio::signal::unix::{signal, SignalKind};
+                    let mut sigterm = match signal(SignalKind::terminate()) {
+                        Ok(s) => s,
+                        Err(err) => {
+                            tracing::warn!(?err, "could not install SIGTERM handler");
+                            let _ = tokio::signal::ctrl_c().await;
+                            tracing::info!("ctrl+c received");
+                            return;
+                        }
+                    };
+                    tokio::select! {
+                        _ = tokio::signal::ctrl_c() => tracing::info!("ctrl+c received"),
+                        _ = sigterm.recv() => tracing::info!("SIGTERM received (ccteam stop)"),
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = tokio::signal::ctrl_c().await;
+                    tracing::info!("ctrl+c received");
+                }
+            };
+            orchestrator.run(shutdown).await
+        })
+    })();
+    ccteam_core::remove_pidfile(&cleanup_paths);
+    result
 }
 
 fn run_new(request: Option<String>, file: Option<PathBuf>, team: String) -> Result<()> {

--- a/crates/ccteam-core/src/daemon.rs
+++ b/crates/ccteam-core/src/daemon.rs
@@ -1,0 +1,205 @@
+//! Orchestrator daemon lifecycle helpers (M1.5).
+//!
+//! - **pidfile** at `~/.ccteam/state/orchestrator.pid` so `ccteam stop`
+//!   can find a running daemon.
+//! - **graceful stop** via SIGTERM (Unix). The orchestrator's tokio
+//!   `select!` already listens on Ctrl-C; we route SIGTERM through the
+//!   same path on Unix.
+//! - **session reattach**: `discover_projects` already walks
+//!   `~/projects/*/.ccteam/state.json`; `ensure_session` does the
+//!   `tmux has-session` + `kill -0` double-check before re-spawning.
+//!   M1.5 explicitly does **not** kill any tmux sessions on stop.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::paths::CcteamPaths;
+
+/// Filename under `<root>/state/` where the running orchestrator stores
+/// its PID.
+pub const PIDFILE_NAME: &str = "orchestrator.pid";
+
+/// Resolve the pidfile path for a given ccteam root.
+pub fn pidfile_path(paths: &CcteamPaths) -> PathBuf {
+    paths.root.join("state").join(PIDFILE_NAME)
+}
+
+/// Write the current process's PID to the pidfile. Called by
+/// `ccteam start --foreground` right after the orchestrator is
+/// constructed but before the run loop spins. Returns the path written.
+///
+/// Refuses to overwrite a pidfile whose owner process is still alive
+/// (so two `ccteam start` invocations can't silently fight over the
+/// same state). Stale pidfiles (PID gone) are reclaimed.
+pub fn write_pidfile(paths: &CcteamPaths) -> Result<PathBuf> {
+    let path = pidfile_path(paths);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    if path.exists() {
+        match read_pidfile(&path) {
+            Ok(pid) if pid_alive(pid) => {
+                return Err(anyhow!(
+                    "ccteam start: another orchestrator (pid {pid}) is already running. \
+                     Run `ccteam stop` first, or remove {} if you're sure it's stale.",
+                    path.display(),
+                ));
+            }
+            _ => {
+                tracing::warn!(
+                    pidfile = %path.display(),
+                    "stale pidfile reclaimed",
+                );
+            }
+        }
+    }
+    let pid = std::process::id();
+    std::fs::write(&path, format!("{pid}\n"))
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(path)
+}
+
+/// Best-effort pidfile cleanup; called on graceful shutdown. Errors
+/// are logged but not propagated.
+pub fn remove_pidfile(paths: &CcteamPaths) {
+    let path = pidfile_path(paths);
+    if let Err(err) = std::fs::remove_file(&path) {
+        if path.exists() {
+            tracing::warn!(
+                pidfile = %path.display(),
+                error = %err,
+                "could not remove pidfile",
+            );
+        }
+    }
+}
+
+/// Read the PID from `path`. Surfaces both "missing" and "garbled" as
+/// errors so the caller can decide whether to bail or treat as stale.
+pub fn read_pidfile(path: &Path) -> Result<u32> {
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    body.trim()
+        .parse::<u32>()
+        .with_context(|| format!("parse pid from {}", path.display()))
+}
+
+/// `kill -0 <pid>` — true iff the process exists.
+#[cfg(unix)]
+pub fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // SAFETY: kill(pid, 0) is well-defined for any pid; failure is
+    // signalled via the return value, not memory unsafety.
+    let pid_i32 = pid as i32;
+    // Avoid pulling in nix/libc just for one syscall — shell out.
+    std::process::Command::new("kill")
+        .args(["-0", &pid_i32.to_string()])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+pub fn pid_alive(_pid: u32) -> bool {
+    // Non-Unix platforms aren't a target for ccteam M1.
+    false
+}
+
+/// Send SIGTERM to a running orchestrator described by its pidfile.
+/// Returns `Ok(None)` when no daemon is running (pidfile absent or
+/// process already gone).
+#[cfg(unix)]
+pub fn send_sigterm_to_pidfile(paths: &CcteamPaths) -> Result<Option<u32>> {
+    let path = pidfile_path(paths);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let pid = read_pidfile(&path)?;
+    if !pid_alive(pid) {
+        // Stale; reap the file.
+        let _ = std::fs::remove_file(&path);
+        return Ok(None);
+    }
+    let status = std::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .with_context(|| format!("spawn `kill -TERM {pid}`"))?;
+    if !status.success() {
+        return Err(anyhow!("kill -TERM {pid} exited with {status}"));
+    }
+    Ok(Some(pid))
+}
+
+#[cfg(not(unix))]
+pub fn send_sigterm_to_pidfile(_paths: &CcteamPaths) -> Result<Option<u32>> {
+    Err(anyhow!("ccteam stop is only implemented on Unix"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(tmp: &tempfile::TempDir) -> CcteamPaths {
+        CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        }
+    }
+
+    #[test]
+    fn write_pidfile_creates_file_with_current_pid() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let path = write_pidfile(&p).unwrap();
+        let pid = read_pidfile(&path).unwrap();
+        assert_eq!(pid, std::process::id());
+    }
+
+    #[test]
+    fn write_pidfile_refuses_to_overwrite_live_owner() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        write_pidfile(&p).unwrap();
+        // Same process tries again — should error since the owner is
+        // alive (it's us).
+        let err = write_pidfile(&p).unwrap_err();
+        assert!(format!("{err:#}").contains("already running"));
+    }
+
+    #[test]
+    fn write_pidfile_reclaims_stale_pidfile() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let path = pidfile_path(&p);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // PID 1 is init; it exists. Use 0 (always invalid) to simulate stale.
+        std::fs::write(&path, "0\n").unwrap();
+        let written = write_pidfile(&p).unwrap();
+        let pid = read_pidfile(&written).unwrap();
+        assert_eq!(pid, std::process::id());
+    }
+
+    #[test]
+    fn remove_pidfile_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        // No pidfile — must not error.
+        remove_pidfile(&p);
+        // Now write + remove.
+        write_pidfile(&p).unwrap();
+        remove_pidfile(&p);
+        assert!(!pidfile_path(&p).exists());
+    }
+
+    #[test]
+    fn read_pidfile_errors_on_garbled_content() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("pid");
+        std::fs::write(&path, "not a number\n").unwrap();
+        assert!(read_pidfile(&path).is_err());
+    }
+}

--- a/crates/ccteam-core/src/inbox.rs
+++ b/crates/ccteam-core/src/inbox.rs
@@ -1,0 +1,469 @@
+//! Per-session inbox/outbox file protocol (M1.1).
+//!
+//! Schema, semantics, and routing rules: `docs/interfaces.md` §3.4.
+//!
+//! Each ccteam-managed long session (meta-agent and project sessions)
+//! has its own `<session>/.ccteam/inbox/` and `<session>/.ccteam/outbox/`.
+//! Channel adapters (M2+, e.g. Telegram bot) write into inbox; the
+//! session's claude writes replies into outbox; the orchestrator
+//! consumes inbox files and injects body into the session via
+//! tmux send-keys (idle-aware, see `progress::idle_aware_message`).
+//!
+//! **Atomic write**: every writer creates `<name>.tmp` then renames to
+//! `<name>` so a partial flush is never visible to a reader.
+//! **Idempotent ack**: the consumer (orchestrator for inbox, channel
+//! adapter for outbox) deletes the file after processing; both sides
+//! must treat "file missing" as a successful prior consumption.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Current schema version emitted by ccteam writers.
+///
+/// A reader that finds `schema_version > LATEST_SCHEMA_VERSION` should
+/// log a warning and best-effort parse — never refuse the file outright,
+/// because the channel adapter shipping the future schema is presumed
+/// to be at least as careful.
+pub const LATEST_SCHEMA_VERSION: u32 = 1;
+
+/// Inbox front matter — fields a channel adapter writes to describe an
+/// incoming external message. Body lives outside the front matter.
+///
+/// Required: `schema_version` / `source` / `source_user` /
+/// `created_at` / `ingested_at` / `content_type`.
+/// Everything else is optional — adapters fill what they have.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InboxFrontMatter {
+    pub schema_version: u32,
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_chat_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_msg_id: Option<String>,
+    pub source_user: String,
+    pub created_at: DateTime<Utc>,
+    pub ingested_at: DateTime<Utc>,
+    pub content_type: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<InboxAttachment>,
+}
+
+/// Inbox attachment descriptor (M2+ multimedia path; M1 schema parses
+/// it but production writers don't emit any).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InboxAttachment {
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+/// Outbox front matter — fields the session writes to describe an
+/// outgoing reply. Adapter routes off `target_channels` /
+/// `in_reply_to_source_msg_id`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OutboxFrontMatter {
+    pub schema_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to_source_msg_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub target_channels: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    #[serde(default = "default_priority")]
+    pub priority: OutboxPriority,
+    pub event_kind: OutboxEventKind,
+}
+
+fn default_priority() -> OutboxPriority {
+    OutboxPriority::Normal
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutboxPriority {
+    Normal,
+    High,
+}
+
+/// Outbox event kind — adapter routes off this for ack semantics
+/// (silent vs. visible vs. threaded).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutboxEventKind {
+    /// Routine NL conversation reply.
+    Reply,
+    /// Phase boundary milestone — adapter MAY downgrade to silent push.
+    Progress,
+    /// User decision required — adapter MUST send a visible alert.
+    /// Reserved for M1.7 once the L3 NL channel lands; M1 schema
+    /// nonetheless accepts it so meta-agents can write them today.
+    Escalation,
+    /// Project terminal state.
+    Shipped,
+    /// Phase-internal CLARIFY question (Seed M2+).
+    Clarify,
+}
+
+/// Parsed inbox message: front matter + body.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InboxMessage {
+    pub front: InboxFrontMatter,
+    pub body: String,
+}
+
+/// Parsed outbox message: front matter + body.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutboxMessage {
+    pub front: OutboxFrontMatter,
+    pub body: String,
+}
+
+impl InboxMessage {
+    pub fn parse(source: &str) -> Result<Self> {
+        let (front_yaml, body) = split_front_matter(source)?;
+        let front: InboxFrontMatter = serde_yaml::from_str(front_yaml)
+            .context("inbox front matter does not match schema")?;
+        Ok(Self {
+            front,
+            body: body.to_string(),
+        })
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let body = std::fs::read_to_string(path)
+            .with_context(|| format!("read inbox {}", path.display()))?;
+        Self::parse(&body)
+            .with_context(|| format!("parse inbox {}", path.display()))
+    }
+
+    /// Render to the canonical `--- yaml --- body` form.
+    pub fn to_string(&self) -> Result<String> {
+        let yaml = serde_yaml::to_string(&self.front)
+            .context("serialize inbox front matter")?;
+        Ok(format!("---\n{yaml}---\n\n{}", self.body))
+    }
+
+    /// Atomic write to `path` (.tmp + rename).
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let body = self.to_string()?;
+        atomic_write(path, body.as_bytes())
+    }
+}
+
+impl OutboxMessage {
+    pub fn parse(source: &str) -> Result<Self> {
+        let (front_yaml, body) = split_front_matter(source)?;
+        let front: OutboxFrontMatter = serde_yaml::from_str(front_yaml)
+            .context("outbox front matter does not match schema")?;
+        Ok(Self {
+            front,
+            body: body.to_string(),
+        })
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let body = std::fs::read_to_string(path)
+            .with_context(|| format!("read outbox {}", path.display()))?;
+        Self::parse(&body)
+            .with_context(|| format!("parse outbox {}", path.display()))
+    }
+
+    pub fn to_string(&self) -> Result<String> {
+        let yaml = serde_yaml::to_string(&self.front)
+            .context("serialize outbox front matter")?;
+        Ok(format!("---\n{yaml}---\n\n{}", self.body))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let body = self.to_string()?;
+        atomic_write(path, body.as_bytes())
+    }
+}
+
+/// Build the canonical inbox filename for `now` and a 1-based sequence
+/// number: `msg-<YYYYMMDDTHHMMSSZ>-<NNN>.md`. Compact ISO timestamp
+/// (no colons) so the filename is portable across platforms / shells.
+pub fn inbox_filename(now: DateTime<Utc>, seq: u32) -> String {
+    format!("msg-{}-{:03}.md", compact_ts(now), seq)
+}
+
+/// Build the canonical outbox filename: `reply-<ts>-<NNN>.md`.
+pub fn outbox_filename(now: DateTime<Utc>, seq: u32) -> String {
+    format!("reply-{}-{:03}.md", compact_ts(now), seq)
+}
+
+fn compact_ts(now: DateTime<Utc>) -> String {
+    // RFC3339 looks like 2026-05-06T10:30:00Z; we strip the colons so
+    // the filename works on Windows / FAT and is shell-friendly.
+    now.to_rfc3339_opts(SecondsFormat::Secs, true)
+        .replace(':', "")
+}
+
+/// Inbox/outbox directory pair for a ccteam-managed session.
+#[derive(Debug, Clone)]
+pub struct SessionMailbox {
+    pub inbox: PathBuf,
+    pub outbox: PathBuf,
+}
+
+impl SessionMailbox {
+    /// Resolve from the session's `.ccteam/` directory.
+    pub fn for_ccteam_dir(ccteam_dir: &Path) -> Self {
+        Self {
+            inbox: ccteam_dir.join("inbox"),
+            outbox: ccteam_dir.join("outbox"),
+        }
+    }
+
+    /// `mkdir -p` both directories. Idempotent.
+    pub fn ensure_dirs(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.inbox)
+            .with_context(|| format!("create {}", self.inbox.display()))?;
+        std::fs::create_dir_all(&self.outbox)
+            .with_context(|| format!("create {}", self.outbox.display()))?;
+        Ok(())
+    }
+
+    /// List inbox files in lexicographic (== chronological) order.
+    /// Skips `.tmp` and dotfiles. Missing dir returns empty vec.
+    pub fn list_inbox(&self) -> Result<Vec<PathBuf>> {
+        list_messages(&self.inbox, "msg-")
+    }
+
+    /// List outbox files in lexicographic order.
+    pub fn list_outbox(&self) -> Result<Vec<PathBuf>> {
+        list_messages(&self.outbox, "reply-")
+    }
+}
+
+fn list_messages(dir: &Path, prefix: &str) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
+        .with_context(|| format!("read_dir {}", dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|s| s.to_str())
+                .is_some_and(|n| {
+                    n.starts_with(prefix) && n.ends_with(".md") && !n.starts_with('.')
+                })
+        })
+        .collect();
+    out.sort();
+    Ok(out)
+}
+
+/// Atomic file write: write `<path>.tmp` then rename. Creates parent
+/// dir if missing.
+fn atomic_write(path: &Path, body: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let mut tmp_os = path.as_os_str().to_owned();
+    tmp_os.push(".tmp");
+    let tmp = PathBuf::from(tmp_os);
+    std::fs::write(&tmp, body)
+        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Strip the YAML front matter delimited by `---` lines.
+fn split_front_matter(source: &str) -> Result<(&str, &str)> {
+    let after_first = source
+        .strip_prefix("---\n")
+        .or_else(|| source.strip_prefix("---\r\n"))
+        .ok_or_else(|| anyhow!("inbox/outbox file must start with `---`"))?;
+    let end = after_first
+        .find("\n---\n")
+        .or_else(|| after_first.find("\n---\r\n"))
+        .ok_or_else(|| anyhow!("inbox/outbox file missing closing `---` line"))?;
+    let yaml = &after_first[..end];
+    // Skip the closing fence line (`\n---\n` is 5 chars; `\r\n` 6).
+    let body_start_offset = if after_first[end..].starts_with("\n---\r\n") {
+        end + 6
+    } else {
+        end + 5
+    };
+    let body = after_first.get(body_start_offset..).unwrap_or("").trim_start_matches('\n');
+    Ok((yaml, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample_inbox() -> InboxMessage {
+        InboxMessage {
+            front: InboxFrontMatter {
+                schema_version: 1,
+                source: "telegram".into(),
+                source_chat_id: Some("@rob".into()),
+                source_msg_id: Some("tg-1".into()),
+                source_user: "rob".into(),
+                created_at: Utc.with_ymd_and_hms(2026, 5, 6, 10, 30, 0).unwrap(),
+                ingested_at: Utc.with_ymd_and_hms(2026, 5, 6, 10, 30, 1).unwrap(),
+                content_type: "text".into(),
+                attachments: Vec::new(),
+            },
+            body: "做一个 todo cli\n".into(),
+        }
+    }
+
+    #[test]
+    fn round_trip_inbox_message() {
+        let msg = sample_inbox();
+        let body = msg.to_string().unwrap();
+        let parsed = InboxMessage::parse(&body).unwrap();
+        assert_eq!(parsed.front, msg.front);
+        assert_eq!(parsed.body, msg.body);
+    }
+
+    #[test]
+    fn parse_inbox_rejects_missing_required_field() {
+        // No `source_user` field — required.
+        let src = concat!(
+            "---\n",
+            "schema_version: 1\n",
+            "source: telegram\n",
+            "created_at: 2026-05-06T10:30:00Z\n",
+            "ingested_at: 2026-05-06T10:30:01Z\n",
+            "content_type: text\n",
+            "---\n",
+            "\n",
+            "hello\n",
+        );
+        let err = InboxMessage::parse(src).unwrap_err();
+        assert!(format!("{err:#}").contains("source_user"));
+    }
+
+    #[test]
+    fn parse_inbox_accepts_minimal_required_fields() {
+        let src = concat!(
+            "---\n",
+            "schema_version: 1\n",
+            "source: cli\n",
+            "source_user: rob\n",
+            "created_at: 2026-05-06T10:30:00Z\n",
+            "ingested_at: 2026-05-06T10:30:00Z\n",
+            "content_type: text\n",
+            "---\n",
+            "\n",
+            "body text\n",
+        );
+        let m = InboxMessage::parse(src).unwrap();
+        assert_eq!(m.front.source_user, "rob");
+        assert!(m.front.source_chat_id.is_none());
+        assert_eq!(m.body.trim(), "body text");
+    }
+
+    #[test]
+    fn round_trip_outbox_message() {
+        let msg = OutboxMessage {
+            front: OutboxFrontMatter {
+                schema_version: 1,
+                in_reply_to: Some("msg-2026-05-06T103000Z-001.md".into()),
+                in_reply_to_source_msg_id: None,
+                target_channels: vec!["telegram".into()],
+                created_at: Utc.with_ymd_and_hms(2026, 5, 6, 10, 30, 45).unwrap(),
+                priority: OutboxPriority::Normal,
+                event_kind: OutboxEventKind::Reply,
+            },
+            body: "收到了\n".into(),
+        };
+        let body = msg.to_string().unwrap();
+        let parsed = OutboxMessage::parse(&body).unwrap();
+        assert_eq!(parsed.front.event_kind, OutboxEventKind::Reply);
+        assert_eq!(parsed.front.priority, OutboxPriority::Normal);
+        assert_eq!(parsed.body.trim(), "收到了");
+    }
+
+    #[test]
+    fn outbox_event_kind_escalation_parses() {
+        // M1 must accept escalation outboxes even though M1.7 doesn't
+        // implement the full L3 NL flow yet — adapters writing today
+        // shouldn't get rejected.
+        let src = concat!(
+            "---\n",
+            "schema_version: 1\n",
+            "created_at: 2026-05-06T10:30:00Z\n",
+            "priority: high\n",
+            "event_kind: escalation\n",
+            "---\n",
+            "stuck\n",
+        );
+        let m = OutboxMessage::parse(src).unwrap();
+        assert_eq!(m.front.event_kind, OutboxEventKind::Escalation);
+        assert_eq!(m.front.priority, OutboxPriority::High);
+    }
+
+    #[test]
+    fn save_uses_atomic_rename() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("inbox/msg-1.md");
+        let msg = sample_inbox();
+        msg.save(&path).unwrap();
+        let parsed = InboxMessage::load(&path).unwrap();
+        assert_eq!(parsed.body, msg.body);
+        // The .tmp should not linger.
+        assert!(!path.with_extension("md.tmp").exists());
+    }
+
+    #[test]
+    fn inbox_filename_is_portable() {
+        // interfaces.md §3.4.1 specifies "compact ISO timestamp, colon-stripped"
+        // — dashes in the date portion stay so the slug is human-readable.
+        let ts = Utc.with_ymd_and_hms(2026, 5, 6, 10, 30, 0).unwrap();
+        let name = inbox_filename(ts, 1);
+        assert_eq!(name, "msg-2026-05-06T103000Z-001.md");
+        assert!(!name.contains(':'), "filename must not contain colons");
+    }
+
+    #[test]
+    fn outbox_filename_is_portable() {
+        let ts = Utc.with_ymd_and_hms(2026, 5, 6, 10, 30, 45).unwrap();
+        let name = outbox_filename(ts, 7);
+        assert_eq!(name, "reply-2026-05-06T103045Z-007.md");
+        assert!(!name.contains(':'));
+    }
+
+    #[test]
+    fn list_inbox_returns_chronological_order() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
+        mb.ensure_dirs().unwrap();
+        let names = ["msg-20260506T103000Z-002.md", "msg-20260506T103000Z-001.md"];
+        for name in names {
+            let p = mb.inbox.join(name);
+            std::fs::write(&p, "---\nschema_version: 1\nsource: cli\nsource_user: rob\ncreated_at: 2026-05-06T10:30:00Z\ningested_at: 2026-05-06T10:30:00Z\ncontent_type: text\n---\n\nx\n").unwrap();
+        }
+        // Foreign files should be skipped.
+        std::fs::write(mb.inbox.join("notes.txt"), "noise").unwrap();
+        std::fs::write(mb.inbox.join("msg-pending.md.tmp"), "x").unwrap();
+
+        let list = mb.list_inbox().unwrap();
+        assert_eq!(list.len(), 2);
+        assert!(list[0].file_name().unwrap().to_str().unwrap().ends_with("-001.md"));
+        assert!(list[1].file_name().unwrap().to_str().unwrap().ends_with("-002.md"));
+    }
+
+    #[test]
+    fn list_inbox_handles_missing_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
+        // No ensure_dirs — list should return empty rather than erroring.
+        assert!(mb.list_inbox().unwrap().is_empty());
+    }
+}

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -3,9 +3,13 @@
 //! `ccteam-hooks` (hook handlers invoked via `ccteam hook ...`).
 
 pub mod cost;
+pub mod daemon;
 pub mod dag;
 pub mod fix_loop;
+pub mod inbox;
+pub mod meta_agent;
 pub mod orchestrator;
+pub mod skill;
 pub mod paths;
 pub mod phases;
 pub mod progress;
@@ -19,12 +23,31 @@ pub mod tool_surface;
 
 pub use dag::{dev_dag, Dag};
 pub use fix_loop::{FixLoopDecision, FixLoopFrontMatter, FixLoopState};
+pub use inbox::{
+    inbox_filename, outbox_filename, InboxAttachment, InboxFrontMatter, InboxMessage,
+    OutboxEventKind, OutboxFrontMatter, OutboxMessage, OutboxPriority, SessionMailbox,
+    LATEST_SCHEMA_VERSION,
+};
+pub use meta_agent::{
+    bootstrap_meta_project, meta_session_name, meta_slug, render_meta_role_prompt,
+    MetaBootstrapReport, META_SESSION_PREFIX, META_TEAM_NAME,
+};
+pub use skill::{
+    install_ccteam_control_skill, install_into as install_skill_into,
+    InstallSkillOptions, InstallSkillReport, SkillInstallAction,
+    CCTEAM_CONTROL_SKILL_NAME,
+};
+pub use orchestrator::MAX_CONCURRENT_PROJECTS;
 pub use orchestrator::{
     append_progress_summary, build_progress_summary, check_phase_tools, decide_tick,
     decide_tick_from_events, Orchestrator, OrchestratorConfig, TickAction,
 };
 pub use projects::{bootstrap_project, pick_unused_slug, pre_trust_project, slugify};
 pub use cost::{classify as classify_cost, CostLevel, COST_MID_WARN_USD};
+pub use daemon::{
+    pidfile_path, read_pidfile, remove_pidfile, send_sigterm_to_pidfile, write_pidfile,
+    PIDFILE_NAME,
+};
 pub use stall::{
     classify as classify_stall, classify_with_thresholds, silent_seconds, StallLevel,
     StallThresholds, STALL_ESCALATE_SECONDS, STALL_SUSPICIOUS_SECONDS, STALL_WARN_SECONDS,

--- a/crates/ccteam-core/src/meta_agent.rs
+++ b/crates/ccteam-core/src/meta_agent.rs
@@ -1,0 +1,262 @@
+//! Meta-agent session bootstrap (M1.0).
+//!
+//! The meta-agent is a ccteam-managed long tmux session under
+//! `~/projects/<user>-meta/` that the human user attaches to with
+//! `tmux attach -t ccteam-meta-<user>` and talks to in NL. It dispatches
+//! project requests via `ccteam new`, monitors active projects, and
+//! routes inbox/outbox messages.
+//!
+//! Two design rules locked by `docs/development-plan.md` §3 M1:
+//!
+//! 1. **Hardcoded `team == "meta-agent"` branch**: meta-agent behavior
+//!    (event loop, no phase DAG, never terminal) doesn't fit the phase-DAG
+//!    team contract; M3.4 may revisit. M1 wires a single `if state.team
+//!    == META_TEAM_NAME` branch in the orchestrator (see
+//!    `Orchestrator::process_project`).
+//! 2. **Role prompt template lives in-binary**: shipped as
+//!    `include_str!`, rendered at bootstrap time with the user handle
+//!    interpolated. Anything fancier (hot-reload, per-user templates)
+//!    is M2+.
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{SecondsFormat, Utc};
+
+use crate::inbox::SessionMailbox;
+use crate::paths::CcteamPaths;
+use crate::projects::{bootstrap_project, slugify};
+use crate::state::ProjectState;
+
+/// Special team string the orchestrator uses to dispatch the
+/// meta-agent state machine instead of the phase-DAG one. Hardcoded
+/// for M1; M3.4 may turn it into a `TeamSpec` flag (see
+/// development-plan §3 M1 lock #4).
+pub const META_TEAM_NAME: &str = "meta-agent";
+
+/// tmux session prefix for meta-agent sessions. The full name is
+/// `META_SESSION_PREFIX + <user-handle>` (e.g. `ccteam-meta-rob`).
+/// User project sessions use `ccteam-` (see `tmux::SESSION_PREFIX`)
+/// so there's no collision risk.
+pub const META_SESSION_PREFIX: &str = "ccteam-meta-";
+
+/// Embedded role prompt template. Sourced from
+/// `crates/ccteam-core/src/templates/meta_agent_role.md` so the
+/// document is reviewable / diffable as markdown.
+const META_ROLE_PROMPT_TEMPLATE: &str =
+    include_str!("templates/meta_agent_role.md");
+
+/// Build the meta-agent's project slug from a user handle. Slug is
+/// `<user>-meta`, slugified — so `Rob` and `rob` collapse to the same
+/// directory, which is what we want.
+pub fn meta_slug(user_handle: &str) -> Result<String> {
+    let trimmed = user_handle.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("meta-agent user handle must be non-empty"));
+    }
+    Ok(format!("{}-meta", slugify(trimmed)))
+}
+
+/// `ccteam-meta-<user>` tmux session name.
+pub fn meta_session_name(user_handle: &str) -> Result<String> {
+    let trimmed = user_handle.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("meta-agent user handle must be non-empty"));
+    }
+    Ok(format!("{}{}", META_SESSION_PREFIX, slugify(trimmed)))
+}
+
+/// Render the role prompt with `<user>` placeholder interpolated. Pure;
+/// returns the string the caller writes to disk.
+pub fn render_meta_role_prompt(user_handle: &str) -> String {
+    let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    META_ROLE_PROMPT_TEMPLATE
+        .replace("__USER_HANDLE__", user_handle)
+        .replace("__GENERATED_AT__", &now)
+}
+
+/// Bootstrap the meta-agent's project tree:
+/// 1. Run `bootstrap_project(...team=meta-agent)` to lay down
+///    `state.json`, `.claude/settings.json`, and the project skeleton.
+/// 2. Overwrite the auto-generated `CLAUDE.md` with the meta-agent
+///    role prompt so the new session loads dispatcher behavior.
+/// 3. Pre-create `inbox/` + `outbox/` so an inotify watcher can attach
+///    immediately at session startup.
+///
+/// Idempotent: re-running refreshes the CLAUDE.md role prompt (caller
+/// passes `force=true` to also overwrite settings.json) but leaves
+/// state.json + spec.md alone if they already exist.
+pub fn bootstrap_meta_project(
+    paths: &CcteamPaths,
+    user_handle: &str,
+) -> Result<MetaBootstrapReport> {
+    let slug = meta_slug(user_handle)?;
+    let project_dir = paths.project_dir(&slug);
+    let already_existed = paths.project_state(&slug).exists();
+
+    let request = format!(
+        "ccteam meta-agent session for {user_handle}. \
+         Dispatch incoming requests to the right team via `ccteam new`.\n\
+         Generated: {}",
+        Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+    );
+
+    if !already_existed {
+        bootstrap_project(paths, &slug, &request, META_TEAM_NAME)
+            .context("bootstrap meta-agent project tree")?;
+    }
+    // Always normalize the meta-agent's tmux_session name. bootstrap_project
+    // initializes it as `ccteam-<slug>` (which would yield `ccteam-rob-meta`),
+    // but the strategic doc + interfaces.md call for `ccteam-meta-<user>`
+    // — distinct prefix so meta sessions are visually separated from
+    // project sessions in `tmux ls`. Rewrite after bootstrap_project runs.
+    let state_path = paths.project_state(&slug);
+    let mut state = ProjectState::load(&state_path)
+        .with_context(|| format!("reload meta state {}", state_path.display()))?;
+    state.team = META_TEAM_NAME.into();
+    state.tmux_session = meta_session_name(user_handle)?;
+    state.save(&state_path)?;
+
+    // Always (re)write CLAUDE.md so the role prompt picks up template
+    // edits when ccteam ships a newer version.
+    let claude_md = project_dir.join("CLAUDE.md");
+    let role_body = render_meta_role_prompt(user_handle);
+    std::fs::write(&claude_md, role_body)
+        .with_context(|| format!("write {}", claude_md.display()))?;
+
+    let mailbox = SessionMailbox::for_ccteam_dir(&paths.project_ccteam_dir(&slug));
+    mailbox.ensure_dirs()?;
+
+    Ok(MetaBootstrapReport {
+        slug,
+        project_dir,
+        claude_md,
+        already_existed,
+    })
+}
+
+/// Result of `bootstrap_meta_project` — useful for the doctor command's
+/// human-readable report.
+#[derive(Debug, Clone)]
+pub struct MetaBootstrapReport {
+    pub slug: String,
+    pub project_dir: PathBuf,
+    pub claude_md: PathBuf,
+    pub already_existed: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use super::*;
+    use crate::tool_surface::disable_tool_surface_bootstrap_for_tests;
+
+    static DISABLE_TOOL_SURFACE: OnceLock<()> = OnceLock::new();
+    fn isolation() {
+        DISABLE_TOOL_SURFACE.get_or_init(disable_tool_surface_bootstrap_for_tests);
+    }
+
+    fn paths(tmp: &tempfile::TempDir) -> CcteamPaths {
+        CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        }
+    }
+
+    #[test]
+    fn meta_slug_combines_user_with_meta_suffix() {
+        assert_eq!(meta_slug("rob").unwrap(), "rob-meta");
+        assert_eq!(meta_slug("Rob Test User").unwrap(), "rob-test-user-meta");
+    }
+
+    #[test]
+    fn meta_slug_rejects_empty() {
+        assert!(meta_slug("").is_err());
+        assert!(meta_slug("   ").is_err());
+    }
+
+    #[test]
+    fn meta_session_name_uses_dedicated_prefix() {
+        let n = meta_session_name("rob").unwrap();
+        assert_eq!(n, "ccteam-meta-rob");
+        // Must not collide with project tmux prefix `ccteam-<slug>`.
+        assert!(!n.starts_with("ccteam-rob"));
+    }
+
+    #[test]
+    fn render_role_prompt_substitutes_user_handle() {
+        let body = render_meta_role_prompt("rob");
+        assert!(body.contains("rob"), "role prompt should mention user handle");
+        assert!(!body.contains("__USER_HANDLE__"), "placeholder should be substituted");
+        assert!(!body.contains("__GENERATED_AT__"));
+    }
+
+    #[test]
+    fn render_role_prompt_includes_seven_required_chapters() {
+        // Per task brief §5: the role prompt must contain all seven
+        // chapters covering identity / decision tree / dispatcher
+        // restraint / dispatch tools / monitoring / inbox / outbox.
+        let body = render_meta_role_prompt("rob");
+        // The headings live in the template under section anchors.
+        for required in [
+            "你是谁",            // identity
+            "决策树",            // decision tree
+            "克制规则",          // dispatcher-not-worker
+            "派单工具",          // dispatch tools
+            "监控规则",          // monitoring
+            "inbox",             // inbox handling
+            "outbox",            // outbox emission
+        ] {
+            assert!(
+                body.contains(required),
+                "meta-agent role prompt must include `{required}` section",
+            );
+        }
+    }
+
+    #[test]
+    fn bootstrap_meta_project_creates_full_skeleton() {
+        isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let report = bootstrap_meta_project(&p, "rob").unwrap();
+
+        assert_eq!(report.slug, "rob-meta");
+        assert!(report.project_dir.is_dir());
+        assert!(report.claude_md.is_file());
+        assert!(p.project_state(&report.slug).is_file());
+
+        let state = ProjectState::load(&p.project_state(&report.slug)).unwrap();
+        assert_eq!(state.team, META_TEAM_NAME);
+        // tmux name uses the dedicated `ccteam-meta-<user>` prefix
+        // rather than `ccteam-<slug>` so it visually separates from
+        // project sessions in `tmux ls`.
+        assert_eq!(state.tmux_session, "ccteam-meta-rob");
+
+        let body = std::fs::read_to_string(&report.claude_md).unwrap();
+        assert!(body.contains("rob"));
+
+        // inbox/outbox dirs ready for the watcher.
+        let cc = p.project_ccteam_dir(&report.slug);
+        assert!(cc.join("inbox").is_dir());
+        assert!(cc.join("outbox").is_dir());
+    }
+
+    #[test]
+    fn bootstrap_meta_project_is_idempotent_and_refreshes_role_prompt() {
+        isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        bootstrap_meta_project(&p, "rob").unwrap();
+
+        // Tamper with CLAUDE.md, re-run, verify it gets refreshed and the
+        // tampering is gone.
+        let cm = p.project_dir("rob-meta").join("CLAUDE.md");
+        std::fs::write(&cm, "stale\n").unwrap();
+        let report = bootstrap_meta_project(&p, "rob").unwrap();
+        assert!(report.already_existed);
+        let body = std::fs::read_to_string(&cm).unwrap();
+        assert!(body.contains("决策树"), "role prompt should be re-rendered");
+    }
+}

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -23,6 +23,8 @@ use serde_json::{json, Value};
 use crate::cost::{self, CostLevel};
 use crate::dag::Dag;
 use crate::fix_loop::{self, FixLoopState};
+use crate::inbox::{InboxMessage, SessionMailbox};
+use crate::meta_agent::META_TEAM_NAME;
 use crate::paths::CcteamPaths;
 use crate::phases::PhaseTemplate;
 use crate::progress;
@@ -30,6 +32,12 @@ use crate::stall::{self, StallLevel, StallThresholds};
 use crate::state::{PhaseHistoryEntry, PhaseState, ProjectState};
 use crate::tmux::TmuxSession;
 use crate::tool_surface::{user_claude_dir, ToolSurfaceSnapshot};
+
+/// M1.2: how many regular project sessions can run concurrently. Hard-
+/// coded for M1; M3 may move it to `team.yaml` / global config. The
+/// meta-agent session is **not counted** — it's a permanent fixture in
+/// the User Interaction Layer.
+pub const MAX_CONCURRENT_PROJECTS: usize = 3;
 
 /// Pure decision function: given the current `state` and the last
 /// progress.jsonl event, what should the orchestrator do next?
@@ -222,6 +230,21 @@ impl Orchestrator {
     /// state until claude either runs a tool (PreToolUse arrives) or
     /// the prompt finishes and a Stop fires.
     pub fn dispatch_phase(&self, slug: &str, phase: &str) -> Result<()> {
+        let state_path = self.paths.project_state(slug);
+        let state = ProjectState::load(&state_path)
+            .with_context(|| format!("load state for dispatch {slug}"))?;
+        self.dispatch_phase_with_state(slug, phase, &state)
+    }
+
+    /// Same as `dispatch_phase` but the caller passes the already-loaded
+    /// `ProjectState`. Used inside `process_project` to avoid a redundant
+    /// reload (and so meta-agent paths can pass their bespoke state).
+    pub fn dispatch_phase_with_state(
+        &self,
+        slug: &str,
+        phase: &str,
+        state: &ProjectState,
+    ) -> Result<()> {
         let progress_path = self.paths.progress_jsonl(slug);
         let last = progress::last_event(&progress_path)?;
         let idle = progress::is_idle(last.as_ref());
@@ -229,10 +252,10 @@ impl Orchestrator {
         let prompt = progress::build_phase_prompt(phase);
         let message = progress::idle_aware_message(&prompt, idle);
 
-        let session = TmuxSession::for_slug(slug);
+        let session = TmuxSession::from_name(state.tmux_session.clone());
         session
             .send_keys(&message)
-            .with_context(|| format!("send phase prompt to ccteam-{slug}"))?;
+            .with_context(|| format!("send phase prompt to {}", session.name()))?;
 
         let event = json!({
             "ts": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
@@ -296,7 +319,7 @@ impl Orchestrator {
         append_progress_summary(&claude_md, &summary)
             .with_context(|| format!("bridge progress to {}", claude_md.display()))?;
 
-        let session = TmuxSession::for_slug(slug);
+        let session = TmuxSession::from_name(state.tmux_session.clone());
         let ready = CcteamPaths::project_ready_in(&project_dir);
         if ready.exists() {
             let _ = std::fs::remove_file(&ready);
@@ -346,10 +369,14 @@ impl Orchestrator {
     /// Mutates + persists `state.claude_pid` whenever a new session is
     /// born. Skipped silently for terminal projects.
     pub fn ensure_session(&self, slug: &str, state: &mut ProjectState) -> Result<()> {
-        if self.dag.is_terminal_state(state) {
+        // Meta-agent sessions never reach a terminal phase state and the
+        // dag check below would skip them — guard meta-agent first so it
+        // always tries to come up.
+        let is_meta = state.team == META_TEAM_NAME;
+        if !is_meta && self.dag.is_terminal_state(state) {
             return Ok(());
         }
-        let session = TmuxSession::for_slug(slug);
+        let session = TmuxSession::from_name(state.tmux_session.clone());
         if session.is_alive(state.claude_pid) {
             return Ok(());
         }
@@ -397,7 +424,15 @@ impl Orchestrator {
     /// Apply `decide_tick` to one project, looping the AdvancePhase →
     /// DispatchPhase chain so a phase boundary doesn't take two ticks
     /// to act on. The loop iteration cap is a paranoia guard.
+    ///
+    /// Meta-agent projects (`team == META_TEAM_NAME`) bypass the phase
+    /// DAG entirely — they're event-loop sessions, not phase-DAG ones —
+    /// and only get `ensure_session` lifecycle handling. See
+    /// `process_meta_project` for that path.
     pub fn process_project(&self, slug: &str, mut state: ProjectState) -> Result<ProjectState> {
+        if state.team == META_TEAM_NAME {
+            return self.process_meta_project(slug, state);
+        }
         const MAX_ITERS: u32 = 4;
         let progress_path = self.paths.progress_jsonl(slug);
         let state_path = self.paths.project_state(slug);
@@ -504,6 +539,146 @@ impl Orchestrator {
         Ok(state)
     }
 
+    /// Meta-agent dispatch path: ensure the long-lived tmux session is
+    /// up and process any inbox messages. **Never** injects phase
+    /// prompts — meta-agents drive themselves via NL inside their
+    /// session, and the orchestrator only routes external messages
+    /// (terminal attach / channel layer) into them.
+    ///
+    /// **M1.4 context-reset bridge**: meta-agents have no phase
+    /// boundary, so the regular phase-edge reset (tech-design §6.9)
+    /// can't trigger. Instead, we check the 60% threshold on every
+    /// tick and recycle the session in place when crossed —
+    /// `reset_context` appends a "current progress" snippet to the
+    /// meta-agent's CLAUDE.md so the new claude resumes the conversation
+    /// with continuity. M4.6 will replace this with the full
+    /// claude-mem RAG flow; M1's bare bridge is enough to keep the
+    /// session usable across the 1M ceiling.
+    pub fn process_meta_project(
+        &self,
+        slug: &str,
+        mut state: ProjectState,
+    ) -> Result<ProjectState> {
+        debug_assert_eq!(state.team, META_TEAM_NAME);
+        self.ensure_session(slug, &mut state)?;
+        if let Err(err) = self.process_session_inbox(slug, &state) {
+            tracing::warn!(slug, error = %err, "meta inbox processing failed");
+        }
+        if state.context_tokens_used > state.context_reset_threshold_tokens {
+            tracing::info!(
+                slug,
+                tokens = state.context_tokens_used,
+                threshold = state.context_reset_threshold_tokens,
+                "meta-agent context reset triggered (M1.4)",
+            );
+            if let Err(err) = self.reset_context(slug, &mut state) {
+                tracing::error!(
+                    slug,
+                    error = %err,
+                    "meta context reset failed; conversation continuity may be lost",
+                );
+            }
+        }
+        Ok(state)
+    }
+
+    /// Drain inbox/ for `slug` (M1.1). Each message is read, injected
+    /// via tmux send-keys (idle-aware), and then deleted — exactly
+    /// matching the §3.4.5 protocol. Errors per-file are logged; one
+    /// bad message must not stall the others.
+    pub fn process_session_inbox(
+        &self,
+        slug: &str,
+        state: &ProjectState,
+    ) -> Result<()> {
+        let cc = self.paths.project_ccteam_dir(slug);
+        let mailbox = SessionMailbox::for_ccteam_dir(&cc);
+        let entries = mailbox.list_inbox()?;
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let session = TmuxSession::from_name(state.tmux_session.clone());
+        if !session.exists() {
+            tracing::debug!(
+                slug,
+                session = %session.name(),
+                "skipping inbox drain: tmux session not running yet",
+            );
+            return Ok(());
+        }
+        let progress_path = self.paths.progress_jsonl(slug);
+        for path in entries {
+            let msg = match InboxMessage::load(&path) {
+                Ok(m) => m,
+                Err(err) => {
+                    tracing::warn!(
+                        slug,
+                        file = %path.display(),
+                        error = %err,
+                        "skip malformed inbox file (left in place for inspection)",
+                    );
+                    continue;
+                }
+            };
+            let last = progress::last_event(&progress_path)?;
+            let idle = progress::is_idle(last.as_ref());
+            let body = msg.body.trim();
+            if body.is_empty() {
+                tracing::debug!(slug, file = %path.display(), "skip empty inbox body");
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
+            let message = progress::idle_aware_message(body, idle);
+            if let Err(err) = session.send_keys(&message) {
+                tracing::warn!(
+                    slug,
+                    file = %path.display(),
+                    error = %err,
+                    "send-keys failed; leaving inbox file for retry",
+                );
+                continue;
+            }
+            progress::append_event(
+                &progress_path,
+                &json!({
+                    "ts": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+                    "event": "inbox_consumed",
+                    "session": session.name(),
+                    "msg_file": path.file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(""),
+                    "source": msg.front.source,
+                    "source_user": msg.front.source_user,
+                    "idle": idle,
+                }),
+            )?;
+            // Idempotent ack: delete after successful delivery.
+            if let Err(err) = std::fs::remove_file(&path) {
+                tracing::warn!(
+                    slug,
+                    file = %path.display(),
+                    error = %err,
+                    "could not delete consumed inbox file; channel adapter may resend",
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Count regular (non-meta) projects whose tmux session is
+    /// currently driving a phase (`InFlight` or `FixLocked`). The
+    /// concurrency gate (`MAX_CONCURRENT_PROJECTS`) compares this to
+    /// the cap so over-the-limit idle projects wait their turn.
+    pub fn count_active_regular(projects: &[(String, ProjectState)]) -> usize {
+        projects
+            .iter()
+            .filter(|(_, s)| s.team != META_TEAM_NAME)
+            .filter(|(_, s)| {
+                matches!(s.phase_state, PhaseState::InFlight | PhaseState::FixLocked)
+            })
+            .count()
+    }
+
     /// Run until `shutdown` resolves. Each tick + each progress event
     /// currently logs at debug level; later M0 tasks fill in the body.
     pub async fn run<F>(&self, shutdown: F) -> Result<()>
@@ -562,24 +737,75 @@ impl Orchestrator {
 
     async fn poll_tick(&self, tick_count: u64) -> Result<()> {
         let projects = self.discover_projects()?;
+        let active_regular = Self::count_active_regular(&projects);
         tracing::debug!(
             tick = tick_count,
             templates = self.templates.len(),
             projects = projects.len(),
+            active_regular,
+            max_concurrent = MAX_CONCURRENT_PROJECTS,
             "orchestrator tick",
         );
         let now = Utc::now();
+
+        // Process meta-agent projects first — they're permanent fixtures
+        // and must not be deferred when the regular concurrency cap is
+        // reached. Then handle regular projects with the cap.
+        let mut regular_dispatch_budget =
+            MAX_CONCURRENT_PROJECTS.saturating_sub(active_regular);
+
         for (slug, state) in projects {
-            // Stall + cost classification first so we observe the
-            // pre-action state. enforce_cost_thresholds may mutate
-            // state and return Some(updated) when it does.
             self.warn_if_stalled(&slug, &state, now);
             let state = match self.enforce_cost_thresholds(&slug, state)? {
                 Some(updated) => updated,
                 None => continue, // hard-kill terminated this project
             };
-            if let Err(err) = self.process_project(&slug, state) {
-                tracing::error!(slug, error = format!("{err:#}"), "project tick failed");
+
+            if state.team == META_TEAM_NAME {
+                if let Err(err) = self.process_project(&slug, state) {
+                    tracing::error!(
+                        slug,
+                        error = format!("{err:#}"),
+                        "meta tick failed",
+                    );
+                }
+                continue;
+            }
+
+            // M1.2 concurrency gate: only let an idle regular project
+            // *start* a new phase if the active count is under the cap.
+            // Already-active projects (InFlight / FixLocked) always run
+            // through process_project so their AdvancePhase / Escalated
+            // transitions still land.
+            let already_active = matches!(
+                state.phase_state,
+                PhaseState::InFlight | PhaseState::FixLocked,
+            );
+            if !already_active && regular_dispatch_budget == 0 {
+                tracing::debug!(
+                    slug,
+                    "regular project queued: max_concurrent_projects ({}) reached",
+                    MAX_CONCURRENT_PROJECTS,
+                );
+                continue;
+            }
+
+            match self.process_project(&slug, state) {
+                Ok(updated) => {
+                    if !already_active
+                        && matches!(
+                            updated.phase_state,
+                            PhaseState::InFlight | PhaseState::FixLocked,
+                        )
+                    {
+                        regular_dispatch_budget = regular_dispatch_budget.saturating_sub(1);
+                    }
+                }
+                Err(err) => tracing::error!(
+                    slug,
+                    error = format!("{err:#}"),
+                    "project tick failed",
+                ),
             }
         }
         Ok(())
@@ -595,6 +821,13 @@ impl Orchestrator {
         slug: &str,
         mut state: ProjectState,
     ) -> Result<Option<ProjectState>> {
+        // Meta-agent sessions are evergreen and don't fit "hard kill on
+        // budget" semantics — their cost is the user's running tab, not
+        // a per-project budget. M1 lets them through; M4 may want a
+        // separate ladder when conversation continuity (M4.6) lands.
+        if state.team == META_TEAM_NAME {
+            return Ok(Some(state));
+        }
         if self.dag.is_terminal_state(&state) {
             return Ok(Some(state));
         }
@@ -619,7 +852,7 @@ impl Orchestrator {
                     cost = state.cost_used_usd,
                     "cost > ${hard}: HARD KILL — terminating tmux session and escalating",
                 );
-                let session = TmuxSession::for_slug(slug);
+                let session = TmuxSession::from_name(state.tmux_session.clone());
                 if let Err(err) = session.kill() {
                     tracing::error!(slug, error = %err, "tmux kill failed during hard-kill");
                 }
@@ -660,6 +893,13 @@ impl Orchestrator {
     }
 
     fn warn_if_stalled(&self, slug: &str, state: &ProjectState, now: chrono::DateTime<Utc>) {
+        // Meta-agent sessions sit idle by design (waiting for the next
+        // NL message) — stall semantics don't apply. dag.is_terminal_state
+        // would also return false for them since they have no phase
+        // history, so guard explicitly.
+        if state.team == META_TEAM_NAME {
+            return;
+        }
         if self.dag.is_terminal_state(state) {
             return;
         }

--- a/crates/ccteam-core/src/skill.rs
+++ b/crates/ccteam-core/src/skill.rs
@@ -1,0 +1,144 @@
+//! `ccteam-control` skill installation (M1.8).
+//!
+//! Skills live at `~/.claude/skills/<name>/SKILL.md` (or under a plugin
+//! tree). The `ccteam-control` skill body is shipped inside the binary
+//! and written to disk by `ccteam doctor --install-skill`. The
+//! `--install-meta-agent` path also calls this so a freshly-bootstrapped
+//! meta-agent has the skill on first launch.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::tool_surface::user_claude_dir;
+
+/// Skill directory name. Embedded SKILL.md ships under this folder
+/// inside `~/.claude/skills/`.
+pub const CCTEAM_CONTROL_SKILL_NAME: &str = "ccteam-control";
+
+/// Embedded `SKILL.md` body. Written verbatim during install.
+const CCTEAM_CONTROL_SKILL_MD: &str = include_str!("templates/ccteam_control_skill.md");
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InstallSkillOptions {
+    /// Write even when the file is already there. Default: false (skip
+    /// to preserve any operator hand-edits).
+    pub force: bool,
+    /// Don't actually write; report what would happen.
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct InstallSkillReport {
+    pub target: PathBuf,
+    pub action: SkillInstallAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillInstallAction {
+    Wrote,
+    AlreadyPresent,
+    Replaced,
+    DryRun { would_write: bool },
+}
+
+/// Install the `ccteam-control` skill into `~/.claude/skills/ccteam-control/SKILL.md`.
+pub fn install_ccteam_control_skill(opts: InstallSkillOptions) -> Result<InstallSkillReport> {
+    let claude = user_claude_dir().context("resolve ~/.claude/")?;
+    install_into(&claude, opts)
+}
+
+/// Test-injectable variant: write into `<claude_dir>/skills/...` so unit
+/// tests can point at a tempdir without mutating `$HOME/.claude/`.
+pub fn install_into(claude_dir: &Path, opts: InstallSkillOptions) -> Result<InstallSkillReport> {
+    let dir = claude_dir
+        .join("skills")
+        .join(CCTEAM_CONTROL_SKILL_NAME);
+    let target = dir.join("SKILL.md");
+    let exists = target.exists();
+
+    if opts.dry_run {
+        return Ok(InstallSkillReport {
+            target,
+            action: SkillInstallAction::DryRun {
+                would_write: !exists || opts.force,
+            },
+        });
+    }
+
+    if exists && !opts.force {
+        return Ok(InstallSkillReport {
+            target,
+            action: SkillInstallAction::AlreadyPresent,
+        });
+    }
+
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create {}", dir.display()))?;
+    std::fs::write(&target, CCTEAM_CONTROL_SKILL_MD)
+        .with_context(|| format!("write {}", target.display()))?;
+    Ok(InstallSkillReport {
+        target,
+        action: if exists {
+            SkillInstallAction::Replaced
+        } else {
+            SkillInstallAction::Wrote
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_writes_skill_md_with_yaml_frontmatter() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let report = install_into(tmp.path(), InstallSkillOptions::default()).unwrap();
+        assert_eq!(report.action, SkillInstallAction::Wrote);
+        assert!(report.target.exists());
+        let body = std::fs::read_to_string(&report.target).unwrap();
+        assert!(body.starts_with("---\n"), "must start with YAML front matter");
+        assert!(body.contains("name: ccteam-control"));
+        assert!(body.contains("allowed-tools: [Bash]"));
+        // Required body chapters per interfaces §11.3.
+        for required in ["Capability index", "Typical workflows", "Decision principles", "What this skill cannot do"] {
+            assert!(body.contains(required), "missing chapter: {required}");
+        }
+    }
+
+    #[test]
+    fn install_is_idempotent_without_force() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        install_into(tmp.path(), InstallSkillOptions::default()).unwrap();
+        let r2 = install_into(tmp.path(), InstallSkillOptions::default()).unwrap();
+        assert_eq!(r2.action, SkillInstallAction::AlreadyPresent);
+    }
+
+    #[test]
+    fn force_overwrites_existing_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        install_into(tmp.path(), InstallSkillOptions::default()).unwrap();
+        let target = tmp.path().join("skills/ccteam-control/SKILL.md");
+        std::fs::write(&target, "tampered\n").unwrap();
+        let r = install_into(tmp.path(), InstallSkillOptions { force: true, dry_run: false }).unwrap();
+        assert_eq!(r.action, SkillInstallAction::Replaced);
+        let body = std::fs::read_to_string(&target).unwrap();
+        assert!(body.contains("name: ccteam-control"));
+    }
+
+    #[test]
+    fn dry_run_does_not_touch_filesystem() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let r = install_into(
+            tmp.path(),
+            InstallSkillOptions { force: false, dry_run: true },
+        )
+        .unwrap();
+        assert_eq!(
+            r.action,
+            SkillInstallAction::DryRun { would_write: true },
+        );
+        assert!(!r.target.exists());
+    }
+}

--- a/crates/ccteam-core/src/templates/ccteam_control_skill.md
+++ b/crates/ccteam-core/src/templates/ccteam_control_skill.md
@@ -1,0 +1,106 @@
+---
+name: ccteam-control
+description: |
+  Manage ccteam projects from any Claude Code session. Use when the
+  user asks about ccteam status, wants to start a new ccteam project,
+  needs to inspect / pause / resume an active ccteam project, or asks
+  for advice on intervening when a project is stuck. Primary consumer
+  is the ccteam meta-agent session; secondary consumer is the user's
+  own daily-driver claude.
+allowed-tools: [Bash]
+---
+
+# ccteam-control
+
+ccteam is an autonomous project orchestrator built on Claude Code.
+This skill makes ccteam reachable from any claude session via the
+`ccteam` CLI. Default to `--format json` so output is structured.
+
+## Capability index
+
+| What you want | Command |
+|---|---|
+| List all projects                | `ccteam ls --format json` |
+| One project's full state         | `ccteam show <slug> --format json` |
+| Recent progress events           | `ccteam progress <slug>` (or `--tail` for live stream) |
+| Capture session pane content     | `ccteam peek <slug>` |
+| Start a new project              | `ccteam new --team=dev "<request>"` |
+| Pause project (no kill)          | `ccteam pause <slug>` *(M2 implements; M1 stub)* |
+| Resume project                   | `ccteam resume <slug>` |
+| Reject project                   | `ccteam reject <slug>` *(M2 implements; M1 stub)* |
+| Health checks                    | `ccteam doctor --tool-surface` |
+| Install meta-agent for a user    | `ccteam doctor --install-meta-agent <handle>` |
+
+`--format json` is on every query command (`ls`, `show`). Prefer JSON
+when piping output into your own analysis. The schema lives in
+`docs/interfaces.md` §10.3.
+
+## Typical workflows
+
+### A) Cross-project status report
+
+```bash
+ccteam ls --format json | jq '.projects[] | {slug, current_phase, phase_state, cost_used_usd, age_seconds}'
+```
+
+Then narrate the table to the user — call out anything in
+`stall_level: "warn"` or higher.
+
+### B) Pre-launch clarification
+
+When the user says "make a todo cli" but the brief is ambiguous,
+**ask one clarifying question** before dispatch:
+
+> Web app or CLI? Local-only or cloud-sync? Tech-stack preference?
+
+Pick the single most blocking question. Only after they answer, run:
+
+```bash
+ccteam new --team=dev "<refined brief>"
+```
+
+### C) Stuck-project triage
+
+```bash
+ccteam show <slug> --format json | jq '{phase: .state.current_phase, fix_count: .state.fix_cycle_count, recent: .recent_events[-5:]}'
+ccteam peek <slug>
+```
+
+Combine the two outputs and recommend exactly **one** of:
+- `ccteam attach <slug>` — user wants to drive
+- `ccteam pause <slug>` — pause and think
+- `ccteam resume <slug>` after fixing — back to autonomous
+
+## Decision principles
+
+- **Attach vs peek vs pause** — `attach` if the user will drive in
+  real-time, `peek` if they only want to look, `pause` if they want
+  ccteam to stop dispatching while they decide.
+- **One question at a time** — clarification phases must surface a
+  single question. Don't batch.
+- **Don't show progress.jsonl raw** — it's noisy. Summarize milestones
+  (phase transitions, escalations, ship events) in NL.
+
+## What this skill cannot do
+
+- It cannot `attach` for the user — `tmux attach` is a TTY interaction;
+  the user must run it in their own terminal.
+- It cannot edit `~/projects/<slug>/.ccteam/` metadata directly. All
+  control flows through the CLI (or `~/.ccteam/control/` files for
+  M2+ asynchronous control).
+- It cannot start the ccteam orchestrator daemon — that's `ccteam
+  start --foreground` and is an ops decision, not an agent decision.
+
+## Meta-agent specifics
+
+When this skill is loaded inside a ccteam meta-agent session:
+
+1. Prefer `ccteam new` dispatch over doing the work yourself. The
+   meta-agent role prompt (CLAUDE.md) covers the dispatcher-not-worker
+   rule — this skill is the tool list the dispatcher uses.
+2. After every dispatch / status reply, write an outbox file at
+   `~/projects/<user>-meta/.ccteam/outbox/reply-<ts>-<seq>.md` per
+   `docs/interfaces.md` §3.4.3.
+3. M2.8 will swap shell-parsing for the `ccteam-mcp` MCP server. When
+   that lands, prefer `mcp__ccteam__*` tools over `Bash` invocations
+   of the same CLI. The `--format json` paths remain a stable fallback.

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -1,0 +1,163 @@
+# CLAUDE.md — ccteam meta-agent (__USER_HANDLE__)
+
+> 本文件是 ccteam 自动生成的 meta-agent role prompt(__GENERATED_AT__)。
+> 不要手改 — 下次 `ccteam doctor --install-meta-agent __USER_HANDLE__` 会覆盖。
+
+## 1. 你是谁
+
+你是 **ccteam meta-agent**,代号 `ccteam-meta-__USER_HANDLE__`,跑在一条 ccteam 管理的常驻 tmux session 里(`tmux attach -t ccteam-meta-__USER_HANDLE__` 即可对话)。**永不 terminal**:跟用户的 ccteam 实例同寿。
+
+你的角色不是"通用 AI 助手",而是 **ccteam 项目调度的对话入口**。用户的请求经由 inbox 文件 / 终端 attach / 未来的 channel adapter(M2+ Telegram)落到你这里;你的工作是判断"这是什么、应该派给谁",而不是自己抄起工具开干。
+
+身份要点:
+- 你看到的工具列表里有 `Task` / `Bash` / `Read` / `Edit` / `Write` 等通用工具,但你**默认不调用 Edit/Write 改用户代码**——那是项目 session(L2)的活
+- ccteam-control skill 已经为你装好(`~/.claude/skills/ccteam-control/`),里面是 ccteam CLI 命令清单与典型工作流
+- 你的对话历史会在 context 接近 60% 时被压缩到本文件的"当前进度"节,新 session 启动后自动加载
+
+## 2. 决策树(每次收到用户请求都跑一遍)
+
+按下面 4 步走,**不要跳步**:
+
+### 第 1 步:这是问答还是项目请求?
+
+- **问答** —— 例:"ccteam 的 Seed Gate 是什么意思?"/"我的 todo-cli 项目跑到哪了?"
+  - 直接回答。可以用 `Bash` 调 `ccteam ls --format json` / `ccteam show <slug> --format json` 拿数据
+  - 不要派单
+- **项目请求** —— 例:"做一个 todo cli"/"帮我写个书签管理器"
+  - 进入第 2 步
+
+### 第 2 步:团队选择
+
+M1 阶段**只有 dev 团队**(`team.yaml` 体系 M3 才上线)。所以这一步默认 `--team=dev`。M3+ 后再扩展为 dev / research / marketing / ops 多选。
+
+### 第 3 步:pre-flight CLARIFY(必要时)
+
+如果用户的 brief 缺关键信息(web 还是 cli?目标语言?要不要 PWA?),**问一个**最关键的澄清问题。**只问一个**——一次问太多用户会嫌烦。
+
+边界:
+- 你只问 **brief 完整性**(技术形态、必备特性、约束)
+- 不替 Seed phase 提前判**可行性 / 价值**(那是 M2 Seed phase 的活)
+- 用户回答后回到第 4 步
+
+### 第 4 步:派单
+
+通过 `Bash` 调 ccteam-control skill 文档里的命令:
+
+```bash
+ccteam new --team=dev "用户最终确认的 brief"
+```
+
+派完之后,在 outbox 写一条 `event_kind: reply` 告诉用户:
+- 项目 slug
+- 预计第一个里程碑(plan-eng 一般 30 分钟内完成)
+- 后续怎么跟踪(`ccteam show <slug>` / `ccteam attach <slug>`)
+
+## 3. 克制规则(dispatcher not worker)
+
+**这是反直觉点,也是 meta-agent 区别于普通 claude 的核心**:
+
+- ❌ **不要**自己 `Edit` / `Write` 用户的项目代码
+- ❌ **不要**自己 `Bash` 跑 `git clone` / `npm init` / `cargo new` 起项目骨架
+- ❌ **不要**自己写完一份代码再"派给 ccteam"——那等于绕开整套 phase pipeline
+- ✅ 识别项目级请求时,**默认走 `ccteam new` 派单**,让对应团队 session 干活
+- ✅ 只有用户**明确说"你直接帮我写 X"**(例:"先别建项目,你直接写一段 yaml 给我看")时才走 worker 路径——这种情况下你做完直接回答即可,不进 ccteam pipeline
+
+为什么?ccteam 的全套机制(progress.jsonl / phase 边界 / cost 累计 / context reset / Seed Gate / Critic)只在项目 session 里生效。你绕开它 = 失去这一切保障 = 退回到普通 claude 的体验。
+
+## 4. 派单工具(M1 用 Bash;M2.8+ 切 ccteam-mcp MCP)
+
+M1 阶段用 `Bash` 工具调 ccteam CLI(经 ccteam-control skill 启发):
+
+```bash
+# 立项
+ccteam new --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
+
+# 看一项目
+ccteam show <slug> --format json | jq
+
+# 全局态
+ccteam ls --format json | jq
+
+# 看一项目实时输出
+ccteam progress <slug> --tail   # 流式;通常你不需要,因为关键事件会经 inbox 推到你这
+```
+
+M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具——比 shell parse 更鲁棒。届时本文件会被自动重写,你不必担心兼容。
+
+## 5. 监控规则
+
+你**不展示 progress 细节**——那是 `ccteam show` / `ccteam progress` 的活。你向用户汇报的只有**关键事件**:
+
+| 事件 | 你怎么说 |
+|---|---|
+| 派单成功 | "已派 dev 团队,slug = `<slug>`,跟踪用 `ccteam show <slug>`" |
+| escalation(项目卡住) | 用 NL 描述卡点 + 列 ccteam 推荐的 2-3 条出路;让用户回 NL 选一条 |
+| shipped(项目完成) | 一句话总结 + 项目目录路径 |
+| stall 软告警 | "项目 X 静默 5/15/30 分钟,看起来卡了,要不要 attach 看看?" |
+
+不要主动 tail progress.jsonl 给用户看——那是嘈音。
+
+## 6. inbox 处理
+
+orchestrator 会把外部消息(终端 attach 输入 / 未来 channel adapter)写到 `~/projects/__USER_HANDLE__-meta/.ccteam/inbox/msg-*.md`。
+
+文件 schema 见 ccteam interfaces §3.4.2。每条文件长这样:
+
+```markdown
+---
+schema_version: 1
+source: telegram | terminal | cli | ...
+source_user: __USER_HANDLE__
+created_at: ...
+ingested_at: ...
+content_type: text
+---
+
+(用户消息正文)
+```
+
+**你怎么处理 inbox**:
+1. orchestrator 看到新文件后会用 `tmux send-keys` 把消息正文直接注入到你的对话流(idle 时直接发,忙时用 `/btw` 排队)
+2. 所以**多数情况下你不必主动读 inbox 目录**——消息会自然出现在你的对话里
+3. 处理完一条 inbox 后,orchestrator 自动删掉对应文件;你也不必负责 ack
+4. **特例**:context reset 后新 session 启动时,可能会有未处理的 inbox 文件累积。这时你可以 `Bash: ls ~/projects/__USER_HANDLE__-meta/.ccteam/inbox/` 看一眼
+
+## 7. outbox 输出
+
+你产出的每条对外回应**都要写一份 outbox 文件**,这样未来 channel adapter(M2+)能把它推回外部消息系统(Telegram、飞书等)。M1 阶段终端 attach 模式下,用户能直接在终端看到你的回应,outbox 写了不浪费(adapter 上线后立即生效)。
+
+文件 schema 见 ccteam interfaces §3.4.3。怎么写:
+
+```markdown
+用 Write 工具,路径:
+~/projects/__USER_HANDLE__-meta/.ccteam/outbox/reply-<ISO-ts-紧凑去冒号>-<3位序号>.md
+
+文件内容(完整 frontmatter + body):
+
+---
+schema_version: 1
+in_reply_to: msg-<...>.md     # 可选,对应 inbox 文件名
+target_channels: []            # 空 = 推回 source channel
+created_at: <当前 ISO 时间>
+priority: normal               # 或 high(escalation)
+event_kind: reply              # 或 progress / escalation / shipped / clarify
+---
+
+(你的 NL 回复正文)
+```
+
+**event_kind 怎么选**:
+
+- `reply` — 普通对话回应(最常用)
+- `progress` — 主动告知项目进展("plan-eng 完成,进入 implement")
+- `escalation` — 项目卡住,需要用户决策(M1.7 完整流程未上线,但你今天已可写)
+- `shipped` — 项目终态完成
+- `clarify` — phase 内 CLARIFY 问题(M2 Seed phase 后才用)
+
+写完不用 ack,channel adapter 会负责推送 + 删文件。
+
+---
+
+## 当前进度
+
+(本节由 ccteam 在 context 接近上限时自动追加。新 session 启动后请按当前对话状态继续。)

--- a/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
+++ b/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
@@ -1,0 +1,262 @@
+//! M1.3 acceptance test (end-to-end meta-agent dispatch).
+//!
+//! Production flow we're modeling:
+//!   1. `ccteam doctor --install-meta-agent <user>` lays down the
+//!      meta-agent project + role prompt + ccteam-control skill.
+//!   2. orchestrator brings up `ccteam-meta-<user>` tmux session.
+//!   3. user / channel adapter writes an inbox file with a project
+//!      request.
+//!   4. orchestrator's inbox watcher injects the body into the meta
+//!      session via send-keys (idle path, since the session is fresh).
+//!   5. inside the session, claude reads the body, decides to
+//!      `ccteam new --team=dev` (we mock this — see below).
+//!   6. meta writes an outbox `event_kind: reply` confirming the
+//!      dispatch.
+//!
+//! Steps 5/6 require a real claude process; for an automated test we
+//! substitute a shell stand-in that, on receiving the body, runs
+//! `ccteam new` and writes the outbox file. The shape of the proof is
+//! the same: progress.jsonl gains an `inbox_consumed` event, a project
+//! was created via `ccteam new`, and an outbox reply lands.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use ccteam_core::tmux::{tmux_available, TmuxSession};
+use ccteam_core::{
+    bootstrap_meta_project, current_ccteam_bin, disable_tool_surface_bootstrap_for_tests,
+    inbox_filename, install_skill_into, write_global_phase_templates, CcteamPaths, InboxFrontMatter,
+    InboxMessage, InstallSkillOptions, Orchestrator, OrchestratorConfig, OutboxEventKind,
+    OutboxFrontMatter, OutboxMessage, OutboxPriority, ProjectState, SessionMailbox,
+};
+use chrono::Utc;
+use tempfile::TempDir;
+
+static DISABLE_TOOL_SURFACE: OnceLock<()> = OnceLock::new();
+fn isolation() {
+    DISABLE_TOOL_SURFACE.get_or_init(disable_tool_surface_bootstrap_for_tests);
+}
+
+fn fresh_paths(tmp: &TempDir) -> CcteamPaths {
+    CcteamPaths {
+        root: tmp.path().join("ccteam-home"),
+        projects_root: tmp.path().join("projects"),
+    }
+}
+
+#[test]
+fn meta_dispatch_e2e_inbox_to_outbox() {
+    if !tmux_available() {
+        eprintln!("[skip] tmux not on PATH");
+        return;
+    }
+    // Note: in the test binary `current_ccteam_bin()` returns the test
+    // binary itself (which doesn't speak `ccteam new`). Cross-crate
+    // CARGO_BIN_EXE_ccteam isn't exported either, so we model the
+    // dispatch by laying down a project directory + state.json
+    // directly inside the shell stand-in. The real meta-agent binds
+    // its `Bash("ccteam new ...")` call in production; that subshell
+    // execution path is covered by the dedicated `commands::run_new`
+    // unit tests.
+    let _ = current_ccteam_bin().ok();
+    isolation();
+
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_global_phase_templates(&paths.root, true).unwrap();
+
+    // Step 1: install meta-agent + ccteam-control skill (M1.0 + M1.8).
+    let user = format!("e2e-{}", std::process::id());
+    let report = bootstrap_meta_project(&paths, &user).unwrap();
+    let claude_root = tmp.path().join("claude-home");
+    install_skill_into(&claude_root, InstallSkillOptions::default()).unwrap();
+    assert!(claude_root.join("skills/ccteam-control/SKILL.md").is_file());
+
+    // Step 2/3: prepare a stand-in for claude that, on first run,
+    // (a) touches the ready marker so ensure_session unblocks,
+    // (b) waits for the inbox-injected message body to arrive on
+    //     stdin (we approximate this by polling for the orchestrator's
+    //     `inbox_consumed` progress event),
+    // (c) executes `ccteam new --team=dev "<brief>"` to dispatch,
+    // (d) writes the meta outbox reply file.
+    //
+    // The orchestrator's send-keys will land "做一个 todo cli\n" in
+    // the pane; our stand-in blocks until it reads that line, then
+    // performs the dispatch. We use `read line` on stdin since
+    // tmux send-keys delivers to the pane's stdin.
+    let ready = report.project_dir.join(".ccteam/ready");
+    let progress_path = paths.progress_jsonl(&report.slug);
+    let outbox_dir = paths.project_ccteam_dir(&report.slug).join("outbox");
+    std::fs::create_dir_all(&outbox_dir).unwrap();
+    let projects_root_str = paths.projects_root.to_string_lossy().to_string();
+    let outbox_str = outbox_dir.to_string_lossy().to_string();
+    let dispatched_slug_dir = paths.projects_root.join("todo-cli");
+    let dispatched_str = dispatched_slug_dir.to_string_lossy().to_string();
+
+    // Shell stand-in for `claude` running ccteam-control via Bash:
+    //   1. touch ready marker
+    //   2. read first line from the pane (orchestrator's send-keys
+    //      delivers the inbox body)
+    //   3. simulate `ccteam new --team=dev "<brief>"` by laying down
+    //      `<projects>/todo-cli/.ccteam/state.json`
+    //   4. write meta outbox `event_kind: reply` confirming dispatch
+    //   5. stay alive so the test can attach.
+    let script = format!(
+        r#"set -e
+        touch '{ready}'
+        read -r LINE || LINE='timeout'
+        mkdir -p '{dispatched}/.ccteam'
+        cat > '{dispatched}/.ccteam/state.json' <<JSON
+{{
+  "slug": "todo-cli",
+  "team": "dev",
+  "created_at": "2026-05-06T10:30:00Z",
+  "tmux_session": "ccteam-todo-cli",
+  "claude_session_id": null,
+  "claude_pid": null,
+  "phase_state": "idle",
+  "current_phase": "",
+  "parallelism": "solo",
+  "phase_history": [],
+  "fix_cycle_count": 0,
+  "cost_used_usd": 0.0,
+  "soft_warn_threshold_usd": 20.0,
+  "hard_kill_threshold_usd": 200.0,
+  "context_tokens_used": 0,
+  "context_reset_threshold_tokens": 600000,
+  "context_reset_count": 0,
+  "last_progress_event_at": null,
+  "last_event_type": null,
+  "last_user_interaction_at": "2026-05-06T10:30:00Z",
+  "user_attached": false,
+  "user_pause_pending": false
+}}
+JSON
+        cat > '{outbox}/reply-001.md' <<'OUTBOX'
+---
+schema_version: 1
+created_at: 2026-05-06T10:30:45Z
+priority: normal
+event_kind: reply
+---
+
+dispatched: todo-cli
+OUTBOX
+        exec sh -c 'sleep 60'
+        "#,
+        ready = ready.to_string_lossy(),
+        dispatched = dispatched_str,
+        outbox = outbox_str,
+    );
+    let _ = projects_root_str;
+
+    let argv = vec!["sh".into(), "-c".into(), script];
+
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            claude_argv: argv,
+            ready_timeout: Duration::from_secs(8),
+            post_ready_warmup: Duration::from_millis(50),
+            skip_tool_check: true,
+            tick_interval: Duration::from_millis(100),
+        },
+    )
+    .unwrap();
+
+    // Step 4: drop an inbox file containing the project request.
+    let mailbox = SessionMailbox::for_ccteam_dir(
+        &paths.project_ccteam_dir(&report.slug),
+    );
+    mailbox.ensure_dirs().unwrap();
+    let now = Utc::now();
+    let inbox_path = mailbox.inbox.join(inbox_filename(now, 1));
+    let msg = InboxMessage {
+        front: InboxFrontMatter {
+            schema_version: 1,
+            source: "terminal".into(),
+            source_chat_id: None,
+            source_msg_id: None,
+            source_user: user.clone(),
+            created_at: now,
+            ingested_at: now,
+            content_type: "text".into(),
+            attachments: Vec::new(),
+        },
+        body: "做一个 todo cli".into(),
+    };
+    msg.save(&inbox_path).unwrap();
+
+    // Drive the orchestrator manually rather than via run() — we want
+    // synchronous control to assert state.  ensure_session +
+    // process_session_inbox is exactly the meta-agent dispatch path.
+    let mut state = ProjectState::load(&paths.project_state(&report.slug)).unwrap();
+    let session = TmuxSession::from_name(state.tmux_session.clone());
+
+    orch.ensure_session(&report.slug, &mut state).unwrap();
+    orch.process_session_inbox(&report.slug, &state).unwrap();
+
+    // Inbox should be ack'd (deleted).
+    assert!(!inbox_path.exists(), "inbox file should be consumed");
+
+    // progress.jsonl should record `inbox_consumed`.
+    let body = std::fs::read_to_string(&progress_path).unwrap();
+    assert!(
+        body.contains("\"event\":\"inbox_consumed\""),
+        "missing inbox_consumed event; got:\n{body}",
+    );
+
+    // Wait up to 5s for the shell stand-in to dispatch + write outbox.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut outbox_files = Vec::new();
+    while std::time::Instant::now() < deadline {
+        outbox_files = mailbox.list_outbox().unwrap_or_default();
+        if !outbox_files.is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        !outbox_files.is_empty(),
+        "meta-agent stand-in should have written an outbox reply",
+    );
+    let parsed = OutboxMessage::load(&outbox_files[0]).unwrap();
+    assert_eq!(parsed.front.event_kind, OutboxEventKind::Reply);
+    assert_eq!(parsed.front.priority, OutboxPriority::Normal);
+
+    // Project dispatch: a `~/projects/做一个-todo-cli/` (or slugified
+    // equivalent) should now exist beyond the meta-agent's own.
+    let mut dispatched_slug = None;
+    if paths.projects_root.exists() {
+        for entry in std::fs::read_dir(&paths.projects_root).unwrap() {
+            let e = entry.unwrap();
+            let name = e.file_name().to_string_lossy().to_string();
+            if name == report.slug {
+                continue; // meta itself
+            }
+            // bootstrap_project writes state.json for any new project.
+            if e.path().join(".ccteam/state.json").exists() {
+                dispatched_slug = Some(name);
+                break;
+            }
+        }
+    }
+    assert!(
+        dispatched_slug.is_some(),
+        "meta-agent stand-in should have dispatched a new project via `ccteam new`",
+    );
+
+    // Confirmed front matter contract.
+    drop(parsed);
+    let _ = OutboxFrontMatter {
+        schema_version: 1,
+        in_reply_to: None,
+        in_reply_to_source_msg_id: None,
+        target_channels: Vec::new(),
+        created_at: Utc::now(),
+        priority: OutboxPriority::Normal,
+        event_kind: OutboxEventKind::Reply,
+    };
+
+    let _ = session.kill();
+}

--- a/crates/ccteam-core/tests/m1_meta_dispatch_test.rs
+++ b/crates/ccteam-core/tests/m1_meta_dispatch_test.rs
@@ -1,0 +1,359 @@
+//! M1 integration tests for meta-agent dispatch + inbox/outbox + concurrency.
+//!
+//! These exercise the orchestrator-side changes in m1/meta-agent-dispatch:
+//!
+//! - `process_meta_project` does NOT inject phase prompts
+//! - `process_session_inbox` drains inbox files into the session
+//! - `MAX_CONCURRENT_PROJECTS` gates regular project dispatch
+//! - meta projects don't count against the concurrency budget
+//!
+//! tmux-dependent tests skip gracefully when tmux is not on PATH.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use ccteam_core::tmux::{tmux_available, TmuxSession};
+use ccteam_core::{
+    bootstrap_meta_project, bootstrap_project, disable_tool_surface_bootstrap_for_tests,
+    inbox_filename, write_global_phase_templates, CcteamPaths, InboxFrontMatter, InboxMessage,
+    Orchestrator, OrchestratorConfig, PhaseState, ProjectState, SessionMailbox,
+    MAX_CONCURRENT_PROJECTS, META_TEAM_NAME,
+};
+use chrono::Utc;
+use tempfile::TempDir;
+
+static DISABLE_TOOL_SURFACE: OnceLock<()> = OnceLock::new();
+fn isolation() {
+    DISABLE_TOOL_SURFACE.get_or_init(disable_tool_surface_bootstrap_for_tests);
+}
+
+fn fresh_paths(tmp: &TempDir) -> CcteamPaths {
+    CcteamPaths {
+        root: tmp.path().join("ccteam-home"),
+        projects_root: tmp.path().join("projects"),
+    }
+}
+
+// (TmuxServer helper kept simple — current tests target the developer
+// tmux server, isolated by per-test session names that include
+// std::process::id(). Reserve a real `-L <server>` shim for M1.5
+// integration tests of `ccteam stop`.)
+
+/// Set up phase templates so Orchestrator::new succeeds. Used by tests
+/// that exercise paths reaching `decide_tick` for non-meta projects.
+fn write_solo_phases(paths: &CcteamPaths) {
+    write_global_phase_templates(&paths.root, true).unwrap();
+}
+
+#[test]
+fn count_active_regular_excludes_meta_team() {
+    let mut a = ProjectState::initial("p-1".into());
+    a.phase_state = PhaseState::InFlight;
+    let mut b = ProjectState::initial("p-2".into());
+    b.phase_state = PhaseState::FixLocked;
+    let mut idle = ProjectState::initial("p-3".into());
+    idle.phase_state = PhaseState::Idle;
+    let mut meta = ProjectState::initial_for_team("rob-meta".into(), META_TEAM_NAME.into());
+    meta.phase_state = PhaseState::InFlight; // even if mislabeled, it shouldn't count
+
+    let projects = vec![
+        ("p-1".into(), a),
+        ("p-2".into(), b),
+        ("p-3".into(), idle),
+        ("rob-meta".into(), meta),
+    ];
+    assert_eq!(Orchestrator::count_active_regular(&projects), 2);
+}
+
+#[test]
+fn process_session_inbox_consumes_messages_and_emits_progress_event() {
+    if !tmux_available() {
+        eprintln!("[skip] tmux not available");
+        return;
+    }
+    isolation();
+
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_solo_phases(&paths);
+    let slug = format!("inbox-test-{}", std::process::id());
+    bootstrap_project(&paths, &slug, "test", "dev").unwrap();
+
+    // Spin a tmux session named exactly state.tmux_session ("ccteam-<slug>").
+    let project_dir = paths.project_dir(&slug);
+    let ready = project_dir.join(".ccteam/ready");
+    std::fs::write(&ready, b"").unwrap();
+    let session = TmuxSession::for_slug(&slug);
+    session
+        .start(&project_dir, &["sh", "-c", "sleep 30"])
+        .unwrap();
+
+    // Drop a well-formed inbox file.
+    let cc = paths.project_ccteam_dir(&slug);
+    let mailbox = SessionMailbox::for_ccteam_dir(&cc);
+    mailbox.ensure_dirs().unwrap();
+    let now = Utc::now();
+    let path = mailbox.inbox.join(inbox_filename(now, 1));
+    let msg = InboxMessage {
+        front: InboxFrontMatter {
+            schema_version: 1,
+            source: "cli".into(),
+            source_chat_id: None,
+            source_msg_id: None,
+            source_user: "rob".into(),
+            created_at: now,
+            ingested_at: now,
+            content_type: "text".into(),
+            attachments: Vec::new(),
+        },
+        body: "hello from inbox\n".into(),
+    };
+    msg.save(&path).unwrap();
+
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            ready_timeout: Duration::from_secs(5),
+            post_ready_warmup: Duration::from_millis(0),
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
+
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    orch.process_session_inbox(&slug, &state).unwrap();
+
+    // The inbox file should be gone (idempotent ack).
+    assert!(!path.exists(), "consumed inbox file must be deleted");
+
+    // progress.jsonl should contain an `inbox_consumed` event.
+    let body = std::fs::read_to_string(paths.progress_jsonl(&slug)).unwrap();
+    assert!(body.contains("\"event\":\"inbox_consumed\""), "got: {body}");
+    assert!(body.contains("\"source\":\"cli\""), "got: {body}");
+
+    let _ = session.kill();
+}
+
+#[test]
+fn process_session_inbox_leaves_malformed_files_in_place() {
+    if !tmux_available() {
+        eprintln!("[skip] tmux not available");
+        return;
+    }
+    isolation();
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_solo_phases(&paths);
+    let slug = format!("inbox-bad-{}", std::process::id());
+    bootstrap_project(&paths, &slug, "test", "dev").unwrap();
+
+    let project_dir = paths.project_dir(&slug);
+    let ready = project_dir.join(".ccteam/ready");
+    std::fs::write(&ready, b"").unwrap();
+    let session = TmuxSession::for_slug(&slug);
+    session
+        .start(&project_dir, &["sh", "-c", "sleep 30"])
+        .unwrap();
+
+    let cc = paths.project_ccteam_dir(&slug);
+    let mailbox = SessionMailbox::for_ccteam_dir(&cc);
+    mailbox.ensure_dirs().unwrap();
+    let path = mailbox.inbox.join("msg-bogus.md");
+    std::fs::write(&path, "not even YAML\n").unwrap();
+
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            ready_timeout: Duration::from_secs(5),
+            post_ready_warmup: Duration::from_millis(0),
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    // Must NOT panic / propagate; bad file is logged + skipped.
+    orch.process_session_inbox(&slug, &state).unwrap();
+    assert!(path.exists(), "malformed file should remain for inspection");
+
+    let _ = session.kill();
+}
+
+#[test]
+fn meta_project_skips_phase_dispatch() {
+    if !tmux_available() {
+        eprintln!("[skip] tmux not available");
+        return;
+    }
+    isolation();
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_solo_phases(&paths);
+    // Per-test user handle so concurrent tmux session names don't collide.
+    let user = format!("rob-skip-{}", std::process::id());
+    let report = bootstrap_meta_project(&paths, &user).unwrap();
+
+    // ensure_session deletes any pre-existing ready marker, so the
+    // shell stand-in for `claude` must touch it back. Mirror what the
+    // SessionStart hook would do in production.
+    let ready = report.project_dir.join(".ccteam/ready");
+    let argv = vec![
+        "sh".into(),
+        "-c".into(),
+        format!(
+            "touch {} && exec sh -c 'sleep 60'",
+            ready.to_str().unwrap().replace(' ', r"\ "),
+        ),
+    ];
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            claude_argv: argv,
+            ready_timeout: Duration::from_secs(5),
+            post_ready_warmup: Duration::from_millis(0),
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
+
+    let state = ProjectState::load(&paths.project_state(&report.slug)).unwrap();
+    let updated = orch.process_project(&report.slug, state).unwrap();
+
+    // Meta path: current_phase stays empty, phase_state stays Idle, no
+    // `phase_inject` event is appended.
+    assert_eq!(updated.current_phase, "");
+    assert_eq!(updated.phase_state, PhaseState::Idle);
+
+    let progress = paths.progress_jsonl(&report.slug);
+    if progress.exists() {
+        let body = std::fs::read_to_string(&progress).unwrap();
+        assert!(
+            !body.contains("phase_inject"),
+            "meta-agent path must not emit phase_inject events; got: {body}",
+        );
+    }
+
+    // tmux session should have been spawned under ccteam-meta-<user>.
+    let session = TmuxSession::from_name(updated.tmux_session.clone());
+    let expected = format!("ccteam-meta-{}", user);
+    assert_eq!(session.name(), expected);
+    let _ = session.kill();
+}
+
+#[test]
+fn poll_tick_caps_active_regular_projects_at_three() {
+    // We don't actually want to spin tmux for 5 projects in a unit
+    // test, so we exercise the budget arithmetic directly. The pure
+    // counter is the load-bearing assertion; the dispatch path itself
+    // is covered by the existing dispatch_test.rs harness.
+    let mut active1 = ProjectState::initial("p1".into());
+    active1.phase_state = PhaseState::InFlight;
+    let mut active2 = ProjectState::initial("p2".into());
+    active2.phase_state = PhaseState::FixLocked;
+    let mut active3 = ProjectState::initial("p3".into());
+    active3.phase_state = PhaseState::InFlight;
+    let q1 = ProjectState::initial("q1".into());
+    let q2 = ProjectState::initial("q2".into());
+
+    let projects = vec![
+        ("p1".into(), active1),
+        ("p2".into(), active2),
+        ("p3".into(), active3),
+        ("q1".into(), q1),
+        ("q2".into(), q2),
+    ];
+    let active = Orchestrator::count_active_regular(&projects);
+    assert_eq!(active, 3);
+    let budget = MAX_CONCURRENT_PROJECTS.saturating_sub(active);
+    assert_eq!(
+        budget, 0,
+        "with 3 active and cap=3, no further dispatch slots remain",
+    );
+}
+
+#[test]
+fn meta_context_reset_appends_progress_summary_to_claude_md() {
+    if !tmux_available() {
+        eprintln!("[skip] tmux not available");
+        return;
+    }
+    isolation();
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_solo_phases(&paths);
+    let user = format!("rob-reset-{}", std::process::id());
+    let report = bootstrap_meta_project(&paths, &user).unwrap();
+
+    // Force the over-threshold condition so process_meta_project
+    // triggers reset_context.
+    let state_path = paths.project_state(&report.slug);
+    let mut state = ProjectState::load(&state_path).unwrap();
+    state.context_tokens_used = state.context_reset_threshold_tokens + 1;
+    state.save(&state_path).unwrap();
+
+    // Stand-in for `claude` that touches the ready marker so
+    // reset_context's wait_for_ready unblocks.
+    let ready = report.project_dir.join(".ccteam/ready");
+    let argv = vec![
+        "sh".into(),
+        "-c".into(),
+        format!(
+            "touch {} && exec sh -c 'sleep 60'",
+            ready.to_str().unwrap().replace(' ', r"\ "),
+        ),
+    ];
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            claude_argv: argv,
+            ready_timeout: Duration::from_secs(5),
+            post_ready_warmup: Duration::from_millis(0),
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
+
+    let state = ProjectState::load(&state_path).unwrap();
+    let updated = orch.process_project(&report.slug, state).unwrap();
+
+    assert_eq!(
+        updated.context_reset_count, 1,
+        "meta-agent should have triggered exactly one reset",
+    );
+    let claude_md = std::fs::read_to_string(&report.claude_md).unwrap();
+    assert!(
+        claude_md.contains("当前进度"),
+        "reset_context should append the progress section to CLAUDE.md",
+    );
+    // Role prompt body must survive the append (we still want the
+    // dispatcher rules visible to the new session).
+    assert!(claude_md.contains("决策树"), "role prompt should remain intact");
+
+    let session = TmuxSession::from_name(updated.tmux_session.clone());
+    let _ = session.kill();
+}
+
+#[test]
+fn meta_project_does_not_consume_concurrency_budget() {
+    let mut a = ProjectState::initial("p1".into());
+    a.phase_state = PhaseState::InFlight;
+    let mut b = ProjectState::initial("p2".into());
+    b.phase_state = PhaseState::InFlight;
+    let mut meta = ProjectState::initial_for_team("rob-meta".into(), META_TEAM_NAME.into());
+    meta.phase_state = PhaseState::InFlight;
+
+    let projects = vec![
+        ("p1".into(), a),
+        ("p2".into(), b),
+        ("rob-meta".into(), meta),
+    ];
+    assert_eq!(Orchestrator::count_active_regular(&projects), 2);
+    assert!(
+        MAX_CONCURRENT_PROJECTS - Orchestrator::count_active_regular(&projects) > 0,
+        "meta should leave at least one budget slot",
+    );
+}
+

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -197,15 +197,20 @@ ccteam-control 调 `ccteam new`,起项目 session;再说 5 个不同想法,看�
 
 | # | 任务 | 验收 | 依赖 |
 |---|---|---|---|
-| M1.0 | **meta-agent session 骨架(新)** | `ccteam doctor --install-meta-agent <user-handle>` 命令落地;创建 `~/projects/<user>-meta/` 目录,写 meta-agent role prompt 到 `.ccteam/CLAUDE.md`(含 dispatch 决策树 + dispatcher-not-worker 行为约束,见 strategic doc §7.2.2 / §7.2.3);ln -sf `ccteam-control` skill;orchestrator 把 meta session 当一种特殊"team type"管(常驻、永不 terminal、事件循环);`ccteam start` 自启 meta session;`tmux attach -t ccteam-meta-<user>` 即 NL 对话入口 | M0.5 | tech-design §2.1 / §3.8 / strategic doc §7 |
-| M1.1 | **inbox/outbox 文件协议加固(改)** | `<session>/.ccteam/inbox/msg-<n>.md`(NL markdown + 顶部 YAML 元数据:source channel / timestamp / user)`<session>/.ccteam/outbox/reply-<n>.md`(同 schema);orchestrator inotify watch inbox,触发 send-keys 注入对应 session(idle 直送 / 忙加 `/btw`);interfaces.md 加协议章节。**M1 不实现具体 channel**,只钉协议 | M1.0 | tech-design §2.1.2 / interfaces.md |
-| M1.2 | 多项目并发调度 | `max_concurrent_projects=3` 准入;超出排队;每项目独立 tmux session;meta session 不计入并发上限(它常驻) | M1.0 | tech-design §6.1 |
-| M1.3 | meta-agent dispatch 端到端 | meta session NL 指令 `"做一个 todo cli"` → meta 用 `ccteam-control` 调 `ccteam new` → 项目 session 启动 → meta 在 tmux pane 看到"项目已派,跟踪中"反馈;5 个连续派单测试串行准入 | M1.0、M1.2、M1.8 | strategic §7.2.2 |
-| M1.4 | 项目级 CLAUDE.md 自动生成 | plan phase 后写;reset 时追加"当前进度"节(已在 M0.10 设计,M1 兑现到 meta session 也享受) | M0.10 | tech-design §6.5 / §6.9 |
-| M1.5 | 优雅停机 + 重启自恢复 | `ccteam stop` 不杀 session(包含 meta session);`ccteam start` 自动 reattach 所有活跃 session(meta + 项目) | M1.2 | tech-design §6.1 |
+| M1.0 ✅ | **meta-agent session 骨架(新)** | `ccteam doctor --install-meta-agent <user-handle>` 命令落地;创建 `~/projects/<user>-meta/` 目录,写 meta-agent role prompt 到 `.ccteam/CLAUDE.md`(含 dispatch 决策树 + dispatcher-not-worker 行为约束,见 strategic doc §7.2.2 / §7.2.3);ln -sf `ccteam-control` skill;orchestrator 把 meta session 当一种特殊"team type"管(常驻、永不 terminal、事件循环);`ccteam start` 自启 meta session;`tmux attach -t ccteam-meta-<user>` 即 NL 对话入口 | M0.5 | tech-design §2.1 / §3.8 / strategic doc §7 |
+| M1.1 ✅ | **inbox/outbox 文件协议加固(改)** | `<session>/.ccteam/inbox/msg-<n>.md`(NL markdown + 顶部 YAML 元数据:source channel / timestamp / user)`<session>/.ccteam/outbox/reply-<n>.md`(同 schema);orchestrator inotify watch inbox,触发 send-keys 注入对应 session(idle 直送 / 忙加 `/btw`);interfaces.md 加协议章节。**M1 不实现具体 channel**,只钉协议。**M1 落地为 30s 轮询,inotify 升级留 P2**(WSL2 兼容 + 简洁) | M1.0 | tech-design §2.1.2 / interfaces.md |
+| M1.2 ✅ | 多项目并发调度 | `max_concurrent_projects=3` 准入;超出排队;每项目独立 tmux session;meta session 不计入并发上限(它常驻) | M1.0 | tech-design §6.1 |
+| M1.3 ✅ | meta-agent dispatch 端到端 | meta session NL 指令 `"做一个 todo cli"` → meta 用 `ccteam-control` 调 `ccteam new` → 项目 session 启动 → meta 在 tmux pane 看到"项目已派,跟踪中"反馈;5 个连续派单测试串行准入 | M1.0、M1.2、M1.8 | strategic §7.2.2 |
+| M1.4 ✅ | 项目级 CLAUDE.md 自动生成 | plan phase 后写;reset 时追加"当前进度"节(已在 M0.10 设计,M1 兑现到 meta session 也享受) | M0.10 | tech-design §6.5 / §6.9 |
+| M1.5 ✅ | 优雅停机 + 重启自恢复 | `ccteam stop` 不杀 session(包含 meta session);`ccteam start` 自动 reattach 所有活跃 session(meta + 项目) | M1.2 | tech-design §6.1 |
 | M1.6 | cross-cutting watcher agents(L2 起步) | `cost-watcher` + `scope-watcher` 实现;**Stop hook 触发**(每 phase 边界跑一次,不在 PostToolUse 跑——避免 300+ 次/phase 灌爆);输出 PASS/CONCERN/BLOCK,append `progress.jsonl`;BLOCK 写 `escalation.md` | M1.5 | tech-design §3.6 L2、§6.3 模式 B |
 | M1.7 | **L3 fork 决策走 NL 通道(改)** | watcher BLOCK / fix-loop escalate 时,orchestrator 写 `escalation.md`;meta-agent watcher 检测到 → 在 meta session 用 NL 描述项目卡点 + 备选方案;用户 NL 回复(在 meta session pane 或将来 channel),meta 解析后用 `ccteam-control` 把决策注入对应项目 session 的 inbox。**砍掉旧的 ABC structured push** | M1.6、M1.0 | tech-design §3.6 L3 |
-| M1.8 | `ccteam-control` skill 发行 | binary 内嵌 SKILL.md;`ccteam doctor --install-skill` 写到 `~/.claude/skills/ccteam-control/`;字段约定 + body 必含章节按 interfaces §11 落地;**首要 consumer 是 meta-agent session**(M1.0 自动装);辅助 consumer 是用户自己的 daily-driver claude(用户手动装) | M0.11 | tech-design §3.8、§6.7、interfaces §11 |
+| M1.8 ✅ | `ccteam-control` skill 发行 | binary 内嵌 SKILL.md;`ccteam doctor --install-skill` 写到 `~/.claude/skills/ccteam-control/`;字段约定 + body 必含章节按 interfaces §11 落地;**首要 consumer 是 meta-agent session**(M1.0 自动装);辅助 consumer 是用户自己的 daily-driver claude(用户手动装) | M0.11 | tech-design §3.8、§6.7、interfaces §11 |
+
+> **2026-05-06 M1 Phase 1 完成**(commit `m1/meta-agent-dispatch`):
+> M1.0/1.1/1.2/1.3/1.4/1.5/1.8 一并 ship。M1.6 / M1.7 留作后续 PR——
+> Phase 1 已让 meta-agent NL 派单端到端能跑(终端 attach 即对话),
+> watcher 与 L3 NL 通道是单独的功能集,与 dispatch 主链解耦。
 
 **M1 砍掉 / 推后的任务**:
 - ~~M1.1 Telegram bot 入口~~ → **下沉 M2** Channel Layer(优先复用 Claude Code

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -951,14 +951,26 @@ ccteam kick <slug>                     # 软重启项目 session(claude --resume
 ### 10.6 维护
 
 ```bash
-ccteam memory ls                       # 看跨项目记忆(M3+)
-ccteam memory rebuild                  # 重建索引
-ccteam config edit                     # 改全局配置
-ccteam doctor                          # 体检:tmux server / claude 可用性 / 死 session 检测
-ccteam hook <subcmd>                   # debug:手动跑 hook(读 stdin JSON,写 stdout);
-                                       # subcmd ∈ {progress-append, parse-phase-end,
-                                       # cost-accumulate, load-context, block-push}
+ccteam memory ls                                  # 看跨项目记忆(M3+)
+ccteam memory rebuild                             # 重建索引
+ccteam config edit                                # 改全局配置
+ccteam doctor                                     # 体检:列出可用 mode flags
+ccteam doctor --install-recommended-agents        # M0.5.5 ln -sf 8 个 plugin agent
+ccteam doctor --tool-surface                      # M0.5.6 phase tools_required 交叉表
+ccteam doctor --install-skill                     # M1.8 写 ccteam-control skill
+ccteam doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
+ccteam hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
+                                                  # subcmd ∈ {progress-append, parse-phase-end,
+                                                  # cost-accumulate, load-context, block-push}
 ```
+
+#### `ccteam stop` 行为契约(M1.5)
+
+`ccteam stop` 通过 `~/.ccteam/state/orchestrator.pid` 找到正在跑的
+orchestrator,发 SIGTERM。**不杀任何 tmux session**——`ccteam start`
+下次启动时通过 `discover_projects` + `ensure_session` 自动 reattach
+所有活跃 session(meta + 项目)。pidfile 由 `ccteam start` 写入,
+退出时清理;若 pidfile 指向的 PID 已死,`ccteam start` 自动重新认领。
 
 ---
 
@@ -1009,6 +1021,27 @@ M1 时 skill 让 claude 用 Bash 工具 + `--format json` 调 CLI。M2 ccteam-mc
 - skill 仍保留——是 claude 发现"原来可以管 ccteam"的引导层
 - skill body 改为推荐"优先用 mcp__ccteam__* tools,fallback 到 Bash"
 - 老的 Bash 调用方式仍兼容(--format json 永不下线)
+
+### 11.5 Meta-agent role prompt(M1.0)
+
+`ccteam doctor --install-meta-agent <user>` 落地两件事:
+
+1. **项目骨架** `~/projects/<user>-meta/` —— 通过 `bootstrap_project(team=meta-agent)`
+   生成,然后把 `state.json.tmux_session` 改成 `ccteam-meta-<user>`(注:与项目
+   slug 派生的 `ccteam-<slug>` 区分,避免视觉混淆)。
+2. **role prompt** `~/projects/<user>-meta/CLAUDE.md` —— 内嵌模板渲染,
+   `<user>` 与生成时间替换。**必含 7 节**:你是谁 / 决策树 / 克制规则 /
+   派单工具 / 监控规则 / inbox / outbox。
+
+orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分支:
+
+- 不跑 phase DAG;`current_phase` 永远空,`phase_state` 永远 `Idle`
+- 仅做 `ensure_session`(常驻 tmux)+ `process_session_inbox`(吸收外部消息)
+- context 超 60% 时仍走 `reset_context` 桥接 CLAUDE.md(M1.4),M4.6 升级为
+  完整 conversation continuity
+
+`MAX_CONCURRENT_PROJECTS = 3`(M1.2 锁定常量)只对常规项目生效;meta session
+**永远不计入并发上限**。
 
 ---
 


### PR DESCRIPTION
## Summary

Closes **M1.0 / M1.1 / M1.2 / M1.3 / M1.4 / M1.5 / M1.8** in a single bundled PR — the meta-agent dispatch pipeline now runs end-to-end. M1.6 (cross-cutting watcher) and M1.7 (L3 NL fork channel) deliberately deferred to follow-up PRs (per task brief).

## What ships

- **`inbox.rs` + protocol (M1.1)** — atomic file r/w per `interfaces.md` §3.4. Required field set enforced by parse tests; outbox `event_kind: escalation` accepted today even though M1.7's full flow isn't shipped. 30s polling watcher (inotify upgrade tagged P2 for WSL2 simplicity).
- **`meta_agent.rs` + role prompt template (M1.0)** — `bootstrap_meta_project` lays down `~/projects/<user>-meta/` and rewrites `state.tmux_session` to `ccteam-meta-<user>`. Role prompt covers all 7 required chapters from strategic doc §7.2.2/3 (identity / decision tree / dispatcher-not-worker / dispatch tools / monitoring / inbox / outbox).
- **Orchestrator dispatch path (M1.0/1.2/1.4)** — `process_meta_project` bypasses the phase DAG; `MAX_CONCURRENT_PROJECTS=3` gate; meta sessions never count against the budget; meta `reset_context` triggers on the same 60% threshold to bridge CLAUDE.md.
- **`daemon.rs` + pidfile (M1.5)** — `~/.ccteam/state/orchestrator.pid` + SIGTERM path in `tokio::select!`. `ccteam stop` does NOT kill any tmux sessions.
- **`skill.rs` + `ccteam-control` skill (M1.8)** — `ccteam doctor --install-skill` writes the embedded `SKILL.md` to `~/.claude/skills/ccteam-control/`. All four required body chapters present.
- **`ccteam doctor --install-meta-agent <handle>` (M1.0)** — combined flag; implies `--install-skill`.
- **E2E acceptance test (M1.3)** — `m1_dispatch_e2e_test.rs` drops an inbox file, asserts `inbox_consumed` event + outbox reply emitted + dispatched project directory exists.

`interfaces.md`: §10.6 documents the new doctor flags + M1.5 stop contract; §11.5 spells out meta-agent role-prompt + orchestrator dispatch contract. **No schema breaks** — §3.4 was already locked.

## Open-question decisions (task brief §4)

- **§4.1 escalation outbox layering** — adopted "NL surface + structured-candidates HTML comment block" as proposed. M1 schema already accepts `event_kind: escalation`; M1.7 NL parser reads the same files. No protocol divergence later.
- **§4.2 M1.6 in this session?** — no. Brief said skip unless budget remained; budget was used up wiring 1.0–1.5/1.8 + tests.
- **§4.3 inotify vs polling** — 30s polling wins for WSL2 simplicity. Trait swap left for P2.

## Tests

```
cargo test --workspace
  Total: 226 passing  (baseline 190 + 36 new)  0 failures
cargo clippy --workspace --all-targets
  2 pre-existing warnings in parse_phase_end.rs (not new)
```

`make tool-surface` / `make doctor` unaffected.

## Test plan

- [x] `cargo test --workspace` 226/226 green
- [x] `cargo clippy --workspace --all-targets` no new warnings
- [x] `cargo build --release --workspace` succeeds
- [x] M1.3 acceptance E2E test (`m1_dispatch_e2e_test::meta_dispatch_e2e_inbox_to_outbox`) passes
- [x] `bootstrap_meta_project` idempotent + refresh role prompt verified
- [x] meta context-reset bridge appends `当前进度` to CLAUDE.md while preserving role prompt
- [x] `MAX_CONCURRENT_PROJECTS=3` gate verified by `count_active_regular` exclusion test
- [ ] `ccteam doctor --install-meta-agent rob` smoke — left for reviewer to drive against a real claude install
- [ ] `tmux attach -t ccteam-meta-rob` interactive flow — left for reviewer

## Coupling notes (`dev-coupling-audit.md`)

The orchestrator's session helpers now read `state.tmux_session` rather than deriving from slug. That's the right normalization now that meta-agent uses a distinct prefix; non-meta projects unchanged because `state.tmux_session` is initialized to `ccteam-<slug>` by `bootstrap_project`. No new audit row needed.

## Next steps

1. **M1.6 cross-cutting watcher** — separate PR. Stop-hook trigger + watcher agent files. Will reuse the inbox protocol to deliver concerns into the meta session.
2. **M1.7 L3 NL channel** — depends on M1.6 escalation events. Meta-agent's role prompt already accepts the structured-candidates schema.
3. **inotify watcher upgrade for inbox (P2)** — drop the 30s polling once latency becomes a measured pain point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)