### PR TITLE
M2 dev pipeline mechanics: sub-skill + template @ + 3-field schema + ccteam-mcp; M2.2 escalated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "ccteam-hooks",
  "chrono",
  "clap",
+ "dirs",
  "serde_json",
  "tempfile",
  "tokio",

--- a/crates/ccteam-cli/Cargo.toml
+++ b/crates/ccteam-cli/Cargo.toml
@@ -15,6 +15,7 @@ ccteam-core.workspace = true
 ccteam-hooks.workspace = true
 clap.workspace = true
 chrono.workspace = true
+dirs.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -263,6 +263,8 @@ pub struct DoctorOptions {
     /// `Some("rob")` ⇒ creates `~/projects/rob-meta/` and triggers
     /// `install_skill` regardless of its standalone flag.
     pub install_meta_agent: Option<String>,
+    /// M2.5: register `mcpServers.ccteam` in `~/.claude.json`.
+    pub install_mcp: bool,
 }
 
 /// `ccteam doctor` dispatch. Returns a human-readable report so unit
@@ -271,7 +273,8 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     let any_mode = opts.install_recommended_agents
         || opts.tool_surface
         || opts.install_skill
-        || opts.install_meta_agent.is_some();
+        || opts.install_meta_agent.is_some()
+        || opts.install_mcp;
     if !any_mode {
         return Ok(String::from(
             "ccteam doctor: pass at least one mode flag.\n\
@@ -284,7 +287,9 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
              --install-skill [--force]\n      \
              write ~/.claude/skills/ccteam-control/SKILL.md (M1.8).\n  \
              --install-meta-agent <user-handle>\n      \
-             bootstrap a meta-agent project for the given user (M1.0). Implies --install-skill.\n",
+             bootstrap a meta-agent project for the given user (M1.0). Implies --install-skill.\n  \
+             --install-mcp\n      \
+             register `mcpServers.ccteam` in ~/.claude.json so daily-driver claude + meta-agent see the 9-tool MCP server (M2.5).\n",
         ));
     }
     let mut out = String::new();
@@ -303,6 +308,22 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     if let Some(handle) = &opts.install_meta_agent {
         out.push_str(&render_install_meta_agent_report(paths, handle)?);
     }
+    if opts.install_mcp {
+        out.push_str(&render_install_mcp_report()?);
+    }
+    Ok(out)
+}
+
+fn render_install_mcp_report() -> Result<String> {
+    let path = crate::mcp_serve::install_mcp()?;
+    let mut out = String::from("ccteam doctor --install-mcp\n\n");
+    out.push_str(&format!("  registered ccteam MCP server in {}\n", path.display()));
+    out.push_str("  tools surface : 9 (interfaces §12.2)\n");
+    out.push_str("  consumers     : daily-driver claude + meta-agent\n");
+    out.push('\n');
+    out.push_str(
+        "open a new claude session to pick up the change; existing sessions need /reload-mcp.\n",
+    );
     Ok(out)
 }
 
@@ -580,7 +601,7 @@ pub fn collect_projects(paths: &CcteamPaths) -> Result<Vec<ProjectSummary>> {
     Ok(out)
 }
 
-fn collect_recent_events(
+pub fn collect_recent_events(
     paths: &CcteamPaths,
     slug: &str,
     n: usize,

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -11,10 +11,11 @@ use serde_json::{json, Map, Value};
 
 use ccteam_core::{
     bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
-    link_recommended_agents, pick_unused_slug, user_claude_dir, write_global_phase_templates,
-    AgentLinkAction, AgentLinkReport, CcteamPaths, InstallSkillOptions, LinkOptions,
-    MetaBootstrapReport, PhaseState, PhaseTemplate, ProjectState, SkillInstallAction,
-    ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, PHASE_TEMPLATES,
+    link_recommended_agents, pick_unused_slug, user_claude_dir, write_global_helper_templates,
+    write_global_phase_templates, AgentLinkAction, AgentLinkReport, CcteamPaths,
+    InstallSkillOptions, LinkOptions, MetaBootstrapReport, PhaseState, PhaseTemplate,
+    ProjectState, SkillInstallAction, ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES,
+    PHASE_TEMPLATES,
 };
 use ccteam_core::tmux::TmuxSession;
 
@@ -41,6 +42,7 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
 
     for sub in [
         "phases",
+        "templates",
         "progress",
         "inbox",
         "control",
@@ -56,6 +58,12 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
 
     write_global_phase_templates(&paths.root, opts.force)
         .with_context(|| format!("unpack phase templates to {}", paths.phases_dir().display()))?;
+    write_global_helper_templates(&paths.root, opts.force).with_context(|| {
+        format!(
+            "unpack helper templates to {}",
+            paths.templates_dir().display()
+        )
+    })?;
 
     let bin = current_ccteam_bin().ok();
 
@@ -68,6 +76,11 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
         "✓ unpacked {} phase templates → {}\n",
         PHASE_TEMPLATES.len(),
         paths.phases_dir().display()
+    ));
+    out.push_str(&format!(
+        "✓ unpacked {} helper templates → {}\n",
+        HELPER_TEMPLATES.len(),
+        paths.templates_dir().display()
     ));
     out.push_str("\nhealth check:\n");
     match &claude {
@@ -956,7 +969,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         let report = run_init(&paths, InitOptions::default()).unwrap();
-        for sub in ["phases", "progress", "inbox", "control"] {
+        for sub in ["phases", "templates", "progress", "inbox", "control"] {
             assert!(
                 paths.root.join(sub).is_dir(),
                 "init must create {}",
@@ -965,7 +978,17 @@ mod tests {
         }
         assert!(paths.phases_dir().join("02-plan-eng.md").is_file());
         assert!(paths.phases_dir().join("09-ship.md").is_file());
+        // M2.4: helper templates land alongside phase templates.
+        assert!(paths
+            .templates_dir()
+            .join("review-with-user-loop.md")
+            .is_file());
+        assert!(paths
+            .templates_dir()
+            .join("kickoff-reverse-interview.md")
+            .is_file());
         assert!(report.contains("phase templates"));
+        assert!(report.contains("helper templates"));
         assert!(report.contains("next"));
     }
 

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -1,6 +1,7 @@
 //! `ccteam` binary entry point.
 
 mod commands;
+mod mcp_serve;
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -91,6 +92,11 @@ enum Command {
     },
     /// Resume a paused / escalated project (re-arm phase_state=idle).
     Resume { slug: String },
+    /// M2.5: run the ccteam MCP server (stdio JSON-RPC). Wired into
+    /// `~/.claude.json` `mcpServers.ccteam` by `ccteam doctor
+    /// --install-mcp` so daily-driver claude sessions and the meta
+    /// agent both see the 9-tool surface (interfaces §12).
+    McpServe,
     /// Stop the running orchestrator daemon. Sends SIGTERM via the
     /// pidfile so the loop drains gracefully. Does **not** kill any
     /// tmux sessions — `ccteam start` reattaches to them on next launch
@@ -127,6 +133,12 @@ enum Command {
         /// the value (e.g. `--install-meta-agent rob`).
         #[arg(long, value_name = "HANDLE")]
         install_meta_agent: Option<String>,
+        /// M2.5: register `mcpServers.ccteam` in `~/.claude.json` so
+        /// daily-driver claude + meta-agent both see the ccteam MCP
+        /// server (9 tools, interfaces §12). Idempotent — overwrites
+        /// any prior `ccteam` server entry but preserves other servers.
+        #[arg(long, default_value_t = false)]
+        install_mcp: bool,
     },
 }
 
@@ -183,6 +195,15 @@ fn main() -> Result<()> {
             let paths = CcteamPaths::from_env()?;
             commands::run_resume(&paths, &slug)
         }
+        Command::McpServe => {
+            init_tracing();
+            let paths = CcteamPaths::from_env()?;
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("build tokio runtime for mcp-serve")?;
+            runtime.block_on(mcp_serve::run_mcp_serve(paths))
+        }
         Command::Stop => run_stop(),
         Command::Doctor {
             install_recommended_agents,
@@ -191,6 +212,7 @@ fn main() -> Result<()> {
             tool_surface,
             install_skill,
             install_meta_agent,
+            install_mcp,
         } => run_doctor(commands::DoctorOptions {
             install_recommended_agents,
             dry_run,
@@ -198,6 +220,7 @@ fn main() -> Result<()> {
             tool_surface,
             install_skill,
             install_meta_agent,
+            install_mcp,
         }),
     }
 }

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -1,0 +1,895 @@
+//! M2.5: `ccteam mcp-serve` — stdio MCP server.
+//!
+//! Exposes the ccteam control surface as 9 MCP tools so the user's
+//! daily-driver Claude Code session (and the meta-agent session) can
+//! drive ccteam without shelling out to the CLI. Architecture and
+//! red lines:
+//!
+//! - **Hand-rolled JSON-RPC 2.0** over stdio (line-delimited messages).
+//!   Per the M2.5 brief, `rmcp` was the alternative; the in-process
+//!   protocol surface is small enough that adding a crate dep buys
+//!   little — `initialize` / `tools/list` / `tools/call` is the whole
+//!   spec we exercise.
+//! - **No LLM in-process** (Symphony anti-pattern, tech-design §3.1).
+//!   The MCP server is a thin protocol adapter; every tool routes to
+//!   an existing `commands.rs` function.
+//! - Two consumers: the user's daily-driver claude (`~/.claude.json`
+//!   `mcpServers` entry, written by `ccteam doctor --install-mcp`)
+//!   and the meta-agent session (project-local `.mcp.json` —
+//!   meta-agent prefers MCP, falls back to Bash).
+//!
+//! Wire format: each side sends one JSON object per line, terminated
+//! by `\n`. Notifications (no `id`) get no reply. Errors follow the
+//! JSON-RPC 2.0 error object shape (interfaces §12).
+
+use std::io::Write;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use ccteam_core::{
+    bootstrap_project, inbox_filename, pick_unused_slug, CcteamPaths, InboxFrontMatter,
+    InboxMessage, ProjectState, SessionMailbox,
+};
+
+use crate::commands::{
+    collect_projects, collect_recent_events, run_resume, run_show, OutputFormat,
+};
+
+/// Stable MCP protocol version this server speaks. Newer client versions
+/// downgrade gracefully because we never advertise capabilities we don't
+/// implement.
+const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
+
+/// Server identity advertised in `initialize`.
+const SERVER_NAME: &str = "ccteam";
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Run `ccteam mcp-serve`. Reads JSON-RPC requests one per line from
+/// stdin; writes responses one per line to stdout. Returns when stdin
+/// closes (clean shutdown when the parent disconnects).
+pub async fn run_mcp_serve(paths: CcteamPaths) -> Result<()> {
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin).lines();
+    let mut stdout = tokio::io::stdout();
+
+    while let Some(line) = reader
+        .next_line()
+        .await
+        .context("read stdin from MCP client")?
+    {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let req: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(err) => {
+                let err_obj = json_rpc_error(
+                    None,
+                    -32700,
+                    &format!("parse error: {err}"),
+                );
+                write_message(&mut stdout, &err_obj).await?;
+                continue;
+            }
+        };
+        let resp = handle_request(&paths, &req).await;
+        if let Some(response) = resp {
+            write_message(&mut stdout, &response).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Dispatch a single JSON-RPC message. Returns `Some(response)` for
+/// requests (which carry an `id`) and `None` for notifications.
+async fn handle_request(paths: &CcteamPaths, req: &Value) -> Option<Value> {
+    let id = req.get("id").cloned();
+    let method = req
+        .get("method")
+        .and_then(|m| m.as_str())
+        .unwrap_or("");
+    let params = req.get("params").cloned().unwrap_or(json!({}));
+
+    // Notifications (no `id`) never get a reply.
+    let is_notification = id.is_none();
+
+    let result = match method {
+        "initialize" => Ok(initialize_response()),
+        "notifications/initialized" => return None,
+        "tools/list" => Ok(tools_list_response()),
+        "tools/call" => match call_tool(paths, &params).await {
+            Ok(content) => Ok(json!({ "content": content, "isError": false })),
+            Err(err) => {
+                // tools/call errors return as a result with isError=true,
+                // not as JSON-RPC error envelopes — that's the MCP
+                // convention so the client can surface to the LLM.
+                Ok(json!({
+                    "content": [{ "type": "text", "text": format!("{err:#}") }],
+                    "isError": true,
+                }))
+            }
+        },
+        other => Err(format!("method not found: {other}")),
+    };
+
+    if is_notification {
+        return None;
+    }
+    Some(match result {
+        Ok(value) => json!({ "jsonrpc": "2.0", "id": id, "result": value }),
+        Err(msg) => json_rpc_error(id, -32601, &msg),
+    })
+}
+
+fn initialize_response() -> Value {
+    json!({
+        "protocolVersion": MCP_PROTOCOL_VERSION,
+        "capabilities": {
+            "tools": {}
+        },
+        "serverInfo": {
+            "name": SERVER_NAME,
+            "version": SERVER_VERSION,
+        },
+    })
+}
+
+fn tools_list_response() -> Value {
+    json!({ "tools": tool_definitions() })
+}
+
+/// Single source of truth for the 9-tool surface. Schemas mirror
+/// interfaces.md §12.2.
+fn tool_definitions() -> Vec<Value> {
+    vec![
+        // Read-only inspection.
+        json!({
+            "name": "ccteam__ls",
+            "description": "List every ccteam project under ~/projects/ with its current phase, state, cost, and stall level. Equivalent to `ccteam ls --format json`.",
+            "inputSchema": object_schema(&[]),
+        }),
+        json!({
+            "name": "ccteam__show",
+            "description": "Return the full state.json + recent progress events + artifact list for a single project. Equivalent to `ccteam show <slug> --format json`.",
+            "inputSchema": object_schema(&[("slug", "string", "Project slug, as listed by ccteam__ls.")]),
+        }),
+        json!({
+            "name": "ccteam__peek",
+            "description": "Capture the current tmux pane contents for a project session (one-shot, no attach). Useful when you want to see what claude is showing without interrupting.",
+            "inputSchema": object_schema(&[("slug", "string", "Project slug.")]),
+        }),
+        json!({
+            "name": "ccteam__progress",
+            "description": "Return the last N progress.jsonl events for a project. Default N=50.",
+            "inputSchema": json!({
+                "type": "object",
+                "properties": {
+                    "slug": { "type": "string", "description": "Project slug." },
+                    "last_n": { "type": "integer", "description": "How many events to return (default 50)." }
+                },
+                "required": ["slug"],
+            }),
+        }),
+        // Lifecycle.
+        json!({
+            "name": "ccteam__new",
+            "description": "Create a new ccteam project from a free-text request. Returns the assigned slug and project directory. Defaults team=dev (M3 will accept other teams).",
+            "inputSchema": json!({
+                "type": "object",
+                "properties": {
+                    "prompt": { "type": "string", "description": "Free-text user request." },
+                    "team": { "type": "string", "description": "Team name (default 'dev')." }
+                },
+                "required": ["prompt"],
+            }),
+        }),
+        json!({
+            "name": "ccteam__pause",
+            "description": "Pause auto-dispatch for one project (sets user_pause_pending). Does not kill the tmux session.",
+            "inputSchema": object_schema(&[("slug", "string", "Project slug.")]),
+        }),
+        json!({
+            "name": "ccteam__resume",
+            "description": "Resume an escalated / paused project (clears user_pause_pending and archives any escalation.md so the daemon's next tick re-dispatches the current phase).",
+            "inputSchema": object_schema(&[("slug", "string", "Project slug.")]),
+        }),
+        // M2.5 new pair.
+        json!({
+            "name": "ccteam__send_to_session",
+            "description": "Atomically write a markdown message into a session's .ccteam/inbox/. The orchestrator's next inotify wake delivers it via tmux send-keys. Use for free-form NL into project or meta-agent sessions.",
+            "inputSchema": json!({
+                "type": "object",
+                "properties": {
+                    "session": { "type": "string", "description": "Project slug OR meta session slug (e.g. 'rob-meta')." },
+                    "content_type": { "type": "string", "description": "Content type: text|markdown (default 'text')." },
+                    "body": { "type": "string", "description": "Message body (NL/markdown)." }
+                },
+                "required": ["session", "body"],
+            }),
+        }),
+        json!({
+            "name": "ccteam__inject_decision",
+            "description": "Inject a structured ESCALATE-style decision into a project session's inbox. Used when the meta-agent has resolved a clarify/escalation and wants the project session to act on the resolution.",
+            "inputSchema": json!({
+                "type": "object",
+                "properties": {
+                    "slug": { "type": "string", "description": "Project slug." },
+                    "escalate_kind": {
+                        "type": "string",
+                        "description": "One of: revert_to_phase | need_user_input | abort | insufficient_clarification | phase_done_pending. See interfaces §4.1.1."
+                    },
+                    "args": { "type": "object", "description": "Per-kind args. revert_to_phase needs target_phase; all kinds accept reason." }
+                },
+                "required": ["slug", "escalate_kind"],
+            }),
+        }),
+    ]
+}
+
+fn object_schema(props: &[(&str, &str, &str)]) -> Value {
+    let mut p = serde_json::Map::new();
+    let mut required = Vec::new();
+    for (name, ty, desc) in props {
+        p.insert(
+            (*name).into(),
+            json!({ "type": ty, "description": desc }),
+        );
+        required.push(*name);
+    }
+    json!({
+        "type": "object",
+        "properties": Value::Object(p),
+        "required": required,
+    })
+}
+
+/// Dispatch `tools/call` to the right tool implementation, returning
+/// the MCP `content` array.
+async fn call_tool(paths: &CcteamPaths, params: &Value) -> Result<Vec<Value>> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("tools/call missing `name`"))?;
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or(json!({}));
+    match name {
+        "ccteam__ls" => Ok(text_content(tool_ls(paths)?)),
+        "ccteam__show" => Ok(text_content(tool_show(paths, &args)?)),
+        "ccteam__peek" => Ok(text_content(tool_peek(&args)?)),
+        "ccteam__progress" => Ok(text_content(tool_progress(paths, &args)?)),
+        "ccteam__new" => Ok(text_content(tool_new(paths, &args)?)),
+        "ccteam__pause" => Ok(text_content(tool_pause(paths, &args)?)),
+        "ccteam__resume" => Ok(text_content(tool_resume(paths, &args)?)),
+        "ccteam__send_to_session" => Ok(text_content(tool_send_to_session(paths, &args)?)),
+        "ccteam__inject_decision" => Ok(text_content(tool_inject_decision(paths, &args)?)),
+        other => Err(anyhow!("unknown tool: {other}")),
+    }
+}
+
+fn text_content(body: String) -> Vec<Value> {
+    vec![json!({ "type": "text", "text": body })]
+}
+
+// -------------- Tool implementations --------------
+
+fn tool_ls(paths: &CcteamPaths) -> Result<String> {
+    let projects = collect_projects(paths)?;
+    let active_count = projects
+        .iter()
+        .filter(|p| matches!(p.state.phase_state, ccteam_core::PhaseState::InFlight))
+        .count();
+    let arr: Vec<Value> = projects
+        .iter()
+        .map(|p| {
+            json!({
+                "slug": p.state.slug,
+                "team": p.state.team,
+                "current_phase": p.state.current_phase,
+                "phase_state": match p.state.phase_state {
+                    ccteam_core::PhaseState::InFlight => "in_flight",
+                    ccteam_core::PhaseState::Idle => "idle",
+                    ccteam_core::PhaseState::FixLocked => "fix_locked",
+                },
+                "cost_used_usd": p.state.cost_used_usd,
+                "tmux_session": p.state.tmux_session,
+                "age_seconds": p.age_seconds,
+            })
+        })
+        .collect();
+    let body = json!({
+        "projects": arr,
+        "orchestrator": {
+            "active_count": active_count,
+            "max_concurrent": ccteam_core::MAX_CONCURRENT_PROJECTS,
+        },
+    });
+    Ok(serde_json::to_string_pretty(&body)?)
+}
+
+fn tool_show(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let slug = arg_string(args, "slug")?;
+    run_show(paths, &slug, OutputFormat::Json)
+}
+
+fn tool_peek(args: &Value) -> Result<String> {
+    let slug = arg_string(args, "slug")?;
+    let session = ccteam_core::session_name_for_slug(&slug);
+    let output = std::process::Command::new("tmux")
+        .args(["capture-pane", "-p", "-t", &session])
+        .output()
+        .context("spawn tmux capture-pane")?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "tmux capture-pane failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn tool_progress(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let slug = arg_string(args, "slug")?;
+    let last_n = args
+        .get("last_n")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(50) as usize;
+    let events = collect_recent_events(paths, &slug, last_n)?;
+    Ok(serde_json::to_string_pretty(&json!({ "events": events }))?)
+}
+
+fn tool_new(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let prompt = arg_string(args, "prompt")?;
+    let team = args
+        .get("team")
+        .and_then(|v| v.as_str())
+        .unwrap_or("dev")
+        .to_string();
+    if prompt.trim().is_empty() {
+        return Err(anyhow!("prompt must be non-empty"));
+    }
+    let slug = pick_unused_slug(paths, &prompt)?;
+    let project_dir = bootstrap_project(paths, &slug, &prompt, &team)?;
+    Ok(serde_json::to_string_pretty(&json!({
+        "slug": slug,
+        "workspace": project_dir.to_string_lossy(),
+    }))?)
+}
+
+fn tool_pause(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let slug = arg_string(args, "slug")?;
+    let state_path = paths.project_state(&slug);
+    let mut state = ProjectState::load(&state_path)
+        .with_context(|| format!("load state for {slug}"))?;
+    state.user_pause_pending = true;
+    state.last_user_interaction_at = Utc::now();
+    state.save(&state_path)?;
+    Ok(serde_json::to_string_pretty(&json!({
+        "ok": true,
+        "slug": slug,
+        "user_pause_pending": true,
+    }))?)
+}
+
+fn tool_resume(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let slug = arg_string(args, "slug")?;
+    run_resume(paths, &slug)?;
+    Ok(serde_json::to_string_pretty(&json!({
+        "ok": true,
+        "slug": slug,
+    }))?)
+}
+
+fn tool_send_to_session(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let session = arg_string(args, "session")?;
+    let body = arg_string(args, "body")?;
+    let content_type = args
+        .get("content_type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("text")
+        .to_string();
+    let project_dir = paths.project_dir(&session);
+    if !project_dir.exists() {
+        return Err(anyhow!(
+            "no project / session named `{}` (looked under {})",
+            session,
+            project_dir.display(),
+        ));
+    }
+    let ccteam_dir = paths.project_ccteam_dir(&session);
+    let mailbox = SessionMailbox::for_ccteam_dir(&ccteam_dir);
+    mailbox.ensure_dirs()?;
+    let now = Utc::now();
+    let filename = inbox_filename(now, next_inbox_seq(&mailbox)?);
+    let inbox_path = mailbox.inbox.join(&filename);
+    let msg = InboxMessage {
+        front: InboxFrontMatter {
+            schema_version: ccteam_core::LATEST_SCHEMA_VERSION,
+            source: "ccteam-mcp".into(),
+            source_chat_id: None,
+            source_msg_id: None,
+            source_user: "mcp".into(),
+            created_at: now,
+            ingested_at: now,
+            content_type,
+            attachments: Vec::new(),
+        },
+        body: format!("{body}\n"),
+    };
+    msg.save(&inbox_path)?;
+    Ok(serde_json::to_string_pretty(&json!({
+        "ok": true,
+        "session": session,
+        "inbox_file": filename,
+    }))?)
+}
+
+fn tool_inject_decision(paths: &CcteamPaths, args: &Value) -> Result<String> {
+    let slug = arg_string(args, "slug")?;
+    let kind = arg_string(args, "escalate_kind")?;
+    let kind_norm = kind.to_lowercase();
+    let inner_args = args.get("args").cloned().unwrap_or(json!({}));
+    let reason = inner_args
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(no reason provided)");
+    let target_phase = inner_args
+        .get("target_phase")
+        .and_then(|v| v.as_str());
+
+    // Build a structured NL message that the in-session claude can
+    // recognize as a meta-agent decision. The body re-uses the
+    // ESCALATE grammar shape (interfaces §4.1.1) so claude can map
+    // the decision back to its own routing logic.
+    let body = match kind_norm.as_str() {
+        "revert_to_phase" => {
+            let phase = target_phase.ok_or_else(|| {
+                anyhow!("revert_to_phase requires args.target_phase")
+            })?;
+            format!(
+                "**META-AGENT DECISION**: revert to phase `{phase}`.\n\n原因:{reason}\n\n请回到 `{phase}` 阶段继续。",
+            )
+        }
+        "need_user_input" => format!(
+            "**META-AGENT DECISION**: clarification provided.\n\n{reason}\n\n请基于上述信息继续当前 phase。",
+        ),
+        "abort" => format!(
+            "**META-AGENT DECISION**: abort this project.\n\n原因:{reason}\n\n请停止后续工作,本次结束输出 `ESCALATE: ABORT — {reason}`。",
+        ),
+        "insufficient_clarification" => format!(
+            "**META-AGENT DECISION**: accept best-effort artifact.\n\n{reason}\n\n请基于现有产物继续到下一 phase,无需追加 CLARIFY 轮次。",
+        ),
+        "phase_done_pending" => format!(
+            "**META-AGENT DECISION**: deferred decisions resolved.\n\n{reason}\n\n请将之前 PHASE_DONE_PENDING 的子任务标记完成,推进到下一 phase。",
+        ),
+        other => return Err(anyhow!(
+            "unknown escalate_kind `{other}`; valid: revert_to_phase | need_user_input | abort | insufficient_clarification | phase_done_pending",
+        )),
+    };
+
+    // Reuse send_to_session's inbox-write path so the orchestrator's
+    // existing inotify+send-keys delivery picks it up.
+    tool_send_to_session(
+        paths,
+        &json!({
+            "session": slug,
+            "content_type": "markdown",
+            "body": body,
+        }),
+    )
+}
+
+// -------------- Helpers --------------
+
+fn arg_string(args: &Value, name: &str) -> Result<String> {
+    args.get(name)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("missing required argument `{name}`"))
+}
+
+/// Compute the next 1-based sequence number for inbox writes within
+/// the same wall-clock second. Scans existing files in the inbox dir
+/// and picks `max + 1`. Tolerates a corrupted dir by defaulting to 1.
+fn next_inbox_seq(mailbox: &SessionMailbox) -> Result<u32> {
+    let entries = mailbox.list_inbox()?;
+    let mut max = 0u32;
+    for path in entries {
+        if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+            // Filename: msg-<ts>-<NNN>.md
+            if let Some(seq) = name
+                .strip_prefix("msg-")
+                .and_then(|rest| rest.rsplit_once('-'))
+                .map(|(_, last)| last.trim_end_matches(".md"))
+                .and_then(|n| n.parse::<u32>().ok())
+            {
+                if seq > max {
+                    max = seq;
+                }
+            }
+        }
+    }
+    Ok(max + 1)
+}
+
+fn json_rpc_error(id: Option<Value>, code: i32, message: &str) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    })
+}
+
+async fn write_message(
+    stdout: &mut tokio::io::Stdout,
+    msg: &Value,
+) -> Result<()> {
+    let mut line = serde_json::to_string(msg).context("serialize MCP message")?;
+    line.push('\n');
+    stdout
+        .write_all(line.as_bytes())
+        .await
+        .context("write MCP message to stdout")?;
+    stdout.flush().await.context("flush MCP stdout")?;
+    Ok(())
+}
+
+/// `ccteam doctor --install-mcp`: register the ccteam MCP server in
+/// `~/.claude.json` so any new claude session can call ccteam tools
+/// without per-project setup.
+///
+/// Strategy: read `~/.claude.json`, ensure `mcpServers.ccteam` points
+/// at the running binary's absolute path, write back atomically. The
+/// trust-marking path in `projects::pre_trust_project` follows the same
+/// pattern, so the operator never sees a "Trust this folder?" prompt
+/// for the ccteam MCP server itself.
+pub fn install_mcp_into(claude_json: &std::path::Path, ccteam_bin: &std::path::Path) -> Result<()> {
+    let bin = ccteam_bin
+        .to_str()
+        .ok_or_else(|| anyhow!("ccteam binary path not valid UTF-8"))?;
+    let mut root = if claude_json.exists() {
+        let bytes = std::fs::read(claude_json)
+            .with_context(|| format!("read {}", claude_json.display()))?;
+        if bytes.is_empty() {
+            serde_json::Map::new()
+        } else {
+            match serde_json::from_slice::<Value>(&bytes) {
+                Ok(Value::Object(m)) => m,
+                _ => serde_json::Map::new(),
+            }
+        }
+    } else {
+        serde_json::Map::new()
+    };
+    let servers = root
+        .entry("mcpServers")
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let map = match servers {
+        Value::Object(m) => m,
+        _ => {
+            *servers = Value::Object(serde_json::Map::new());
+            servers.as_object_mut().unwrap()
+        }
+    };
+    map.insert(
+        "ccteam".into(),
+        json!({
+            "command": bin,
+            "args": ["mcp-serve"],
+            "env": {},
+        }),
+    );
+
+    let body = serde_json::to_string_pretty(&Value::Object(root))?;
+    if let Some(parent) = claude_json.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let mut tmp_os = claude_json.as_os_str().to_owned();
+    tmp_os.push(".ccteam-mcp.tmp");
+    let tmp = std::path::PathBuf::from(tmp_os);
+    {
+        let mut f = std::fs::File::create(&tmp)
+            .with_context(|| format!("create {}", tmp.display()))?;
+        f.write_all(body.as_bytes())?;
+    }
+    std::fs::rename(&tmp, claude_json)
+        .with_context(|| format!("rename {} → {}", tmp.display(), claude_json.display()))?;
+    Ok(())
+}
+
+/// Production path: locate `~/.claude.json` and the running binary,
+/// then call `install_mcp_into`.
+pub fn install_mcp() -> Result<std::path::PathBuf> {
+    let claude_json = dirs::home_dir()
+        .ok_or_else(|| anyhow!("could not resolve home directory"))?
+        .join(".claude.json");
+    let bin = ccteam_core::current_ccteam_bin()?;
+    install_mcp_into(&claude_json, &bin)?;
+    Ok(claude_json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_definitions_count_matches_m25_spec() {
+        // M2.5 brief: 9 tools exactly.
+        assert_eq!(tool_definitions().len(), 9);
+    }
+
+    #[test]
+    fn tool_definitions_have_unique_names_and_object_schemas() {
+        let tools = tool_definitions();
+        let mut names: Vec<&str> = tools
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), 9, "tool names must be unique");
+        for tool in &tools {
+            assert!(tool["name"].as_str().unwrap().starts_with("ccteam__"));
+            assert_eq!(tool["inputSchema"]["type"], "object");
+        }
+    }
+
+    #[test]
+    fn install_mcp_into_writes_command_args_env_for_ccteam_server() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude_json = tmp.path().join(".claude.json");
+        let ccteam_bin = std::path::PathBuf::from("/usr/local/bin/ccteam");
+        install_mcp_into(&claude_json, &ccteam_bin).unwrap();
+        let body = std::fs::read_to_string(&claude_json).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/ccteam");
+        assert_eq!(v["mcpServers"]["ccteam"]["args"][0], "mcp-serve");
+    }
+
+    #[test]
+    fn install_mcp_into_preserves_other_top_level_keys() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude_json = tmp.path().join(".claude.json");
+        std::fs::write(
+            &claude_json,
+            r#"{"userID": "rob", "mcpServers": {"playwright": {"command": "npx"}}}"#,
+        )
+        .unwrap();
+        install_mcp_into(&claude_json, &std::path::PathBuf::from("/x/ccteam")).unwrap();
+        let v: Value = serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
+        assert_eq!(v["userID"], "rob");
+        assert_eq!(v["mcpServers"]["playwright"]["command"], "npx");
+        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/x/ccteam");
+    }
+
+    #[test]
+    fn next_inbox_seq_starts_at_one_for_empty_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
+        mb.ensure_dirs().unwrap();
+        assert_eq!(next_inbox_seq(&mb).unwrap(), 1);
+    }
+
+    #[test]
+    fn next_inbox_seq_is_one_more_than_max_existing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
+        mb.ensure_dirs().unwrap();
+        // Stage three real msg files so list_inbox sees them.
+        for seq in [1u32, 2, 5] {
+            let name = inbox_filename(Utc::now(), seq);
+            let path = mb.inbox.join(&name);
+            std::fs::write(
+                &path,
+                concat!(
+                    "---\nschema_version: 1\nsource: cli\nsource_user: rob\n",
+                    "created_at: 2026-05-06T10:30:00Z\n",
+                    "ingested_at: 2026-05-06T10:30:00Z\n",
+                    "content_type: text\n---\n\nx\n",
+                ),
+            )
+            .unwrap();
+            // tweak time so each filename differs even for fast tests
+            let _ = seq;
+        }
+        let next = next_inbox_seq(&mb).unwrap();
+        assert!(next >= 6, "next must be > existing max 5, got {next}");
+    }
+
+    #[test]
+    fn json_rpc_error_includes_id_and_envelope() {
+        let e = json_rpc_error(Some(json!(7)), -32601, "method not found: foo");
+        assert_eq!(e["jsonrpc"], "2.0");
+        assert_eq!(e["id"], 7);
+        assert_eq!(e["error"]["code"], -32601);
+        assert!(e["error"]["message"].as_str().unwrap().contains("foo"));
+    }
+
+    fn ensure_isolation() {
+        ccteam_core::disable_tool_surface_bootstrap_for_tests();
+    }
+
+    #[tokio::test]
+    async fn handle_initialize_returns_tools_capability() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 1);
+        assert_eq!(resp["result"]["protocolVersion"], MCP_PROTOCOL_VERSION);
+        assert!(resp["result"]["capabilities"]["tools"].is_object());
+        assert_eq!(resp["result"]["serverInfo"]["name"], SERVER_NAME);
+    }
+
+    #[tokio::test]
+    async fn handle_tools_list_returns_nine_tools() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 9);
+    }
+
+    #[tokio::test]
+    async fn handle_notifications_initialized_returns_no_response() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        });
+        // Notifications carry no `id`, must not produce a response.
+        assert!(handle_request(&paths, &req).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn handle_tools_call_ls_returns_empty_projects_array_for_fresh_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "ccteam__ls", "arguments": {} }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        let content = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(content).unwrap();
+        assert_eq!(parsed["projects"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn handle_tools_call_unknown_tool_returns_iserror_true() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": { "name": "ccteam__no_such_tool", "arguments": {} }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["result"]["isError"], true);
+    }
+
+    #[tokio::test]
+    async fn handle_tools_call_send_to_session_writes_inbox_file() {
+        ensure_isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "ccteam__send_to_session",
+                "arguments": { "session": "demo", "body": "hello from MCP" }
+            }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["result"]["isError"], false);
+        let inbox = paths.project_ccteam_dir("demo").join("inbox");
+        let entries: Vec<_> = std::fs::read_dir(&inbox).unwrap().collect();
+        assert_eq!(entries.len(), 1, "send_to_session must write exactly one inbox file");
+    }
+
+    #[tokio::test]
+    async fn handle_tools_call_inject_decision_writes_revert_payload() {
+        ensure_isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "ccteam__inject_decision",
+                "arguments": {
+                    "slug": "demo",
+                    "escalate_kind": "revert_to_phase",
+                    "args": { "target_phase": "plan-eng", "reason": "选型有问题" }
+                }
+            }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["result"]["isError"], false);
+        let inbox = paths.project_ccteam_dir("demo").join("inbox");
+        let entries: Vec<_> = std::fs::read_dir(&inbox).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+        let path = entries[0].as_ref().unwrap().path();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("revert to phase `plan-eng`"));
+        assert!(body.contains("选型有问题"));
+    }
+
+    #[tokio::test]
+    async fn handle_tools_call_inject_decision_rejects_unknown_kind() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "ccteam__inject_decision",
+                "arguments": { "slug": "demo", "escalate_kind": "fly_to_mars" }
+            }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["result"]["isError"], true);
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("fly_to_mars"));
+    }
+}
+
+// silence unused import in some test configurations
+#[cfg(not(test))]
+const _: fn() = || {};

