### PR TITLE
M1 follow-up: ccteam decisions cross-project queue + meta role surfacing

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -13,8 +13,8 @@ use ccteam_core::{
     bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
     link_recommended_agents, pick_unused_slug, user_claude_dir, write_global_phase_templates,
     AgentLinkAction, AgentLinkReport, CcteamPaths, InstallSkillOptions, LinkOptions,
-    MetaBootstrapReport, PhaseState, PhaseTemplate, ProjectState, SkillInstallAction,
-    ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, PHASE_TEMPLATES,
+    MetaBootstrapReport, OutboxEventKind, OutboxMessage, PhaseState, PhaseTemplate, ProjectState,
+    SessionMailbox, SkillInstallAction, ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, PHASE_TEMPLATES,
 };
 use ccteam_core::tmux::TmuxSession;
 
@@ -233,6 +233,242 @@ pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
         let _ = std::fs::rename(&esc, &archive);
     }
     Ok(())
+}
+
+/// One row in the cross-project decisions queue (`ccteam decisions`).
+///
+/// A "decision" = an outbox file in any project's `.ccteam/outbox/` whose
+/// front matter has `event_kind: clarify` or `event_kind: escalation`.
+/// These are the messages a user must look at; everything else (replies,
+/// progress, shipped) is informational and excluded.
+#[derive(Debug, Clone)]
+pub struct DecisionRow {
+    pub slug: String,
+    pub current_phase: String,
+    pub team: String,
+    pub event_kind: OutboxEventKind,
+    pub priority: ccteam_core::OutboxPriority,
+    pub created_at: chrono::DateTime<Utc>,
+    pub age_seconds: u64,
+    pub outbox_filename: String,
+    pub summary: String,
+}
+
+/// `ccteam decisions`. Aggregate the cross-project decisions queue and
+/// render it. interfaces.md §5.6.4 — meta-agent uses this as the
+/// surface for "你有 N 条待决策" UX. M1 follow-up increment.
+pub fn run_decisions(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
+    let rows = collect_decisions(paths)?;
+    Ok(match format {
+        OutputFormat::Text => render_decisions_text(&rows),
+        OutputFormat::Json => render_decisions_json(&rows)?,
+    })
+}
+
+/// Walk every project under `projects_root`, scan their outbox dirs, and
+/// emit one `DecisionRow` per outbox file whose `event_kind` warrants
+/// user attention. Broken outbox files are warned and skipped — never
+/// fatal, because one malformed file shouldn't blank the whole queue.
+pub fn collect_decisions(paths: &CcteamPaths) -> Result<Vec<DecisionRow>> {
+    let dir = &paths.projects_root;
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let now = Utc::now();
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir)
+        .with_context(|| format!("read_dir {}", dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(slug) = entry.file_name().to_str().map(String::from) else {
+            continue;
+        };
+        let project_dir = entry.path();
+        let ccteam_dir = project_dir.join(".ccteam");
+        if !ccteam_dir.exists() {
+            continue;
+        }
+        // Resolve current phase + team from state.json. Missing /
+        // unparseable state.json is *not* a decisions-queue error; the
+        // outbox can still be surfaced under "<unknown>".
+        let (current_phase, team) = match ProjectState::load(&paths.project_state(&slug)) {
+            Ok(s) => {
+                let phase = if s.current_phase.is_empty() {
+                    "<idle>".to_string()
+                } else {
+                    s.current_phase
+                };
+                (phase, s.team)
+            }
+            Err(_) => ("<unknown>".to_string(), "<unknown>".to_string()),
+        };
+
+        let mailbox = SessionMailbox::for_ccteam_dir(&ccteam_dir);
+        let files = match mailbox.list_outbox() {
+            Ok(f) => f,
+            Err(err) => {
+                tracing::warn!(slug, error = %err, "skip project: outbox listing failed");
+                continue;
+            }
+        };
+        for path in files {
+            let msg = match OutboxMessage::load(&path) {
+                Ok(m) => m,
+                Err(err) => {
+                    tracing::warn!(
+                        slug,
+                        path = %path.display(),
+                        error = %err,
+                        "skip outbox file: parse failed",
+                    );
+                    continue;
+                }
+            };
+            // Filter: only items the user has to look at. Replies /
+            // progress / shipped notifications are not "decisions".
+            if !matches!(
+                msg.front.event_kind,
+                OutboxEventKind::Clarify | OutboxEventKind::Escalation
+            ) {
+                continue;
+            }
+            let age = now
+                .signed_duration_since(msg.front.created_at)
+                .num_seconds()
+                .max(0) as u64;
+            let outbox_filename = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            out.push(DecisionRow {
+                slug: slug.clone(),
+                current_phase: current_phase.clone(),
+                team: team.clone(),
+                event_kind: msg.front.event_kind,
+                priority: msg.front.priority,
+                created_at: msg.front.created_at,
+                age_seconds: age,
+                outbox_filename,
+                summary: summarize_body(&msg.body),
+            });
+        }
+    }
+    // Highest priority first, then oldest first within priority — old
+    // unanswered escalations should never get buried under a fresh
+    // clarify.
+    out.sort_by(|a, b| {
+        b.priority
+            .cmp(&a.priority)
+            .then_with(|| a.created_at.cmp(&b.created_at))
+    });
+    Ok(out)
+}
+
+/// Pull a one-line summary from the outbox body. Strips the first
+/// markdown heading (if any), trims, and truncates to 80 chars.
+fn summarize_body(body: &str) -> String {
+    let line = body
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with("# "))
+        .unwrap_or("");
+    if line.chars().count() <= 80 {
+        line.to_string()
+    } else {
+        let truncated: String = line.chars().take(77).collect();
+        format!("{truncated}...")
+    }
+}
+
+fn render_decisions_text(rows: &[DecisionRow]) -> String {
+    if rows.is_empty() {
+        return "no pending decisions across all projects.\n".to_string();
+    }
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{} pending decision{} across all projects:\n\n",
+        rows.len(),
+        if rows.len() == 1 { "" } else { "s" },
+    ));
+    out.push_str("slug                       phase             team             kind         age      summary\n");
+    out.push_str("------------------------   ---------------   --------------   ----------   ------   -------\n");
+    for row in rows {
+        let age = format_age(row.age_seconds);
+        let kind = match row.event_kind {
+            OutboxEventKind::Clarify => "clarify",
+            OutboxEventKind::Escalation => "escalation",
+            // Filtered upstream; defensive default.
+            _ => "other",
+        };
+        out.push_str(&format!(
+            "{:<26} {:<17} {:<16} {:<12} {:<8} {}\n",
+            ellipsize(&row.slug, 26),
+            ellipsize(&row.current_phase, 17),
+            ellipsize(&row.team, 16),
+            kind,
+            age,
+            row.summary,
+        ));
+    }
+    out
+}
+
+fn render_decisions_json(rows: &[DecisionRow]) -> Result<String> {
+    let arr: Vec<Value> = rows
+        .iter()
+        .map(|row| {
+            json!({
+                "slug": row.slug,
+                "current_phase": row.current_phase,
+                "team": row.team,
+                "event_kind": match row.event_kind {
+                    OutboxEventKind::Clarify => "clarify",
+                    OutboxEventKind::Escalation => "escalation",
+                    OutboxEventKind::Reply => "reply",
+                    OutboxEventKind::Progress => "progress",
+                    OutboxEventKind::Shipped => "shipped",
+                },
+                "priority": match row.priority {
+                    ccteam_core::OutboxPriority::Normal => "normal",
+                    ccteam_core::OutboxPriority::High => "high",
+                },
+                "created_at": row.created_at.to_rfc3339(),
+                "age_seconds": row.age_seconds,
+                "outbox_filename": row.outbox_filename,
+                "summary": row.summary,
+            })
+        })
+        .collect();
+    let body = json!({
+        "total": rows.len(),
+        "decisions": arr,
+    });
+    Ok(serde_json::to_string_pretty(&body)? + "\n")
+}
+
+fn format_age(seconds: u64) -> String {
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3600 {
+        format!("{}m", seconds / 60)
+    } else if seconds < 86400 {
+        format!("{}h", seconds / 3600)
+    } else {
+        format!("{}d", seconds / 86400)
+    }
+}
+
+fn ellipsize(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    }
 }
 
 /// `ccteam doctor` flags. Each mode is a separate boolean / option so
