### PR TITLE
feat: M4 cross-project memory via official mechanisms (memory-bridge + retro prompts + spike)

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -588,6 +588,8 @@ pub struct DoctorOptions {
     pub install_meta_agent: Option<String>,
     /// M2.5: register `mcpServers.ccteam` in `~/.claude.json`.
     pub install_mcp: bool,
+    /// M4.2: install `~/.claude/rules/ccteam-lessons-<team>.md` placeholders.
+    pub install_memory_bridge: bool,
 }
 
 /// `ccteam doctor` dispatch. Returns a human-readable report so unit
@@ -597,7 +599,8 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         || opts.tool_surface
         || opts.install_skill
         || opts.install_meta_agent.is_some()
-        || opts.install_mcp;
+        || opts.install_mcp
+        || opts.install_memory_bridge;
     if !any_mode {
         return Ok(String::from(
             "ccteam doctor: pass at least one mode flag.\n\
@@ -612,7 +615,9 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
              --install-meta-agent <user-handle>\n      \
              bootstrap a meta-agent project for the given user (M1.0). Implies --install-skill.\n  \
              --install-mcp\n      \
-             register `mcpServers.ccteam` in ~/.claude.json so daily-driver claude + meta-agent see the 9-tool MCP server (M2.5).\n",
+             register `mcpServers.ccteam` in ~/.claude.json so daily-driver claude + meta-agent see the 9-tool MCP server (M2.5).\n  \
+             --install-memory-bridge [--dry-run]\n      \
+             write ~/.claude/rules/ccteam-lessons-{dev,product-research}.md placeholders so the retro phase has somewhere to Edit cross-project lessons into (M4.2).\n",
         ));
     }
     let mut out = String::new();
@@ -634,6 +639,44 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     if opts.install_mcp {
         out.push_str(&render_install_mcp_report()?);
     }
+    if opts.install_memory_bridge {
+        out.push_str(&render_install_memory_bridge_report(&opts)?);
+    }
+    Ok(out)
+}
+
+fn render_install_memory_bridge_report(opts: &DoctorOptions) -> Result<String> {
+    let install_opts = ccteam_core::InstallMemoryBridgeOptions {
+        dry_run: opts.dry_run,
+    };
+    let reports = ccteam_core::install_memory_bridge(install_opts)?;
+    let mut out = if opts.dry_run {
+        String::from("ccteam doctor --install-memory-bridge (dry-run)\n\n")
+    } else {
+        String::from("ccteam doctor --install-memory-bridge\n\n")
+    };
+    for r in &reports {
+        let label = match &r.action {
+            ccteam_core::MemoryBridgeAction::Wrote => "wrote",
+            ccteam_core::MemoryBridgeAction::AlreadyPresent => "already-present",
+            ccteam_core::MemoryBridgeAction::RepairedMarkedSection => "repaired",
+            ccteam_core::MemoryBridgeAction::DryRun { would_write: true } => "would write",
+            ccteam_core::MemoryBridgeAction::DryRun { would_write: false } => {
+                "no-op (already present)"
+            }
+        };
+        out.push_str(&format!(
+            "  {:<24} {:<24} {}\n",
+            r.team,
+            label,
+            r.target.display(),
+        ));
+    }
+    out.push('\n');
+    out.push_str(
+        "rules files auto-load into every Claude Code session whose cwd matches the\n\
+         `paths:` frontmatter; the retro phase Edits the marked block on project end.\n",
+    );
     Ok(out)
 }
 
@@ -1492,6 +1535,31 @@ mod tests {
         assert!(body.contains("tool-surface"));
         assert!(body.contains("install-skill"));
         assert!(body.contains("install-meta-agent"));
+        assert!(body.contains("install-memory-bridge"));
+    }
+
+    #[test]
+    fn run_doctor_install_memory_bridge_writes_both_team_files() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
+
+        let opts = DoctorOptions {
+            install_memory_bridge: true,
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(report.contains("install-memory-bridge"));
+        assert!(report.contains("dev"));
+        assert!(report.contains("product-research"));
+
+        let dev_path = tmp.path().join("rules/ccteam-lessons-dev.md");
+        let pr_path = tmp.path().join("rules/ccteam-lessons-product-research.md");
+        assert!(dev_path.is_file(), "dev lessons not written");
+        assert!(pr_path.is_file(), "product-research lessons not written");
+
+        std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
 
     #[test]

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -148,6 +148,13 @@ enum Command {
         /// any prior `ccteam` server entry but preserves other servers.
         #[arg(long, default_value_t = false)]
         install_mcp: bool,
+        /// M4.2: write `~/.claude/rules/ccteam-lessons-{dev,product-research}.md`
+        /// with `<!-- ccteam-managed:lessons begin/end -->` markers + `paths:`
+        /// frontmatter scope. Idempotent — re-runs no-op when markers are
+        /// intact, repair (single canonical block at end-of-file) when not.
+        /// User content outside markers is preserved.
+        #[arg(long, default_value_t = false)]
+        install_memory_bridge: bool,
     },
 }
 
@@ -228,6 +235,7 @@ fn main() -> Result<()> {
             install_skill,
             install_meta_agent,
             install_mcp,
+            install_memory_bridge,
         } => run_doctor(commands::DoctorOptions {
             install_recommended_agents,
             dry_run,
@@ -236,6 +244,7 @@ fn main() -> Result<()> {
             install_skill,
             install_meta_agent,
             install_mcp,
+            install_memory_bridge,
         }),
     }
 }

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod golden_rules;
 pub mod inbox;
 pub mod meta_agent;
 pub mod orchestrator;
+pub mod memory_bridge;
 pub mod skill;
 pub mod paths;
 pub mod phases;
