### PR TITLE
fix(F22): prefix project slugs with team name — activate M4 cross-project memory paths scoping

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -140,7 +140,7 @@ pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String>
         bail!("ccteam new: --team must be non-empty");
     }
     ensure_team_resolvable(paths, team)?;
-    let slug = pick_unused_slug(paths, request)?;
+    let slug = pick_unused_slug(paths, request, team)?;
     bootstrap_project(paths, &slug, request, team)?;
     Ok(slug)
 }
@@ -1216,7 +1216,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         let slug = run_new(&paths, "Build a bookmark manager", "dev").unwrap();
-        assert!(slug.starts_with("build-a-bookmark-manager"));
+        // F22: slug now carries the team prefix so ~/.claude/rules/ccteam-lessons-dev.md
+        // `paths: ~/projects/dev-*` matches at session start.
+        assert!(slug.starts_with("dev-build-a-bookmark-manager"));
         let project = paths.project_dir(&slug);
         assert!(project.join(".ccteam/spec.md").exists());
         assert!(project.join(".ccteam/state.json").exists());

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -354,7 +354,7 @@ fn tool_new(paths: &CcteamPaths, args: &Value) -> Result<String> {
     if prompt.trim().is_empty() {
         return Err(anyhow!("prompt must be non-empty"));
     }
-    let slug = pick_unused_slug(paths, &prompt)?;
+    let slug = pick_unused_slug(paths, &prompt, &team)?;
     let project_dir = bootstrap_project(paths, &slug, &prompt, &team)?;
     Ok(serde_json::to_string_pretty(&json!({
         "slug": slug,

--- a/crates/ccteam-cli/tests/m3_product_research_e2e_test.rs
+++ b/crates/ccteam-cli/tests/m3_product_research_e2e_test.rs
@@ -48,7 +48,7 @@ fn setup_product_research(
 ) -> (String, Orchestrator) {
     isolation();
     write_all_global_team_templates(&paths.root, false).unwrap();
-    let slug = pick_unused_slug(paths, brief).unwrap();
+    let slug = pick_unused_slug(paths, brief, "product-research").unwrap();
     bootstrap_project(paths, &slug, brief, "product-research").unwrap();
     let orch =
         Orchestrator::new(paths.clone(), OrchestratorConfig::default()).unwrap();

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -65,21 +65,35 @@ pub fn random_suffix() -> String {
     format!("{:04x}", nanos & 0xFFFF)
 }
 
-/// Pick an unused slug under `paths.projects_root`. Tries the bare
-/// slugified base first, then `<base>-<suffix>` with up to 16 retries.
-pub fn pick_unused_slug(paths: &CcteamPaths, base: &str) -> Result<String> {
+/// Pick an unused slug under `paths.projects_root`, prefixed with the
+/// project's team name so `~/.claude/rules/ccteam-lessons-<team>.md`
+/// `paths:` frontmatter (`~/projects/<team>-*`) actually matches the
+/// project directory at session start (M4 main path; F22 fix, 2026-05-06).
+///
+/// Tries `<team>-<base>` first, then `<team>-<base>-<suffix>` with up
+/// to 16 retries on collision.
+///
+/// Meta-agent projects don't go through this function — they use
+/// `meta_slug(handle)` which hand-crafts `<handle>-meta` (suffix
+/// convention established before F22; rules don't scope to meta).
+pub fn pick_unused_slug(
+    paths: &CcteamPaths,
+    base: &str,
+    team: &str,
+) -> Result<String> {
     let base = slugify(base);
-    if !paths.project_dir(&base).exists() {
-        return Ok(base);
+    let prefixed = format!("{team}-{base}");
+    if !paths.project_dir(&prefixed).exists() {
+        return Ok(prefixed);
     }
     for _ in 0..16 {
-        let candidate = format!("{base}-{}", random_suffix());
+        let candidate = format!("{prefixed}-{}", random_suffix());
         if !paths.project_dir(&candidate).exists() {
             return Ok(candidate);
         }
     }
     Err(anyhow!(
-        "could not pick an unused slug after 16 attempts (base: {base})",
+        "could not pick an unused slug after 16 attempts (base: {prefixed})",
     ))
 }
 
@@ -500,6 +514,47 @@ mod tests {
         let s = slugify(&"a".repeat(80));
         assert_eq!(s.len(), 40);
         assert!(s.chars().all(|c| c == 'a'));
+    }
+
+    fn pick_paths(tmp: &tempfile::TempDir) -> CcteamPaths {
+        CcteamPaths {
+            root: tmp.path().join("ccteam-home"),
+            projects_root: tmp.path().join("projects"),
+        }
+    }
+
+    #[test]
+    fn pick_unused_slug_prefixes_team_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let dev = pick_unused_slug(&paths, "make a todo cli", "dev").unwrap();
+        let pr = pick_unused_slug(&paths, "AI recipe generator", "product-research").unwrap();
+        assert_eq!(dev, "dev-make-a-todo-cli");
+        assert_eq!(pr, "product-research-ai-recipe-generator");
+    }
+
+    #[test]
+    fn pick_unused_slug_appends_suffix_on_collision_under_team_prefix() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        // Pre-create the bare prefixed slug directory so the next pick
+        // must fall back to a `<team>-<base>-<suffix>` form.
+        std::fs::create_dir_all(paths.project_dir("dev-todo-cli")).unwrap();
+        let s = pick_unused_slug(&paths, "todo cli", "dev").unwrap();
+        assert!(s.starts_with("dev-todo-cli-"), "expected suffix retry, got {s}");
+        assert_ne!(s, "dev-todo-cli");
+    }
+
+    #[test]
+    fn pick_unused_slug_keeps_team_prefix_distinct_per_team() {
+        // Same brief under different teams must produce distinct slugs.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let dev = pick_unused_slug(&paths, "shared brief", "dev").unwrap();
+        let pr = pick_unused_slug(&paths, "shared brief", "product-research").unwrap();
+        assert_eq!(dev, "dev-shared-brief");
+        assert_eq!(pr, "product-research-shared-brief");
+        assert_ne!(dev, pr);
     }
 
     #[test]

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -23,15 +23,15 @@
 ## 摘要
 
 23 条发现(2026-05-05 加 F21、升级 F20 P1→P0,共增 1 条;2026-05-06 修复 F21;
-2026-05-06 M4.4 spike 加 F22 P0 + F23 P1 conditional),分布:
+2026-05-06 M4.4 spike 加 F22 P0 + F23 P1 conditional;2026-05-06 修复 F22),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
-| **P0 阻塞泛化** | 8 | F1, F2, F3, F4, F12, F13, F20(2026-05-05 升级), F22(2026-05-06 M4.4 spike) |
+| **P0 阻塞泛化** | 7 | F1, F2, F3, F4, F12, F13, F20(2026-05-05 升级) |
 | **P1 该做但可后置** | 10 | F5, F6, F7, F8, F9, F10, F11, F15, F19, F23(conditional) |
 | **P2 边角** | 3 | F16, F17, F18 |
 | **N/A 已是领域无关** | 1 | F14 |
-| **已修复** | 1 | F21(@a5fb21d) |
+| **已修复** | 2 | F21(@a5fb21d)、F22(2026-05-06 follow-up PR) |
 
 **P0 关键路径**:F1(`auto_loop` 字段)+ F2(DAG 由 phase 模板推断)+ F3
 (`FIRST_PHASE` 改 DAG entry node)+ F4(`is_terminal` 改 DAG 终点判断)+
@@ -391,37 +391,25 @@ change。按 CLAUDE.md §五.3 "不写 backwards-compat shim",直接换。
   里、orchestrator 假装支持(没崩),但实际行为不一致。常规审计扫现状代码
   vs 文档断言,容易漏掉这种"文档说有、代码静默忽略"的隐性债
 
-### F22 — 项目 slug 缺 team 前缀,导致 `~/.claude/rules/*.md` `paths:` scope 失效(2026-05-06 加,M4.4 spike 发现)
+### F22 — 项目 slug 缺 team 前缀,导致 `~/.claude/rules/*.md` `paths:` scope 失效(**已修复:2026-05-06 follow-up PR**)
 
-- **文件:行号**:`crates/ccteam-core/src/projects.rs:70` `pick_unused_slug` /
-  `crates/ccteam-core/src/projects.rs:96` `bootstrap_project`
-- **现状**:`ccteam new --team=dev "X"` 产出 `~/projects/<slug>/`,**slug 不带
-  team 前缀**;但 M4.2 安装的 `~/.claude/rules/ccteam-lessons-dev.md` frontmatter
-  写 `paths: [~/projects/dev-*]`,Claude Code 按 cwd 匹配 → 当前所有 dev 项目
-  都不在 `dev-*` 名下 → rules 文件对真正想读它的 phase session 不可见
-- **是否真 dev-specific**:**否——是协议约定缺失。** 已有先例:meta-agent 项目
-  通过 `bootstrap_meta_project` 写 `<handle>-meta` 后缀;非 meta 项目应同样
-  prefix `<team>-<slug>`
-- **解耦方案**:
-  1. `pick_unused_slug` 加 `team: &str` 参数,return `format!("{team}-{base}")`
-  2. `bootstrap_project` 调用方传 team
-  3. `interfaces.md` 项目目录约定段落同步("ccteam project dirs follow
-     `~/projects/<team>-<slug>/`")
-  4. 不写"老 slug 兼容"shim:M4 之前的项目 state.json 已记录 team,但目录
-     名不变;新建项目走新规则,doctor 不迁移历史(CLAUDE.md §五.3
-     "不写 backwards-compat shim")
-- **优先级**:**P0**——M4 主路径(rules 自动加载到 phase Claude)依赖此;
-  本 M4 PR 只发现不修(slug 是协议,改它需要同步 interfaces.md +
-  state.json 路径解析,跨 PR scope)
+- **文件:行号**:`crates/ccteam-core/src/projects.rs::pick_unused_slug` 现接受
+  `team: &str` 参数;`crates/ccteam-cli/src/commands.rs::run_new` + `mcp_serve.rs::handle_new`
+  调用点更新
+- **修复**:`pick_unused_slug` 产出 `<team>-<base>`(collision 时 `<team>-<base>-<suffix>`);
+  meta-agent 走自己的 `meta_slug(handle)` → `<handle>-meta`,不动
+- **何为 fix-the-fix**:`interfaces.md §1.2` 项目目录约定改为 `~/projects/<team>-<slug>/`;
+  M4.4 spike report §3 改 closed,§4 deferred check 解锁
+- **migration**:历史项目目录(F22 前创建)保留原名;orchestrator 通过 state.json
+  `team` 字段识别身份,目录名只是路径方便。新建项目走新规则。
 - **来源**:`docs/m4-spike-2026-05-06.md` §3
-- **下一步**:独立 PR 修(优先于 §4 deferred check 重跑)
 
 ### F23 — 容器 bind-mount `~/.claude/rules/` 待 M4.4 spike §4 重跑后定夺(2026-05-06 加)
 
 - **文件:行号**:N/A(未发现现状代码缺陷,**待 spike 验证**)
 - **现状**:M4.4 §4 deferred 检查"`--dangerously-skip-permissions` 容器
-  里 `~/.claude/rules/*.md` 是否被 Claude Code 当做 context 注入"——F22 修好之前
-  无法跑,所以是潜在隐患而非确认问题
+  里 `~/.claude/rules/*.md` 是否被 Claude Code 当做 context 注入"——**F22 修复后
+  spike 已解锁**,等谁跑一次就能定夺(F23 → P0 / 关闭)
 - **是否真 dev-specific**:**否——是基础设施层。**
 - **解耦方案**(若 spike 失败):doctor 加 `--bind-mount-claude-rules`
   子模式(往容器配置追加只读 mount),sketch 见

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -51,10 +51,16 @@
     └── orchestrator.json  # orchestrator 自身 in-memory 状态的快照
 ```
 
-### 1.2 项目级目录(`~/projects/<slug>/`)
+### 1.2 项目级目录(`~/projects/<team>-<slug>/`)
+
+> **2026-05-06 F22**:项目目录现在带 `<team>-` 前缀(如 `~/projects/dev-todo-cli/`、
+> `~/projects/product-research-ai-recipe/`),让 `~/.claude/rules/ccteam-lessons-<team>.md`
+> 的 `paths: ~/projects/<team>-*` frontmatter 在 phase Claude session 启动时正确匹配。
+> meta-agent 项目仍走 `<handle>-meta` 后缀约定(rules 不 scope 到 meta)。
+> 历史项目目录(F22 之前创建)保持原名,通过 state.json `team` 字段识别身份。
 
 ```
-~/projects/<slug>/
+~/projects/<team>-<slug>/
 ├── src/                          # 实际代码
 ├── tests/
 ├── package.json / pyproject.toml
@@ -1245,8 +1251,8 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 | `~/.ccteam/log/<slug>/` | stream-json 归档(可选,调试用) |
 | `~/.ccteam/tmux/<slug>.layout` | 项目 tmux pane 布局模板 |
 | `~/.ccteam/state/orchestrator.json` | orchestrator 自身快照 |
-| `~/projects/<slug>/.ccteam/` | 项目元数据(详见 §1.2) |
-| `~/projects/<slug>/CLAUDE.md` | 自动生成的项目运营手册 |
+| `~/projects/<team>-<slug>/.ccteam/` | 项目元数据(详见 §1.2;F22 后带 team 前缀) |
+| `~/projects/<team>-<slug>/CLAUDE.md` | 自动生成的项目运营手册 |
 | `~/projects/<slug>/.claude/settings.json` | 项目级 Claude Code 配置(详见 §6.1) |
 | `~/projects/<slug>/.ccteam/sub-modules/<name>/` | multi-session 子模块元数据(M3+;详见 §1.3) |
 

--- a/docs/m4-spike-2026-05-06.md
+++ b/docs/m4-spike-2026-05-06.md
@@ -14,7 +14,7 @@
 | `ccteam doctor --install-memory-bridge` writes both team files | ✅ verified live | none |
 | Re-run is idempotent (no-op on intact markers) | ✅ verified live | none |
 | Marked-section repair preserves user content outside markers | ✅ verified live | none |
-| `paths:` frontmatter `~/projects/<team>-*` scoping works | ⚠️ **blocked — slug gap** | open follow-up (see §3) |
+| `paths:` frontmatter `~/projects/<team>-*` scoping works | ✅ **fixed by F22** (2026-05-06 follow-up PR) — slugs now `<team>-<base>` | none |
 | `~/.claude/rules/*.md` auto-loads in `--dangerously-skip-permissions` container | ⏳ deferred to live runtime | open follow-up (see §4) |
 | `claude-mem` MCP tools detection by phase prompt conditional | ✅ tool surface visible when installed | none |
 | retro Edit on marked section idempotent end-to-end | ⏳ deferred (covered by unit tests) | optional follow-up |
@@ -77,7 +77,7 @@ crates/ccteam-cli/src/commands.rs:648:fn render_install_memory_bridge_report(opt
 
 Only file-write and rendering code, no retrieval. Red line clean.
 
-## 3. ⚠️ Open follow-up — slug gap blocks `paths:` frontmatter scoping
+## 3. ✅ Closed (2026-05-06 follow-up PR) — slug team prefix landed
 
 The shipped lessons files declare:
 
@@ -113,13 +113,14 @@ cross-project lessons to auto-load into the right phase Claude. Without
 team-prefixed slugs, M4.1's retro phase will write to lessons files
 that nothing reads.
 
-**Suggested fix (separate PR)**: change `pick_unused_slug` to prepend
-`<team>-` so `ccteam new --team=dev "X"` produces `~/projects/dev-x`.
-Migration story: existing un-prefixed slugs keep working (orchestrator
-state.json already records team), only new-create paths change. Track
-as **F22 dev-coupling-audit follow-up** (separate from this M4 PR per
-CLAUDE.md §五.1 — "改了协议必须同步 interfaces.md" — slug naming is
-protocol; this M4 PR doesn't touch it).
+**Fix landed** (separate PR after this report): `pick_unused_slug` now
+takes `team: &str` and produces `<team>-<base>` (or `<team>-<base>-<suffix>`
+on collision). M4 main path now actually fires — `~/.claude/rules/`
+auto-loads cross-project lessons into the right phase Claude sessions.
+
+Migration: historical pre-F22 project dirs keep working (orchestrator
+identifies team via `state.json` regardless of dir name), only new-create
+paths change. interfaces.md §1.2 updated to reflect the new convention.
 
 Alternative quicker fix considered and rejected: drop `paths:` entirely
 and let the rules file auto-load into all Claude sessions globally. Loses
@@ -215,13 +216,15 @@ unexpected interactions.
 
 **Does NOT ship** (open follow-ups):
 
-- F22 — slug team prefix (`<team>-<slug>` vs current bare `<slug>`).
-  Required for `paths:` scoping to actually fire.
+- ~~F22 — slug team prefix~~ ✅ **closed in 2026-05-06 follow-up PR**;
+  `~/projects/<team>-<slug>/` now produced by `pick_unused_slug`.
 - F23 — container bind-mount step in doctor, contingent on §4 spike
-  failing once F22 lands.
+  failing now that F22 has landed. Methodology is ready (§4); next
+  re-run will determine whether the bind-mount is actually needed.
 
-When F22 lands, re-run the §4 methodology and update this report
-(or supersede it with `m4-spike-<new-date>.md`).
+§4 deferred check is **now unblocked**; can be performed with
+`ccteam doctor --install-memory-bridge` + `ccteam new --team=dev "X"`
++ phase prompt sentinel pattern from §4.
 
 ## References
 

--- a/docs/user-quickstart-v0.1.md
+++ b/docs/user-quickstart-v0.1.md
@@ -1,7 +1,7 @@
 # ccteam 用户快速指南 V0.1
 
 > **版本**:V0.1(2026-05-06)
-> **覆盖功能**:M0(单项目 CLI)、M0.5(工具触发面)、M1(meta-agent + decisions)、M2(sub-skill / phase YAML / `ccteam-mcp`)、M2.3 follow-up(golden_rules)、M3(team abstraction + product-research team)、**M4.1–M4.4(跨项目记忆基础设施 — 注意 F22 阻塞实际生效,详见 §10)**
+> **覆盖功能**:M0(单项目 CLI)、M0.5(工具触发面)、M1(meta-agent + decisions)、M2(sub-skill / phase YAML / `ccteam-mcp`)、M2.3 follow-up(golden_rules)、M3(team abstraction + product-research team)、**M4.1–M4.4 跨项目记忆**(2026-05-06 F22 修复后**完全生效**;新项目目录带 `<team>-` 前缀)
 > **未覆盖(后续里程碑)**:M5 Critic / multi_session / TUI / web dashboard
 >
 > 本文档面向**第一次手动跑 ccteam 全流程的用户**。每一步给可复制的命令 + 预期看到的现象;
@@ -55,7 +55,7 @@ ccteam doctor --install-memory-bridge            # 写 ~/.claude/rules/ccteam-le
 ccteam doctor --install-meta-agent <你的 handle> # 创建 ~/projects/<handle>-meta/(meta-agent 工作目录)
 ```
 
-> **关于 `--install-memory-bridge`**:M4 跨项目记忆基础设施。装了之后,每次 dev / product-research 项目跑完 ship / REJECT verdict,Claude 会把跨项目 lessons append 到对应文件的 `<!-- ccteam-managed:lessons -->` marked section;下个项目启动时**官方 rules 机制**自动加载到上下文。**当前限制**:`paths:` frontmatter scope 到 `~/projects/<team>-*`,但 V0.1 bootstrap 仍创建 `~/projects/<slug>/`(无 team 前缀),所以**写入有效但下个项目不自动加载**(F22 待修;详见 §10)。装了不亏 — 写入会累积,F22 修完即自动激活。
+> **关于 `--install-memory-bridge`**:M4 跨项目记忆基础设施。装了之后,每次 dev / product-research 项目跑完 ship / REJECT verdict,Claude 会把跨项目 lessons append 到对应文件的 `<!-- ccteam-managed:lessons -->` marked section;下个项目启动时**官方 rules 机制**自动加载到上下文(2026-05-06 F22 修复后,新项目目录形如 `~/projects/dev-<slug>/` / `~/projects/product-research-<slug>/`,跟 rules `paths: ~/projects/<team>-*` 完全匹配)。
 
 把 `<你的 handle>` 换成你想叫自己的名字(snake-case,例:`rob` / `alice`)。这名字后面会出现在 tmux session 名 `ccteam-meta-<handle>`、meta-agent 项目目录、决策回执等地方。
 
@@ -274,7 +274,7 @@ cat ~/.claude/rules/ccteam-lessons-dev.md
 # marked section 内多了一段以本项目 slug + 日期为 H2,4 个 H3 字段(tech_stack /
 # pitfalls / successful_designs / do_not_do_again);下次 dev 项目启动时官方 rules
 # 机制自动加载这文件到 plan-eng phase 上下文
-# (V0.1 注意:F22 阻塞 paths scope,自动加载暂不工作 — 详见 §10)
+# (新项目目录带 dev- / product-research- 前缀,rules paths 自动匹配)
 ```
 
 ### 5.4 价值
@@ -357,7 +357,7 @@ cat ~/.claude/rules/ccteam-lessons-product-research.md
 # (market_signals / differentiation_findings / feasibility_assessment / verdict_rationale)
 # 下次有相似 idea 进 product-research kickoff 时,Claude 会先扫这文件,
 # 命中重复 idea 直接短路 5 phase 流程倾向 REJECT
-# (V0.1 注意:F22 阻塞 paths scope,自动加载暂不工作 — 详见 §10)
+# (新项目目录带 dev- / product-research- 前缀,rules paths 自动匹配)
 ```
 
 ### 6.6 (可选)claude-mem 增强:跨项目深度检索
@@ -375,7 +375,7 @@ claude-mem 会:
 
 ccteam phase prompt(plan-eng / kickoff / verdict)写了 conditional:**"如果工具列表里看到 `mcp__*claude-mem*search`,你可以调它做跨项目语义检索"** —— LLM 自看 tool surface 决定调不调,**ccteam 不写检测代码、不写集成代码**。
 
-没装就完全跳过 — V0.1 默认机制(`~/.claude/rules/` + auto-memory)已够用(F22 修完后)。
+没装就完全跳过 — V0.1 默认机制(`~/.claude/rules/` + auto-memory)已够用。
 
 ---
 
@@ -474,7 +474,7 @@ ccteam doctor --tool-surface             # 验证 phase tools_required 没被新
 
 | 想做 | 现状 | 何时能做 |
 |---|---|---|
-| 跨项目记忆("上次类似项目我们怎么做的") | **基础设施已 ship**(M4.1–M4.4,2026-05-06):retro 写入有效;**但 F22 阻塞实际生效** —— `~/.claude/rules/ccteam-lessons-<team>.md` 的 `paths: ~/projects/<team>-*` 跟 bootstrap 实际产 `~/projects/<slug>/` 不匹配,下个项目启动时 rules 不自动加载 | F22 修(slug 加 team 前缀;dev-coupling-audit.md F22 P0)— **即将到来的独立 PR**;修完即激活 |
+| 跨项目记忆("上次类似项目我们怎么做的") | **完全 ship**(M4.1–M4.4 + F22 修复,2026-05-06):新项目目录带 `<team>-` 前缀(`~/projects/dev-<slug>/`),rules `paths` 自动匹配,phase Claude 启动时自动加载跨项目 lessons | 现已可用 |
 | 多 agent 并行写代码(speed-up) | `parallelism: agent_team` schema 已落但 **enablement 永久 deferred**(spike A) | Claude Code 释出 first-class Agent Teams CLI 后 |
 | 大项目子模块拆分 (`multi_session`) | 未 ship | M4 后期(M4.8) |
 | Critic agent("接口不优雅"反馈) | 未 ship | M5 |


### PR DESCRIPTION
## Summary

Closes **F22** (P0 from `docs/dev-coupling-audit.md`, surfaced by M4.4 spike §3). Pre-this-PR, M4 cross-project memory had a fully shipped infrastructure (rules templates, memory-bridge installer, retro phase prompts) but **the auto-load half of the design didn't actually fire**: `~/.claude/rules/ccteam-lessons-<team>.md` declares `paths: ~/projects/<team>-*`, while `pick_unused_slug` produced bare `~/projects/<slug>/` directories with no team prefix. So Claude Code matched zero project sessions to the rules → cross-project lessons were dark.

This PR makes `pick_unused_slug` take a `team: &str` argument and produce `<team>-<base>` (collision retry: `<team>-<base>-<suffix>`). New projects land at `~/projects/dev-<slug>/` / `~/projects/product-research-<slug>/`, matching the rules `paths:` exactly.

## Effect

- M4 main path now actually fires:phase Claude session 启动时 auto-load 跨项目 lessons via 官方 rules 机制
- retro phase Edits 写到 lessons 文件,下个项目自动读
- F23 spike methodology(`m4-spike-2026-05-06.md` §4)解锁,可以跑容器 bind-mount 验证

## Commits

1. `9a59456 fix(F22): prefix project slugs with team name so rules paths scoping fires` — code fix
2. `e7ce2b6 docs: F22 closed — update interfaces / spike report / audit / V0.1 walkthrough` — cross-doc sweep

## Code change footprint

- `crates/ccteam-core/src/projects.rs::pick_unused_slug` — signature + impl
- `crates/ccteam-cli/src/commands.rs::run_new` — call site updated
- `crates/ccteam-cli/src/mcp_serve.rs::handle_new` — call site updated
- `crates/ccteam-cli/tests/m3_product_research_e2e_test.rs` — call site updated
- 1 existing unit test asserts updated to expect `dev-` prefix
- 3 new unit tests:
  - `pick_unused_slug_prefixes_team_name`
  - `pick_unused_slug_appends_suffix_on_collision_under_team_prefix`
  - `pick_unused_slug_keeps_team_prefix_distinct_per_team`

Meta-agent projects untouched — `bootstrap_meta_project` uses `meta_slug(handle)` → `<handle>-meta` (suffix convention pre-dates F22; rules don't scope to meta).

## Migration

Historical pre-F22 project directories keep working. Orchestrator identifies team via `state.json.team` regardless of directory name. Only new-create paths change. Per `CLAUDE.md §五.3`: no backwards-compat shim.

## Doc sweep

- `docs/interfaces.md` §1.2 + §13: project directory convention now `~/projects/<team>-<slug>/` with explicit migration callout
- `docs/m4-spike-2026-05-06.md`: TL;DR row flipped to ✅; §3 retitled "Closed"; §6 follow-up list updated
- `docs/dev-coupling-audit.md`: 摘要 P0 count 8→7, 已修复 1→2; F22 marked closed; F23 unblocked
- `docs/user-quickstart-v0.1.md`: §0 / §2 callout / §5 / §6 / §10 — F22 caveat language replaced with "完全 ship"

## Test plan

- [x] `cargo test --workspace`: **369 passing / 0 failed** (post-M4 baseline 366 + 3 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: 4 pre-existing errors on main confirmed independent of this PR
- [ ] (Reviewer to spot-check) on a fresh machine: `ccteam doctor --install-memory-bridge` then `ccteam new --team=dev "X"` produces `~/projects/dev-X/` and the dev rules auto-load into the project's plan-eng phase Claude session
- [ ] Eventually: F23 spike methodology runs to confirm container bind-mount question

## References

- 痛点 10(每项目从零开始)— M4 main path now operational end-to-end
- `docs/m4-spike-2026-05-06.md` §3 — original gap analysis (now closed)
- `docs/dev-coupling-audit.md` F22 — audit entry (now 已修复)
- Closes F22

🤖 Generated with [Claude Code](https://claude.com/claude-code)