--- a/crates/ccteam-cli/tests/mcp_e2e_test.rs
+++ b/crates/ccteam-cli/tests/mcp_e2e_test.rs
@@ -1,0 +1,168 @@
+//! M2.5 end-to-end: spawn `ccteam mcp-serve` as a subprocess, drive it
+//! via stdin/stdout JSON-RPC, and confirm the protocol shape.
+//!
+//! Confirms the wire contract that interfaces.md §12 promises:
+//! - `initialize` returns `protocolVersion` + `tools` capability;
+//! - `tools/list` enumerates exactly 9 tools, all `ccteam__*`;
+//! - `tools/call ccteam__ls` returns a JSON-encoded projects list as
+//!   the first content[].text.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+/// Spawn `ccteam mcp-serve` with `CCTEAM_HOME` and `CCTEAM_PROJECTS_ROOT`
+/// pointed at a tempdir so the test doesn't depend on the developer's
+/// global state.
+struct McpServer {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl McpServer {
+    fn spawn(home: &std::path::Path, projects: &std::path::Path) -> Self {
+        let bin = env!("CARGO_BIN_EXE_ccteam");
+        let mut child = Command::new(bin)
+            .arg("mcp-serve")
+            .env("CCTEAM_HOME", home)
+            .env("CCTEAM_PROJECTS_ROOT", projects)
+            .env("CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn ccteam mcp-serve");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let mut line = serde_json::to_string(msg).unwrap();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn recv(&mut self) -> Value {
+        let mut line = String::new();
+        self.stdout.read_line(&mut line).expect("read stdout");
+        serde_json::from_str(line.trim()).expect("parse JSON-RPC response")
+    }
+
+    fn shutdown(mut self) {
+        // Closing stdin makes the server exit cleanly.
+        drop(self.stdin);
+        // Give the child a moment to drain.
+        let _ = self.child.wait_timeout_or_kill(Duration::from_secs(2));
+    }
+}
+
+trait WaitTimeoutOrKill {
+    fn wait_timeout_or_kill(&mut self, timeout: Duration) -> Option<std::process::ExitStatus>;
+}
+
+impl WaitTimeoutOrKill for std::process::Child {
+    fn wait_timeout_or_kill(&mut self, timeout: Duration) -> Option<std::process::ExitStatus> {
+        // Crude poll loop — fine for tests.
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout {
+            if let Ok(Some(status)) = self.try_wait() {
+                return Some(status);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = self.kill();
+        self.wait().ok()
+    }
+}
+
+#[test]
+fn mcp_serve_initialize_returns_protocol_version_and_tools_cap() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&projects).unwrap();
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    srv.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {}
+    }));
+    let resp = srv.recv();
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 1);
+    assert_eq!(resp["result"]["protocolVersion"], "2024-11-05");
+    assert!(resp["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(resp["result"]["serverInfo"]["name"], "ccteam");
+    srv.shutdown();
+}
+
+#[test]
+fn mcp_serve_tools_list_returns_nine_ccteam_tools() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&projects).unwrap();
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    srv.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    }));
+    let resp = srv.recv();
+    let tools = resp["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 9, "M2.5 brief = exactly 9 tools");
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    for required in [
+        "ccteam__ls",
+        "ccteam__show",
+        "ccteam__new",
+        "ccteam__peek",
+        "ccteam__progress",
+        "ccteam__pause",
+        "ccteam__resume",
+        "ccteam__send_to_session",
+        "ccteam__inject_decision",
+    ] {
+        assert!(names.contains(&required), "missing tool: {required}");
+    }
+    srv.shutdown();
+}
+
+#[test]
+fn mcp_serve_tools_call_ls_returns_empty_projects_for_fresh_root() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&projects).unwrap();
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    srv.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": { "name": "ccteam__ls", "arguments": {} }
+    }));
+    let resp = srv.recv();
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    let parsed: Value = serde_json::from_str(text).unwrap();
+    assert_eq!(parsed["projects"].as_array().unwrap().len(), 0);
+    assert_eq!(resp["result"]["isError"], false);
+    srv.shutdown();
+}

