### PR TITLE
fix: e2e P0 blockers (idle classification, fix completion_signal, resume terminal)

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -15,7 +15,8 @@ use ccteam_core::{
     write_all_global_team_templates, write_global_helper_templates,
     write_global_phase_templates, AgentLinkAction, AgentLinkReport, CcteamPaths,
     InstallSkillOptions, LinkOptions, MetaBootstrapReport, OutboxEventKind, OutboxMessage,
-    PhaseState, PhaseTemplate, ProjectState, SessionMailbox, SkillInstallAction, TeamSpec,
+    PhaseHistoryEntry, PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
+    SkillInstallAction, TeamSpec,
     ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES, PHASE_TEMPLATES, TEAM_BUNDLES,
 };
 use ccteam_core::tmux::TmuxSession;
@@ -294,6 +295,15 @@ pub fn run_progress(paths: &CcteamPaths, slug: &str, tail: bool) -> Result<()> {
 /// the escalation marker if present, and sets phase_state back to idle so
 /// the daemon's next tick re-dispatches the current phase. Real
 /// `--resume` (claude session continuation) is M1+.
+///
+/// E2E 2026-05-06 F8: when the previous run ended in `escalate`, the
+/// last `phase_history` entry has `status: "escalated"` which makes
+/// `Dag::is_terminal_state` permanently return true. `is_terminal_state`
+/// blocks every subsequent tick at `NoOp`, so the daemon never picks
+/// the project back up even after the user resumes. Append a
+/// `"resumed"` entry (append-only — we don't mutate the prior
+/// escalated entry, so the escalation history stays auditable) so
+/// `is_terminal_state` lifts the flag.
 pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
     let state_path = paths.project_state(slug);
     let mut state = ProjectState::load(&state_path)
@@ -302,6 +312,17 @@ pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
     state.user_attached = false;
     state.phase_state = PhaseState::Idle;
     state.last_user_interaction_at = Utc::now();
+    if matches!(
+        state.phase_history.last().map(|h| h.status.as_str()),
+        Some("escalated"),
+    ) {
+        state.phase_history.push(PhaseHistoryEntry {
+            phase: state.current_phase.clone(),
+            status: "resumed".into(),
+            duration_s: 0,
+            cost_usd: 0.0,
+        });
+    }
     state.save(&state_path)?;
 
     let esc = paths.project_ccteam_dir(slug).join("escalation.md");
@@ -1342,6 +1363,65 @@ mod tests {
         assert_eq!(s2.phase_state, PhaseState::Idle);
         assert!(!s2.user_pause_pending);
         assert!(!esc.exists(), "escalation.md should be archived after resume");
+    }
+
+    #[test]
+    fn run_resume_appends_resumed_history_after_escalated_entry() {
+        // E2E 2026-05-06 F8: an escalated `phase_history` entry leaves
+        // `Dag::is_terminal_state` permanently true. `ccteam resume`
+        // must append a paired `"resumed"` entry so future ticks
+        // dispatch again. Append-only — the original escalated entry
+        // stays intact for audit.
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let slug = run_new(&paths, "demo", "dev").unwrap();
+
+        let state_path = paths.project_state(&slug);
+        let mut state = ProjectState::load(&state_path).unwrap();
+        state.phase_state = PhaseState::InFlight;
+        state.current_phase = "fix".into();
+        state.phase_history.push(PhaseHistoryEntry {
+            phase: "fix".into(),
+            status: "escalated".into(),
+            duration_s: 0,
+            cost_usd: 0.0,
+        });
+        state.save(&state_path).unwrap();
+
+        run_resume(&paths, &slug).unwrap();
+        let s2 = ProjectState::load(&state_path).unwrap();
+        assert_eq!(s2.phase_history.len(), 2, "resume must append, not mutate");
+        assert_eq!(s2.phase_history[0].status, "escalated");
+        assert_eq!(s2.phase_history[1].status, "resumed");
+        assert_eq!(s2.phase_history[1].phase, "fix");
+    }
+
+    #[test]
+    fn run_resume_does_not_append_resumed_when_no_escalation() {
+        // Non-escalated resume (e.g. user attached + paused) must not
+        // pollute phase_history with a spurious resumed entry — that
+        // would keep growing on repeat resumes for benign pauses.
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let slug = run_new(&paths, "demo", "dev").unwrap();
+
+        let state_path = paths.project_state(&slug);
+        let mut state = ProjectState::load(&state_path).unwrap();
+        state.user_pause_pending = true;
+        state.phase_history.push(PhaseHistoryEntry {
+            phase: "implement".into(),
+            status: "passed".into(),
+            duration_s: 0,
+            cost_usd: 0.0,
+        });
+        state.save(&state_path).unwrap();
+
+        run_resume(&paths, &slug).unwrap();
+        let s2 = ProjectState::load(&state_path).unwrap();
+        assert_eq!(s2.phase_history.len(), 1);
+        assert_eq!(s2.phase_history[0].status, "passed");
     }
 
     #[test]

--- a/crates/ccteam-core/src/dag.rs
+++ b/crates/ccteam-core/src/dag.rs
@@ -105,18 +105,27 @@ impl Dag {
     }
 
     /// True when the project has reached a terminal state: any
-    /// history entry escalated, or the last passed history entry
-    /// landed on a DAG endpoint.
+    /// history entry escalated **without a subsequent `resumed`
+    /// entry**, or any passed history entry landed on a DAG endpoint.
+    ///
+    /// E2E 2026-05-06 F8: `ccteam resume` appends a `"resumed"` entry
+    /// after an `"escalated"` one to lift the terminal flag — without
+    /// it, the orchestrator's tick stayed `NoOp` forever and no
+    /// further phases advanced even after the user manually
+    /// re-injected the next phase. We pair escalated/resumed in
+    /// history rather than mutating the original entry so the audit
+    /// trail of past escalations stays intact.
     pub fn is_terminal_state(&self, state: &ProjectState) -> bool {
+        let mut escalated_active = false;
         for h in &state.phase_history {
-            if h.status == "escalated" {
-                return true;
-            }
-            if h.status == "passed" && self.is_terminal_phase(&h.phase) {
-                return true;
+            match h.status.as_str() {
+                "escalated" => escalated_active = true,
+                "resumed" => escalated_active = false,
+                "passed" if self.is_terminal_phase(&h.phase) => return true,
+                _ => {}
             }
         }
-        false
+        escalated_active
     }
 }
 

--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -114,9 +114,14 @@ pub fn latest_terminal_event_for_phase<'a>(
 /// `Stop` / `Notification:idle_prompt` are the canonical "claude is
 /// waiting" signals. Phase-boundary events (`session_start`,
 /// `phase_done`, `escalate`, `SessionEnd`) also imply nothing is
-/// in-flight. Anything else (`PreToolUse`, `PostToolUse`, `phase_inject`,
-/// `SubagentStop`) means a tool call is mid-flight — caller should use
-/// `/btw` to queue without interrupting.
+/// in-flight. `SubagentStop` fires 2–5 s after `Stop` whenever the
+/// finished turn used `Task`; the main loop is already idle by then,
+/// so we treat it the same as `Stop` (E2E 2026-05-06: classifying it
+/// as busy caused the next phase prompt to be wrapped in `/btw`,
+/// which spawns a tool-less side-agent and stalls the project).
+/// Anything else (`PreToolUse`, `PostToolUse`, `phase_inject`) means a
+/// tool call is mid-flight — caller should use `/btw` to queue without
+/// interrupting.
 pub fn is_idle(last: Option<&Value>) -> bool {
     let Some(event) = last else {
         return true;
@@ -124,7 +129,13 @@ pub fn is_idle(last: Option<&Value>) -> bool {
     let kind = event.get("event").and_then(|s| s.as_str()).unwrap_or("");
     matches!(
         kind,
-        "Stop" | "notification" | "session_start" | "SessionEnd" | "phase_done" | "escalate"
+        "Stop"
+            | "SubagentStop"
+            | "notification"
+            | "session_start"
+            | "SessionEnd"
+            | "phase_done"
+            | "escalate"
     )
 }
 
@@ -205,6 +216,17 @@ mod tests {
             let e = json!({"event": kind});
             assert!(is_idle(Some(&e)), "{kind} should be treated as idle");
         }
+    }
+
+    #[test]
+    fn idle_treats_subagent_stop_as_idle() {
+        // E2E 2026-05-06 F1+F2: Claude Code emits SubagentStop 2–5 s
+        // after Stop whenever a turn used Task. The main loop is already
+        // idle at that point — classifying it as busy caused the next
+        // phase inject to be wrapped in `/btw`, which spawns a toolless
+        // side-agent that cannot execute the next phase.
+        let e = json!({"event": "SubagentStop"});
+        assert!(is_idle(Some(&e)));
     }
 
     #[test]

--- a/crates/ccteam-core/tests/phases_test.rs
+++ b/crates/ccteam-core/tests/phases_test.rs
@@ -68,3 +68,23 @@ fn every_m0_template_body_ends_with_phase_done_or_escalate() {
         );
     }
 }