@@ -37,6 +38,10 @@ pub use inbox::{
 pub use meta_agent::{
     bootstrap_meta_project, meta_session_name, meta_slug, render_meta_role_prompt,
     MetaBootstrapReport, META_SESSION_PREFIX, META_TEAM_NAME,
+};
+pub use memory_bridge::{
+    install_into as install_memory_bridge_into, install_memory_bridge,
+    InstallMemoryBridgeOptions, MemoryBridgeAction, MemoryBridgeReport,
 };
 pub use skill::{
     install_ccteam_control_skill, install_into as install_skill_into,

--- a/crates/ccteam-core/src/memory_bridge.rs
+++ b/crates/ccteam-core/src/memory_bridge.rs
@@ -1,0 +1,352 @@
+//! `ccteam doctor --install-memory-bridge` (M4.2).
+//!
+//! Lays down `~/.claude/rules/ccteam-lessons-{dev,product-research}.md`
+//! occupying the only ccteam-managed section in each file. Anything the
+//! user writes outside the `<!-- ccteam-managed:lessons begin/end -->`
+//! marker pair is preserved on re-runs; the marker pair itself is
+//! repaired (deduped / re-added at end-of-file) when malformed.
+//!
+//! The file body itself never holds a project's lessons — those land
+//! between the markers via the retro phase's `Edit` call. This module
+//! only owns the bridge file's frontmatter + structural skeleton.
+//!
+//! M4 architectural red line: this is the *only* ccteam-core code that
+//! touches the cross-project memory surface. Retrieval lives entirely
+//! inside Claude sessions via official `/memory` and rule auto-load.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::tool_surface::user_claude_dir;
+
+const DEV_TEMPLATE: &str = include_str!("templates/memory_bridge_dev.md");
+const PRODUCT_RESEARCH_TEMPLATE: &str =
+    include_str!("templates/memory_bridge_product_research.md");
+
+const MARKER_BEGIN: &str = "<!-- ccteam-managed:lessons begin -->";
+const MARKER_END: &str = "<!-- ccteam-managed:lessons end -->";
+
+/// Default body Claude lessons land in. Re-installed verbatim whenever
+/// the marker pair is missing / duplicated and the file needs repair.
+const CANONICAL_MARKED_BLOCK: &str = "<!-- ccteam-managed:lessons begin -->\n\
+(Empty until first retro. Phase prompts append lessons here using `Edit`.)\n\
+<!-- ccteam-managed:lessons end -->";
+
+/// Teams whose lessons file the bridge ships. Keep in lock-step with
+/// `teams/<name>.yaml` — every team consuming `retro_schema` needs a
+/// matching rules file or its retro phase has nowhere to `Edit`.
+const TEAMS: &[(&str, &str)] = &[
+    ("dev", DEV_TEMPLATE),
+    ("product-research", PRODUCT_RESEARCH_TEMPLATE),
+];
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct InstallMemoryBridgeOptions {
+    /// Don't actually write; report what would happen.
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct MemoryBridgeReport {
+    pub team: String,
+    pub target: PathBuf,
+    pub action: MemoryBridgeAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryBridgeAction {
+    /// File did not exist; full template written.
+    Wrote,
+    /// File present and the marker pair is intact (exactly one begin,
+    /// one end, in order). No write occurred.
+    AlreadyPresent,
+    /// File present but markers were missing / duplicated / unbalanced.
+    /// Stripped every existing marker block, appended one canonical
+    /// block at end-of-file. User content outside markers preserved.
+    RepairedMarkedSection,
+    DryRun {
+        would_write: bool,
+    },
+}
+
+/// Install both team lessons files into `~/.claude/rules/`.
+pub fn install_memory_bridge(
+    opts: InstallMemoryBridgeOptions,
+) -> Result<Vec<MemoryBridgeReport>> {
+    let claude = user_claude_dir().context("resolve ~/.claude/")?;
+    install_into(&claude, opts)
+}
+
+/// Test-injectable variant: write under `<claude_dir>/rules/...` so unit
+/// tests can point at a tempdir without mutating `$HOME/.claude/`.
+pub fn install_into(
+    claude_dir: &Path,
+    opts: InstallMemoryBridgeOptions,
+) -> Result<Vec<MemoryBridgeReport>> {
+    let rules_dir = claude_dir.join("rules");
+    if !opts.dry_run {
+        std::fs::create_dir_all(&rules_dir)
+            .with_context(|| format!("create {}", rules_dir.display()))?;
+    }
+    let mut reports = Vec::with_capacity(TEAMS.len());
+    for (team, template) in TEAMS {
+        let target = rules_dir.join(format!("ccteam-lessons-{team}.md"));
+        let action = install_one(&target, template, opts)
+            .with_context(|| format!("install memory bridge for team {team}"))?;
+        reports.push(MemoryBridgeReport {
+            team: (*team).to_string(),
+            target,
+            action,
+        });
+    }
+    Ok(reports)
+}
+
+fn install_one(
+    target: &Path,
+    canonical_template: &str,
+    opts: InstallMemoryBridgeOptions,
+) -> Result<MemoryBridgeAction> {
+    if !target.exists() {
+        if opts.dry_run {
+            return Ok(MemoryBridgeAction::DryRun { would_write: true });
+        }
+        std::fs::write(target, canonical_template)
+            .with_context(|| format!("write {}", target.display()))?;
+        return Ok(MemoryBridgeAction::Wrote);
+    }
+    let body = std::fs::read_to_string(target)
+        .with_context(|| format!("read {}", target.display()))?;
+    if marked_section_intact(&body) {
+        return Ok(if opts.dry_run {
+            MemoryBridgeAction::DryRun { would_write: false }
+        } else {
+            MemoryBridgeAction::AlreadyPresent
+        });
+    }
+    if opts.dry_run {
+        return Ok(MemoryBridgeAction::DryRun { would_write: true });
+    }
+    let repaired = repair_marked_section(&body);
+    std::fs::write(target, repaired)
+        .with_context(|| format!("write {}", target.display()))?;
+    Ok(MemoryBridgeAction::RepairedMarkedSection)
+}
+
+/// Exactly one begin marker, exactly one end marker, begin precedes end.
+/// Content between the markers is Claude's territory and never inspected.
+fn marked_section_intact(body: &str) -> bool {
+    let begins = body.match_indices(MARKER_BEGIN).count();
+    let ends = body.match_indices(MARKER_END).count();
+    if begins != 1 || ends != 1 {
+        return false;
+    }
+    let bi = body.find(MARKER_BEGIN).expect("just counted one");
+    let ei = body.find(MARKER_END).expect("just counted one");
+    bi < ei
+}
+
+/// Strip every begin/end block from `body`, preserving everything
+/// outside marker pairs, then append one fresh canonical block.
+fn repair_marked_section(body: &str) -> String {
+    let user_content = strip_all_marked_blocks(body);
+    let trimmed = user_content.trim_end();
+    let mut out = String::with_capacity(trimmed.len() + CANONICAL_MARKED_BLOCK.len() + 4);
+    out.push_str(trimmed);
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str(CANONICAL_MARKED_BLOCK);
+    out.push('\n');
+    out
+}
+
+fn strip_all_marked_blocks(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut rest = body;
+    loop {
+        let Some(bi) = rest.find(MARKER_BEGIN) else {
+            out.push_str(rest);
+            break;
+        };
+        out.push_str(&rest[..bi]);
+        let after_begin = &rest[bi + MARKER_BEGIN.len()..];
+        let Some(ei) = after_begin.find(MARKER_END) else {
+            // Unbalanced begin — drop everything from here to EOF;
+            // canonical block will be appended fresh.
+            break;
+        };
+        rest = &after_begin[ei + MARKER_END.len()..];
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read(path: &Path) -> String {
+        std::fs::read_to_string(path).unwrap()
+    }
+
+    #[test]
+    fn install_creates_both_lessons_files_with_intact_markers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let reports =
+            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        assert_eq!(reports.len(), 2);
+        for r in &reports {
+            assert_eq!(r.action, MemoryBridgeAction::Wrote);
+            assert!(r.target.is_file(), "{} not written", r.target.display());
+            let body = read(&r.target);
+            assert!(marked_section_intact(&body), "markers not intact");
+            assert!(body.contains("paths:"), "frontmatter paths missing");
+        }
+        let dev = &reports[0];
+        assert_eq!(dev.team, "dev");
+        assert!(read(&dev.target).contains("~/projects/dev-*"));
+        let pr = &reports[1];
+        assert_eq!(pr.team, "product-research");
+        assert!(read(&pr.target).contains("~/projects/product-research-*"));
+    }
+
+    #[test]
+    fn install_idempotent_when_files_present_and_intact() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        // Capture baseline content (including default empty marked block body).
+        let dev_target = tmp.path().join("rules/ccteam-lessons-dev.md");
+        let baseline = read(&dev_target);
+
+        let reports2 =
+            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        for r in &reports2 {
+            assert_eq!(r.action, MemoryBridgeAction::AlreadyPresent);
+        }
+        // File must not have been touched.
+        assert_eq!(read(&dev_target), baseline);
+    }
+
+    #[test]
+    fn install_preserves_lessons_written_between_markers() {
+        // Simulate a retro phase having edited the marked block.
+        let tmp = tempfile::TempDir::new().unwrap();
+        install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        let dev_target = tmp.path().join("rules/ccteam-lessons-dev.md");
+        let with_lessons = read(&dev_target).replace(
+            "(Empty until first retro. Phase prompts append lessons here using `Edit`.)",
+            "## tech_stack\n- Rust 1.78 + tokio\n\n## pitfalls\n- forgot to clone Arc",
+        );
+        std::fs::write(&dev_target, &with_lessons).unwrap();
+
+        let reports =
+            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        assert_eq!(reports[0].action, MemoryBridgeAction::AlreadyPresent);
+        let after = read(&dev_target);
+        assert!(after.contains("Rust 1.78 + tokio"), "lessons clobbered");
+        assert!(after.contains("forgot to clone Arc"), "lessons clobbered");
+    }
+
+    #[test]
+    fn install_repairs_missing_markers_and_keeps_user_content() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rules_dir = tmp.path().join("rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        let target = rules_dir.join("ccteam-lessons-dev.md");
+        std::fs::write(
+            &target,
+            "---\nname: my own rules file\n---\n\n# manually authored notes\n\n\
+             - a personal note\n",
+        )
+        .unwrap();
+
+        let reports =
+            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        assert_eq!(reports[0].action, MemoryBridgeAction::RepairedMarkedSection);
+        let after = read(&target);
+        assert!(after.contains("# manually authored notes"));
+        assert!(after.contains("- a personal note"));
+        assert!(marked_section_intact(&after));
+    }
+
+    #[test]
+    fn install_repairs_duplicated_marker_blocks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rules_dir = tmp.path().join("rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        let target = rules_dir.join("ccteam-lessons-dev.md");
+        // User accidentally pasted the marker block twice.
+        let dup = format!(
+            "# header\n\nsome user prose\n\n{block}\n\n{block}\n",
+            block = CANONICAL_MARKED_BLOCK,
+        );
+        std::fs::write(&target, &dup).unwrap();
+
+        let reports =
+            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        assert_eq!(reports[0].action, MemoryBridgeAction::RepairedMarkedSection);
+        let after = read(&target);
+        assert!(marked_section_intact(&after));
+        assert_eq!(after.matches(MARKER_BEGIN).count(), 1);
+        assert_eq!(after.matches(MARKER_END).count(), 1);
+        assert!(after.contains("some user prose"), "user prose dropped");
+    }
+
+    #[test]
+    fn install_repairs_unbalanced_begin_marker() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rules_dir = tmp.path().join("rules");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        let target = rules_dir.join("ccteam-lessons-dev.md");
+        // Begin marker but no end — file got cut off mid-write.
+        let body = format!(
+            "# header\n\nuser prose stays\n\n{MARKER_BEGIN}\nstray content with no end marker\n",
+        );
+        std::fs::write(&target, &body).unwrap();
+
+        let reports =
+            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        assert_eq!(reports[0].action, MemoryBridgeAction::RepairedMarkedSection);
+        let after = read(&target);
+        assert!(marked_section_intact(&after));
+        assert!(after.contains("user prose stays"));
+        assert!(
+            !after.contains("stray content with no end marker"),
+            "unbalanced block contents should be dropped",
+        );
+    }
+
+    #[test]
+    fn dry_run_reports_actions_without_touching_disk() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let opts = InstallMemoryBridgeOptions { dry_run: true };
+        let reports = install_into(tmp.path(), opts).unwrap();
+        for r in &reports {
+            assert_eq!(r.action, MemoryBridgeAction::DryRun { would_write: true });
+            assert!(!r.target.exists(), "dry-run wrote {}", r.target.display());
+        }
+        // Now install for real; second dry-run should report no-op.
+        install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        let reports2 = install_into(tmp.path(), opts).unwrap();
+        for r in &reports2 {
+            assert_eq!(r.action, MemoryBridgeAction::DryRun { would_write: false });
+        }
+    }
+
+    #[test]
+    fn marked_section_intact_rejects_zero_or_multiple_pairs() {
+        assert!(!marked_section_intact(""));
+        assert!(!marked_section_intact("# only header"));
+        assert!(!marked_section_intact(&format!(
+            "{MARKER_BEGIN}\n{MARKER_BEGIN}\nx\n{MARKER_END}\n{MARKER_END}\n",
+        )));
+        // End before begin → not intact.
+        assert!(!marked_section_intact(&format!(
+            "{MARKER_END}\nx\n{MARKER_BEGIN}\n",
+        )));
+        assert!(marked_section_intact(&format!(
+            "header\n{MARKER_BEGIN}\nbody\n{MARKER_END}\nfooter\n",
+        )));
+    }
+}

--- a/crates/ccteam-core/src/templates/memory_bridge_dev.md
+++ b/crates/ccteam-core/src/templates/memory_bridge_dev.md
@@ -1,0 +1,23 @@
+---
+name: ccteam dev team — cross-project lessons
+description: Auto-populated by ccteam retro phase. Lessons learned across dev projects.
+paths:
+  - "~/projects/dev-*"
+---
+
+# ccteam dev team — cross-project lessons
+
+Auto-populated by the ccteam `ship` phase retro segment. The retro segment
+overwrites only the marked block below — anything you write outside of it is
+preserved across `ccteam doctor --install-memory-bridge` re-runs.
+
+Field layout matches `teams/dev.yaml.retro_schema`:
+
+- **tech_stack** — Languages, frameworks, key libraries used.
+- **pitfalls** — Mistakes / surprises to avoid next time.
+- **successful_designs** — Design choices that paid off.
+- **do_not_do_again** — Anti-patterns observed.
+
+<!-- ccteam-managed:lessons begin -->
+(Empty until first retro. Phase prompts append lessons here using `Edit`.)
+<!-- ccteam-managed:lessons end -->

--- a/crates/ccteam-core/src/templates/memory_bridge_product_research.md
+++ b/crates/ccteam-core/src/templates/memory_bridge_product_research.md
@@ -1,0 +1,24 @@
+---
+name: ccteam product-research team — cross-project lessons
+description: Auto-populated by ccteam retro phase. Lessons learned across product-research projects.
+paths:
+  - "~/projects/product-research-*"
+---
+
+# ccteam product-research team — cross-project lessons
+
+Auto-populated by the ccteam `verdict` phase retro segment (REJECT branch).
+The retro segment overwrites only the marked block below — anything you write
+outside of it is preserved across `ccteam doctor --install-memory-bridge`
+re-runs.
+
+Field layout matches `teams/product-research.yaml.retro_schema`:
+
+- **market_signals** — Top market signals collected (demand, saturation, pricing).
+- **differentiation_findings** — Unique angles found / ruled out.
+- **feasibility_assessment** — Tech / business feasibility verdict.
+- **verdict_rationale** — Why this verdict (PASS / CONCERN / REJECT / CLARIFY).
+
+<!-- ccteam-managed:lessons begin -->
+(Empty until first retro. Phase prompts append lessons here using `Edit`.)
+<!-- ccteam-managed:lessons end -->

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -22,12 +22,13 @@
 
 ## 摘要
 
-21 条发现(2026-05-05 加 F21、升级 F20 P1→P0,共增 1 条;2026-05-06 修复 F21),分布:
+23 条发现(2026-05-05 加 F21、升级 F20 P1→P0,共增 1 条;2026-05-06 修复 F21;
+2026-05-06 M4.4 spike 加 F22 P0 + F23 P1 conditional),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
-| **P0 阻塞泛化** | 7 | F1, F2, F3, F4, F12, F13, F20(2026-05-05 升级) |
-| **P1 该做但可后置** | 9(原 10,F21 已修复) | F5, F6, F7, F8, F9, F10, F11, F15, F19, ~~F21~~ |
+| **P0 阻塞泛化** | 8 | F1, F2, F3, F4, F12, F13, F20(2026-05-05 升级), F22(2026-05-06 M4.4 spike) |
+| **P1 该做但可后置** | 10 | F5, F6, F7, F8, F9, F10, F11, F15, F19, F23(conditional) |
 | **P2 边角** | 3 | F16, F17, F18 |
 | **N/A 已是领域无关** | 1 | F14 |
 | **已修复** | 1 | F21(@a5fb21d) |
@@ -389,6 +390,44 @@ change。按 CLAUDE.md §五.3 "不写 backwards-compat shim",直接换。
 - **审计漏报原因**:本条是"已 spec 未实现"的半完成态——schema 写在 interfaces.md
   里、orchestrator 假装支持(没崩),但实际行为不一致。常规审计扫现状代码
   vs 文档断言,容易漏掉这种"文档说有、代码静默忽略"的隐性债
+
+### F22 — 项目 slug 缺 team 前缀,导致 `~/.claude/rules/*.md` `paths:` scope 失效(2026-05-06 加,M4.4 spike 发现)
+
+- **文件:行号**:`crates/ccteam-core/src/projects.rs:70` `pick_unused_slug` /
+  `crates/ccteam-core/src/projects.rs:96` `bootstrap_project`
+- **现状**:`ccteam new --team=dev "X"` 产出 `~/projects/<slug>/`,**slug 不带
+  team 前缀**;但 M4.2 安装的 `~/.claude/rules/ccteam-lessons-dev.md` frontmatter
+  写 `paths: [~/projects/dev-*]`,Claude Code 按 cwd 匹配 → 当前所有 dev 项目
+  都不在 `dev-*` 名下 → rules 文件对真正想读它的 phase session 不可见
+- **是否真 dev-specific**:**否——是协议约定缺失。** 已有先例:meta-agent 项目
+  通过 `bootstrap_meta_project` 写 `<handle>-meta` 后缀;非 meta 项目应同样
+  prefix `<team>-<slug>`
+- **解耦方案**:
+  1. `pick_unused_slug` 加 `team: &str` 参数,return `format!("{team}-{base}")`
+  2. `bootstrap_project` 调用方传 team
+  3. `interfaces.md` 项目目录约定段落同步("ccteam project dirs follow
+     `~/projects/<team>-<slug>/`")
+  4. 不写"老 slug 兼容"shim:M4 之前的项目 state.json 已记录 team,但目录
+     名不变;新建项目走新规则,doctor 不迁移历史(CLAUDE.md §五.3
+     "不写 backwards-compat shim")
+- **优先级**:**P0**——M4 主路径(rules 自动加载到 phase Claude)依赖此;
+  本 M4 PR 只发现不修(slug 是协议,改它需要同步 interfaces.md +
+  state.json 路径解析,跨 PR scope)
+- **来源**:`docs/m4-spike-2026-05-06.md` §3
+- **下一步**:独立 PR 修(优先于 §4 deferred check 重跑)
+
+### F23 — 容器 bind-mount `~/.claude/rules/` 待 M4.4 spike §4 重跑后定夺(2026-05-06 加)
+
+- **文件:行号**:N/A(未发现现状代码缺陷,**待 spike 验证**)
+- **现状**:M4.4 §4 deferred 检查"`--dangerously-skip-permissions` 容器
+  里 `~/.claude/rules/*.md` 是否被 Claude Code 当做 context 注入"——F22 修好之前
+  无法跑,所以是潜在隐患而非确认问题
+- **是否真 dev-specific**:**否——是基础设施层。**
+- **解耦方案**(若 spike 失败):doctor 加 `--bind-mount-claude-rules`
+  子模式(往容器配置追加只读 mount),sketch 见
+  `docs/m4-spike-2026-05-06.md` §4
+- **优先级**:**P1 conditional**——F22 修完后跑 spike;失败才升 P0
+- **来源**:`docs/m4-spike-2026-05-06.md` §4
 
 ---
 

--- a/docs/m4-spike-2026-05-06.md
+++ b/docs/m4-spike-2026-05-06.md
@@ -1,0 +1,233 @@
+# M4.4 Spike — Container bind-mount + paths frontmatter (2026-05-06)
+
+> 0.5-day verification accompanying M4.1–M4.3 (PR `feat/m4-cross-project-memory`).
+> Validates the assumptions behind ccteam's "zero retrieval code" memory
+> design: the rules + auto-memory bridge actually has to load into the
+> right Claude sessions, scoped to the right team, for the M4 main path
+> to be useful. This report records what's verified now vs. what still
+> needs runtime confirmation.
+
+## TL;DR
+
+| Check | Result | Action |
+|---|---|---|
+| `ccteam doctor --install-memory-bridge` writes both team files | ✅ verified live | none |
+| Re-run is idempotent (no-op on intact markers) | ✅ verified live | none |
+| Marked-section repair preserves user content outside markers | ✅ verified live | none |
+| `paths:` frontmatter `~/projects/<team>-*` scoping works | ⚠️ **blocked — slug gap** | open follow-up (see §3) |
+| `~/.claude/rules/*.md` auto-loads in `--dangerously-skip-permissions` container | ⏳ deferred to live runtime | open follow-up (see §4) |
+| `claude-mem` MCP tools detection by phase prompt conditional | ✅ tool surface visible when installed | none |
+| retro Edit on marked section idempotent end-to-end | ⏳ deferred (covered by unit tests) | optional follow-up |
+
+## 1. Idempotency + repair (live verified)
+
+Ran against the developer's actual `~/.claude/`:
+
+```bash
+$ ccteam doctor --install-memory-bridge   # first run
+  dev               wrote                /home/rob/.claude/rules/ccteam-lessons-dev.md
+  product-research  wrote                /home/rob/.claude/rules/ccteam-lessons-product-research.md
+
+$ ccteam doctor --install-memory-bridge   # second run
+  dev               already-present      /home/rob/.claude/rules/ccteam-lessons-dev.md
+  product-research  already-present      /home/rob/.claude/rules/ccteam-lessons-product-research.md
+
+$ ccteam doctor --install-memory-bridge --dry-run
+  dev               no-op (already present)
+  product-research  no-op (already present)
+```
+
+**Repair test** — manually corrupted the dev file with two duplicated marker
+blocks plus interleaved user prose; re-ran the doctor:
+
+```
+$ ccteam doctor --install-memory-bridge
+  dev               repaired             /home/rob/.claude/rules/ccteam-lessons-dev.md
+```
+
+Post-repair file contains: every line of user prose preserved (in source
+order), exactly one canonical marked block at end-of-file, both stray block
+contents discarded. Matches `crates/ccteam-core/src/memory_bridge.rs` unit
+test `install_repairs_duplicated_marker_blocks`.
+
+## 2. claude-mem detection path (live verified)
+
+This developer's machine has `claude-mem` installed via the official
+plugin marketplace. Tool surface enumerates:
+
+```
+mcp__plugin_claude-mem_mcp-search__search
+mcp__plugin_claude-mem_mcp-search__timeline
+mcp__plugin_claude-mem_mcp-search__get_observations
+mcp__plugin_claude-mem_mcp-search____IMPORTANT
+… plus smart_search / smart_outline / smart_unfold
+```
+
+The phase prompt conditional ("if you see `mcp__*claude-mem*search`-like
+tools, you may call them") matches all of these by glob. ccteam writes no
+detection code — confirmed by the M4 red line grep:
+
+```bash
+$ grep -rnE "fn .+_memory|fn .+_retrieve|sentence|sqlite.*memory|chromadb|claude.?mem" \
+    crates/ccteam-core/src/ crates/ccteam-cli/src/
+crates/ccteam-core/src/orchestrator.rs:1027:    /// claude-mem RAG flow; …  (comment only, M1 docstring)
+crates/ccteam-core/src/memory_bridge.rs:74:pub fn install_memory_bridge(  (file write, no retrieval)
+crates/ccteam-cli/src/commands.rs:648:fn render_install_memory_bridge_report(opts: …)  (CLI render)
+```
+
+Only file-write and rendering code, no retrieval. Red line clean.
+
+## 3. ⚠️ Open follow-up — slug gap blocks `paths:` frontmatter scoping
+
+The shipped lessons files declare:
+
+```yaml
+# ccteam-lessons-dev.md
+paths:
+  - "~/projects/dev-*"
+
+# ccteam-lessons-product-research.md
+paths:
+  - "~/projects/product-research-*"
+```
+
+**but** current bootstrap (`crates/ccteam-core/src/projects.rs`,
+`pick_unused_slug` + `bootstrap_project`) creates projects at
+`~/projects/<slug>/` with no team prefix:
+
+```
+$ ccteam new --team=dev "make a markdown editor"
+created project make-a-markdown-editor (team: dev)
+  spec   : /home/rob/projects/make-a-markdown-editor/.ccteam/spec.md
+```
+
+Claude Code matches `paths:` against the session's cwd. With current
+slugs, `~/projects/dev-*` matches **zero** dev projects — so the dev
+lessons file is effectively dark for the very sessions it was authored
+for. Only the meta-agent project (`bootstrap_meta_project` writes
+`<handle>-meta` slugs) follows a team-suffix convention; that's the
+existing precedent we'd lift.
+
+**Why this is a real follow-up, not noise**: the M4 main path requires
+cross-project lessons to auto-load into the right phase Claude. Without
+team-prefixed slugs, M4.1's retro phase will write to lessons files
+that nothing reads.
+
+**Suggested fix (separate PR)**: change `pick_unused_slug` to prepend
+`<team>-` so `ccteam new --team=dev "X"` produces `~/projects/dev-x`.
+Migration story: existing un-prefixed slugs keep working (orchestrator
+state.json already records team), only new-create paths change. Track
+as **F22 dev-coupling-audit follow-up** (separate from this M4 PR per
+CLAUDE.md §五.1 — "改了协议必须同步 interfaces.md" — slug naming is
+protocol; this M4 PR doesn't touch it).
+
+Alternative quicker fix considered and rejected: drop `paths:` entirely
+and let the rules file auto-load into all Claude sessions globally. Loses
+team isolation (dev sessions see product-research lessons and vice versa),
+re-introduces the "old project's wrong-team lessons pollute new project"
+failure mode the schema design was fighting against (tech-design §3.7).
+
+## 4. ⏳ Deferred — `~/.claude/rules/*.md` auto-load in container sessions
+
+Cannot verify from this dev's daily-driver Claude session (the canonical
+test is "spawn a `ccteam new` project session that runs Claude inside the
+configured tool-isolation container, with `--dangerously-skip-permissions`,
+and check whether the dev lessons file shows up in its session-start
+context"). That requires:
+
+- a project under `~/projects/dev-*` to exist (blocked by §3 today)
+- the orchestrator running and dispatching plan-eng phase
+- inspection of the project session's first few messages
+
+**Methodology when §3 is fixed**:
+
+1. `ccteam doctor --install-memory-bridge` (already shipped).
+2. Manually `Edit` `~/.claude/rules/ccteam-lessons-dev.md` to add a
+   sentinel string inside the marked block, e.g. `SENTINEL_M4_SPIKE_2026_05_06`.
+3. `ccteam new --team=dev "spike echo sentinel"` (assumes §3 fix landed
+   so slug becomes `dev-spike-echo-sentinel`).
+4. Add a one-liner to the top of `phases/02-plan-eng.md`:
+   "if you see SENTINEL_M4_SPIKE_2026_05_06 in your context, copy it
+    verbatim into your first reply."
+5. `ccteam start --foreground` and watch `progress.jsonl`. If the first
+   assistant message echoes the sentinel → auto-load works through the
+   container. If not → container is masking `~/.claude/rules/`; doctor
+   needs a `--bind-mount-claude-rules` step that adds the rules dir to
+   the project's tool-isolation config.
+
+The expected outcome (per Claude Code official docs at
+https://code.claude.com/docs/en/memory) is that auto-load works:
+`~/.claude/rules/*.md` is part of the standard tool surface, not opt-in.
+The `--dangerously-skip-permissions` flag affects tool *execution*
+authorization, not file *reading* into context. The container question
+is whether the operator's container config remaps `$HOME` or shadows
+`~/.claude/`; the default ccteam container (M2.x) does neither.
+
+**If the deferred check fails**, the doctor extension is small:
+
+```rust
+// crates/ccteam-cli/src/commands.rs (sketch)
+fn render_bind_mount_claude_rules() -> Result<String> {
+    // Append to the project-level container config:
+    //   mounts:
+    //     - source: ~/.claude/rules
+    //       target: /root/.claude/rules
+    //       readonly: true
+    // Idempotent — skip if already present.
+}
+```
+
+No need to implement until the spike actually fails. Tracking as
+**F23 dev-coupling-audit follow-up**.
+
+## 5. retro idempotency (covered by unit tests, optional E2E)
+
+Live unit tests already cover:
+
+- `install_creates_both_lessons_files_with_intact_markers`
+- `install_idempotent_when_files_present_and_intact`
+- `install_preserves_lessons_written_between_markers` ← **this is the retro
+  idempotency check** (simulates retro phase having written content between
+  markers; verifies subsequent doctor re-run preserves that content)
+- `install_repairs_missing_markers_and_keeps_user_content`
+- `install_repairs_duplicated_marker_blocks`
+- `install_repairs_unbalanced_begin_marker`
+
+End-to-end retro simulation (using a real Claude session writing the
+marked block via `Edit`) would re-validate the same invariants the unit
+tests already cover, so deferring as low-value unless §3 + §4 surface
+unexpected interactions.
+
+## 6. What this PR ships, what it doesn't
+
+**Ships in this PR** (M4.1–M4.4):
+
+- `ccteam doctor --install-memory-bridge` (M4.2) — placeholder rules
+  files, idempotent, marker-repair logic, 9 new tests
+- Retro phase prompts rewrite (M4.1) — dev `phases/09-ship.md` +
+  product-research `phases-product-research/06-verdict.md` REJECT branch,
+  driven by `team.yaml.retro_schema` (product-research schema populated
+  for the first time, closes F20)
+- Seed phase prompts (M4.3) — `02-plan-eng.md` / `01-kickoff.md` /
+  `06-verdict.md` reference cross-project lessons + `/memory` + optional
+  claude-mem
+- This spike report
+
+**Does NOT ship** (open follow-ups):
+
+- F22 — slug team prefix (`<team>-<slug>` vs current bare `<slug>`).
+  Required for `paths:` scoping to actually fire.
+- F23 — container bind-mount step in doctor, contingent on §4 spike
+  failing once F22 lands.
+
+When F22 lands, re-run the §4 methodology and update this report
+(or supersede it with `m4-spike-<new-date>.md`).
+
+## References
+
+- 痛点 10 — every project starts from zero
+- `docs/tech-design.md` §3.7 — Cross-project Memory architecture
+- `docs/development-plan.md` §6 — M4.1–M4.4 task table
+- `references/research/claude-code-memory-research.md` §六 — M4 decision
+  basis (rules + auto-memory + optional claude-mem MCP)
+- `crates/ccteam-core/src/memory_bridge.rs` — installer + tests

--- a/phases-product-research/01-kickoff.md
+++ b/phases-product-research/01-kickoff.md
@@ -15,6 +15,22 @@ max_clarify_rounds: 5
 
 你是 product-research 团队的 kickoff phase。本团队回答的核心问题:**这个 idea 值不值得做?** 不写代码,只产研究报告。
 
+## 跨项目经验(反向面试前先看)
+
+`~/.claude/rules/ccteam-lessons-product-research.md` 在 session 启动时已自动加载。
+**先扫一遍**,尤其历史的 REJECT 条目——若本 idea 已被 REJECT 过(同一市场、同一痛点),
+可以在 brief 里直接标"重复 idea"并在 verdict phase 倾向 REJECT,不用走完整 5 phase。
+
+需要深挖某个 topic 时:
+- `/memory` 浏览本仓 auto-memory
+- `Read ~/.claude/projects/<encoded>/memory/<topic>.md` 直接读 topic 文件
+
+**可选**:如果工具列表里出现 `mcp__*claude-mem*search` 之类工具(用户装了
+[claude-mem](https://github.com/thedotmack/claude-mem)),可以调它做跨项目语义检索
+("有没有相似失败 idea")。没有就跳过。
+
+## 反向面试
+
 `@.ccteam/spec.md` 是用户的一句话原始需求。多数情况下它**太薄**——只列了 idea 名字,没说目标用户、平台、核心场景、约束、不做什么。
 
 照下面的反向面试方法做:

--- a/phases-product-research/06-verdict.md
+++ b/phases-product-research/06-verdict.md
@@ -63,8 +63,49 @@ confidence: 0.0-1.0
 
 - **PASS**:推荐派 dev 团队 spec(`ccteam new --team=dev "<refined brief>"`),列必带的关键事实
 - **CONCERN**:建议先做 1-2 周轻量验证(调用第三方 API 跑通核心 flow / 找 5 个目标用户访谈),再决定要不要派 dev
-- **REJECT**:建议不做。如果用户仍要做,**不要直接派 dev**——先写 retro 记录这次否决,让跨项目记忆能召回(M4 落地后)
+- **REJECT**:建议不做。如果用户仍要做,**不要直接派 dev**——先按下文「REJECT 分支 retro」要求把这次否决落进跨项目 lessons 库,再让用户决定
 - **CLARIFY**:列出还需要的信息
+
+## REJECT 分支 retro
+
+**只在 `verdict = REJECT` 时执行**(PASS / CONCERN 的 retro 由下游 dev 项目的 ship phase 写;
+CLARIFY 不是终态)。两处落地(基于 `teams/product-research.yaml.retro_schema`):
+
+1. **本仓库 auto-memory** → 调 `/memory` 写本项目特定 lessons,topic 文件结构你自定。
+
+2. **跨项目 lessons 库** → 用 `Edit` 修改 `~/.claude/rules/ccteam-lessons-product-research.md`,
+   **只改 `<!-- ccteam-managed:lessons begin/end -->` 之间内容**(不动标记,也不动
+   marked 外的用户段)。在 marked section 内 append 一段以本项目 slug + 日期为
+   H2 标题的新条目;字段顺序与 description 取自
+   `teams/product-research.yaml.retro_schema`(每字段一个 H3):
+
+   - `market_signals` — Top market signals collected (demand, saturation, pricing)
+   - `differentiation_findings` — Unique angles found / ruled out
+   - `feasibility_assessment` — Tech / business feasibility verdict
+   - `verdict_rationale` — Why this verdict (PASS / CONCERN / REJECT / CLARIFY)
+
+   格式:
+
+   ```
+   ## <项目 slug> (YYYY-MM-DD) — REJECT
+
+   ### market_signals
+   <一段总结>
+
+   ### differentiation_findings
+   <一段总结>
+
+   ### feasibility_assessment
+   <一段总结>
+
+   ### verdict_rationale
+   <一段总结,引 rationale.md>
+   ```
+
+   若 `~/.claude/rules/ccteam-lessons-product-research.md` 不存在,说明用户没跑过
+   `ccteam doctor --install-memory-bridge`;在 `.ccteam/rationale.md` 末尾追加一行
+   "memory bridge missing — run ccteam doctor --install-memory-bridge",跨项目
+   lessons 这次跳过(不 ESCALATE,verdict 已写完)。
 
 ## verdict 决定退出方式
 

--- a/phases-product-research/06-verdict.md
+++ b/phases-product-research/06-verdict.md
@@ -21,6 +21,16 @@ max_clarify_rounds: 5
 
 综合所有上游产物,做出 **PASS / CONCERN / REJECT / CLARIFY** 判断,产出三份产物。
 
+## 跨项目经验(裁决前先比对)
+
+`~/.claude/rules/ccteam-lessons-product-research.md` 在 session 启动时已自动加载。
+**先扫一遍历史 REJECT 条目**——若上游产物的市场/差异化/可行性结论与某条历史
+REJECT 高度相似(同一市场饱和、同一差异化死路、同样的可行性死结),
+verdict 倾向 REJECT 并在 rationale.md 里引该历史条目作证据。
+
+需要深挖时:`/memory` 浏览本仓 auto-memory;装了 claude-mem 时可调
+`mcp__*claude-mem*search` 做跨项目语义匹配。
+
 ## 三份产物
 
 ### 1. `.ccteam/verdict.md`

--- a/phases/02-plan-eng.md
+++ b/phases/02-plan-eng.md
@@ -18,6 +18,19 @@ max_clarify_rounds: 3
 ccteam 是**高质量软件元开发系统**,不是"凑合能跑就行"的玩具——这个阶段
 的产出会直接驱动后续 implement / test / fix。规划质量决定终产物质量。
 
+## 跨项目经验(开始规划前先看)
+
+`~/.claude/rules/ccteam-lessons-dev.md` 在 session 启动时已自动加载到上下文。
+**先扫一遍**,尤其 `do_not_do_again` 段——别把上一个项目踩过的坑当成新发现重新来一遍。
+
+需要深挖某个 topic 时:
+- `/memory` 浏览本仓 auto-memory
+- `Read ~/.claude/projects/<encoded>/memory/<topic>.md` 直接读 topic 文件
+
+**可选**:如果工具列表里出现 `mcp__*claude-mem*search` 之类工具(用户装了
+[claude-mem](https://github.com/thedotmack/claude-mem)),可以调它做跨项目语义检索;
+没有就跳过,默认机制已够用。
+
 ## 输入
 
 - `@.ccteam/spec.md` —— 用户原始需求

--- a/phases/09-ship.md
+++ b/phases/09-ship.md
@@ -17,11 +17,50 @@ sub_skills: []
 
 1. 运行最终测试一次,确认全绿(否则 `ESCALATE`)
 2. 创建 git commit(message 简洁说明本项目做了什么)
-3. 写 `.ccteam/retro.md`,30 行内回顾:
-   - 实际花费 vs plan-eng 估算
-   - 关键技术决策(后续项目能复用的)
-   - 踩过的坑(不要再做的事)
-   - 给跨项目记忆的"建议复用 / 不要再做"摘要
+3. 写 retro,**三处落地**(基于 `teams/dev.yaml.retro_schema`):
+
+   a. **本项目 retro 报告** → `.ccteam/retro.md`,30 行内回顾:
+      - 实际花费 vs plan-eng 估算
+      - 关键技术决策(后续项目能复用的)
+      - 踩过的坑
+
+   b. **本仓库 auto-memory** → 调 `/memory` 写入项目特定 lessons,topic 文件结构你自定;
+      只记本仓库未来延续会用到的事(不重复 `.ccteam/retro.md` 内容)。
+
+   c. **跨项目 lessons 库** → 用 `Edit` 修改 `~/.claude/rules/ccteam-lessons-dev.md`,
+      **只改 `<!-- ccteam-managed:lessons begin/end -->` 之间内容**(不动标记,也不动
+      marked 外的用户段)。在 marked section 内 append 一段以本项目 slug + 日期为
+      H2 标题的新条目;字段顺序与 description 取自 `teams/dev.yaml.retro_schema`
+      (每字段一个 H3):
+
+      - `tech_stack` — Languages, frameworks, key libraries used
+      - `pitfalls` — Mistakes / surprises to avoid next time
+      - `successful_designs` — Design choices that paid off
+      - `do_not_do_again` — Anti-patterns observed
+
+      格式:
+
+      ```
+      ## <项目 slug> (YYYY-MM-DD)
+
+      ### tech_stack
+      <一段总结>
+
+      ### pitfalls
+      <一段总结>
+
+      ### successful_designs
+      <一段总结>
+
+      ### do_not_do_again
+      <一段总结>
+      ```
+
+      若 `~/.claude/rules/ccteam-lessons-dev.md` 不存在,说明用户没跑过
+      `ccteam doctor --install-memory-bridge`;在 `.ccteam/retro.md` 里留一句
+      "memory bridge missing — run ccteam doctor --install-memory-bridge",
+      跨项目 lessons 这次跳过(不 ESCALATE,本项目已 ship)。
+
 4. 若项目有 README 需求则生成
 
 最后一行:`PHASE_DONE: ship`(或 `ESCALATE: <一句话原因>`)。

--- a/teams/product-research.yaml
+++ b/teams/product-research.yaml
@@ -33,6 +33,15 @@ golden_rules: []
 # both leave critic_dimensions empty until M5 wires the Critic loop.
 critic_dimensions: []
 
-# Retro phase fields. Empty disables retro emission for this team.
-# product-research retros are not yet defined; M4.1 may revise.
-retro_schema: []
+# Retro fields the M4.1 retro phase emits per product-research project
+# (REJECT branch only — PASS / CONCERN hand off to dev without producing a
+# product-research-side retro entry; the dev project's own retro covers it).
+retro_schema:
+  - field: market_signals
+    description: Top market signals collected (demand, saturation, pricing)
+  - field: differentiation_findings
+    description: Unique angles found / ruled out
+  - field: feasibility_assessment
+    description: Tech / business feasibility verdict
+  - field: verdict_rationale
+    description: Why this verdict (PASS / CONCERN / REJECT / CLARIFY)


### PR DESCRIPTION
## Summary

- **M4.2** — `ccteam doctor --install-memory-bridge` creates marked-section
  lessons files at `~/.claude/rules/ccteam-lessons-{dev,product-research}.md`.
  Idempotent: re-runs no-op when markers intact, repair (single canonical
  block at end-of-file, user content outside markers preserved) when not.
- **M4.1** — dev `phases/09-ship.md` + product-research
  `phases-product-research/06-verdict.md` retro segments rewritten. Claude
  writes per-repo lessons via `/memory` and edits cross-project lessons via
  `Edit` on the marker-bounded section. `teams/product-research.yaml.retro_schema`
  populated for the first time (4 fields).
- **M4.3** — `phases/02-plan-eng.md`, `phases-product-research/01-kickoff.md`,
  and `phases-product-research/06-verdict.md` (header) gain a "cross-project
  experience" segment: rules already auto-injected, `/memory` for deeper
  digging, and a conditional optional `mcp__*claude-mem*search` reference
  that the LLM evaluates against its own tool surface (no detection code).
- **M4.4 spike** — `docs/m4-spike-2026-05-06.md` documents live-verified
  install + idempotency + repair, claude-mem detection path, and flags two
  follow-ups in `dev-coupling-audit.md`: F22 (P0, slug gap blocking `paths:`
  frontmatter scoping) and F23 (P1 conditional, container bind-mount —
  contingent on F22 + a re-run).

**ccteam-core code change**: ZERO retrieval / RAG / index code (M4 architectural
red line). All retrieval happens inside Claude sessions via official `/memory`
+ rules auto-load. The only ccteam-core code added is `memory_bridge.rs` —
file-write only.

## Commits

1. `feat(M4.2): doctor --install-memory-bridge` — base, no-op without retro prompts
2. `feat(M4.1): team-aware retro phase prompts` — populates schema + rewrites retros
3. `feat(M4.3): seed/verdict phase prompts reference cross-project lessons`
4. `feat(M4.4): spike report — install verified, paths scoping blocked by slug gap`

## Test plan

- [x] `cargo test --workspace` — 366 / 0 failed (357 baseline + 9 new memory-bridge unit + integration)
- [x] No new clippy warnings introduced (6 pre-existing warnings on main confirmed
      independent of this PR via `git stash` + clippy on stashed state)
- [x] Red-line grep — only file-write functions match `_memory|_retrieve|sentence|sqlite|chromadb|claude.?mem` in core/cli; one orchestrator.rs match is a pre-existing docstring
- [x] Live install (against actual `~/.claude/`): wrote / re-run no-op / dry-run / repair-after-corruption all behave per spec
- [x] Live `claude-mem` MCP tool surface visible — phase prompt conditional matches by glob
- [ ] **Deferred** to F22 fix: rules auto-load into `ccteam new` project sessions (paths frontmatter currently scopes to `~/projects/<team>-*` but bootstrap creates `~/projects/<slug>/`; spike methodology in §4 of report)

## References

- 痛点 10 — every project starts from zero (`docs/requirements.md`)
- `docs/tech-design.md` §3.7 — Cross-project Memory architecture
- `docs/development-plan.md` §6 — M4.1–M4.4 task table
- `references/research/claude-code-memory-research.md` §六 — M4 decision basis
- **Closes F20** (dev-coupling-audit.md cross-project memory schema P0 — schema now consumed by retro prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)