@@ -1071,5 +1307,231 @@ mod tests {
             would: Box::new(AgentLinkAction::Linked),
         });
         assert_eq!(label, "would: linked");
+    }
+
+    // -------- ccteam decisions (M1 follow-up) --------
+
+    /// Helper: write an outbox file with caller-controlled front matter
+    /// to `<projects_root>/<slug>/.ccteam/outbox/<filename>`. Uses
+    /// `OutboxMessage::save` so the file goes through the same atomic
+    /// write path used in production.
+    fn write_outbox(
+        paths: &CcteamPaths,
+        slug: &str,
+        filename: &str,
+        kind: OutboxEventKind,
+        priority: ccteam_core::OutboxPriority,
+        created_at: chrono::DateTime<Utc>,
+        body: &str,
+    ) {
+        let dir = paths.project_ccteam_dir(slug).join("outbox");
+        std::fs::create_dir_all(&dir).unwrap();
+        let msg = OutboxMessage {
+            front: ccteam_core::OutboxFrontMatter {
+                schema_version: 1,
+                in_reply_to: None,
+                in_reply_to_source_msg_id: None,
+                target_channels: Vec::new(),
+                created_at,
+                priority,
+                event_kind: kind,
+            },
+            body: body.to_string(),
+        };
+        msg.save(&dir.join(filename)).unwrap();
+    }
+
+    fn write_state(paths: &CcteamPaths, slug: &str, phase: &str, team: &str) {
+        let dir = paths.project_ccteam_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut state = ProjectState::initial_for_team(slug.to_string(), team.to_string());
+        state.current_phase = phase.to_string();
+        state.save(&paths.project_state(slug)).unwrap();
+    }
+
+    #[test]
+    fn run_decisions_text_says_empty_when_no_projects() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let body = run_decisions(&paths, OutputFormat::Text).unwrap();
+        assert!(body.contains("no pending decisions"));
+    }
+
+    #[test]
+    fn run_decisions_excludes_reply_progress_shipped_event_kinds() {
+        // Only clarify / escalation should show up in the queue.
+        // Replies / progress / shipped notifications are informational,
+        // not user-actionable.
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        write_state(&paths, "alpha", "plan-eng", "dev");
+        let now = Utc::now();
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-1.md",
+            OutboxEventKind::Reply,
+            ccteam_core::OutboxPriority::Normal,
+            now,
+            "informational",
+        );
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-2.md",
+            OutboxEventKind::Progress,
+            ccteam_core::OutboxPriority::Normal,
+            now,
+            "informational",
+        );
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-3.md",
+            OutboxEventKind::Shipped,
+            ccteam_core::OutboxPriority::Normal,
+            now,
+            "informational",
+        );
+        let rows = collect_decisions(&paths).unwrap();
+        assert!(rows.is_empty(), "non-decision event_kinds must be filtered out");
+    }
+
+    #[test]
+    fn run_decisions_aggregates_clarify_and_escalation_across_projects() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        write_state(&paths, "alpha", "plan-eng", "dev");
+        write_state(&paths, "beta", "kickoff", "product-research");
+        let t1 = Utc::now() - chrono::Duration::hours(2);
+        let t2 = Utc::now() - chrono::Duration::minutes(30);
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-1.md",
+            OutboxEventKind::Clarify,
+            ccteam_core::OutboxPriority::Normal,
+            t1,
+            "选 SQLite 还是 Postgres?",
+        );
+        write_outbox(
+            &paths,
+            "beta",
+            "reply-1.md",
+            OutboxEventKind::Escalation,
+            ccteam_core::OutboxPriority::High,
+            t2,
+            "exceeded max_clarify_rounds",
+        );
+        let rows = collect_decisions(&paths).unwrap();
+        assert_eq!(rows.len(), 2);
+        // High-priority escalation must come first regardless of being
+        // newer than the clarify.
+        assert!(matches!(rows[0].event_kind, OutboxEventKind::Escalation));
+        assert_eq!(rows[0].slug, "beta");
+        assert_eq!(rows[1].slug, "alpha");
+    }
+
+    #[test]
+    fn run_decisions_json_serializes_complete_row_shape() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        write_state(&paths, "alpha", "plan-eng", "dev");
+        let opened = chrono::DateTime::parse_from_rfc3339("2026-05-06T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-1.md",
+            OutboxEventKind::Clarify,
+            ccteam_core::OutboxPriority::Normal,
+            opened,
+            "需要确认部署目标",
+        );
+        let body = run_decisions(&paths, OutputFormat::Json).unwrap();
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["total"], 1);
+        let row = &parsed["decisions"][0];
+        assert_eq!(row["slug"], "alpha");
+        assert_eq!(row["current_phase"], "plan-eng");
+        assert_eq!(row["team"], "dev");
+        assert_eq!(row["event_kind"], "clarify");
+        assert_eq!(row["priority"], "normal");
+        assert_eq!(row["outbox_filename"], "reply-1.md");
+        assert!(row["summary"].as_str().unwrap().contains("部署"));
+    }
+
+    #[test]
+    fn run_decisions_skips_unparseable_outbox_files() {
+        // A malformed outbox file in one project must not blank the
+        // queue — other projects should still surface.
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        write_state(&paths, "alpha", "plan-eng", "dev");
+        write_state(&paths, "broken", "plan-eng", "dev");
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-1.md",
+            OutboxEventKind::Clarify,
+            ccteam_core::OutboxPriority::Normal,
+            Utc::now(),
+            "valid question",
+        );
+        // Hand-write garbage that doesn't parse as an outbox file.
+        let bad_dir = paths.project_ccteam_dir("broken").join("outbox");
+        std::fs::create_dir_all(&bad_dir).unwrap();
+        std::fs::write(bad_dir.join("reply-bad.md"), "not even a yaml header").unwrap();
+
+        let rows = collect_decisions(&paths).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].slug, "alpha");
+    }
+
+    #[test]
+    fn run_decisions_summary_truncates_long_first_line() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        write_state(&paths, "alpha", "plan-eng", "dev");
+        let long_line = "x".repeat(200);
+        write_outbox(
+            &paths,
+            "alpha",
+            "reply-1.md",
+            OutboxEventKind::Clarify,
+            ccteam_core::OutboxPriority::Normal,
+            Utc::now(),
+            &long_line,
+        );
+        let rows = collect_decisions(&paths).unwrap();
+        assert_eq!(rows.len(), 1);
+        let summary = &rows[0].summary;
+        assert!(summary.ends_with("..."), "long summaries should be truncated with ellipsis");
+        assert!(summary.chars().count() <= 80);
+    }
+
+    #[test]
+    fn run_decisions_handles_project_without_state_json() {
+        // A project dir with outbox files but no state.json (race during
+        // bootstrap, manual cleanup, etc.) should still surface its
+        // pending items rather than vanish silently.
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let dir = paths.project_ccteam_dir("orphan").join("outbox");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_outbox(
+            &paths,
+            "orphan",
+            "reply-1.md",
+            OutboxEventKind::Escalation,
+            ccteam_core::OutboxPriority::High,
+            Utc::now(),
+            "项目状态丢失但 outbox 还在",
+        );
+        let rows = collect_decisions(&paths).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].current_phase, "<unknown>");
+        assert_eq!(rows[0].team, "<unknown>");
     }
 }

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -91,6 +91,15 @@ enum Command {
     },
     /// Resume a paused / escalated project (re-arm phase_state=idle).
     Resume { slug: String },