+
+#[test]
+fn fix_phase_completion_signal_matches_body_phase_done_sigil() {
+    // E2E 2026-05-06 F6 regression: the fix phase declared
+    // `completion_signal: TESTS_GREEN` in YAML while the body told
+    // Claude to output `PHASE_DONE: fix`. The fix-loop never observed
+    // the signal, looped 3x, and falsely escalated despite all tests
+    // passing. Auto-loop phases must declare the signal Claude is
+    // actually instructed to emit.
+    let dir = phases_dir();
+    let template = PhaseTemplate::load(&dir.join("06-fix.md")).unwrap();
+    assert!(template.auto_loop, "fix phase is auto-loop driven");
+    assert_eq!(template.completion_signal, "PHASE_DONE: fix");
+    let body = std::fs::read_to_string(dir.join("06-fix.md")).unwrap();
+    assert!(
+        body.contains(&template.completion_signal),
+        "fix body must contain its declared completion_signal `{}`",
+        template.completion_signal,
+    );
+}

--- a/crates/ccteam-core/tests/state_machine_test.rs
+++ b/crates/ccteam-core/tests/state_machine_test.rs
@@ -5,8 +5,9 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use ccteam_core::{
-    decide_tick, dev_dag, progress, write_global_phase_templates, CcteamPaths, Orchestrator,
-    OrchestratorConfig, Parallelism, PhaseHistoryEntry, PhaseState, ProjectState, TickAction,
+    decide_tick, decide_tick_from_events, dev_dag, progress, write_global_phase_templates,
+    CcteamPaths, Orchestrator, OrchestratorConfig, Parallelism, PhaseHistoryEntry, PhaseState,
+    ProjectState, TickAction,
 };
 
 fn fresh_state(current_phase: &str, phase_state: PhaseState) -> ProjectState {
@@ -110,6 +111,37 @@ fn decide_tick_classifies_busy_events_as_noop() {
             "{kind} must be NoOp",
         );
     }