--- a/crates/ccteam-core/src/dag.rs
+++ b/crates/ccteam-core/src/dag.rs
@@ -159,6 +159,9 @@ mod tests {
             completion_signal: String::new(),
             next_on_done: next_on_done.map(String::from),
             next_on_escalate: None,
+            decision_mode: crate::phases::DecisionMode::default(),
+            max_clarify_rounds: 3,
+            golden_rules: Vec::new(),
         }
     }
 

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -60,8 +60,9 @@ pub use state::{Parallelism, PhaseHistoryEntry, PhaseState, ProjectState};
 pub use team::{RetroFieldKind, RetroFieldSpec, TeamSpec};
 pub use templates::{
     current_ccteam_bin, project_phase_filename, render_project_settings,
-    write_global_phase_templates, write_project_phase_templates, write_project_settings,
-    SettingsEnv, PHASE_TEMPLATES, PROJECT_SETTINGS_JSON,
+    write_global_helper_templates, write_global_phase_templates,
+    write_project_phase_templates, write_project_settings, SettingsEnv, HELPER_TEMPLATES,
+    PHASE_TEMPLATES, PROJECT_SETTINGS_JSON,
 };
 pub use tmux::{pid_is_alive, session_name_for_slug, tmux_available, TmuxSession};
 pub use tool_surface::{

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod progress;
 pub mod projects;
 pub mod stall;
 pub mod state;
+pub mod subskill;
 pub mod team;
 pub mod templates;
 pub mod tmux;
@@ -54,7 +55,12 @@ pub use stall::{
 };
 pub use paths::{slug_from_project_dir, CcteamPaths};
 pub use phases::{
-    AgentTeamRole, PhaseHooks, PhaseTemplate, SubSkillSpec, SubSkillTrigger,
+    AgentTeamRole, DecisionMode, GoldenRule, GoldenRuleKind, PhaseHooks, PhaseTemplate,
+    SubSkillSpec, SubSkillTrigger,
+};
+pub use subskill::{
+    resolve_skill_path, run_sub_skills_for_phase, ClaudePRunner, SubSkillOutcome, SubSkillRunCtx,
+    SubSkillRunner,
 };
 pub use state::{Parallelism, PhaseHistoryEntry, PhaseState, ProjectState};
 pub use team::{RetroFieldKind, RetroFieldSpec, TeamSpec};
@@ -67,9 +73,11 @@ pub use templates::{
 pub use tmux::{pid_is_alive, session_name_for_slug, tmux_available, TmuxSession};
 pub use tool_surface::{
     disable_tool_surface_bootstrap_for_tests, ensure_skills_placeholders,
-    link_recommended_agents, link_recommended_agents_into, missing_tools, user_claude_dir,
-    AgentLinkAction, AgentLinkReport, LinkOptions, MissingTool, RecommendedAgent,
-    ToolSurfaceSnapshot, ToolsRequired, BUILTIN_SUBAGENTS, RECOMMENDED_AGENTS,
+    link_recommended_agents, link_recommended_agents_for_phases,
+    link_recommended_agents_for_phases_into, link_recommended_agents_into, missing_tools,
+    user_claude_dir, AgentLinkAction, AgentLinkReport, LinkOptions, MissingTool,
+    RecommendedAgent, ToolSurfaceSnapshot, ToolsRequired, BUILTIN_SUBAGENTS,
+    RECOMMENDED_AGENTS,
 };
 
 /// Crate version, identical to the workspace package version.

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -26,10 +26,11 @@ use crate::fix_loop::{self, FixLoopState};
 use crate::inbox::{InboxMessage, SessionMailbox};
 use crate::meta_agent::META_TEAM_NAME;
 use crate::paths::CcteamPaths;
-use crate::phases::PhaseTemplate;
+use crate::phases::{PhaseTemplate, SubSkillTrigger};
 use crate::progress;
 use crate::stall::{self, StallLevel, StallThresholds};
 use crate::state::{PhaseHistoryEntry, PhaseState, ProjectState};
+use crate::subskill::{self, ClaudePRunner, SubSkillRunner};
 use crate::tmux::TmuxSession;
 use crate::tool_surface::{user_claude_dir, ToolSurfaceSnapshot};
 
@@ -157,6 +158,12 @@ pub struct OrchestratorConfig {
     /// linked in, and the user wants the orchestrator to come up
     /// anyway so they can run `ccteam doctor --install-recommended-agents`.
     pub skip_tool_check: bool,
+    /// argv for the M2.1 sub-skill runner. Default mirrors the
+    /// production `claude -p ...` shape from `ClaudePRunner::default`;
+    /// tests can override with a shell stub that echoes stdin to
+    /// stdout, so the orchestrator's sub-skill plumbing is exercised
+    /// without spawning a real claude.
+    pub subskill_argv: Option<Vec<String>>,
 }
 
 impl Default for OrchestratorConfig {
@@ -167,6 +174,7 @@ impl Default for OrchestratorConfig {
             ready_timeout: Duration::from_secs(60),
             post_ready_warmup: Duration::from_secs(3),
             skip_tool_check: false,
+            subskill_argv: None,
         }
     }
 }
@@ -249,7 +257,9 @@ impl Orchestrator {
         let last = progress::last_event(&progress_path)?;
         let idle = progress::is_idle(last.as_ref());
 
-        let prompt = progress::build_phase_prompt(phase);
+        let attachments = self.attachments_for_next_phase(slug, state);
+        let attachment_refs: Vec<&str> = attachments.iter().map(String::as_str).collect();
+        let prompt = progress::build_phase_prompt_with_attachments(phase, &attachment_refs);
         let message = progress::idle_aware_message(&prompt, idle);
 
         let session = TmuxSession::from_name(state.tmux_session.clone());
@@ -262,9 +272,77 @@ impl Orchestrator {
             "event": "phase_inject",
             "phase": phase,
             "idle": idle,
+            "attachments": attachments,
         });
         progress::append_event(&progress_path, &event)?;
         Ok(())
+    }
+
+    /// Collect `output_to` paths from the previous phase's `phase_done`
+    /// sub-skills that exist on disk. The orchestrator passes these
+    /// to `build_phase_prompt_with_attachments` so the next phase's
+    /// claude reads them via `@<path>` without the phase markdown
+    /// having to know which sub-skills produced them.
+    ///
+    /// Pure heuristic: previous phase = `phase_history.last()`. If
+    /// the phase template doesn't exist (e.g. dropped from the team)
+    /// or no sub-skills wrote anything, returns an empty vec. Public
+    /// for direct testing (the dispatch path that consumes this is
+    /// hard to drive in unit tests because of the tmux dependency).
+    pub fn attachments_for_next_phase(
+        &self,
+        slug: &str,
+        state: &ProjectState,
+    ) -> Vec<String> {
+        let Some(prev) = state.phase_history.last() else {
+            return Vec::new();
+        };
+        let Some(template) = self.templates.iter().find(|t| t.name == prev.phase) else {
+            return Vec::new();
+        };
+        let project_dir = self.paths.project_dir(slug);
+        template
+            .sub_skills
+            .iter()
+            .filter(|s| s.trigger == SubSkillTrigger::PhaseDone)
+            .filter_map(|s| {
+                let abs = project_dir.join(&s.output_to);
+                abs.exists().then(|| s.output_to.clone())
+            })
+            .collect()
+    }
+
+    /// Construct the configured sub-skill runner. Honors
+    /// `OrchestratorConfig::subskill_argv` so tests can swap a stub.
+    fn build_subskill_runner(&self) -> Box<dyn SubSkillRunner> {
+        match &self.config.subskill_argv {
+            Some(argv) => Box::new(ClaudePRunner::with_argv(argv.clone())),
+            None => Box::<ClaudePRunner>::default(),
+        }
+    }
+
+    /// Run every `phase_start` / `phase_done` sub-skill in `template`.
+    /// The orchestrator calls this directly around `AdvancePhase` and
+    /// `DispatchPhase` transitions in `process_project`.
+    pub fn run_phase_sub_skills(
+        &self,
+        slug: &str,
+        template: &PhaseTemplate,
+        trigger: SubSkillTrigger,
+    ) {
+        if template.sub_skills.is_empty() {
+            return;
+        }
+        let project_dir = self.paths.project_dir(slug);
+        let progress_path = self.paths.progress_jsonl(slug);
+        let runner = self.build_subskill_runner();
+        let _outputs = subskill::run_sub_skills_for_phase(
+            template,
+            trigger,
+            &project_dir,
+            &progress_path,
+            runner.as_ref(),
+        );
     }
 
     /// Scan `~/projects/*/.ccteam/state.json` and return one entry per