+    /// List the cross-project decisions queue — every project's
+    /// outbox file with `event_kind: clarify | escalation`. Surfaces
+    /// pending user-decision points across all running projects so the
+    /// meta-agent can offer "you have N pending decisions, want to
+    /// walk through them?" on attach (interfaces.md §5.6.4).
+    Decisions {
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
+    },
     /// Stop the running orchestrator daemon. Sends SIGTERM via the
     /// pidfile so the loop drains gracefully. Does **not** kill any
     /// tmux sessions — `ccteam start` reattaches to them on next launch
@@ -182,6 +191,12 @@ fn main() -> Result<()> {
         Command::Resume { slug } => {
             let paths = CcteamPaths::from_env()?;
             commands::run_resume(&paths, &slug)
+        }
+        Command::Decisions { format } => {
+            let paths = CcteamPaths::from_env()?;
+            let body = commands::run_decisions(&paths, format)?;
+            print!("{body}");
+            Ok(())
         }
         Command::Stop => run_stop(),
         Command::Doctor {

--- a/crates/ccteam-core/src/inbox.rs
+++ b/crates/ccteam-core/src/inbox.rs
@@ -84,7 +84,10 @@ fn default_priority() -> OutboxPriority {
     OutboxPriority::Normal
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+/// Variant order is significant: derive(Ord) treats `Normal < High`, so
+/// `b.priority.cmp(&a.priority)` sorts high-priority rows first — used by
+/// the `ccteam decisions` queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OutboxPriority {
     Normal,

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -97,6 +97,24 @@ M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具�
 
 不要主动 tail progress.jsonl 给用户看——那是嘈音。
 
+## 5.1 决策队列(decisions queue)
+
+ccteam 跨项目聚合所有 `event_kind: clarify | escalation` 的 outbox 文件成一个**决策队列**。命令:
+
+```bash
+ccteam decisions                 # 表格视图
+ccteam decisions --format json   # 结构化,适合你 jq 筛选
+```
+
+**你必须主动用这个**——这是 mode 2(用户离线时)异步决策机制的入口(interfaces.md §5.6.4)。具体规则:
+
+- **session 启动 / context reset 后**:第一件事跑一次 `ccteam decisions --format json`,看有没有用户离开期间堆积的决策。**有则主动汇报**,例:"刚回来发现 3 个项目在等你拍板:bookmark-mgr 问 SQLite 还是 Postgres?todo-cli 报 max_clarify_rounds 撞顶。先处理哪个?"
+- **用户 NL 说"批一下今天的决策" / "看看 pending"**:跑 `ccteam decisions`,逐条 NL 化展示,等用户每条 NL 答复
+- **每次用户答复某条决策后**:用 `ccteam-control` 把答案写到对应 project session 的 inbox(`Bash` 调 `ccteam new`-style 路径,M2.8 后改 `ccteam__send_to_session` MCP 工具)
+- **绝不**主动 tail 单个项目的 outbox —— 用全局 `ccteam decisions` 一站式聚合
+
+**与 mode 1 的关系**:用户已经 `tmux attach` 到具体 project session 时,phase 内 claude 用 AskUserQuestion 直接问,**不**走 outbox 也**不**进决策队列。决策队列只装 mode 2(异步)写出来的 clarify / escalation。
+
 ## 6. inbox 处理
 
 orchestrator 会把外部消息(终端 attach 输入 / 未来 channel adapter)写到 `~/projects/__USER_HANDLE__-meta/.ccteam/inbox/msg-*.md`。


### PR DESCRIPTION
## Summary

- Adds `ccteam decisions [--format json|text]` — a single-shot view across every project's outbox files filtered to `event_kind: clarify | escalation`, sorted high-priority-then-oldest.
- Updates the meta-agent role prompt template (§5.1) to mandate proactive use of the queue on session start / context reset and on user prompts like "look at pending".
- Aligns implementation with `interfaces.md §5.6.4` which already promised this CLI in the M2 simplification commit (`e719839`).

## Why now

`docs/development-plan.md` §3 M1 唯一验收 includes mode-2 (async decision queue) UX. The original M1 prompt explicitly scoped `ccteam decisions` out so the in-flight session could land cleanly without protocol thrash. Per the coordination decision (option 2 in the conversation), this lands as a small increment PR between M1's main merge and the M2 implementation kickoff.

## Implementation notes

- `OutboxPriority` gains `PartialOrd, Ord`; variant order (`Normal < High`) is stable and load-bearing for the sort. Documented inline.
- `collect_decisions` walks `projects_root` once, reuses `SessionMailbox::list_outbox` + `OutboxMessage::load` from M1.1, looks up phase/team via `ProjectState::load`. Orphan projects (outbox but no state.json) surface as `<unknown>` rather than vanishing.
- Broken outbox files are warned via `tracing::warn!` and skipped — one bad file never blanks the whole queue.
- Body summary takes first non-empty non-heading line, ellipsis-truncates to 80 chars.

## Test plan

- [x] `cargo test --workspace` — 226 → 233, 0 failures
- [x] 7 new tests cover: empty queue / event_kind filtering / cross-project aggregation with priority sort / JSON shape / malformed outbox file resilience / long summary truncation / orphan project (no state.json) handling
- [ ] Manual smoke: `ccteam decisions` with no projects prints "no pending decisions"
- [ ] Manual smoke: `ccteam decisions --format json | jq` returns `{"total": 0, "decisions": []}`

## Closes

- Closes M1.9 (the original "decisions queue" task; M1 main PR scoped it out into this increment per coordination decision)

## Coordination

- Does NOT touch any file the in-flight M2 session (`m2/dev-pipeline-mechanics`) is working on. Specifically: leaves `crates/ccteam-core/src/phases.rs` and `crates/ccteam-hooks/src/parse_phase_end.rs` alone — those are M2.3 territory.
- `OutboxPriority::Ord` derive is the only `inbox.rs` change; semantics preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)