+}
+
+#[test]
+fn decide_tick_advances_through_phase_done_then_subagent_stop_sequence() {
+    // E2E 2026-05-06 F1+F2 regression: when the finished turn used Task,
+    // Claude Code emits Stop, parse-phase-end appends phase_done, and
+    // SubagentStop fires 2–5 s later. The literal last event in
+    // progress.jsonl is SubagentStop, but the project did finish — the
+    // tick must still resolve to AdvancePhase. Pair this with the
+    // is_idle change so the subsequent inject is sent bare instead of
+    // wrapped in `/btw` (which would spawn a toolless side-agent).
+    let dag = dev_dag();
+    let state = fresh_state("plan-eng", PhaseState::InFlight);
+    let events = vec![
+        json!({"event": "phase_inject", "phase": "plan-eng"}),
+        json!({"event": "PostToolUse", "tool": "Write"}),
+        json!({"event": "Stop"}),
+        json!({"event": "phase_done", "phase": "plan-eng"}),
+        json!({"event": "SubagentStop"}),
+    ];
+    assert_eq!(
+        decide_tick_from_events(&dag, &state, &events),
+        TickAction::AdvancePhase {
+            from: "plan-eng".into(),
+            to: Some("implement".into()),
+        },
+    );
+    // And the dispatcher's idle classifier must read the trailing
+    // SubagentStop as idle so the next prompt is sent bare.
+    let last = events.last();
+    assert!(progress::is_idle(last));
 }
 
 #[test]

--- a/crates/ccteam-core/tests/state_machine_test.rs
+++ b/crates/ccteam-core/tests/state_machine_test.rs
@@ -185,6 +185,76 @@ fn is_terminal_state_true_after_any_escalation() {
 }
 
 #[test]