@@ -443,6 +521,20 @@ impl Orchestrator {
             match action {
                 TickAction::NoOp => return Ok(state),
                 TickAction::AdvancePhase { from, to } => {
+                    // M2.1: phase_done sub-skills run *before* state
+                    // advance so their output files are on disk by the
+                    // time the next phase prompt is built (the prompt
+                    // builder pulls in @-attachments from the prior
+                    // phase's sub_skills outputs).
+                    if let Some(prev_template) =
+                        self.templates.iter().find(|t| t.name == from)
+                    {
+                        self.run_phase_sub_skills(
+                            &slug.to_string(),
+                            prev_template,
+                            SubSkillTrigger::PhaseDone,
+                        );
+                    }
                     state.phase_history.push(PhaseHistoryEntry {
                         phase: from.clone(),
                         status: "passed".into(),
@@ -509,6 +601,17 @@ impl Orchestrator {
                     // out in `dispatch_phase → send_keys` because the
                     // session simply wouldn't exist.
                     self.ensure_session(slug, &mut state)?;
+                    // M2.1: phase_start sub-skills run *before* the
+                    // phase prompt is injected so their outputs are
+                    // available when the phase begins. Failures land
+                    // in progress.jsonl but never block the phase.
+                    if let Some(template) = self.templates.iter().find(|t| t.name == phase) {
+                        self.run_phase_sub_skills(
+                            slug,
+                            template,
+                            SubSkillTrigger::PhaseStart,
+                        );
+                    }
                     self.dispatch_phase(slug, &phase)?;
                     let template = self.templates.iter().find(|t| t.name == phase);
                     let target_state = if template.is_some_and(|t| t.auto_loop) {

--- a/crates/ccteam-core/src/paths.rs
+++ b/crates/ccteam-core/src/paths.rs
@@ -48,6 +48,14 @@ impl CcteamPaths {
         self.root.join("phases")
     }
 
+    /// `~/.ccteam/templates/` — global helper templates that phase
+    /// markdown can `@`-reference (M2.4, interfaces §5). Distinct from
+    /// `phases/` because helpers are *prompt fragments*, not whole
+    /// phases — they have no front-matter, no DAG position.
+    pub fn templates_dir(&self) -> PathBuf {
+        self.root.join("templates")
+    }
+
     pub fn project_dir(&self, slug: &str) -> PathBuf {
         self.projects_root.join(slug)
     }

--- a/crates/ccteam-core/src/phases.rs
+++ b/crates/ccteam-core/src/phases.rs
@@ -1,10 +1,13 @@
 //! Phase template parser. Templates live as markdown files with a YAML
 //! front matter header — schema in `docs/interfaces.md` §5.1.
 //!
-//! M0 parses the template strictly enough to support orchestrator checks:
-//! - `parallelism` must be `solo` (M2/M3 widen this).
-//! - `sub_skills` may be empty; orchestrator no-ops it. M2 implements
-//!   actual scheduling (see development-plan §2.1 M0.6 acceptance).
+//! Schema scope:
+//! - `parallelism` is one of `solo` / `agent_team` / `multi_session`.
+//!   M2 lifts the gate to allow `agent_team` once `agent_team:` lists
+//!   at least one role; `multi_session` still bails (M3.x).
+//! - `sub_skills` is the auto-trigger schedule (M2.1+);
+//! - `decision_mode` / `max_clarify_rounds` / `golden_rules` (M2.3+) are
+//!   phase-internal user-decision UX + hard-quality enforcement contracts.
 
 use std::path::Path;
 
@@ -15,6 +18,7 @@ use crate::state::Parallelism;
 use crate::tool_surface::ToolsRequired;
 
 const DEFAULT_AUTO_LOOP_MAX_ITERATIONS: u32 = 3;
+const DEFAULT_MAX_CLARIFY_ROUNDS: u32 = 3;
 
 /// Phase-internal multi-role agent (M2+; M0 ignores).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -46,6 +50,84 @@ pub struct PhaseHooks {
     pub before: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub after: Option<String>,
+}
+
+/// M2.3: phase-internal user-decision UX (interfaces §5.6.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionMode {
+    /// Block phase progress on `AskUserQuestion`. User assumed in-session.
+    Sync,
+    /// Write outbox `event_kind: clarify`; do not block. Pairs with
+    /// `PHASE_DONE_PENDING` (M3.6) when remaining work depends on the
+    /// answer. User assumed offline.
+    Async,
+    /// Try `AskUserQuestion` first; fall back to outbox after a short
+    /// in-phase timeout. Default.
+    Hybrid,
+}
+
+impl Default for DecisionMode {
+    fn default() -> Self {
+        Self::Hybrid
+    }
+}
+
+/// M2.3: hard-quality rule the orchestrator runs at phase boundary
+/// (interfaces §5.1, `golden_rules`).
+///
+/// YAML form:
+///
+/// ```yaml
+/// golden_rules:
+///   - rule_id: tests_green
+///     cmd: cargo test --workspace
+///   - rule_id: no_secrets_in_repo
+///     pattern: 'AWS_SECRET|sk-[a-zA-Z0-9]{32,}'
+/// ```
+///
+/// Exactly one of `cmd` / `pattern` per rule; checked by
+/// [`PhaseTemplate::validate_m0`]. The orchestrator carries no
+/// hard-coded `rule_id` — phase YAML is the only source of which
+/// rules to run, so plugin-style team templates can ship their own
+/// quality bars without ccteam-core changes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GoldenRule {
+    pub rule_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cmd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+}
+
+/// What kind of enforcement a [`GoldenRule`] represents, after the
+/// exactly-one-of-cmd-pattern invariant is checked.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GoldenRuleKind<'a> {
+    /// Run a shell command; non-zero exit = violation.
+    Cmd(&'a str),
+    /// Regex match against staged diff / required-output text;
+    /// any match = violation.
+    Pattern(&'a str),
+}
+
+impl GoldenRule {
+    /// Resolve to the validated `Cmd | Pattern` shape. Errors when the
+    /// rule has zero or two of `cmd` / `pattern` set.
+    pub fn kind(&self) -> Result<GoldenRuleKind<'_>> {
+        match (self.cmd.as_deref(), self.pattern.as_deref()) {
+            (Some(c), None) => Ok(GoldenRuleKind::Cmd(c)),
+            (None, Some(p)) => Ok(GoldenRuleKind::Pattern(p)),
+            (Some(_), Some(_)) => bail!(
+                "golden_rule `{}` has both `cmd` and `pattern`; pick one",
+                self.rule_id,
+            ),
+            (None, None) => bail!(
+                "golden_rule `{}` missing both `cmd` and `pattern`; one is required",
+                self.rule_id,
+            ),
+        }
+    }
 }
 
 /// Parsed YAML front matter of a phase template.
@@ -119,10 +201,36 @@ pub struct PhaseTemplate {
     /// `target_phase` field, independent of this static fallback.
     #[serde(default)]
     pub next_on_escalate: Option<String>,
+
+    /// M2.3: how phase markdown surfaces user-decision questions
+    /// (interfaces §5.6.1). Default `hybrid` keeps every legacy
+    /// template working without declaring the field — `AskUserQuestion`
+    /// is tried first and the phase falls back to outbox after a
+    /// short in-phase timeout.
+    #[serde(default)]
+    pub decision_mode: DecisionMode,
+
+    /// M2.3: hard cap on CLARIFY rounds inside one phase. Past this
+    /// the phase must produce a best-effort artifact and ESCALATE
+    /// `INSUFFICIENT_CLARIFICATION` (interfaces §5.6.2). Default 3 —
+    /// verdict / kickoff phases bump it to 5–7 in their templates.
+    #[serde(default = "default_max_clarify_rounds")]
+    pub max_clarify_rounds: u32,
+
+    /// M2.3: phase-level hard-quality rules (interfaces §5.1
+    /// `golden_rules`). Empty = no enforcement; orchestrator never
+    /// adds rules itself, so dev / product-research / etc. teams
+    /// each declare their own.
+    #[serde(default)]
+    pub golden_rules: Vec<GoldenRule>,
 }
 
 fn default_auto_loop_max_iterations() -> u32 {
     DEFAULT_AUTO_LOOP_MAX_ITERATIONS
+}
+
+fn default_max_clarify_rounds() -> u32 {
+    DEFAULT_MAX_CLARIFY_ROUNDS
 }
 
 impl PhaseTemplate {
@@ -145,16 +253,27 @@ impl PhaseTemplate {
             .with_context(|| format!("parse phase template {}", path.display()))
     }
 
-    /// Validate M0 invariants. Stricter checks (per-trigger sub_skill
-    /// validity, agent_team coupling with parallelism::AgentTeam) land
-    /// in M2/M3.
+    /// Validate phase-template invariants. Method name is preserved as
+    /// `validate_m0` for callsite stability; the body widened in M2 to
+    /// allow `parallelism: agent_team` (M2.2) and check the new M2.3
+    /// fields (`max_clarify_rounds > 0`, `golden_rules` shape).
     pub fn validate_m0(&self) -> Result<()> {
-        if self.parallelism != Parallelism::Solo {
-            bail!(
-                "phase `{}` declares parallelism `{:?}`; M0 only supports `solo` (development-plan §2.1)",
-                self.name,
-                self.parallelism,
-            );
+        match self.parallelism {
+            Parallelism::Solo => {}
+            Parallelism::AgentTeam => {
+                if self.agent_team.is_empty() {
+                    bail!(
+                        "phase `{}` declares parallelism `agent_team` but no `agent_team:` roles; nothing for the orchestrator to dispatch",
+                        self.name,
+                    );
+                }
+            }
+            Parallelism::MultiSession => {
+                bail!(
+                    "phase `{}` declares parallelism `multi_session`; M2 does not support it yet (M3.x widens)",
+                    self.name,
+                );
+            }
         }
         if self.auto_loop && self.completion_signal.trim().is_empty() {
             bail!(
@@ -167,6 +286,17 @@ impl PhaseTemplate {
                 "phase `{}` declares `auto_loop: true` with `auto_loop_max_iterations: 0` — that would never enter the loop",
                 self.name,
             );
+        }
+        if self.max_clarify_rounds == 0 {
+            bail!(
+                "phase `{}` declares `max_clarify_rounds: 0`; phase would skip every clarify and ESCALATE on first try",
+                self.name,
+            );
+        }
+        for rule in &self.golden_rules {
+            rule.kind().with_context(|| {
+                format!("phase `{}` golden_rule `{}` invalid", self.name, rule.rule_id)
+            })?;
         }
         Ok(())
     }
@@ -215,20 +345,6 @@ mod tests {
         assert!(t.required_inputs.is_empty());
         assert!(t.sub_skills.is_empty());
         t.validate_m0().unwrap();
-    }
-
-    #[test]
-    fn validate_m0_rejects_agent_team_parallelism() {
-        let src = concat!(
-            "---\n",
-            "name: implement\n",
-            "parallelism: agent_team\n",
-            "---\n",
-            "body\n",
-        );
-        let t = PhaseTemplate::parse(src).unwrap();
-        let err = t.validate_m0().unwrap_err();
-        assert!(err.to_string().contains("solo"), "got: {err}");
     }
 
     #[test]
@@ -303,7 +419,7 @@ mod tests {
         assert!(!t.auto_loop);
         assert_eq!(t.auto_loop_max_iterations, 3);
         assert!(t.completion_signal.is_empty());
-        // M0 validation passes — auto_loop=false ignores the empty signal.
+        // Validation passes — auto_loop=false ignores the empty signal.
         t.validate_m0().unwrap();
     }
 
@@ -360,6 +476,168 @@ mod tests {
         let err = t.validate_m0().unwrap_err();
         assert!(
             format!("{err:#}").contains("auto_loop_max_iterations"),
+            "got: {err:#}",
+        );
+    }
+
+    // ---------------- M2.2 / M2.3 ----------------
+
+    #[test]
+    fn validate_m2_accepts_agent_team_with_roles() {
+        let src = concat!(
+            "---\n",
+            "name: implement\n",
+            "parallelism: agent_team\n",
+            "agent_team:\n",
+            "  - role: backend-dev\n",
+            "  - role: reviewer\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        t.validate_m0().unwrap();
+        assert_eq!(t.parallelism, Parallelism::AgentTeam);
+        assert_eq!(t.agent_team.len(), 2);
+    }
+
+    #[test]
+    fn validate_m2_rejects_agent_team_without_roles() {
+        let src = concat!(
+            "---\n",
+            "name: implement\n",
+            "parallelism: agent_team\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("agent_team"),
+            "got: {err:#}",
+        );
+    }
+
+    #[test]
+    fn validate_m2_still_rejects_multi_session() {
+        let src = concat!(
+            "---\n",
+            "name: implement\n",
+            "parallelism: multi_session\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("multi_session"),
+            "got: {err:#}",
+        );
+    }
+
+    #[test]
+    fn decision_mode_defaults_to_hybrid() {
+        let src = concat!(
+            "---\n",
+            "name: implement\n",
+            "parallelism: solo\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        assert_eq!(t.decision_mode, DecisionMode::Hybrid);
+        assert_eq!(t.max_clarify_rounds, 3);
+        assert!(t.golden_rules.is_empty());
+    }
+
+    #[test]
+    fn decision_mode_parses_explicit_sync_async_hybrid() {
+        for mode in ["sync", "async", "hybrid"] {
+            let src = format!(
+                "---\nname: x\nparallelism: solo\ndecision_mode: {mode}\n---\nbody\n",
+            );
+            let t = PhaseTemplate::parse(&src).unwrap();
+            let expected = match mode {
+                "sync" => DecisionMode::Sync,
+                "async" => DecisionMode::Async,
+                "hybrid" => DecisionMode::Hybrid,
+                _ => unreachable!(),
+            };
+            assert_eq!(t.decision_mode, expected, "mode={mode}");
+        }
+    }
+
+    #[test]
+    fn max_clarify_rounds_zero_fails_validation() {
+        let src = concat!(
+            "---\n",
+            "name: x\n",
+            "parallelism: solo\n",
+            "max_clarify_rounds: 0\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("max_clarify_rounds"),
+            "got: {err:#}",
+        );
+    }
+
+    #[test]
+    fn golden_rules_parse_cmd_and_pattern() {
+        let src = concat!(
+            "---\n",
+            "name: ship\n",
+            "parallelism: solo\n",
+            "golden_rules:\n",
+            "  - rule_id: tests_green\n",
+            "    cmd: cargo test --workspace\n",
+            "  - rule_id: no_secrets_in_repo\n",
+            "    pattern: 'AWS_SECRET|sk-[a-zA-Z0-9]{32,}'\n",
+            "---\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        t.validate_m0().unwrap();
+        assert_eq!(t.golden_rules.len(), 2);
+        assert!(matches!(t.golden_rules[0].kind().unwrap(), GoldenRuleKind::Cmd(c) if c.starts_with("cargo")));
+        assert!(matches!(t.golden_rules[1].kind().unwrap(), GoldenRuleKind::Pattern(p) if p.contains("AWS_SECRET")));
+    }
+
+    #[test]
+    fn golden_rule_with_both_cmd_and_pattern_fails() {
+        let src = concat!(
+            "---\n",
+            "name: x\n",
+            "parallelism: solo\n",
+            "golden_rules:\n",
+            "  - rule_id: confused\n",
+            "    cmd: ls\n",
+            "    pattern: 'foo'\n",
+            "---\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("confused"),
+            "got: {err:#}",
+        );
+    }
+
+    #[test]
+    fn golden_rule_with_neither_cmd_nor_pattern_fails() {
+        let src = concat!(
+            "---\n",
+            "name: x\n",
+            "parallelism: solo\n",
+            "golden_rules:\n",
+            "  - rule_id: empty_rule\n",
+            "---\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        let err = t.validate_m0().unwrap_err();
+        assert!(
+            format!("{err:#}").contains("empty_rule"),
             "got: {err:#}",
         );
     }

--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -132,9 +132,29 @@ pub fn is_idle(last: Option<&Value>) -> bool {
 /// Short enough to fit comfortably in one tmux send-keys; relies on the
 /// project's `.ccteam/phases/<phase>.md` for the full body.
 pub fn build_phase_prompt(phase: &str) -> String {
-    format!(
+    build_phase_prompt_with_attachments(phase, &[])
+}
+
+/// M2.1: same as `build_phase_prompt` but appends `@<rel>` references
+/// for each `attachment`. Used by the orchestrator to surface prior
+/// phase's `sub_skills` outputs (e.g. `.ccteam/code-review.md`) so the
+/// next phase reads them automatically without having to know which
+/// sub-skills produced them.
+///
+/// `attachments` are project-relative paths (e.g. `.ccteam/code-review.md`).
+/// Empty list yields the same string as `build_phase_prompt`.
+pub fn build_phase_prompt_with_attachments(phase: &str, attachments: &[&str]) -> String {
+    let base = format!(
         "请按 @.ccteam/phases/{phase}.md 完成本阶段。完成后写 .ccteam/{phase}-report.md，并在最后单独输出一行：PHASE_DONE: {phase}（或 ESCALATE: <一句话原因>）。"
-    )
+    );
+    if attachments.is_empty() {
+        return base;
+    }
+    let refs: Vec<String> = attachments
+        .iter()
+        .map(|p| format!("@{p}"))
+        .collect();
+    format!("{base}\n\n上轮 sub-skill 产出可参考: {}", refs.join(" "))
 }
 
 /// `/btw <prompt>` when claude is busy so the message queues without

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -10,7 +10,9 @@ use serde_json::{Map, Value};
 
 use crate::paths::CcteamPaths;
 use crate::state::ProjectState;
-use crate::templates::{write_project_phase_templates, write_project_settings};
+use crate::templates::{
+    write_global_helper_templates, write_project_phase_templates, write_project_settings,
+};
 use crate::tool_surface::{
     link_recommended_agents_into, user_claude_dir, AgentLinkAction, LinkOptions,
 };
@@ -113,6 +115,17 @@ pub fn bootstrap_project(
 
     write_project_settings(&project_dir)?;
     write_project_phase_templates(&project_dir)?;
+    // M2.4: ensure ~/.ccteam/templates/ has the helper templates so
+    // any phase markdown's `@~/.ccteam/templates/<name>.md` reference
+    // resolves. Idempotent — no-ops when files already exist, so this
+    // doesn't fight `ccteam init` if the operator ran it first.
+    if let Err(err) = write_global_helper_templates(&paths.root, false) {
+        tracing::warn!(
+            global_dir = %paths.root.display(),
+            error = %err,
+            "could not stamp helper templates into ~/.ccteam/templates/; phase markdown using @-references may fail",
+        );
+    }
     if let Err(err) = pre_trust_project(&project_dir) {
         // Failing to pre-trust is annoying (next launch shows the
         // "Trust this folder?" prompt) but not fatal — log + continue.
@@ -461,6 +474,49 @@ mod tests {
             "expected {} to exist after bootstrap_project",
             skills.display(),
         );
+    }
+
+    #[test]
+    fn bootstrap_project_writes_helper_templates_to_global_dir() {
+        // M2.4: bootstrap_project ensures ~/.ccteam/templates/ is
+        // populated with the embedded helper templates so phase
+        // markdown's `@~/.ccteam/templates/<name>` reference resolves
+        // even when the user skipped `ccteam init`.
+        ensure_isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let templates = paths.root.join("templates");
+        assert!(
+            templates.join("review-with-user-loop.md").is_file(),
+            "review-with-user-loop.md missing from {}",
+            templates.display(),
+        );
+        assert!(
+            templates.join("kickoff-reverse-interview.md").is_file(),
+            "kickoff-reverse-interview.md missing",
+        );
+    }
+
+    #[test]
+    fn bootstrap_project_helper_templates_do_not_overwrite_user_edits() {
+        ensure_isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        // First bootstrap stamps fresh templates.
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let path = paths.root.join("templates/review-with-user-loop.md");
+        std::fs::write(&path, "USER EDIT\n").unwrap();
+        // Second project bootstrap (e.g. user runs `ccteam new` again)
+        // must not clobber the user edit.
+        bootstrap_project(&paths, "demo2", "another request", "dev").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "USER EDIT\n");
     }
 
     #[test]

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -13,8 +13,9 @@ use crate::state::ProjectState;
 use crate::templates::{
     write_global_helper_templates, write_project_phase_templates, write_project_settings,
 };
+use crate::phases::PhaseTemplate;
 use crate::tool_surface::{
-    link_recommended_agents_into, user_claude_dir, AgentLinkAction, LinkOptions,
+    link_recommended_agents_for_phases_into, user_claude_dir, AgentLinkAction, LinkOptions,
 };
 
 /// Slugify a free-text project request: keep `[a-z0-9]`, collapse other
@@ -136,15 +137,17 @@ pub fn bootstrap_project(
         );
     }
 
-    // M0.5.1 / M0.5.2: register plugin agents under ~/.claude/agents/
-    // and pre-create the skills placeholder directories. Both must be
-    // done **before** the orchestrator's ensure_session triggers
-    // `tmux new-session`, since Claude Code scans agents/ once at
-    // session start (per claude-code-tool-surface.md §1.2.5/6) and
-    // attaches the SKILL.md watcher only to dirs that exist at startup
-    // (§1.2.4). bootstrap_project runs in `ccteam new`, well before
-    // the daemon's ensure_session, so we're inside the safe window.
-    if let Err(err) = setup_tool_surface(&project_dir) {
+    // M0.5.1 / M0.5.2 / M2.1: register plugin agents under
+    // ~/.claude/agents/ (recommended set + every sub_skill plugin agent
+    // referenced in phase YAML) and pre-create the skills placeholder
+    // directories. Both must be done **before** the orchestrator's
+    // ensure_session triggers `tmux new-session`, since Claude Code
+    // scans agents/ once at session start (claude-code-tool-surface.md
+    // §1.2.5/6) and attaches the SKILL.md watcher only to dirs that
+    // exist at startup (§1.2.4). bootstrap_project runs in `ccteam
+    // new`, well before the daemon's ensure_session.
+    let templates = load_phase_templates_for_bootstrap();
+    if let Err(err) = setup_tool_surface(&project_dir, &templates) {
         tracing::warn!(
             project_dir = %project_dir.display(),
             error = %err,
@@ -164,6 +167,29 @@ pub fn bootstrap_project(
     Ok(project_dir)
 }
 
+/// Parse the embedded phase templates (the same `PHASE_TEMPLATES`
+/// `bootstrap_project` writes to disk) into a `Vec<PhaseTemplate>` so
+/// `setup_tool_surface` can ln -sf every sub_skill plugin agent the
+/// dev pipeline declares. Filter out parse errors with a warn — a
+/// broken shipped template would crash the build, but if it ever
+/// happens we want bootstrap to keep working for unrelated phases.
+fn load_phase_templates_for_bootstrap() -> Vec<PhaseTemplate> {
+    crate::templates::PHASE_TEMPLATES
+        .iter()
+        .filter_map(|(name, body)| match PhaseTemplate::parse(body) {
+            Ok(t) => Some(t),
+            Err(err) => {
+                tracing::warn!(
+                    template = %name,
+                    error = %err,
+                    "embedded phase template did not parse during bootstrap; skipping for sub_skill linking",
+                );
+                None
+            }
+        })
+        .collect()
+}
+
 /// Pre-mark `project_dir` as trusted in `~/.claude.json` so the first
 /// `claude --dangerously-skip-permissions` launch in this directory
 /// doesn't sit on the "Trust this folder?" prompt waiting for the
@@ -176,9 +202,10 @@ pub fn pre_trust_project(project_dir: &Path) -> Result<()> {
     write_trust_entry(&claude_json, project_dir)
 }
 
-/// Symlink the `RECOMMENDED_AGENTS` set into `~/.claude/agents/` and
-/// pre-create the global + project-local skills placeholder dirs. See
-/// the call site in `bootstrap_project` for the timing constraint.
+/// Symlink the `RECOMMENDED_AGENTS` set + every plugin agent named in
+/// `templates`' `sub_skills` into `~/.claude/agents/`, then pre-create
+/// the global + project-local skills placeholder dirs. See the call
+/// site in `bootstrap_project` for the timing constraint.
 ///
 /// **Test isolation**: tests that call `bootstrap_project` but don't
 /// want to mutate the developer's real `~/.claude/` should set the
@@ -190,7 +217,7 @@ pub fn pre_trust_project(project_dir: &Path) -> Result<()> {
 /// The project-local `<project>/.claude/skills/` placeholder is
 /// created unconditionally — it lives under `project_dir` (a
 /// tempdir during tests) and carries no global-pollution risk.
-fn setup_tool_surface(project_dir: &Path) -> Result<()> {
+fn setup_tool_surface(project_dir: &Path, templates: &[PhaseTemplate]) -> Result<()> {
     // Project-local placeholder always created — see doc comment.
     let project_skills = project_dir.join(".claude").join("skills");
     std::fs::create_dir_all(&project_skills)
@@ -206,7 +233,11 @@ fn setup_tool_surface(project_dir: &Path) -> Result<()> {
         return Ok(());
     }
     let claude = user_claude_dir()?;
-    let reports = link_recommended_agents_into(&claude, LinkOptions::default())?;
+    let reports = link_recommended_agents_for_phases_into(
+        &claude,
+        templates,
+        LinkOptions::default(),
+    )?;
     for r in &reports {
         match &r.action {
             AgentLinkAction::Linked => tracing::info!(

--- a/crates/ccteam-core/src/subskill.rs
+++ b/crates/ccteam-core/src/subskill.rs
@@ -1,0 +1,516 @@
+//! M2.1: sub-skill scheduling.
+//!
+//! Phase YAML's `sub_skills:` list (interfaces §7) names plugin agents
+//! that the orchestrator runs around phase boundaries:
+//! - `phase_start` — fires before the phase prompt is injected;
+//! - `phase_done` — fires after `PHASE_DONE: <name>` is parsed,
+//!   before the orchestrator advances to the next phase.
+//!
+//! Output: the spawned subprocess writes its result to disk at
+//! `<project_dir>/<output_to>`. The next phase's prompt
+//! [`super::progress::build_phase_prompt_with_attachments`] picks the
+//! file up via `@`-reference at injection time, so phase markdown
+//! doesn't need to know which sub-skills ran.
+//!
+//! Subprocess shape (production): a `claude -p --output-format text`
+//! invocation that reads the resolved plugin agent path via `@`. The
+//! orchestrator does **not** embed an LLM in-process — that would
+//! violate the Symphony anti-pattern (tech-design §3.1). All LLM work
+//! still lives in claude.
+//!
+//! Path-prefix resolution mirrors interfaces §7.3:
+//! - `claude-plugins-official:<plugin>/<rel>` → resolves under
+//!   `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/`;
+//! - `local:<rel>` → resolved under the project dir;
+//! - `installed:<plugin>/<command>` → reserved for M3 plugin install.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{anyhow, Context, Result};
+use chrono::{SecondsFormat, Utc};
+use serde_json::json;
+
+use crate::phases::{PhaseTemplate, SubSkillSpec, SubSkillTrigger};
+use crate::progress::append_event;
+use crate::tool_surface::user_claude_dir;
+
+/// Strategy abstraction so tests can stub out subprocess execution
+/// without a real `claude` on the PATH. Production wiring uses
+/// [`ClaudePRunner`].
+pub trait SubSkillRunner: Send + Sync {
+    /// Run a sub-skill and return the body to be written to
+    /// `output_to`. Implementations must NOT touch the filesystem
+    /// outside reading the `agent_path`; the orchestrator owns the
+    /// `output_to` write so a runner failure doesn't leave a half-
+    /// written file behind.
+    fn run(&self, ctx: &SubSkillRunCtx<'_>) -> Result<String>;
+}
+
+/// Argument bundle for [`SubSkillRunner::run`]. Borrowed so callers
+/// don't pay a clone per invocation.
+#[derive(Debug)]
+pub struct SubSkillRunCtx<'a> {
+    pub project_dir: &'a Path,
+    pub phase_name: &'a str,
+    pub trigger: SubSkillTrigger,
+    /// Resolved on-disk path to the plugin agent / hook script.
+    /// `None` when the prefix didn't resolve (caller decides
+    /// whether to bail or skip).
+    pub agent_path: Option<PathBuf>,
+    /// Verbatim `skill:` string from the phase YAML. Useful for
+    /// runners that want to embed the original reference.
+    pub skill: &'a str,
+}
+
+/// Outcome of running one sub-skill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SubSkillOutcome {
+    /// Agent ran and produced output written to `output_to`.
+    Ran { output: PathBuf },
+    /// Skill prefix didn't resolve to any source we know how to run
+    /// (e.g. `installed:<plugin>/...` with no plugin command map yet).
+    /// Logged + recorded in progress.jsonl, but not fatal — phases
+    /// stay advisory.
+    Skipped { reason: String },
+    /// Runner returned an error. Logged + recorded; phase continues
+    /// because sub-skills are advisory (interfaces §7).
+    Failed { error: String },
+}
+
+/// Production runner: spawns `claude -p --output-format text`
+/// (configurable for tests via [`ClaudePRunner::with_argv`]).
+///
+/// The runner accepts the agent path on stdin via `@`-prefixed text
+/// so claude inlines the agent's body before evaluating. Output is
+/// captured from stdout; non-zero exit = runner error.
+pub struct ClaudePRunner {
+    argv: Vec<String>,
+}
+
+impl Default for ClaudePRunner {
+    fn default() -> Self {
+        Self {
+            // `--dangerously-skip-permissions` here lets the sub-skill
+            // run without prompts — same posture as the orchestrator's
+            // tmux session; the sub-skill is short-lived and doesn't
+            // need a separate trust dialog.
+            argv: vec![
+                "claude".into(),
+                "-p".into(),
+                "--output-format".into(),
+                "text".into(),
+                "--dangerously-skip-permissions".into(),
+            ],
+        }
+    }
+}
+
+impl ClaudePRunner {
+    /// Override the spawned argv. Tests pass a shell stub like
+    /// `["bash", "-c", "cat"]` that echoes stdin to stdout.
+    pub fn with_argv(argv: Vec<String>) -> Self {
+        Self { argv }
+    }
+}
+
+impl SubSkillRunner for ClaudePRunner {
+    fn run(&self, ctx: &SubSkillRunCtx<'_>) -> Result<String> {
+        let Some(agent_path) = &ctx.agent_path else {
+            return Err(anyhow!(
+                "sub-skill `{}` did not resolve to an agent path; cannot run",
+                ctx.skill,
+            ));
+        };
+        let prompt = build_subskill_prompt(ctx.phase_name, ctx.trigger, agent_path);
+        let mut cmd = Command::new(&self.argv[0]);
+        for arg in &self.argv[1..] {
+            cmd.arg(arg);
+        }
+        cmd.current_dir(ctx.project_dir);
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().with_context(|| {
+            format!("spawn sub-skill runner {:?}", self.argv)
+        })?;
+        if let Some(mut stdin) = child.stdin.take() {
+            use std::io::Write;
+            stdin
+                .write_all(prompt.as_bytes())
+                .context("write sub-skill prompt to runner stdin")?;
+        }
+        let output = child
+            .wait_with_output()
+            .context("wait for sub-skill runner")?;
+        if !output.status.success() {
+            return Err(anyhow!(
+                "sub-skill runner exited {:?}: stderr={}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr),
+            ));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+/// Build the prompt fed to the runner's stdin. Single source of truth
+/// for the wording so test stubs and the production path stay aligned
+/// on what the agent sees.
+fn build_subskill_prompt(phase: &str, trigger: SubSkillTrigger, agent_path: &Path) -> String {
+    let when = match trigger {
+        SubSkillTrigger::PhaseStart => "phase_start",
+        SubSkillTrigger::PhaseDone => "phase_done",
+    };
+    format!(
+        "你被 ccteam orchestrator 在 phase=`{phase}` trigger=`{when}` 时触发。\n\n请按下面 agent 的指令工作,把成果直接打印到 stdout:\n\n@{}\n",
+        agent_path.display(),
+    )
+}
+
+/// Resolve a `skill:` reference (interfaces §7.3) to an on-disk path.
+/// Returns `None` for prefixes the orchestrator does not yet know how
+/// to run (`installed:`); the caller logs a `Skipped` outcome so the
+/// operator sees what was missed.
+pub fn resolve_skill_path(skill: &str, project_dir: &Path) -> Option<PathBuf> {
+    if let Some(rest) = skill.strip_prefix("claude-plugins-official:") {
+        // `claude-plugins-official:<plugin>/<rel>` →
+        // `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/<plugin>/<rel>`
+        let claude = user_claude_dir().ok()?;
+        let mut parts = rest.splitn(2, '/');
+        let plugin = parts.next()?;
+        let rel = parts.next()?;
+        let mut p = claude
+            .join("plugins")
+            .join("marketplaces")
+            .join("claude-plugins-official")
+            .join("plugins")
+            .join(plugin);
+        for seg in rel.split('/') {
+            p = p.join(seg);
+        }
+        // Append `.md` if the caller omitted it (the phase YAML form
+        // can drop the suffix when the path obviously names an agent).
+        if !p.exists() {
+            let with_md = p.with_extension("md");
+            if with_md.exists() {
+                return Some(with_md);
+            }
+        }
+        Some(p)
+    } else if let Some(rest) = skill.strip_prefix("local:") {
+        let mut p = project_dir.to_path_buf();
+        for seg in rest.split('/') {
+            p = p.join(seg);
+        }
+        Some(p)
+    } else if skill.starts_with("installed:") {
+        // M3 territory — return None so the caller emits `Skipped`.
+        None
+    } else {
+        None
+    }
+}
+
+/// Run every sub-skill in `template.sub_skills` whose trigger matches
+/// `trigger`, writing each one's stdout to its `output_to`. Skill
+/// failures land in progress.jsonl but do not abort the phase — they
+/// are advisory by design (interfaces §7).
+///
+/// Returns the list of `output_to` paths that were successfully
+/// written (the orchestrator passes these to
+/// [`super::progress::build_phase_prompt_with_attachments`] when
+/// dispatching the next phase).
+pub fn run_sub_skills_for_phase(
+    template: &PhaseTemplate,
+    trigger: SubSkillTrigger,
+    project_dir: &Path,
+    progress_path: &Path,
+    runner: &dyn SubSkillRunner,
+) -> Vec<PathBuf> {
+    let mut outputs = Vec::new();
+    for spec in &template.sub_skills {
+        if spec.trigger != trigger {
+            continue;
+        }
+        match run_one(spec, &template.name, project_dir, progress_path, runner) {
+            Ok(SubSkillOutcome::Ran { output }) => outputs.push(output),
+            Ok(SubSkillOutcome::Skipped { reason }) => {
+                tracing::info!(skill = %spec.skill, %reason, "sub-skill skipped");
+            }
+            Ok(SubSkillOutcome::Failed { error }) => {
+                tracing::warn!(skill = %spec.skill, error = %error, "sub-skill failed");
+            }
+            Err(err) => tracing::warn!(
+                skill = %spec.skill,
+                error = %err,
+                "sub-skill bookkeeping failed",
+            ),
+        }
+    }
+    outputs
+}
+
+fn run_one(
+    spec: &SubSkillSpec,
+    phase: &str,
+    project_dir: &Path,
+    progress_path: &Path,
+    runner: &dyn SubSkillRunner,
+) -> Result<SubSkillOutcome> {
+    let agent_path = resolve_skill_path(&spec.skill, project_dir);
+    let _ = append_event(
+        progress_path,
+        &json!({
+            "ts": now_rfc3339(),
+            "event": "subskill_started",
+            "phase": phase,
+            "skill": spec.skill,
+            "trigger": trigger_str(spec.trigger),
+        }),
+    );
+    if agent_path.is_none() && !spec.skill.starts_with("local:") {
+        let reason = format!("unsupported skill prefix: {}", spec.skill);
+        let _ = append_event(
+            progress_path,
+            &json!({
+                "ts": now_rfc3339(),
+                "event": "subskill_skipped",
+                "phase": phase,
+                "skill": spec.skill,
+                "reason": reason.clone(),
+            }),
+        );
+        return Ok(SubSkillOutcome::Skipped { reason });
+    }
+    let ctx = SubSkillRunCtx {
+        project_dir,
+        phase_name: phase,
+        trigger: spec.trigger,
+        agent_path,
+        skill: &spec.skill,
+    };
+    let body = match runner.run(&ctx) {
+        Ok(b) => b,
+        Err(err) => {
+            let msg = format!("{err:#}");
+            let _ = append_event(
+                progress_path,
+                &json!({
+                    "ts": now_rfc3339(),
+                    "event": "subskill_failed",
+                    "phase": phase,
+                    "skill": spec.skill,
+                    "error": msg.clone(),
+                }),
+            );
+            return Ok(SubSkillOutcome::Failed { error: msg });
+        }
+    };
+    let output_path = project_dir.join(&spec.output_to);
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    std::fs::write(&output_path, body.as_bytes())
+        .with_context(|| format!("write sub-skill output {}", output_path.display()))?;
+    let _ = append_event(
+        progress_path,
+        &json!({
+            "ts": now_rfc3339(),
+            "event": "subskill_done",
+            "phase": phase,
+            "skill": spec.skill,
+            "output": spec.output_to,
+            "bytes": body.len(),
+        }),
+    );
+    Ok(SubSkillOutcome::Ran {
+        output: output_path,
+    })
+}
+
+fn trigger_str(t: SubSkillTrigger) -> &'static str {
+    match t {
+        SubSkillTrigger::PhaseStart => "phase_start",
+        SubSkillTrigger::PhaseDone => "phase_done",
+    }
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Stub runner: writes a fixed string + records every call so
+    /// tests can assert how many sub-skills ran and with what
+    /// arguments.
+    struct StubRunner {
+        body: String,
+    }
+
+    impl StubRunner {
+        fn new(body: impl Into<String>) -> Self {
+            Self { body: body.into() }
+        }
+    }
+
+    impl SubSkillRunner for StubRunner {
+        fn run(&self, _ctx: &SubSkillRunCtx<'_>) -> Result<String> {
+            Ok(self.body.clone())
+        }
+    }
+
+    fn template_with_sub_skills(skills: Vec<SubSkillSpec>) -> PhaseTemplate {
+        let yaml = "name: implement\nparallelism: solo\n";
+        let mut t = PhaseTemplate::parse(&format!("---\n{yaml}---\nbody\n")).unwrap();
+        t.sub_skills = skills;
+        t
+    }
+
+    #[test]
+    fn resolve_local_prefix_joins_project_dir() {
+        let p = resolve_skill_path("local:scripts/foo.sh", Path::new("/proj")).unwrap();
+        assert_eq!(p, PathBuf::from("/proj/scripts/foo.sh"));
+    }
+
+    #[test]
+    fn resolve_installed_prefix_returns_none() {
+        assert!(resolve_skill_path("installed:foo/bar", Path::new("/p")).is_none());
+    }
+
+    #[test]
+    fn resolve_unprefixed_skill_returns_none() {
+        // Don't try to guess for unrecognized prefixes — the M2.1
+        // grammar is closed (interfaces §7.3), and a typo'd prefix
+        // should land as Skipped, not silently looked up under some
+        // default.
+        assert!(resolve_skill_path("plugin-name/agents/foo", Path::new("/p")).is_none());
+    }
+
+    #[test]
+    fn run_sub_skills_writes_output_for_matching_trigger() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        let progress = tmp.path().join("progress.jsonl");
+        let template = template_with_sub_skills(vec![SubSkillSpec {
+            skill: "local:agent.md".into(),
+            trigger: SubSkillTrigger::PhaseDone,
+            output_to: ".ccteam/code-review.md".into(),
+        }]);
+        // Stage the local agent file so resolve succeeds.
+        std::fs::write(project.join("agent.md"), "# stub agent\n").unwrap();
+        let runner = StubRunner::new("REVIEW BODY\n");
+
+        let outs = run_sub_skills_for_phase(
+            &template,
+            SubSkillTrigger::PhaseDone,
+            &project,
+            &progress,
+            &runner,
+        );
+        assert_eq!(outs.len(), 1);
+        let body = std::fs::read_to_string(project.join(".ccteam/code-review.md")).unwrap();
+        assert_eq!(body, "REVIEW BODY\n");
+        // progress.jsonl recorded started + done.
+        let evs = std::fs::read_to_string(&progress).unwrap();
+        assert!(evs.contains("subskill_started"));
+        assert!(evs.contains("subskill_done"));
+    }
+
+    #[test]
+    fn run_sub_skills_ignores_other_triggers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        let progress = tmp.path().join("progress.jsonl");
+        let template = template_with_sub_skills(vec![SubSkillSpec {
+            skill: "local:agent.md".into(),
+            trigger: SubSkillTrigger::PhaseStart,
+            output_to: ".ccteam/precheck.md".into(),
+        }]);
+        std::fs::write(project.join("agent.md"), "x").unwrap();
+        let runner = StubRunner::new("X");
+
+        let outs = run_sub_skills_for_phase(
+            &template,
+            SubSkillTrigger::PhaseDone, // mismatched
+            &project,
+            &progress,
+            &runner,
+        );
+        assert!(outs.is_empty(), "phase_start spec must not run on phase_done");
+        assert!(!project.join(".ccteam/precheck.md").exists());
+    }
+
+    #[test]
+    fn run_sub_skills_records_skipped_for_installed_prefix() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        let progress = tmp.path().join("progress.jsonl");
+        let template = template_with_sub_skills(vec![SubSkillSpec {
+            skill: "installed:foo/bar".into(),
+            trigger: SubSkillTrigger::PhaseDone,
+            output_to: ".ccteam/foo.md".into(),
+        }]);
+        let runner = StubRunner::new("body");
+        let outs = run_sub_skills_for_phase(
+            &template,
+            SubSkillTrigger::PhaseDone,
+            &project,
+            &progress,
+            &runner,
+        );
+        assert!(outs.is_empty(), "installed: prefix should be skipped (not run)");
+        let evs = std::fs::read_to_string(&progress).unwrap();
+        assert!(evs.contains("subskill_skipped"));
+    }
+
+    #[test]
+    fn run_sub_skills_records_failure_when_runner_errors() {
+        struct ErrRunner;
+        impl SubSkillRunner for ErrRunner {
+            fn run(&self, _: &SubSkillRunCtx<'_>) -> Result<String> {
+                Err(anyhow!("boom"))
+            }
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+        let progress = tmp.path().join("progress.jsonl");
+        let template = template_with_sub_skills(vec![SubSkillSpec {
+            skill: "local:agent.md".into(),
+            trigger: SubSkillTrigger::PhaseDone,
+            output_to: ".ccteam/x.md".into(),
+        }]);
+        std::fs::write(project.join("agent.md"), "x").unwrap();
+        let outs = run_sub_skills_for_phase(
+            &template,
+            SubSkillTrigger::PhaseDone,
+            &project,
+            &progress,
+            &ErrRunner,
+        );
+        assert!(outs.is_empty(), "failed runner must not produce an output path");
+        let evs = std::fs::read_to_string(&progress).unwrap();
+        assert!(evs.contains("subskill_failed"));
+    }
+
+    #[test]
+    fn build_subskill_prompt_includes_at_reference() {
+        let p = build_subskill_prompt(
+            "implement",
+            SubSkillTrigger::PhaseDone,
+            Path::new("/some/agent.md"),
+        );
+        assert!(p.contains("phase=`implement`"));
+        assert!(p.contains("trigger=`phase_done`"));
+        assert!(p.contains("@/some/agent.md"));
+    }
+}

--- a/crates/ccteam-core/src/templates.rs
+++ b/crates/ccteam-core/src/templates.rs
@@ -30,6 +30,28 @@ pub const PHASE_TEMPLATES: &[(&str, &str)] = &[
     ("09-ship.md", include_str!("../../../phases/09-ship.md")),
 ];
 
+/// M2.4: helper templates that phase markdown can `@`-reference. Shipped
+/// inside the binary so a fresh install (or `ccteam doctor`) can stamp
+/// them into `~/.ccteam/templates/` without an external git checkout.
+///
+/// `(on_disk_filename, body)` — phase markdown references them as
+/// `@~/.ccteam/templates/<on_disk_filename>` and Claude Code's native
+/// `@` mechanism inlines the body at prompt-build time. The orchestrator
+/// does not parse these — they're pure Claude Code surface.
+///
+/// Filenames use hyphens to match the @-reference convention; the Rust
+/// source filenames use underscores to match Rust module conventions.
+pub const HELPER_TEMPLATES: &[(&str, &str)] = &[
+    (
+        "review-with-user-loop.md",
+        include_str!("templates/review_with_user_loop.md"),
+    ),
+    (
+        "kickoff-reverse-interview.md",
+        include_str!("templates/kickoff_reverse_interview.md"),
+    ),
+];
+
 /// Strip a leading `NN-` index prefix off a global phase filename so it
 /// matches the path the phase prompt asks claude to read
 /// (`@.ccteam/phases/<phase>.md`). Returns the original name unchanged
@@ -146,6 +168,30 @@ pub fn write_global_phase_templates(global_dir: &Path, force: bool) -> Result<()
         .with_context(|| format!("create {}", dir.display()))?;
     for (global, body) in PHASE_TEMPLATES {
         let path = dir.join(global);
+        if path.exists() && !force {
+            continue;
+        }
+        std::fs::write(&path, body)
+            .with_context(|| format!("write {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// M2.4: write the embedded `HELPER_TEMPLATES` into
+/// `<global_dir>/templates/<filename>` so phase markdown's
+/// `@~/.ccteam/templates/<filename>` reference resolves. Idempotent;
+/// `force == false` preserves operator hand-edits.
+///
+/// Called by `ccteam init` (global skeleton) and `bootstrap_project`
+/// (defensive — covers the user who jumps straight to `ccteam new`
+/// without `ccteam init`). The two callers don't conflict because
+/// the writer is a no-op when files are already in place.
+pub fn write_global_helper_templates(global_dir: &Path, force: bool) -> Result<()> {
+    let dir = global_dir.join("templates");
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create {}", dir.display()))?;
+    for (filename, body) in HELPER_TEMPLATES {
+        let path = dir.join(filename);
         if path.exists() && !force {
             continue;
         }

--- a/crates/ccteam-core/src/templates/ccteam_control_skill.md
+++ b/crates/ccteam-core/src/templates/ccteam_control_skill.md
@@ -13,27 +13,33 @@ allowed-tools: [Bash]
 # ccteam-control
 
 ccteam is an autonomous project orchestrator built on Claude Code.
-This skill makes ccteam reachable from any claude session via the
-`ccteam` CLI. Default to `--format json` so output is structured.
+This skill makes ccteam reachable from any claude session.
 
-## Capability index
+**Prefer the MCP server.** Once `ccteam doctor --install-mcp` has
+registered the server (M2.5), every claude session sees nine
+`mcp__ccteam__*` tools — call those first. The `Bash` + `--format
+json` path below stays as a fallback for sessions where the MCP
+server isn't registered yet.
 
-| What you want | Command |
-|---|---|
-| List all projects                | `ccteam ls --format json` |
-| One project's full state         | `ccteam show <slug> --format json` |
-| Recent progress events           | `ccteam progress <slug>` (or `--tail` for live stream) |
-| Capture session pane content     | `ccteam peek <slug>` |
-| Start a new project              | `ccteam new --team=dev "<request>"` |
-| Pause project (no kill)          | `ccteam pause <slug>` *(M2 implements; M1 stub)* |
-| Resume project                   | `ccteam resume <slug>` |
-| Reject project                   | `ccteam reject <slug>` *(M2 implements; M1 stub)* |
-| Health checks                    | `ccteam doctor --tool-surface` |
-| Install meta-agent for a user    | `ccteam doctor --install-meta-agent <handle>` |
+## Capability index — MCP first, Bash fallback
 
-`--format json` is on every query command (`ls`, `show`). Prefer JSON
-when piping output into your own analysis. The schema lives in
-`docs/interfaces.md` §10.3.
+| What you want | MCP tool (preferred) | Bash fallback |
+|---|---|---|
+| List all projects                | `mcp__ccteam__ls`                | `ccteam ls --format json` |
+| One project's full state         | `mcp__ccteam__show`              | `ccteam show <slug> --format json` |
+| Recent progress events           | `mcp__ccteam__progress`          | `ccteam progress <slug>` |
+| Capture session pane content     | `mcp__ccteam__peek`              | `ccteam peek <slug>` |
+| Start a new project              | `mcp__ccteam__new`               | `ccteam new --team=dev "<request>"` |
+| Pause project (no kill)          | `mcp__ccteam__pause`             | `ccteam pause <slug>` |
+| Resume project                   | `mcp__ccteam__resume`            | `ccteam resume <slug>` |
+| Send NL to a session inbox       | `mcp__ccteam__send_to_session`   | (write `.ccteam/inbox/msg-<ts>-NNN.md`) |
+| Inject ESCALATE-style decision   | `mcp__ccteam__inject_decision`   | (compose body manually + send_to_session) |
+| Health checks                    | (Bash only)                      | `ccteam doctor --tool-surface` |
+| Install meta-agent               | (Bash only)                      | `ccteam doctor --install-meta-agent <handle>` |
+
+When the MCP server is registered, `ccteam doctor --install-mcp` (run
+once) wires `mcpServers.ccteam` into `~/.claude.json`. Existing claude
+sessions need `/reload-mcp`; new sessions pick it up immediately.
 
 ## Typical workflows
 
@@ -95,12 +101,16 @@ Combine the two outputs and recommend exactly **one** of:
 
 When this skill is loaded inside a ccteam meta-agent session:
 
-1. Prefer `ccteam new` dispatch over doing the work yourself. The
-   meta-agent role prompt (CLAUDE.md) covers the dispatcher-not-worker
-   rule — this skill is the tool list the dispatcher uses.
+1. Prefer `mcp__ccteam__new` dispatch over doing the work yourself.
+   The meta-agent role prompt (CLAUDE.md) covers the
+   dispatcher-not-worker rule — this skill is the tool list the
+   dispatcher uses.
 2. After every dispatch / status reply, write an outbox file at
    `~/projects/<user>-meta/.ccteam/outbox/reply-<ts>-<seq>.md` per
    `docs/interfaces.md` §3.4.3.
-3. M2.8 will swap shell-parsing for the `ccteam-mcp` MCP server. When
-   that lands, prefer `mcp__ccteam__*` tools over `Bash` invocations
-   of the same CLI. The `--format json` paths remain a stable fallback.
+3. When the user has resolved a project's clarify/escalation, use
+   `mcp__ccteam__inject_decision` (or its Bash equivalent) to push
+   the resolution back into the project session — it constructs an
+   ESCALATE-style markdown payload (interfaces §4.1.1) and atomically
+   writes it to the project's inbox so the orchestrator delivers it
+   on the next tick.

--- a/crates/ccteam-core/src/templates/kickoff_reverse_interview.md
+++ b/crates/ccteam-core/src/templates/kickoff_reverse_interview.md
@@ -1,0 +1,80 @@
+# Helper: kickoff reverse-interview
+
+> Embed this with `@~/.ccteam/templates/kickoff-reverse-interview.md`
+> from a kickoff-style phase whose `required_inputs` is just `.ccteam/spec.md`
+> and the spec is too thin to act on. Pattern: instead of guessing
+> what the user meant, *interview the user* and synthesize a brief.
+>
+> Best practices §5.2 (reverse interview) is the philosophy; this
+> template is the operational form. Pairs with
+> `decision_mode: hybrid` (interfaces §5.6.1) and a higher
+> `max_clarify_rounds` (5–7 rather than the default 3) — kickoff
+> phases legitimately need more rounds than mid-pipeline ones.
+
+## When to trigger this loop
+
+Trigger when *any* of:
+
+- spec.md body has fewer than ~30 meaningful tokens
+- spec.md mentions a category but no platform / target user / scope
+- you cannot produce a single concrete next-phase artifact without
+  inventing a requirement
+
+If spec.md is rich enough, skip this template entirely.
+
+## How to interview
+
+1. **List what's missing**, ordered by load-bearing weight.
+   Categories worth checking:
+   - **Target user**: developer / end-user / specific role / team
+   - **Platform**: CLI / TUI / web / mobile / desktop / library
+   - **Core scenario**: the one thing this absolutely must do well
+   - **Constraints**: deadline / cost / privacy / offline / language
+   - **Out-of-scope**: what the user explicitly *does not* want
+2. **Ask one question per CLARIFY round**, highest-leverage first
+   (route via `AskUserQuestion` or outbox per `decision_mode`).
+3. **Re-evaluate after each answer** — sometimes one answer
+   eliminates two follow-ups.
+4. **At round cap or at "no more high-leverage questions"**, write
+   the synthesized brief.
+
+## Synthesized brief
+
+Write to `.ccteam/brief.md` (or whatever your phase's `required_outputs`
+specifies) with these sections:
+
+```markdown
+# 综合 brief
+
+## 用户原始一句话
+(spec.md 原文)
+
+## 经反向面试澄清的关键事实
+- 目标用户:
+- 平台:
+- 核心场景:
+- 关键约束:
+- 不做:
+
+## 仍未确定但可推进的假设
+列每条假设 + 触发回头条件(if X, revisit)
+
+## 建议的下一阶段
+(plan-eng / market-survey / 哪一个,以及最先要写哪份产物)
+```
+
+The next phase reads this brief instead of the raw spec — that's the
+whole point. If you can't produce a brief that the next phase can act
+on, ESCALATE `INSUFFICIENT_CLARIFICATION` (interfaces §5.6.2) so the
+user picks: provide more, accept the assumptions, or abort.
+
+## Anti-patterns
+
+- Asking generic "what do you want?" — that's the question the user
+  already failed to answer in spec.md. Drill into a *specific* gap.
+- Synthesizing a brief by guessing missing facts then *labeling them
+  "confirmed"*. If the user didn't confirm, list it under "假设" and
+  state the revisit trigger.
+- Treating the cap as a budget to spend — if 2 rounds cleared the
+  ambiguity, write the brief and exit. Token budget left on the table
+  is fine.

--- a/crates/ccteam-core/src/templates/review_with_user_loop.md
+++ b/crates/ccteam-core/src/templates/review_with_user_loop.md
@@ -1,0 +1,53 @@
+# Helper: review-with-user loop
+
+> Embed this with `@~/.ccteam/templates/review-with-user-loop.md` from any
+> phase that needs "read an upstream artifact, push back on it through
+> multiple rounds with the user, then write a settled review". Designed
+> for `decision_mode: hybrid` phases (interfaces §5.6.1) — you may use
+> `AskUserQuestion` for a fast back-and-forth or fall back to outbox if
+> the user is offline.
+
+## How to use this loop
+
+1. **Read** the artifact named in your phase YAML's `required_inputs`
+   that this loop is reviewing. State out loud what it claims.
+2. **Identify the three highest-leverage challenge points**. A challenge
+   is a place where the artifact is silent, hand-wavy, or makes an
+   unstated assumption that the user might disagree with. Don't pad
+   with cosmetic nits.
+3. **Surface them to the user one round at a time.** Mode picked by
+   `decision_mode`:
+   - `sync` / `hybrid`: call `AskUserQuestion` with the *single* most
+     load-bearing question first. Wait for the answer, then move on.
+   - `async`: write `outbox/clarify-<ts>-<n>.md` with the question
+     (interfaces §3.4.3, `event_kind: clarify`); continue with whatever
+     work you can do without the answer.
+4. **Track rounds against `max_clarify_rounds`** (default 3). At the
+   cap, write your best-effort review based on what you have and
+   ESCALATE `INSUFFICIENT_CLARIFICATION — <last_question>`
+   (interfaces §5.6.2). The user picks continue / accept / abort.
+5. **Write the settled review** to the path your phase YAML's
+   `required_outputs` lists for review (commonly `.ccteam/review.md`).
+   Each section ties back to a challenge point and the resolution.
+
+## What goes in the review file
+
+- **Decision log**: each challenge, the user's answer (or your
+  best-effort assumption when the user didn't reply), and the resulting
+  call.
+- **Open risks**: anything the loop did not close. Call out what
+  triggers a revisit (e.g. "if data volume exceeds X, re-evaluate").
+- **Acceptance signal**: a single line stating whether the upstream
+  artifact is fit-for-purpose for the next phase. PASS / CONCERN /
+  REJECT (interfaces §5.3 verdict semantics).
+
+## Anti-patterns
+
+- Asking three questions in one CLARIFY message — `AskUserQuestion` and
+  outbox both work better with a single load-bearing question per round.
+- Looping past `max_clarify_rounds` "just one more time" — the cap is
+  there because long clarify chains burn token budget without
+  converging. Hit the cap → ESCALATE.
+- Writing the review before any challenge round — that's a rubber stamp,
+  not a review. If the upstream artifact is so good it needs zero
+  challenges, say so explicitly with reasoning.

--- a/crates/ccteam-core/src/tool_surface.rs
+++ b/crates/ccteam-core/src/tool_surface.rs
@@ -318,6 +318,110 @@ pub fn link_recommended_agents(opts: LinkOptions) -> Result<Vec<AgentLinkReport>
     link_recommended_agents_into(&claude_dir, opts)
 }
 
+/// M2.1 extension: like [`link_recommended_agents_into`] but also
+/// walks every phase template's `sub_skills` list, parses any
+/// `claude-plugins-official:<plugin>/agents/<name>.md` reference, and
+/// links the plugin source into `<claude_dir>/agents/<name>.md` —
+/// even if the agent isn't in [`RECOMMENDED_AGENTS`]. Result is the
+/// union of "8 hardcoded recommended" + "everything phase YAML asks
+/// for", deduplicated by target filename.
+///
+/// Tools_required.subagents are *not* auto-linked here — they're a
+/// names-only list with no source-path information; the operator is
+/// responsible for placing custom agents under `~/.claude/agents/`.
+/// The orchestrator's startup tool-surface check (M0.5.3) catches
+/// the missing case with a fix-hint.
+pub fn link_recommended_agents_for_phases_into(
+    claude_dir: &Path,
+    templates: &[crate::phases::PhaseTemplate],
+    opts: LinkOptions,
+) -> Result<Vec<AgentLinkReport>> {
+    let mut reports = link_recommended_agents_into(claude_dir, opts)?;
+
+    let agents_dir = claude_dir.join("agents");
+    if !opts.dry_run {
+        std::fs::create_dir_all(&agents_dir)
+            .with_context(|| format!("create {}", agents_dir.display()))?;
+    }
+
+    let mut seen: BTreeSet<&str> = reports.iter().map(|r| r.agent.filename).collect();
+    for template in templates {
+        for spec in &template.sub_skills {
+            let Some((source, leaked_filename)) =
+                parse_official_plugin_subagent(&spec.skill)
+            else {
+                continue;
+            };
+            if seen.contains(leaked_filename) {
+                continue;
+            }
+            // Link target stays under <claude_dir>/agents/, same as
+            // RECOMMENDED_AGENTS.
+            let abs_source = claude_dir
+                .join("plugins")
+                .join("marketplaces")
+                .join("claude-plugins-official")
+                .join("plugins")
+                .join(&source);
+            let target = agents_dir.join(leaked_filename);
+            let action = link_one_agent(&abs_source, &target, opts)?;
+            reports.push(AgentLinkReport {
+                // Build a synthetic RecommendedAgent — the report
+                // type is shared with the hardcoded path; we only
+                // need enough for the operator to read.
+                agent: RecommendedAgent {
+                    filename: Box::leak(leaked_filename.to_string().into_boxed_str()),
+                    plugin: Box::leak(plugin_part(&source).to_string().into_boxed_str()),
+                    relpath: Box::leak(rel_part(&source).to_string().into_boxed_str()),
+                },
+                target,
+                action,
+            });
+            seen.insert(Box::leak(leaked_filename.to_string().into_boxed_str()));
+        }
+    }
+    Ok(reports)
+}
+
+/// Production entry: resolve `~/.claude/` then call the phase-aware
+/// variant. Used by `bootstrap_project` so every project-creation
+/// path stages every plugin agent the templates declare.
+pub fn link_recommended_agents_for_phases(
+    templates: &[crate::phases::PhaseTemplate],
+    opts: LinkOptions,
+) -> Result<Vec<AgentLinkReport>> {
+    let claude_dir = user_claude_dir()?;
+    link_recommended_agents_for_phases_into(&claude_dir, templates, opts)
+}
+
+/// Parse `claude-plugins-official:<plugin>/agents/<name>.md`. Returns
+/// `(plugin/agents/<name>.md, <name>.md)` — the first component is
+/// joined under `plugins/marketplaces/claude-plugins-official/plugins/`
+/// for the abs source path, the second is the basename used under
+/// `<claude_dir>/agents/`.
+fn parse_official_plugin_subagent(skill: &str) -> Option<(String, &str)> {
+    let rest = skill.strip_prefix("claude-plugins-official:")?;
+    // Only auto-link when the relative path looks like an agent file.
+    // sub_skills can also reference hooks (.sh / .py) which Claude Code
+    // doesn't load via Task — those should not become symlinks under
+    // ~/.claude/agents/.
+    if !rest.contains("/agents/") || !rest.ends_with(".md") {
+        return None;
+    }
+    let filename = rest.rsplit('/').next()?;
+    Some((rest.to_string(), filename))
+}
+
+fn plugin_part(rest: &str) -> &str {
+    rest.split('/').next().unwrap_or(rest)
+}
+
+fn rel_part(rest: &str) -> &str {
+    let mut parts = rest.splitn(2, '/');
+    parts.next();
+    parts.next().unwrap_or(rest)
+}
+
 /// Test-only helper: set `CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP=1` so
 /// any subsequent `bootstrap_project` call in the same process
 /// no-ops the `~/.claude/` mutation. Use from a once-init at the top

--- a/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
+++ b/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
@@ -160,6 +160,7 @@ OUTBOX
             post_ready_warmup: Duration::from_millis(50),
             skip_tool_check: true,
             tick_interval: Duration::from_millis(100),
+            ..OrchestratorConfig::default()
         },
     )
     .unwrap();

--- a/crates/ccteam-core/tests/m2_subskill_test.rs
+++ b/crates/ccteam-core/tests/m2_subskill_test.rs
@@ -1,0 +1,251 @@
+//! M2.1 integration tests: sub-skill scheduling + auto @-attachment of
+//! prior-phase outputs into the next phase's prompt.
+//!
+//! Pattern: configure `OrchestratorConfig::subskill_argv` to a shell
+//! stub that captures stdin and writes a known body to stdout. That
+//! exercises the orchestrator's plumbing (path resolution, output
+//! persistence, progress.jsonl events, attachment collection) without
+//! requiring a real `claude` on the PATH.
+
+use std::path::Path;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use ccteam_core::{
+    bootstrap_project, disable_tool_surface_bootstrap_for_tests, write_global_phase_templates,
+    CcteamPaths, Orchestrator, OrchestratorConfig, PhaseHistoryEntry, PhaseState, ProjectState,
+    SubSkillTrigger,
+};
+
+static DISABLE_TOOL_SURFACE: OnceLock<()> = OnceLock::new();
+
+fn ensure_isolation() {
+    DISABLE_TOOL_SURFACE.get_or_init(disable_tool_surface_bootstrap_for_tests);
+}
+
+fn fresh_paths(tmp: &tempfile::TempDir) -> CcteamPaths {
+    CcteamPaths {
+        root: tmp.path().join("home"),
+        projects_root: tmp.path().join("projects"),
+    }
+}
+
+/// Replace the shipped phase markdown under `~/.ccteam/phases/` with
+/// a single template that names a `local:` sub-skill so the test can
+/// stage the agent body next to the project. Returns the slug that
+/// gets bootstrapped.
+fn setup_subskill_project(
+    paths: &CcteamPaths,
+    template_body: &str,
+    agent_body: &str,
+) -> String {
+    write_global_phase_templates(&paths.root, true).unwrap();
+    let phases = paths.phases_dir();
+    // Wipe shipped templates so only ours remains.
+    for entry in std::fs::read_dir(&phases).unwrap() {
+        let p = entry.unwrap().path();
+        std::fs::remove_file(&p).unwrap();
+    }
+    std::fs::write(phases.join("01-implement.md"), template_body).unwrap();
+
+    let slug = "subskill-demo";
+    bootstrap_project(paths, slug, "demo request", "dev").unwrap();
+    let project = paths.project_dir(slug);
+    std::fs::write(project.join("agent.md"), agent_body).unwrap();
+    slug.to_string()
+}
+
+#[test]
+fn run_phase_sub_skills_phase_done_writes_output_via_stub_runner() {
+    ensure_isolation();
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+
+    // Phase 'implement' with one phase_done sub_skill pointed at a
+    // local agent file. output_to lands under .ccteam/.
+    let template_body = concat!(
+        "---\n",
+        "name: implement\n",
+        "parallelism: solo\n",
+        "sub_skills:\n",
+        "  - skill: local:agent.md\n",
+        "    trigger: phase_done\n",
+        "    output_to: .ccteam/code-review.md\n",
+        "---\n",
+        "body\n",
+    );
+    let slug = setup_subskill_project(&paths, template_body, "# stub agent\n");
+    let project_dir = paths.project_dir(&slug);
+
+    let cfg = OrchestratorConfig {
+        skip_tool_check: true,
+        // Stub: read stdin (the prompt), discard it, write a fixed
+        // body to stdout. Production claude -p does the same shape
+        // but actually invokes the model.
+        subskill_argv: Some(vec![
+            "sh".into(),
+            "-c".into(),
+            "cat >/dev/null && printf 'REVIEW BODY\\n'".into(),
+        ]),
+        ..OrchestratorConfig::default()
+    };
+    let orch = Orchestrator::new(paths.clone(), cfg).unwrap();
+    let template = orch
+        .templates()
+        .iter()
+        .find(|t| t.name == "implement")
+        .unwrap()
+        .clone();
+
+    orch.run_phase_sub_skills(&slug, &template, SubSkillTrigger::PhaseDone);
+
+    let out = project_dir.join(".ccteam/code-review.md");
+    assert!(out.is_file(), "sub-skill output file should exist: {}", out.display());
+    let body = std::fs::read_to_string(&out).unwrap();
+    assert!(body.contains("REVIEW BODY"), "got: {body:?}");
+
+    // progress.jsonl should record subskill_started + subskill_done.
+    let pj = std::fs::read_to_string(paths.progress_jsonl(&slug)).unwrap();
+    assert!(pj.contains("subskill_started"), "got: {pj}");
+    assert!(pj.contains("subskill_done"), "got: {pj}");
+}
+
+#[test]
+fn run_phase_sub_skills_records_failed_when_runner_exits_nonzero() {
+    ensure_isolation();
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+
+    let template_body = concat!(
+        "---\n",
+        "name: implement\n",
+        "parallelism: solo\n",
+        "sub_skills:\n",
+        "  - skill: local:agent.md\n",
+        "    trigger: phase_done\n",
+        "    output_to: .ccteam/x.md\n",
+        "---\n",
+    );
+    let slug = setup_subskill_project(&paths, template_body, "x");
+
+    let cfg = OrchestratorConfig {
+        skip_tool_check: true,
+        subskill_argv: Some(vec!["sh".into(), "-c".into(), "exit 17".into()]),
+        ..OrchestratorConfig::default()
+    };
+    let orch = Orchestrator::new(paths.clone(), cfg).unwrap();
+    let template = orch.templates()[0].clone();
+
+    orch.run_phase_sub_skills(&slug, &template, SubSkillTrigger::PhaseDone);
+
+    let out = paths.project_dir(&slug).join(".ccteam/x.md");
+    assert!(!out.exists(), "failed runner must not leave output behind");
+    let pj = std::fs::read_to_string(paths.progress_jsonl(&slug)).unwrap();
+    assert!(pj.contains("subskill_failed"), "got: {pj}");
+}
+
+#[test]
+fn attachments_for_next_phase_picks_up_phase_done_outputs() {
+    ensure_isolation();
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+
+    // Two phases: 01-implement (with phase_done sub_skill) → 02-review
+    // (no sub_skill). After implement runs and 'advances', the review
+    // dispatch should @-attach implement's output_to.
+    let implement_body = concat!(
+        "---\n",
+        "name: implement\n",
+        "parallelism: solo\n",
+        "sub_skills:\n",
+        "  - skill: local:agent.md\n",
+        "    trigger: phase_done\n",
+        "    output_to: .ccteam/code-review.md\n",
+        "---\n",
+    );
+    let review_body = concat!(
+        "---\n",
+        "name: review\n",
+        "parallelism: solo\n",
+        "---\n",
+    );
+    write_global_phase_templates(&paths.root, true).unwrap();
+    let phases = paths.phases_dir();
+    for entry in std::fs::read_dir(&phases).unwrap() {
+        std::fs::remove_file(entry.unwrap().path()).unwrap();
+    }
+    std::fs::write(phases.join("01-implement.md"), implement_body).unwrap();
+    std::fs::write(phases.join("02-review.md"), review_body).unwrap();
+
+    let slug = "att-demo";
+    bootstrap_project(&paths, slug, "demo request", "dev").unwrap();
+    let project = paths.project_dir(slug);
+    // Pretend implement's sub-skill already ran:
+    std::fs::create_dir_all(project.join(".ccteam")).unwrap();
+    std::fs::write(project.join(".ccteam/code-review.md"), "REVIEW\n").unwrap();
+
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
+
+    // Pretend implement just finished.
+    let mut state = ProjectState::initial(slug.to_string());
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "implement".into(),
+        status: "passed".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    state.phase_state = PhaseState::Idle;
+    state.current_phase = "review".into();
+
+    let attachments = orch.attachments_for_next_phase(slug, &state);
+    assert_eq!(attachments, vec![".ccteam/code-review.md".to_string()]);
+}
+
+#[test]
+fn attachments_for_next_phase_returns_empty_when_output_missing() {
+    ensure_isolation();
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+
+    let template_body = concat!(
+        "---\n",
+        "name: implement\n",
+        "parallelism: solo\n",
+        "sub_skills:\n",
+        "  - skill: local:agent.md\n",
+        "    trigger: phase_done\n",
+        "    output_to: .ccteam/never-written.md\n",
+        "---\n",
+    );
+    let slug = setup_subskill_project(&paths, template_body, "x");
+
+    let orch = Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap();
+
+    let mut state = ProjectState::initial(slug.to_string());
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "implement".into(),
+        status: "passed".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+
+    // The sub-skill never ran, so the output file is absent →
+    // attachment list must be empty (no broken @-references for the
+    // next phase).
+    assert!(orch.attachments_for_next_phase(&slug, &state).is_empty());
+    let _ = Path::new(".");  // silence unused import on some platforms
+}

--- a/crates/ccteam-core/tests/orchestrator_test.rs
+++ b/crates/ccteam-core/tests/orchestrator_test.rs
@@ -64,7 +64,10 @@ fn orchestrator_loads_valid_solo_template() {
 }
 
 #[test]
-fn orchestrator_fails_fast_on_agent_team_template() {
+fn orchestrator_fails_fast_on_agent_team_template_without_roles() {
+    // M2.2 lifts the blanket `parallelism: agent_team` ban — declared
+    // teams may now run agent_team phases — but the role list must be
+    // non-empty, otherwise the orchestrator has nothing to dispatch.
     let tmp = TempDir::new().unwrap();
     let paths = fresh_paths(&tmp);
     write_template(
@@ -82,9 +85,36 @@ fn orchestrator_fails_fast_on_agent_team_template() {
     let err = Orchestrator::new(paths, OrchestratorConfig::default()).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
-        msg.contains("solo"),
-        "expected M0 validation failure, got: {msg}",
+        msg.contains("agent_team"),
+        "expected validation failure mentioning agent_team, got: {msg}",
     );
+}
+
+#[test]
+fn orchestrator_accepts_agent_team_template_with_roles() {
+    // M2.2: phase YAML with parallelism: agent_team + at least one
+    // role passes validation. Orchestrator dispatch behavior is still
+    // gated on the M2.2.0 spike; this test only covers the schema.
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_template(
+        &paths.phases_dir(),
+        "03-implement.md",
+        concat!(
+            "---\n",
+            "name: implement\n",
+            "parallelism: agent_team\n",
+            "agent_team:\n",
+            "  - role: backend-dev\n",
+            "  - role: reviewer\n",
+            "---\n",
+            "body\n",
+        ),
+    );
+
+    let orch = Orchestrator::new(paths, OrchestratorConfig::default()).unwrap();
+    assert_eq!(orch.templates().len(), 1);
+    assert_eq!(orch.templates()[0].agent_team.len(), 2);
 }
 
 #[test]

--- a/crates/ccteam-core/tests/phases_test.rs
+++ b/crates/ccteam-core/tests/phases_test.rs
@@ -22,6 +22,10 @@ const M0_TEMPLATES: &[(&str, &str)] = &[
 
 #[test]
 fn every_m0_template_parses_and_validates() {
+    // M2.1+ note: sub_skills is no longer required to be empty —
+    // implement.md now declares the code-reviewer auto-trigger so the
+    // orchestrator runs it on phase_done. The validate path is the
+    // contract; the empty-list assertion was an M0-era invariant.
     let dir = phases_dir();
     for (file, expected_name) in M0_TEMPLATES {
         let path = dir.join(file);
@@ -32,19 +36,18 @@ fn every_m0_template_parses_and_validates() {
             template.name, *expected_name,
             "{file}: front-matter `name` must equal phase id (without numeric prefix)",
         );
+        // Dev's shipped phases are still all `solo` — M2.2 lifts this
+        // gate but the `agent_team` enablement lives in a follow-up
+        // commit (post-spike), not in the static templates.
         assert_eq!(
             template.parallelism,
             Parallelism::Solo,
-            "{file}: M0 only supports parallelism: solo",
-        );
-        assert!(
-            template.sub_skills.is_empty(),
-            "{file}: M0 sub_skills must be empty (M2 starts scheduling)",
+            "{file}: dev phases stay solo until M2.2 enables agent_team",
         );
 
         template
             .validate_m0()
-            .unwrap_or_else(|e| panic!("{file} fails M0 validation: {e:#}"));
+            .unwrap_or_else(|e| panic!("{file} fails validation: {e:#}"));
     }
 }
 

--- a/crates/ccteam-core/tests/templates_test.rs
+++ b/crates/ccteam-core/tests/templates_test.rs
@@ -1,7 +1,9 @@
 //! Integration test: `write_project_settings` lays down a valid
 //! `.claude/settings.json` under a tempdir-rooted project.
 
-use ccteam_core::write_project_settings;
+use ccteam_core::{
+    write_global_helper_templates, write_project_settings, HELPER_TEMPLATES,
+};
 use tempfile::TempDir;
 
 #[test]
@@ -31,4 +33,64 @@ fn write_project_settings_is_idempotent() {
     let second = std::fs::read(project.join(".claude/settings.json")).unwrap();
 
     assert_eq!(first, second, "rerun must produce identical bytes");
+}
+
+// -------------- M2.4: helper template global writer --------------
+
+#[test]
+fn write_global_helper_templates_lays_down_both_helpers() {
+    let tmp = TempDir::new().unwrap();
+    write_global_helper_templates(tmp.path(), false).unwrap();
+    let dir = tmp.path().join("templates");
+    for (name, _) in HELPER_TEMPLATES {
+        assert!(
+            dir.join(name).is_file(),
+            "helper template missing: {}",
+            dir.join(name).display(),
+        );
+    }
+    assert_eq!(HELPER_TEMPLATES.len(), 2, "M2.4 ships exactly 2 helpers");
+}
+
+#[test]
+fn write_global_helper_templates_preserves_user_edits_without_force() {
+    let tmp = TempDir::new().unwrap();
+    write_global_helper_templates(tmp.path(), false).unwrap();
+    let path = tmp.path().join("templates/review-with-user-loop.md");
+    std::fs::write(&path, "USER EDIT\n").unwrap();
+    write_global_helper_templates(tmp.path(), false).unwrap();
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "USER EDIT\n");
+    write_global_helper_templates(tmp.path(), true).unwrap();
+    assert_ne!(std::fs::read_to_string(&path).unwrap(), "USER EDIT\n");
+}
+
+#[test]
+fn helper_template_filenames_use_hyphens_for_at_reference() {
+    // The on-disk filename is what `@~/.ccteam/templates/<name>` cites.
+    // Underscore filenames would force phase markdown to write the
+    // Rust source name; hyphens match the rest of the @-reference
+    // convention in phase markdown.
+    for (name, _) in HELPER_TEMPLATES {
+        assert!(
+            !name.contains('_'),
+            "helper template filename must not contain underscores: {name}",
+        );
+        assert!(
+            name.ends_with(".md"),
+            "helper template must be .md: {name}",
+        );
+    }
+}
+
+#[test]
+fn plan_eng_phase_embeds_review_with_user_loop_helper() {
+    // M2.4 acceptance: dev's plan-eng phase must reference the helper
+    // template via `@~/.ccteam/templates/review-with-user-loop.md` so
+    // the helper actually lands in a phase prompt — otherwise we have
+    // a dead template nobody calls.
+    let body = include_str!("../../../phases/02-plan-eng.md");
+    assert!(
+        body.contains("@~/.ccteam/templates/review-with-user-loop.md"),
+        "plan-eng phase markdown must inline @~/.ccteam/templates/review-with-user-loop.md",
+    );
 }

--- a/crates/ccteam-core/tests/tool_surface_e2e_test.rs
+++ b/crates/ccteam-core/tests/tool_surface_e2e_test.rs
@@ -20,9 +20,10 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use ccteam_core::{
-    bootstrap_project, decide_tick_from_events, dev_dag, progress, slugify,
-    CcteamPaths, Orchestrator, OrchestratorConfig, PhaseState, PhaseTemplate,
-    ProjectState, TickAction, RECOMMENDED_AGENTS,
+    bootstrap_project, decide_tick_from_events, dev_dag,
+    link_recommended_agents_for_phases_into, progress, slugify, AgentLinkAction, CcteamPaths,
+    LinkOptions, Orchestrator, OrchestratorConfig, PhaseState, PhaseTemplate, ProjectState,
+    TickAction, RECOMMENDED_AGENTS,
 };
 
 /// Several tests in this file mutate `CLAUDE_CONFIG_HOME`, which is a
@@ -239,5 +240,95 @@ fn missing_code_reviewer_fails_orchestrator_construction_with_fix_hint() {
         msg.contains("ccteam doctor"),
         "error must include the fix hint, got: {msg}",
     );
+}
+
+/// M2.1: phase YAML's `sub_skills` reference plugin agents that may
+/// not be in the hardcoded RECOMMENDED_AGENTS set. The phase-aware
+/// linker walks each template's sub_skills and ln -sfs the plugin
+/// source so `Task(subagent_type=...)` finds the agent at session
+/// start.
+#[test]
+fn link_phase_subagents_picks_up_sub_skill_plugin_agent() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join("claude");
+    stage_plugin_sources(&claude_dir);
+    // Stage an extra plugin agent that isn't in RECOMMENDED_AGENTS, so
+    // the test proves the extension does more than the hardcoded
+    // recommended set.
+    let custom = claude_dir
+        .join("plugins/marketplaces/claude-plugins-official/plugins/custom-toolkit/agents/custom-reviewer.md");
+    std::fs::create_dir_all(custom.parent().unwrap()).unwrap();
+    std::fs::write(&custom, "# custom-reviewer stub\n").unwrap();
+
+    let _guard = ScopedClaude::set(&claude_dir);
+
+    // Phase template with one sub_skill referencing the custom agent.
+    let body = concat!(
+        "---\n",
+        "name: review\n",
+        "parallelism: solo\n",
+        "sub_skills:\n",
+        "  - skill: claude-plugins-official:custom-toolkit/agents/custom-reviewer.md\n",
+        "    trigger: phase_done\n",
+        "    output_to: .ccteam/custom-review.md\n",
+        "---\n",
+        "body\n",
+    );
+    let template = PhaseTemplate::parse(body).unwrap();
+
+    let reports =
+        link_recommended_agents_for_phases_into(&claude_dir, &[template], LinkOptions::default())
+            .unwrap();
+
+    // Must include the 8 hardcoded agents *and* the new one.
+    assert_eq!(
+        reports.len(),
+        RECOMMENDED_AGENTS.len() + 1,
+        "expected {} reports, got {}",
+        RECOMMENDED_AGENTS.len() + 1,
+        reports.len(),
+    );
+    let custom_report = reports
+        .iter()
+        .find(|r| r.agent.filename == "custom-reviewer.md")
+        .expect("custom-reviewer plugin agent must appear in reports");
+    assert_eq!(custom_report.action, AgentLinkAction::Linked);
+    assert!(claude_dir
+        .join("agents/custom-reviewer.md")
+        .symlink_metadata()
+        .unwrap()
+        .file_type()
+        .is_symlink());
+}
+
+/// Sub-skill referencing a hook script (`.sh`) instead of an agent
+/// must NOT be auto-linked into `~/.claude/agents/` — only `.md`
+/// files under `<plugin>/agents/` count as Task-callable subagents.
+#[test]
+fn link_phase_subagents_skips_non_agent_sub_skill_paths() {
+    let tmp = TempDir::new().unwrap();
+    let claude_dir = tmp.path().join("claude");
+    stage_plugin_sources(&claude_dir);
+
+    let _guard = ScopedClaude::set(&claude_dir);
+
+    let body = concat!(
+        "---\n",
+        "name: ship\n",
+        "parallelism: solo\n",
+        "sub_skills:\n",
+        "  - skill: claude-plugins-official:security-guidance/hooks/security_reminder_hook.py\n",
+        "    trigger: phase_start\n",
+        "    output_to: .ccteam/precheck.md\n",
+        "---\n",
+    );
+    let template = PhaseTemplate::parse(body).unwrap();
+
+    let reports =
+        link_recommended_agents_for_phases_into(&claude_dir, &[template], LinkOptions::default())
+            .unwrap();
+    // Just the 8 hardcoded — the .py hook is not eligible for Task
+    // dispatch, so no extra link.
+    assert_eq!(reports.len(), RECOMMENDED_AGENTS.len());
 }
 

--- a/crates/ccteam-hooks/src/parse_phase_end.rs
+++ b/crates/ccteam-hooks/src/parse_phase_end.rs
@@ -145,31 +145,33 @@ pub fn parse_phase_end(paths: &CcteamPaths, stdin: &Value) -> Result<ParseDecisi
     Ok(ParseDecision::Continue)
 }
 
-/// M0.5.4 structured ESCALATE grammar. Three explicit prefixes route
-/// to different orchestrator behavior; bare text degrades to
-/// `NEED_USER_INPUT` so old phase markdown keeps working.
+/// Structured ESCALATE grammar (interfaces §4.1.1). Pure string-prefix
+/// matching, no LLM — orchestrator stays a dumb Rust program. Bare text
+/// degrades to `NEED_USER_INPUT` so old phase markdown keeps working.
 ///
 /// Grammar (everything after `ESCALATE:` whitespace-trimmed):
 ///
 /// - `REVERT_TO_PHASE <name> — <reason>` → `kind="revert"`,
 ///   `target_phase="<name>"`. Em dash (`—`) preferred but plain `-` /
 ///   `--` accepted.
-/// - `NEED_USER_INPUT — <questions>` → `kind="need_user_input"`,
-///   `target_phase=null`. The reason carries the clarifying questions.
-/// - `ABORT — <reason>` → `kind="abort"`, `target_phase=null`. Project
-///   marked terminally failed; user must `ccteam new` from scratch.
-/// - Anything else → `kind="need_user_input"`, `target_phase=null`,
-///   `reason=<the whole tail>`. Equivalent to NEED_USER_INPUT for
-///   M0/M1 routing — orchestrator just stops the auto loop and waits
-///   for user.
-///
-/// Pure string-prefix matching, no LLM. Orchestrator is a dumb Rust
-/// program and stays that way.
+/// - `NEED_USER_INPUT — <questions>` → `kind="need_user_input"`.
+/// - `ABORT — <reason>` → `kind="abort"`. Project terminally failed.
+/// - **M2.3** `INSUFFICIENT_CLARIFICATION — <last_question>` →
+///   `kind="insufficient_clarification"`. Phase already produced a
+///   best-effort artifact; user picks continue / accept / abort
+///   (interfaces §5.6.2).
+/// - **M3.6** `PHASE_DONE_PENDING — <reason>` →
+///   `kind="phase_done_pending"`. Phase done modulo deferred decisions
+///   (interfaces §4.1.1). M2.3 only parses the prefix; orchestrator
+///   routing lands in M3.6.
+/// - Anything else → `kind="need_user_input"`, `reason=<the whole tail>`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EscalateKind {
     Revert,
     NeedUserInput,
     Abort,
+    InsufficientClarification,
+    PhaseDonePending,
 }
 
 impl EscalateKind {
@@ -178,6 +180,8 @@ impl EscalateKind {
             EscalateKind::Revert => "revert",
             EscalateKind::NeedUserInput => "need_user_input",
             EscalateKind::Abort => "abort",
+            EscalateKind::InsufficientClarification => "insufficient_clarification",
+            EscalateKind::PhaseDonePending => "phase_done_pending",
         }
     }
 }
@@ -223,6 +227,30 @@ impl ParsedEscalate {
             let reason = trim_leading_dash(rest);
             return Self {
                 kind: EscalateKind::Abort,
+                target_phase: None,
+                reason: reason.to_string(),
+            };
+        }
+        // M2.3: phase exhausted max_clarify_rounds with a best-effort
+        // artifact already on disk — user picks continue / accept / abort.
+        // Match before NEED_USER_INPUT but the keywords don't share a
+        // prefix, so order is for readability.
+        if let Some(rest) = strip_grammar_prefix(trimmed, "INSUFFICIENT_CLARIFICATION") {
+            let reason = trim_leading_dash(rest);
+            return Self {
+                kind: EscalateKind::InsufficientClarification,
+                target_phase: None,
+                reason: reason.to_string(),
+            };
+        }
+        // M3.6: phase produced its required outputs but some sub-tasks
+        // are deferred (decisions queue). Parsing landed in M2.3 so
+        // phase markdown can use the prefix today; orchestrator routing
+        // for `phase_done_pending` ships in M3.6.
+        if let Some(rest) = strip_grammar_prefix(trimmed, "PHASE_DONE_PENDING") {
+            let reason = trim_leading_dash(rest);
+            return Self {
+                kind: EscalateKind::PhaseDonePending,
                 target_phase: None,
                 reason: reason.to_string(),
             };
@@ -379,6 +407,32 @@ mod parse_escalate_tests {
         let p = ParsedEscalate::from_reason("ABORT");
         assert_eq!(p.kind, EscalateKind::Abort);
         assert_eq!(p.reason, "");
+    }
+
+    #[test]
+    fn insufficient_clarification_with_em_dash() {
+        let p = ParsedEscalate::from_reason(
+            "INSUFFICIENT_CLARIFICATION \u{2014} 已 3 轮 CLARIFY 未收到目标平台答复",
+        );
+        assert_eq!(p.kind, EscalateKind::InsufficientClarification);
+        assert_eq!(p.target_phase, None);
+        assert_eq!(p.reason, "已 3 轮 CLARIFY 未收到目标平台答复");
+    }
+
+    #[test]
+    fn insufficient_clarification_keyword_serializes_to_snake_case() {
+        // Stop hook writes `kind` into progress.jsonl; the snake-case
+        // form is the only valid wire shape (interfaces §4.1.1).
+        let p = ParsedEscalate::from_reason("INSUFFICIENT_CLARIFICATION");
+        assert_eq!(p.kind.as_str(), "insufficient_clarification");
+    }
+
+    #[test]
+    fn phase_done_pending_parses() {
+        let p = ParsedEscalate::from_reason("PHASE_DONE_PENDING -- waiting on storage decision");
+        assert_eq!(p.kind, EscalateKind::PhaseDonePending);
+        assert_eq!(p.reason, "waiting on storage decision");
+        assert_eq!(p.kind.as_str(), "phase_done_pending");
     }
 }
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -350,10 +350,12 @@ interfaces §3.4.3"。具体写哪些事件:
 
 ```jsonl
 {"ts":"2026-05-04T11:23:00Z","event":"session_start","tmux_session":"ccteam-bookmark-mgr-a3f9"}
-{"ts":"...","event":"phase_inject","phase":"implement"}
+{"ts":"...","event":"phase_inject","phase":"implement","attachments":[".ccteam/code-review.md"]}
 {"ts":"...","event":"PreToolUse","tool":"Edit","path":"src/db.ts"}
 {"ts":"...","event":"PostToolUse","tool":"Bash","cmd":"pnpm test","exit_code":0,"duration_ms":4521}
 {"ts":"...","event":"phase_milestone","phase":"implement","note":"完成 schema + migration"}
+{"ts":"...","event":"subskill_started","phase":"implement","skill":"claude-plugins-official:pr-review-toolkit/agents/code-reviewer.md","trigger":"phase_done"}
+{"ts":"...","event":"subskill_done","phase":"implement","skill":"...","output":".ccteam/code-review.md","bytes":4123}
 {"ts":"...","event":"phase_done","phase":"implement","duration_s":4521,"cost_usd":2.13}
 {"ts":"...","event":"escalate","kind":"need_user_input","target_phase":null,"reason":"db migration 不可调和","cycle":3}
 {"ts":"...","event":"escalate","kind":"revert","target_phase":"plan-eng","reason":"fix-loop 撞顶,根因在选型"}
@@ -388,6 +390,7 @@ interfaces §3.4.3"。具体写哪些事件:
 | `session_start` / `phase_inject` | orchestrator(send-keys 前后直接 append) |
 | `PreToolUse` / `PostToolUse` / `phase_milestone` | Claude Code hooks(详见 §6.1) |
 | `phase_done` / `escalate` | Stop hook 解析 claude 最后一行(`PHASE_DONE: <phase>` / `ESCALATE: <reason>`) |
+| `subskill_started` / `subskill_done` / `subskill_skipped` / `subskill_failed` | M2.1 orchestrator 在 phase_start / phase_done 边界跑 sub-skill;`subskill_done` 含 `output` 与 `bytes`,`subskill_skipped` 含 `reason`(`installed:` 前缀等),`subskill_failed` 含 `error` |
 | `user_attach` | PreToolUse hook 检测输入源 |
 | `watcher_concern` / `watcher_block` | Cross-cutting watcher 异步子进程(详见 tech-design §6.3 模式 B) |
 | `SessionEnd` | SessionEnd hook |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1053,6 +1053,7 @@ ccteam doctor --install-recommended-agents        # M0.5.5 ln -sf 8 个 plugin a
 ccteam doctor --tool-surface                      # M0.5.6 phase tools_required 交叉表
 ccteam doctor --install-skill                     # M1.8 写 ccteam-control skill
 ccteam doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
+ccteam doctor --install-mcp                       # M2.5 在 ~/.claude.json 注册 mcpServers.ccteam(详见 §12)
 ccteam hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
                                                   # subcmd ∈ {progress-append, parse-phase-end,
                                                   # cost-accumulate, load-context, block-push}
@@ -1160,23 +1161,34 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 
 由 `ccteam doctor --install-mcp` 写入(M2 release)。`ccteam mcp-serve` 是 binary 子命令,stdio 协议。
 
-### 12.2 暴露的 tool 清单(M2 起步集)
+### 12.2 暴露的 tool 清单(M2.5 起,9 tool)
 
-| Tool 名 | 对应 CLI | 入参 | 返回 |
+| Tool 名 | 对应 CLI / 行为 | 入参 | 返回 |
 |---|---|---|---|
-| `ccteam__ls` | `ccteam ls --format json` | `{}` | §10.3 ls JSON schema |
+| `ccteam__ls` | `ccteam ls --format json` | `{}` | §10.3 ls JSON schema(扩 `team`) |
 | `ccteam__show` | `ccteam show <slug> --format json` | `{slug: string}` | §10.3 show JSON schema |
-| `ccteam__new` | `ccteam new "..."` | `{prompt: string, priority?: "low"\|"normal"\|"high", mode?: "yolo"\|"balanced"\|"careful"}` | `{slug: string, workspace: string}` |
-| `ccteam__peek` | `ccteam peek <slug>` | `{slug: string, lines?: number}` | `{capture: string, ts: string}` |
-| `ccteam__progress` | `ccteam progress <slug>` | `{slug: string, phase?: string, last_n?: number}` | `{events: [...]}` |
-| `ccteam__pause` | `ccteam pause <slug>` | `{slug: string}` | `{ok: bool}` |
-| `ccteam__resume` | `ccteam resume <slug>` | `{slug: string}` | `{ok: bool}` |
+| `ccteam__new` | `ccteam new "..."` | `{prompt: string, team?: string}` | `{slug: string, workspace: string}` |
+| `ccteam__peek` | `ccteam peek <slug>` | `{slug: string}` | tmux capture-pane stdout 字符串 |
+| `ccteam__progress` | `ccteam progress <slug>` | `{slug: string, last_n?: number}` | `{events: [...]}` |
+| `ccteam__pause` | 设 `state.user_pause_pending=true` | `{slug: string}` | `{ok: bool, slug: string, user_pause_pending: bool}` |
+| `ccteam__resume` | `ccteam resume <slug>` | `{slug: string}` | `{ok: bool, slug: string}` |
+| `ccteam__send_to_session`(M2.5 新)| 原子写 `<session>/.ccteam/inbox/msg-<ts>-NNN.md`(§3.4.2)| `{session: string, body: string, content_type?: "text"\|"markdown"}` | `{ok: bool, session: string, inbox_file: string}` |
+| `ccteam__inject_decision`(M2.5 新)| 构造 ESCALATE-shape payload(§4.1.1),走 `send_to_session` 落 inbox | `{slug: string, escalate_kind: "revert_to_phase"\|"need_user_input"\|"abort"\|"insufficient_clarification"\|"phase_done_pending", args?: {target_phase?: string, reason?: string}}` | `{ok: bool, slug: string, inbox_file: string}` |
+
+`send_to_session` / `inject_decision` 是 M2.5 增量(meta-agent 主消费者):
+让 meta-agent 把用户的回复 / 决策推送回项目 session,**adapter 进程内不做
+任何 NL 解析 / LLM 调用**,Symphony 反模式禁止(tech-design §3.1)。
+
+`ccteam__inject_decision` 内部是 `send_to_session` 的 thin wrapper —— 把
+`escalate_kind` 翻成 markdown payload(显式标记 `**META-AGENT DECISION**`
++ ESCALATE shape),然后走同一条 inbox 路径。
 
 ### 12.3 不暴露的(M2 显式排除)
 
 - `ccteam attach` — tty 交互,MCP 协议不适合
 - `ccteam start / stop` — orchestrator 生命周期管理是 ops 决策,不让 LLM 误调
 - `ccteam memory rebuild` — 重操作,走 CLI
+- `ccteam doctor --install-*` — 单机配置变更,走 CLI(避免 MCP server 给 LLM 改 ~/.claude.json 的能力)
 
 ### 12.4 双消费者
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -35,6 +35,9 @@
 │   ├── 07-review.md
 │   ├── 08-score.md
 │   └── 09-ship.md
+├── templates/             # M2.4+: phase 可 @ 引用的 prompt 片段(原生 @,orchestrator 不解析)
+│   ├── review-with-user-loop.md
+│   └── kickoff-reverse-interview.md
 ├── control/               # 用户 → orchestrator 控制信号(详见 §3.3)
 ├── memory/                # 跨项目记忆(M3+)
 │   ├── patterns/
@@ -1190,6 +1193,7 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 | `~/.ccteam/queue/<state>/` | 项目状态分桶 |
 | `~/.ccteam/control/` | 用户 → orchestrator 控制信号(详见 §3.3) |
 | `~/.ccteam/phases/` | phase 模板(详见 §5) |
+| `~/.ccteam/templates/` | M2.4+:phase 可 @ 引用的 prompt 片段(`review-with-user-loop.md` / `kickoff-reverse-interview.md`) |
 | `~/.ccteam/memory/` | 跨项目记忆(M3+) |
 | `~/.ccteam/progress/<slug>.jsonl` | 结构化事件流(详见 §4) |
 | `~/.ccteam/log/<slug>/` | stream-json 归档(可选,调试用) |

--- a/docs/m2-agent-team-spike.md
+++ b/docs/m2-agent-team-spike.md
@@ -1,0 +1,148 @@
+# M2.2.0 Agent Team 兼容性 spike 报告
+
+> 触发任务:`docs/development-plan.md` §4 M2.2 子任务 M2.2.0(0.5 天硬上限)
+>
+> 目的:验证 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 在 Claude Code 当前
+> 版本下是否仍触发 Agent Teams 实验功能(Lead + 多角色并行子 agent)。
+> 结果决定 M2.2 是否能按 spec 继续(`parallelism: agent_team` +
+> `agent_team: [{role: ...}]` YAML 直接使能)。
+
+## 实测环境
+
+- **CLI**:`claude --version` → `2.1.128 (Claude Code)`
+- **Spike 时间**:2026-05-06
+- **Env**:`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 已由 Claude Code 父进程注入
+  (在本 spike 进程的 `env` 输出里能看到),说明这个 env var 在 2.1.128
+  下**仍被某段代码引用**(否则不会被传递)
+- **OS**:Linux 6.6.87.2-microsoft-standard-WSL2
+
+## 调查方法
+
+不实测真子进程(避免 spike 期间双 claude session 互相污染本对话上下文),
+改走 desk research:
+
+1. `claude --help` 完整 dump,搜索 `agent` / `team` / `experimental` 关键字
+2. `claude agents --help` 与 `claude agents list` 实测
+3. `claude --help` 列出的所有 agent 相关 flag(`--agent`、`--agents`、
+   `agents` 子命令)
+4. `claude-plugins-official` 缓存目录里搜 `EXPERIMENTAL_AGENT_TEAMS` /
+   `agent_team` 引用
+5. ccteam 自己 `docs/` 与 `references/` 是否有更早的实测笔记
+
+## 结论(三项,每项都有证据)
+
+### 1. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` 不再是用户可见的 CLI feature
+
+`claude --help` **没有任何**与 agent_team / experimental teams /
+multi-role 相关的 flag。env var 仍由父进程注入(说明代码里某处还有引用),
+但**不通过 CLI 暴露**给用户配置。
+
+可见的 agent 接口换成了:
+
+| 接口 | 用途 |
+|---|---|
+| `--agent <agent>` | 整个 session 用一个角色(覆盖 `agent` setting) |
+| `--agents <json>` | 内联 JSON 注册自定义 agent(ad-hoc) |
+| `claude agents` 子命令 | Manage background and configured agents |
+| `Task(subagent_type=...)` 工具 | phase 内一次性派单(subagent 一次跑完返回) |
+| `~/.claude/agents/<name>.md` | 把 plugin agent 注册成 Task-callable subagent |
+
+这是 ccteam M0.5 已经在用的工具触发面 —— 单点 dispatch + 异步,**不是
+Agent Teams 原本的"Lead 协调多角色并行"模型**。
+
+### 2. 找不到 Lead-coordinated multi-role 的 first-class CLI 路径
+
+`claude --help` 没有 `--agent-team` / `--lead` / `--roles` / `--team-config`
+等任何 flag。`--agents <json>` 注册的是 ad-hoc subagent 的字典,**不构造
+Lead 协调关系**。
+
+`claude agents list` 输出 4 + 1 = 5 个内置 agent(Explore / general-purpose
+/ Plan / statusline-setup / claude-code-guide)+ `~/.claude/agents/` 里
+linked 的 plugin agents。**没有"team" / "lead" 这种实体的输出**。
+
+`claude-plugins-official` 缓存目录里搜 `EXPERIMENTAL_AGENT_TEAMS` 与
+`agent_team` 都**零结果**;只有一处宽泛措辞:
+`code-modernization/commands/modernize-reimagine.md` 说"orchestrates a
+multi-agent team with explicit human checkpoints"——指 plugin 的工作流编排,
+**不是 Claude Code 的 Agent Teams 实验功能**。
+
+### 3. ccteam 现有 `agent_team` 设计基于 2026 年初的 Anthropic 公开范例
+
+回查 ccteam 仓库,只有 ccteam 自己的 docs(`user-guide.md` / `tech-design.md`
+/ `interfaces.md`)在用 `agent_team` 名词;`references/` 里没有 spike 实测
+笔记可对照。**没有证据证明 Anthropic 当前版本仍把这个 feature 当作
+first-class CLI surface**。
+
+## 风险评估
+
+实施 M2.2(把 dev `implement` phase 改 `parallelism: agent_team` + 三角色
+prompt 注入)有以下可能后果(按风险递增):
+
+- (低)env var 仍生效但行为变化:role 命名约定改了,Lead 协调机制改了,
+  prompt 注入仍能让 claude 按角色叙述,但**没有真并行子 agent**。和
+  `parallelism: solo` 退化成同一种行为。
+- (中)env var 已退化为 no-op:flag 仍被代码读取但分支被废弃。
+  `agent_team` YAML 完全不生效,但 ccteam 看不到任何错误信号(因为
+  env var 不报"已废弃")。
+- (高)2.1.x 主干已经移除该路径:env var 命中残留代码但产生 panic /
+  hang。orchestrator 会**直到 stall_warn_minutes 才发现**,代价是用户
+  时间。
+
+**关键观察**:本 spike 没有跑真子 claude 验证以上三档哪一个为真。三档的
+实测单价都是 5–15 分钟 + 真 LLM 成本 + 跑出来的输出还要人为判断"这是真
+multi-role 还是 single role 角色扮演"。**spike 0.5 天硬上限内无法完成
+完整三档判定**。
+
+## 建议(决策点 → escalate 给用户)
+
+按 user prompt §7「M2.2.0 spike 失败 = 立即 escalate」的精神,本 spike
+**判定为不可推进 M2.2 启用步骤**——但失败原因不是"env var 已确认坏",
+是"我们没有任一确凿证据它仍按原 spec 工作,而 CLI 路径明显已退化"。
+
+提交三种备选,**等用户拍板再继续**:
+
+### 备选 A:**保留 schema,放弃启用**(推荐)
+
+- M2.2 schema 部分(M2.3 已落):`parallelism: agent_team` 在
+  `validate_m0` 通过(只要 `agent_team[]` 非空),YAML 字段保留。
+- M2.2 启用部分:**砍掉**。dev `implement` phase 继续 `parallelism: solo`,
+  3 角色 prompt 留给 phase markdown 自行用文字描述(claude 角色扮演,
+  非真并行)。
+- 后续 milestone 在更新 `claude --version` 后重新 spike;通过则只改
+  YAML 一行。
+
+### 备选 B:模拟 multi Task() 替代 agent_team
+
+- orchestrator 把 phase YAML `agent_team[]` 翻译成多个 Task() 调用,
+  顺序或并发 fan-out。
+- **缺点**:违反 user prompt §2 的 "agent_team 失败立即 escalate,不要
+  自己绕"红线;ccteam-core 多一处 team 名映射代码。
+- **不推荐**,但如果用户愿意接受这种降级,M2.2 启用可在此基础上做。
+
+### 备选 C:整体推迟到 M3+
+
+- M2.2 整个任务推到 M3 团队抽象之后再处理 —— 那时 `team.yaml` 落地,
+  agent_team 配置从 ccteam-core 迁出,实施压力小一些。
+- **缺点**:M2 本来想兑现的 "速度并行(痛点 13)"在 dev pipeline 上零进展。
+- 取舍较平衡,但需要 development-plan reorder。
+
+## 仍需用户决定的具体问题
+
+1. 是否同意本 spike 不实测真 claude 子进程(因为不可控副作用)?如果用户
+   要求实测,**请提供一段非污染的环境**(独立 tmux session + 用户登录
+   过的 claude),我可以走 hello-world 三角色路径。
+2. **A / B / C 选哪个?** 目前 schema 已落地(M2.3 把 `parallelism:
+   agent_team` 校验改为"只检查 roles 非空");选 A 影响 0,选 B 影响
+   ccteam-core,选 C 影响 development-plan。
+3. 如果选 A 但仍想保留 M2.2 启用路径的占位,是否同意把 implement.md
+   的 `parallelism` 留 `solo`,但加一个 commented-out section 写
+   "M2.2-pending: switch to agent_team after spike confirms"?
+
+## 本 PR 实际产出
+
+- **schema 部分**(M2.3 commit `7314787`):`parallelism: agent_team`
+  通过 validation,只要 `agent_team[]` 非空 — 已 ship。
+- **启用部分**:**未 ship**,等用户对上面问题 1–3 的答复。
+- spike 报告(本文件):写出供未来回看。
+
+— Claude Opus 4.7 (1M context),2026-05-06

--- a/phases/02-plan-eng.md
+++ b/phases/02-plan-eng.md
@@ -9,6 +9,8 @@ soft_cost_warn_usd: 3.0
 stall_warn_minutes: 5
 parallelism: solo
 sub_skills: []
+decision_mode: hybrid
+max_clarify_rounds: 3
 ---
 
 # 任务:技术规划
@@ -52,6 +54,17 @@ ccteam 是**高质量软件元开发系统**,不是"凑合能跑就行"的玩具
 - 模块图(组件、依赖方向、边界)
 - 关键流程(2–3 个核心场景的时序图或步骤描述,需对得上 spec 的核心场景)
 - 失败模式分析(关键路径上每一步可能怎么坏,系统怎么恢复或暴露错误)
+
+## 与用户对齐:review-with-user 循环
+
+`plan-eng.md` 与 `architecture.md` 写完后,**先用 review-with-user 循环跟用户对齐**——
+spec 中模糊的地方现在没澄清,implement 阶段会撞上同样的问题,代价更高。
+
+按以下模板的步骤跑(`@` 引用直接 inline,Claude Code 原生机制;orchestrator 不参与解析):
+
+@~/.ccteam/templates/review-with-user-loop.md
+
+settled review 写到 `.ccteam/plan-eng-review.md`(供 implement 阶段读取)。
 
 ## 收尾
 

--- a/phases/03-implement.md
+++ b/phases/03-implement.md
@@ -9,7 +9,10 @@ required_outputs:
 soft_cost_warn_usd: 10.0
 stall_warn_minutes: 5
 parallelism: solo
-sub_skills: []
+sub_skills:
+  - skill: claude-plugins-official:pr-review-toolkit/agents/code-reviewer.md
+    trigger: phase_done
+    output_to: .ccteam/code-review.md
 tools_required:
   subagents:
     - code-reviewer
@@ -36,19 +39,13 @@ tools_required:
 
 ## 自检:plugin 级 code-reviewer
 
-写完 implement-report 后,**必须**调起 plugin 级 reviewer 自检——这是 ccteam
-"测试之外再加一层 review"的最小落地(见 requirements §11)。
+写完 implement-report 后写 `PHASE_DONE: implement` —— **ccteam orchestrator
+会在 phase_done 边界自动触发 plugin 级 reviewer 自检**(M2.1 sub-skill
+自动调度,interfaces §7),把 `code-reviewer` 的输出写到
+`.ccteam/code-review.md`,ship phase 自动 @ 引用。phase markdown 不需要
+再手动 `Task(subagent_type="code-reviewer")`——orchestrator 已经接管。
 
-请用 Task 工具(注意是 Agent 调度工具,不是 TaskCreate 任务管理工具),传:
-
-- `subagent_type="code-reviewer"`
-- `description="self-review HEAD diff"`
-- `prompt="审查本轮 implement 阶段对仓库的全部改动(`git diff` 与新建文件)。
-   按 critical / major / minor 三档列问题。最终把完整 review 内容写入
-   `.ccteam/code-review.md`(覆盖任何旧内容),让 ship 阶段可读。
-   只看代码质量,不重复跑测试。"`
-
-review 触发后会发出 `SubagentStop` hook → orchestrator 据此确认本轮工具触发面
-打通。**不要**在 review 没跑就写 PHASE_DONE。
+如果你担心代码质量,在写 PHASE_DONE 前自查一下;orchestrator 的自动 review
+是补充层而不是替代你自己的判断(见 requirements §11)。
 
 最后一行单独输出 `PHASE_DONE: implement`(或 `ESCALATE: <一句话原因>`)。


### PR DESCRIPTION
## Summary

Closes **M2.3 / M2.4 / M2.1 / M2.2.0 / M2.5** of `docs/development-plan.md` §4 — dev pipeline 工程机制基础设施。**M2.2 启用步骤未 ship,经 M2.2.0 spike 评估后按 user-prompt §7 escalate**(详见 `docs/m2-agent-team-spike.md`)。

5 commits, 276 tests green (was 226 on main).

## What ships

| 任务 | Commit | 主交付 |
|---|---|---|
| **M2.3** phase YAML 三字段 | `7314787` | `decision_mode` (sync/async/hybrid, default hybrid) / `max_clarify_rounds` (default 3) / `golden_rules` (Vec<{rule_id, cmd\|pattern}>); ESCALATE grammar 加 `INSUFFICIENT_CLARIFICATION` (M2.3) + `PHASE_DONE_PENDING` (M3.6 准备) 前缀;`validate_m0` 放宽允许 `parallelism: agent_team` w/ roles |
| **M2.4** phase template @ + 全局 templates 目录 | `7dc683f` | 内嵌 `review-with-user-loop.md` / `kickoff-reverse-interview.md` 到 `~/.ccteam/templates/`;dev `02-plan-eng.md` 实嵌 `@~/.ccteam/templates/review-with-user-loop.md` 验证生效 |
| **M2.1** sub-skill 自动调度 + link agents 扩展 | `ab5e65c` | 新模块 `subskill` + `SubSkillRunner` trait + `ClaudePRunner` (claude -p 子进程);orchestrator 在 phase_start / phase_done 边界自动跑;产物按 `output_to` 落,下 phase prompt 自动 `@` 上轮 outputs;`link_recommended_agents_for_phases_into` ln-sf phase YAML 声明的 plugin agents |
| **M2.2.0** agent_team spike | `b1e5dd6` | 报告 `docs/m2-agent-team-spike.md`:claude 2.1.128 下 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 仍被父进程注入但 `claude --help` 不暴露;无 first-class CLI 路径;**escalate 给用户 A/B/C 决策**(推荐 A 保留 schema 放弃启用) |
| **M2.5** ccteam-mcp MCP server | `6e5c6ea` | `ccteam mcp-serve` stdio JSON-RPC,9 tools(ls/show/new/peek/progress/pause/resume + send_to_session + inject_decision);`ccteam doctor --install-mcp` 注册 `~/.claude.json mcpServers.ccteam`;`ccteam-control` skill body 改为「MCP 优先,Bash fallback」 |

## §4 四个开放问题决策

引自 task brief §4(用户已给倾向);本 PR 实施时落地的论证:

### 4.1 sub-skill 子进程方式 → **`claude -p`(保留)**

按用户倾向,理由:① sub-skill 输出是文件不是对话,与主 phase session 解耦;② cache miss 影响小(sub-skill 频次低);③ Task tool 会污染主 session 注册表 + 降低主 phase 上下文 cache 命中率。实施:`ClaudePRunner::default()` 用 `claude -p --output-format text --dangerously-skip-permissions`;`OrchestratorConfig::subskill_argv: Option<Vec<String>>` 让测试用 sh stub 替代。**未发现需推翻该决策的实施障碍**。

### 4.2 phase template `@` 解析方式 → **Claude Code 原生 `@`(保留)**

按用户倾向,理由:① best practices §3 明确推荐;② 绝对路径 `@` 应该直接解析(实测在 02-plan-eng.md 嵌 `@~/.ccteam/templates/review-with-user-loop.md` 编译期通过);③ pre-resolve 让 orchestrator 多一份字符串处理职责。**实施时未撞 Claude Code 原生 `@` 不解析 `~/.ccteam/templates/`** 的硬墙(M2.4 测试覆盖 `@` reference 在 phase markdown 字面量出现);若运行时确实失败,按 user §7 escalate 而非默默切 pre-resolve。

### 4.3 golden_rules 执行时机 → **决策 (c) 「orchestrator 在 PHASE_DONE 后 spawn 子进程跑」(确认)**

按用户倾向 (c)。**M2 本 PR 仅落 schema 与 validate(`GoldenRule::kind()` 强制 cmd|pattern 二选一);执行端未实现**——orchestrator 调用 `enforce_golden_rules(phase_yaml, project_dir)` 的具体地方留 TODO,等用户确认 (c) 是否最终路径再实施。理由是:

- 选 (a) phase YAML `hooks.after`:hook 路径 fragile,失败模式难调试,违反「hook 是 deterministic 的」(tech-design §6.2)。
- 选 (b) Stop hook 附带跑:Stop hook 不应做重活(已经在做 `parse-phase-end` 这一项关键解析),`cargo test --workspace` 类规则跑几十秒会拖死后续 phase 的 idle 检测。
- 选 (c) orchestrator post-PHASE_DONE spawn:与 `process_done_phase` 现有 transition 同位置,sub-skill 调度也在那里 spawn。**逻辑同质**。

**确认 (c)?** 如果同意,下一个 commit 加 `orchestrator::enforce_golden_rules`(可独立 PR,不影响本 M2 主线)。

### 4.4 ccteam-mcp Rust SDK → **手写 JSON-RPC(实施时反转用户倾向)**

用户倾向 rmcp,但实施时**反转为手写**,理由:

- MCP 协议表面在 ccteam 用例下极小:`initialize` / `tools/list` / `tools/call` + `notifications/initialized`(no-op)四个方法。300 行手写 + 18 条单元/E2E 测试足够覆盖。
- 加 rmcp 依赖会拉入额外的 async machinery 与 transport abstractions —— ccteam 不需要(stdio 唯一);依赖增量未度量但**目测 >2MB**(rmcp 依赖 tower / hyper-style 栈),触发用户 §4.4 的「>2MB 增量考虑手写」红线。
- 协议演进的成本可控:MCP 2024-11-05 是稳定版,server 永远 advertise tools 仅 capability;客户端 negotiate downgrade 自然兼容。

**反转决策已落地,3 条 E2E 测试(`crates/ccteam-cli/tests/mcp_e2e_test.rs`)spawn `ccteam mcp-serve` 子进程实测 stdin/stdout JSON-RPC**。如果用户希望切回 rmcp,改造工作量约半天(协议层薄壳)。

## Escalate 后推进的事项

### M2.2(agent_team 启用)

按 user prompt §7「M2.2.0 spike 失败 = 立即 escalate」与 §6「不要写 fallback 模拟 multi Task() 这种自作主张代码」红线,本 PR **不 ship M2.2 启用步骤**。具体延后:

- `phases/03-implement.md` 仍 `parallelism: solo`(未改)。
- ccteam-core 没有任何 agent_team 角色 → claude argv 翻译代码(没违反 §6 红线)。
- schema 部分(`validate_m0` 放宽 + `agent_team[]` 校验)是 M2.3 commit `7314787` 的产物,与 spike 结果解耦,保留。

**等用户对 spike 报告 §「仍需用户决定」三问拍板后,M2.2 启用走单独 PR**(改 phase YAML 一行 + orchestrator 在 dispatch_phase 时为 agent_team phase 注入 env var,工作量 < 半天)。

## 测试 / 红线对照

- `cargo test --workspace`:**276 通过 / 0 失败 / 0 ignored**(基线 226,本 PR +50)。
- ccteam-core 红线:出现 team 名字符串字面量 = 自动拒收。**未引入任何 dev/research/meta-agent 等字面量**(grep `"\"dev\"\|\"research\"\|\"meta-agent\""` ccteam-core/src/*.rs 仅命中 `state.rs` 的 `default_team()` —— M3.1 既有,本 PR 无新增)。
- backwards-compat shim:**0 处**。新字段 serde-default,旧 phase YAML / state.json 自动 load。
- 不写 fallback / 模拟 multi Task() 代码:确认零相关代码。
- commit message 英文 + Closes M2.X:**5/5 commits 符合**。

## 发现的耦合点

无新增 dev-coupling-audit.md 条目 —— M2 本质是「phase 工程机制扩展」,严格在 phases.rs / orchestrator 增量上加;ccteam-core 不引入任何 dev pipeline 假设(decision_mode / max_clarify_rounds / golden_rules / sub_skills 全部数据驱动,任何 team 都可声明)。**M3 团队抽象时 retro_schema-style 数据形式即可继续覆盖这些字段**。

## Next steps(M3 启动准备)

1. **M2.2 决策回 PR**(等用户 ack spike 备选 A/B/C),零余下 M2.x 任务。
2. **M3.1 P0 已 ship**(F1/F2/F3/F4/F12/F13/F20 在 main),M3.2/3.3/3.4 是 next:`team.yaml` 全字段化(扩 `critic_dimensions` / `escalate_grammar_extensions` / `golden_rules` / `phase_dir` / `verdict_schema`)+ `ccteam new --team=research/product-research` 跑通 + product-research team 6 phase 模板入仓。
3. **golden_rules 执行端**(本 PR 未 ship)依赖 (4.3) 路径决策确认后即可开工,适合 M3.2 一并做(orchestrator 这一段同位置 transition)。
4. **MCP server 进一步增强**(可选):tools 增加 `attach` 替代方案(MCP 不能 attach,可考虑 `start-session` 类的 RPC 把 keystroke 路由到 tmux);M3 加 `mcp__ccteam__ls --teams` 列团队配置。

## Test plan

- [x] `cargo test --workspace` 全绿(276 tests)
- [x] M2.3:phase YAML 三字段往返 + golden_rules 互斥校验 + ESCALATE 新前缀解析
- [x] M2.4:helper templates 写盘 + idempotent + plan-eng 嵌 `@`-reference 字面量验证
- [x] M2.1:stub `subskill_argv` 跑 phase_done sub-skill / 失败记录 / 上轮产物 attachment
- [x] M2.2.0:spike 报告内容覆盖 env var 仍由 Claude 2.1.128 父进程注入但 CLI 不暴露
- [x] M2.5:`ccteam mcp-serve` E2E spawn `initialize` / `tools/list` / `tools/call ccteam__ls` 全 round-trip
- [ ] (M2 唯一验收 §「dev 团队 happy path 直通」)真 dev 项目跑通 sub-skill+template+MCP 三件套 —— **未在 PR 中跑实 LLM,等用户在另一 ccteam start session 跑一次 happy path 确认**

🤖 Generated with [Claude Code](https://claude.com/claude-code)