+fn is_terminal_state_false_after_resumed_follows_escalated() {
+    // E2E 2026-05-06 F8: an escalated entry followed by a resumed
+    // entry must lift the terminal flag — otherwise `decide_tick`
+    // returns NoOp forever and the daemon stops dispatching the
+    // project even after `ccteam resume` clears phase_state.
+    let dag = dev_dag();
+    let mut state = fresh_state("fix", PhaseState::Idle);
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "fix".into(),
+        status: "escalated".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    assert!(dag.is_terminal_state(&state), "escalated alone is terminal");
+
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "fix".into(),
+        status: "resumed".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    assert!(
+        !dag.is_terminal_state(&state),
+        "escalated + resumed must lift the terminal flag",
+    );
+
+    // Re-escalate on a later phase: terminal again.
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "ship".into(),
+        status: "escalated".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    assert!(dag.is_terminal_state(&state), "later escalation re-arms");
+
+    // Resume again: non-terminal.
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "ship".into(),
+        status: "resumed".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    assert!(!dag.is_terminal_state(&state), "second resume lifts again");
+}
+
+#[test]
+fn is_terminal_state_true_after_passed_endpoint_even_following_resumed() {
+    // A successful ship after a resume cycle is still terminal —
+    // resume only clears the escalated flag, it doesn't override the
+    // ship-passed terminal.
+    let dag = dev_dag();
+    let mut state = fresh_state("ship", PhaseState::Idle);
+    for status in ["escalated", "resumed"] {
+        state.phase_history.push(PhaseHistoryEntry {
+            phase: "fix".into(),
+            status: status.into(),
+            duration_s: 0,
+            cost_usd: 0.0,
+        });
+    }
+    state.phase_history.push(PhaseHistoryEntry {
+        phase: "ship".into(),
+        status: "passed".into(),
+        duration_s: 0,
+        cost_usd: 0.0,
+    });
+    assert!(dag.is_terminal_state(&state));
+}
+
+#[test]
 fn is_terminal_state_false_when_non_endpoint_passes() {
     // After F4: "passed" on a non-endpoint phase is NOT terminal.
     // Old logic only checked for "ship" string match — this test

--- a/phases/06-fix.md
+++ b/phases/06-fix.md
@@ -10,7 +10,7 @@ parallelism: solo
 sub_skills: []
 auto_loop: true
 auto_loop_max_iterations: 3
-completion_signal: TESTS_GREEN
+completion_signal: "PHASE_DONE: fix"
 ---
 
 # 任务:修 bug(fix-cycle)
@@ -31,6 +31,7 @@ completion_signal: TESTS_GREEN
 
 最后一行:
 
-- **本轮全绿** → `PHASE_DONE: fix`(orchestrator 转回 test-run 复跑确认)
-- **仍有失败但 < 3 轮** → `PHASE_DONE: fix`(orchestrator 自动重入 fix-cycle)
-- **第 3 轮仍失败** → `ESCALATE: <一句话原因>`
+- **本轮全绿** → `PHASE_DONE: fix`(完成信号;orchestrator 推进下一相位)
+- **仍有失败但 < 3 轮** → 不要输出 `PHASE_DONE: fix`(那会被 orchestrator 当作完成);
+  只写本轮的 fix-report,Stop hook 会自动重喂 prompt 进入下一轮 fix-cycle
+- **第 3 轮仍失败** → `ESCALATE: <一句话原因>`(或留空让 orchestrator 在第 3 轮后自动 escalate)


### PR DESCRIPTION
## Summary

- **F1+F2**: `SubagentStop` classified as idle in `is_idle()`. Claude
  Code emits `SubagentStop` 2–5 s after `Stop` whenever the finished
  turn used `Task`; the previous classification routed every
  post-`Task` phase inject through `/btw`, spawning a tool-less
  side-agent that stalled the project. Every dev phase transition
  hit this.
- **F6**: `phases/06-fix.md` `completion_signal` aligned with the
  body's `PHASE_DONE: fix` sigil. The fix-loop never observed the
  declared `TESTS_GREEN` and falsely escalated after 3 rounds despite
  37/37 tests passing. Body updated so red iterations no longer emit
  the success sigil — the Stop hook reinjects until the cap.
- **F8**: `ccteam resume` appends a paired `"resumed"` PhaseHistoryEntry
  after an `"escalated"` entry; `Dag::is_terminal_state` walks the
  history forward, toggling escalated/resumed, and only returns true
  for an unresolved escalation (or a `passed` on a DAG endpoint).
  Append-only — the escalation entry stays intact for audit.

## Test plan

- [x] `cargo test --workspace` — 357 passing (350 baseline + 7 new),
      0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` —
      delta clean (4 pre-existing warnings on `origin/main`,
      none introduced by this PR; verified by clippying the same files
      on pristine `origin/main`)
- [ ] (manual smoke) restart orchestrator on a dev project,
      observe plan-eng → implement transition lands without
      `/btw` wrapping; observe an escalated project's `ccteam resume`
      followed by a tick now dispatches the next phase

## References

- E2E report: `docs/e2e-2026-05-06.md` §F1+F2 / §F6 / §F8
- Pain points: 痛点 11 (关键节点不把控) + 痛点 4 (bug 修复无限循环)
- tech-design §3.5 fix-loop / §6.2 hooks idle-aware / §6.9 idle-aware inject

P1 items (F3 meta-skill API doc, F7 stall-warn dedup) are explicitly
out of scope for this PR — followups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)