### PR TITLE
M0.16: anti-pattern foundation — TeamSpec flags + seed-on-bootstrap + claude_md template

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -11,13 +11,13 @@ use serde_json::{json, Map, Value};
 
 use ccteam_core::{
     bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
-    link_recommended_agents, pick_unused_slug, team_bundle, user_claude_dir,
+    link_recommended_agents, pick_unused_slug, user_claude_dir,
     write_all_global_team_templates, write_global_helper_templates,
     write_global_phase_templates, AgentLinkAction, AgentLinkReport, CcteamPaths,
     InstallSkillOptions, LinkOptions, MetaBootstrapReport, OutboxEventKind, OutboxMessage,
     PhaseHistoryEntry, PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
     SkillInstallAction, TeamSpec,
-    ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES, PHASE_TEMPLATES, TEAM_BUNDLES,
+    ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES, PHASE_TEMPLATES,
 };
 use ccteam_core::tmux::TmuxSession;
 
@@ -127,11 +127,15 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
 /// orchestrator can route this project through the matching phase set.
 ///
 /// **M3.3 fail-fast**: non-dev teams require a `team.yaml` to be
-/// loadable — either as `~/.ccteam/teams/<team>/team.yaml` on disk
-/// or as an entry in the embedded `TEAM_BUNDLES` registry. The dev
-/// team is grandfathered in (no team.yaml required) so legacy
-/// installs without `ccteam init` still work. Meta-agent is also
-/// allowed without a team.yaml — its bootstrap path is bespoke.
+/// loadable from `~/.ccteam/teams/<team>/team.yaml`. The dev team is
+/// grandfathered in (no team.yaml required) so legacy installs
+/// without `ccteam init` still work. Meta-agent is also allowed
+/// without a team.yaml — its bootstrap path is bespoke.
+///
+/// V0.2 §6.4 candidate 3: shipped seeds (dev / product-research /
+/// meta-agent) are stamped to disk inside `run_new` so a fresh
+/// install no longer needs an explicit `ccteam init` for the
+/// validation to find them.
 pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String> {
     if request.trim().is_empty() {
         bail!("ccteam new: request must be non-empty");
@@ -139,23 +143,32 @@ pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String>
     if team.trim().is_empty() {
         bail!("ccteam new: --team must be non-empty");
     }
+    // Self-heal shipped seeds before validating — without this, a
+    // first-time `ccteam new --team product-research` against a
+    // freshly-installed binary would fail with "unknown team".
+    // force=false preserves operator hand-edits.
+    if let Err(err) = ccteam_core::write_all_global_team_templates(&paths.root, false) {
+        tracing::warn!(
+            error = %err,
+            root = %paths.root.display(),
+            "ccteam new: could not seed shipped team templates",
+        );
+    }
     ensure_team_resolvable(paths, team)?;
     let slug = pick_unused_slug(paths, request, team)?;
     bootstrap_project(paths, &slug, request, team)?;
     Ok(slug)
 }
 
-/// Resolve `team` against the on-disk + embedded team registry.
-/// Returns `Ok(())` when the team is bootable; otherwise returns a
+/// Resolve `team` against the on-disk team registry. Returns
+/// `Ok(())` when the team is bootable; otherwise returns a
 /// fail-fast error pointing the user at the missing team.yaml.
 ///
 /// Resolution order:
-/// 1. `dev` and `meta-agent` always succeed (legacy paths).
+/// 1. `dev` and `meta-agent` always succeed (legacy / bespoke paths).
 /// 2. If `~/.ccteam/teams/<team>/team.yaml` is on disk, load + validate it.
-/// 3. Else if the team is in the embedded `TEAM_BUNDLES`, succeed
-///    (bootstrap_project will write `~/.ccteam/teams/<team>/team.yaml`
-///    via the templates path on init).
-/// 4. Otherwise fail with a help message.
+/// 3. Otherwise fail with a help message listing the teams currently
+///    on disk.
 fn ensure_team_resolvable(paths: &CcteamPaths, team: &str) -> Result<()> {
     if team == "dev" || team == ccteam_core::META_TEAM_NAME {
         return Ok(());
@@ -167,29 +180,41 @@ fn ensure_team_resolvable(paths: &CcteamPaths, team: &str) -> Result<()> {
         })?;
         return Ok(());
     }
-    if team_bundle(team).is_some() {
-        // Embedded bundle exists; user just hasn't run `ccteam init`
-        // (or did but skipped this team). Recommend init so the
-        // orchestrator startup scan picks the team up consistently.
-        tracing::info!(
-            team,
-            "team has embedded bundle but no team.yaml on disk; \
-             stamp it via `ccteam init` so the orchestrator picks the team up consistently",
-        );
-        return Ok(());
-    }
+    let known = list_disk_teams(paths)
+        .ok()
+        .filter(|t| !t.is_empty())
+        .map(|t| t.join(", "))
+        .unwrap_or_else(|| "(none yet — run `ccteam doctor --reset-shipped-teams`)".into());
     bail!(
         "ccteam new: unknown team `{team}` — \
          create {} (see docs/interfaces.md §5.5 for schema), \
          then re-run.\n\
-         Known embedded teams: {}.",
+         Teams currently on disk: {known}.",
         yaml_path.display(),
-        TEAM_BUNDLES
-            .iter()
-            .map(|(n, _)| *n)
-            .collect::<Vec<_>>()
-            .join(", "),
     )
+}
+
+/// Enumerate teams discoverable under `<global_dir>/teams/<name>/team.yaml`.
+/// Used for error messages so users see what is actually available
+/// (V0.2 §6.4 candidate 3 — disk-driven team registry).
+fn list_disk_teams(paths: &CcteamPaths) -> Result<Vec<String>> {
+    let teams_dir = paths.root.join("teams");
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(&teams_dir) {
+        Ok(e) => e,
+        Err(_) => return Ok(out),
+    };
+    for entry in entries.flatten() {
+        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false)
+            && entry.path().join("team.yaml").exists()
+        {
+            if let Some(name) = entry.file_name().to_str().map(String::from) {
+                out.push(name);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
 }
 
 /// `ccteam ls`. Returns either a human table or the interfaces.md §10.3
@@ -590,6 +615,14 @@ pub struct DoctorOptions {
     pub install_mcp: bool,
     /// M4.2: install `~/.claude/rules/ccteam-lessons-<team>.md` placeholders.
     pub install_memory_bridge: bool,
+    /// V0.2 M0.16.2: re-write every shipped team
+    /// (`~/.ccteam/teams/<name>/team.yaml` + `~/.ccteam/<phase_dir>/*.md`)
+    /// using the in-binary seed bundle. `force=true` overwrites operator
+    /// hand-edits; `force=false` is equivalent to the auto-seed run on
+    /// `Orchestrator::new`. Useful after a ccteam upgrade ships
+    /// schema-additive team.yaml changes (e.g. the V0.2 `evergreen` /
+    /// `cost_policy` fields landed by M0.16).
+    pub reset_shipped_teams: bool,
 }
 
 /// `ccteam doctor` dispatch. Returns a human-readable report so unit
@@ -600,7 +633,8 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         || opts.install_skill
         || opts.install_meta_agent.is_some()
         || opts.install_mcp
-        || opts.install_memory_bridge;
+        || opts.install_memory_bridge
+        || opts.reset_shipped_teams;
     if !any_mode {
         return Ok(String::from(
             "ccteam doctor: pass at least one mode flag.\n\
@@ -617,7 +651,9 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
              --install-mcp\n      \
              register `mcpServers.ccteam` in ~/.claude.json so daily-driver claude + meta-agent see the 9-tool MCP server (M2.5).\n  \
              --install-memory-bridge [--dry-run]\n      \
-             write ~/.claude/rules/ccteam-lessons-{dev,product-research}.md placeholders so the retro phase has somewhere to Edit cross-project lessons into (M4.2).\n",
+             write ~/.claude/rules/ccteam-lessons-<team>.md placeholders for every team with non-empty retro_schema (M4.2; V0.2 M0.16.2 — disk-driven team discovery).\n  \
+             --reset-shipped-teams [--force]\n      \
+             re-seed shipped team templates (~/.ccteam/teams/<name>/team.yaml + ~/.ccteam/<phase_dir>/*.md) from the in-binary bundle. Without --force, operator hand-edits are preserved; with --force, every shipped file is overwritten (V0.2 M0.16.2).\n",
         ));
     }
     let mut out = String::new();
@@ -640,16 +676,47 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         out.push_str(&render_install_mcp_report()?);
     }
     if opts.install_memory_bridge {
-        out.push_str(&render_install_memory_bridge_report(&opts)?);
+        out.push_str(&render_install_memory_bridge_report(paths, &opts)?);
+    }
+    if opts.reset_shipped_teams {
+        out.push_str(&render_reset_shipped_teams_report(paths, &opts)?);
     }
     Ok(out)
 }
 
-fn render_install_memory_bridge_report(opts: &DoctorOptions) -> Result<String> {
+fn render_reset_shipped_teams_report(
+    paths: &CcteamPaths,
+    opts: &DoctorOptions,
+) -> Result<String> {
+    ccteam_core::write_all_global_team_templates(&paths.root, opts.force)?;
+    let mut out = String::from("ccteam doctor --reset-shipped-teams\n\n");
+    if opts.force {
+        out.push_str(
+            "  Re-wrote every shipped team's team.yaml + phase markdowns under \
+             ~/.ccteam/ (--force overwrote operator hand-edits).\n",
+        );
+    } else {
+        out.push_str(
+            "  Seeded shipped teams under ~/.ccteam/ (skipped existing files; \
+             pass --force to overwrite operator hand-edits).\n",
+        );
+    }
+    Ok(out)
+}
+
+fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<String> {
+    // V0.2 §6.4 candidate 3: bridge teams are now discovered by
+    // scanning `~/.ccteam/teams/<name>/team.yaml`. Make sure shipped
+    // seeds are present before the scan so a fresh install (no
+    // `ccteam init` yet) still lays down dev / product-research
+    // bridges. force=false preserves operator hand-edits.
+    if !opts.dry_run {
+        ccteam_core::write_all_global_team_templates(&paths.root, false)?;
+    }
     let install_opts = ccteam_core::InstallMemoryBridgeOptions {
         dry_run: opts.dry_run,
     };
-    let reports = ccteam_core::install_memory_bridge(install_opts)?;
+    let reports = ccteam_core::install_memory_bridge(&paths.root, install_opts)?;
     let mut out = if opts.dry_run {
         String::from("ccteam doctor --install-memory-bridge (dry-run)\n\n")
     } else {
@@ -1203,7 +1270,7 @@ fn truncate(s: &str, n: usize) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::OnceLock;
+    use std::sync::{Mutex, OnceLock};
 
     use super::*;
     use ccteam_core::{disable_tool_surface_bootstrap_for_tests, progress};
@@ -1217,6 +1284,19 @@ mod tests {
     static DISABLE_TOOL_SURFACE: OnceLock<()> = OnceLock::new();
     fn ensure_isolation() {
         DISABLE_TOOL_SURFACE.get_or_init(disable_tool_surface_bootstrap_for_tests);
+    }
+
+    /// Serialize tests that mutate `CLAUDE_CONFIG_HOME`. Per CLAUDE.md
+    /// §六, env-mutating tests really belong under
+    /// `crates/*/tests/*.rs` (separate processes), but until that
+    /// migration these tests can race against each other since they
+    /// run in the same process. The mutex makes them deterministic.
+    /// V0.2 M0.16.2 widened the timing window with the extra
+    /// `write_all_global_team_templates` call before
+    /// `install_memory_bridge`.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
     }
 
     fn fresh_paths(tmp: &TempDir) -> CcteamPaths {
@@ -1262,9 +1342,11 @@ mod tests {
     fn run_new_records_team_in_state_json() {
         // M3.1 F12/F13: --team must persist into state.json so the
         // orchestrator can route this project's phase set.
-        // M3.3: non-dev teams now require ensure_team_resolvable to
-        // succeed — `product-research` is in the embedded TEAM_BUNDLES
-        // so the check passes without a team.yaml on disk.
+        // V0.2 M0.16.2: non-dev teams require team.yaml on disk;
+        // `run_new` self-heals shipped seeds first, so
+        // `product-research`'s yaml lands at
+        // ~/.ccteam/teams/product-research/team.yaml during this
+        // call — no manual `ccteam init` needed.
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
@@ -1276,8 +1358,9 @@ mod tests {
 
     #[test]
     fn run_new_rejects_unknown_team_with_helpful_error() {
-        // M3.3: unknown team (not embedded, not on disk) must fail-fast
-        // with a clear pointer to ~/.ccteam/teams/<team>/team.yaml.
+        // M3.3 + V0.2 M0.16.2: unknown team (not in shipped seeds, not
+        // on disk after self-heal) must fail-fast with a clear pointer
+        // to ~/.ccteam/teams/<team>/team.yaml.
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
@@ -1289,17 +1372,18 @@ mod tests {
             msg.contains("teams/marketing/team.yaml"),
             "should point at the missing path",
         );
-        // Should also list the known embedded teams so users see the
-        // catalog of options:
+        // After M0.16.2 self-heal, the disk-driven team list includes
+        // the shipped seeds — the error message lists those so users
+        // see the catalog of options:
         assert!(msg.contains("dev"));
         assert!(msg.contains("product-research"));
     }
 
     #[test]
     fn run_new_accepts_team_yaml_on_disk_for_user_team() {
-        // M3.3: a user-authored team (not in embedded TEAM_BUNDLES)
-        // becomes valid as soon as ~/.ccteam/teams/<team>/team.yaml is
-        // on disk. The fail-fast check loads + validates the YAML.
+        // M3.3: a user-authored team (not shipped) becomes valid as
+        // soon as ~/.ccteam/teams/<team>/team.yaml is on disk. The
+        // fail-fast check loads + validates the YAML.
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
@@ -1559,6 +1643,7 @@ mod tests {
     #[test]
     fn run_doctor_install_memory_bridge_writes_both_team_files() {
         ensure_isolation();
+        let _guard = env_lock().lock().unwrap();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
@@ -1586,6 +1671,7 @@ mod tests {
         // --install-skill, so a single invocation gets the user a
         // ready-to-attach session.
         ensure_isolation();
+        let _guard = env_lock().lock().unwrap();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         // Redirect ~/.claude/ to the tempdir so the skill install
@@ -1617,6 +1703,7 @@ mod tests {
     #[test]
     fn run_doctor_install_skill_only_lays_down_skill_md() {
         ensure_isolation();
+        let _guard = env_lock().lock().unwrap();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
@@ -1640,6 +1727,84 @@ mod tests {
             would: Box::new(AgentLinkAction::Linked),
         });
         assert_eq!(label, "would: linked");
+    }
+
+    // ---------------- V0.2 M0.16.2: shipped-team seed regen ----------------
+
+    #[test]
+    fn run_doctor_reset_shipped_teams_seeds_all_teams_under_global_dir() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let opts = DoctorOptions {
+            reset_shipped_teams: true,
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(report.contains("reset-shipped-teams"));
+        // Every shipped team's team.yaml lands on disk under the
+        // declared layout. (Layout migration to teams/<name>/ is
+        // M0.17; for now teams/<name>/team.yaml is what
+        // write_all_global_team_templates writes.)
+        for team in ["dev", "product-research", "meta-agent"] {
+            let yaml = paths.root.join("teams").join(team).join("team.yaml");
+            assert!(
+                yaml.is_file(),
+                "shipped team `{team}` not seeded at {}",
+                yaml.display(),
+            );
+        }
+    }
+
+    #[test]
+    fn run_doctor_reset_shipped_teams_preserves_operator_edits_without_force() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+
+        // First seed lays down the shipped dev/team.yaml. Tamper with
+        // it the way an operator would.
+        run_doctor(&paths, DoctorOptions {
+            reset_shipped_teams: true,
+            ..DoctorOptions::default()
+        }).unwrap();
+        let dev_yaml = paths.root.join("teams").join("dev").join("team.yaml");
+        std::fs::write(&dev_yaml, "name: dev\ndescription: hand-edited\n").unwrap();
+
+        // Re-run without --force; the hand-edit must survive.
+        run_doctor(&paths, DoctorOptions {
+            reset_shipped_teams: true,
+            ..DoctorOptions::default()
+        }).unwrap();
+        let body = std::fs::read_to_string(&dev_yaml).unwrap();
+        assert!(body.contains("hand-edited"), "operator edit clobbered without --force");
+
+        // Now with --force, the seed wins again.
+        run_doctor(&paths, DoctorOptions {
+            reset_shipped_teams: true,
+            force: true,
+            ..DoctorOptions::default()
+        }).unwrap();
+        let body = std::fs::read_to_string(&dev_yaml).unwrap();
+        assert!(body.contains("Software development team"));
+        assert!(!body.contains("hand-edited"));
+    }
+
+    #[test]
+    fn run_new_self_heals_shipped_seeds_for_first_time_install() {
+        // V0.2 §6.4 candidate 3: a fresh install (no `ccteam init`) where
+        // ~/.ccteam/teams/ is empty must still let `ccteam new --team
+        // product-research` succeed because run_new self-heals.
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        assert!(!paths.root.join("teams").exists(), "precondition: empty global dir");
+
+        let slug = run_new(&paths, "Verify product-research bootstraps", "product-research")
+            .expect("run_new must auto-seed shipped templates before validation");
+        assert!(slug.starts_with("product-research-"));
+        // The seed must have landed during run_new.
+        assert!(paths.root.join("teams/product-research/team.yaml").is_file());
     }
 
     // -------- ccteam decisions (M1 follow-up) --------

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -148,13 +148,22 @@ enum Command {
         /// any prior `ccteam` server entry but preserves other servers.
         #[arg(long, default_value_t = false)]
         install_mcp: bool,
-        /// M4.2: write `~/.claude/rules/ccteam-lessons-{dev,product-research}.md`
+        /// M4.2: write `~/.claude/rules/ccteam-lessons-<team>.md`
         /// with `<!-- ccteam-managed:lessons begin/end -->` markers + `paths:`
         /// frontmatter scope. Idempotent — re-runs no-op when markers are
         /// intact, repair (single canonical block at end-of-file) when not.
-        /// User content outside markers is preserved.
+        /// User content outside markers is preserved. Discovers teams by
+        /// scanning `~/.ccteam/teams/<name>/team.yaml` for non-empty
+        /// `retro_schema` (V0.2 M0.16.2).
         #[arg(long, default_value_t = false)]
         install_memory_bridge: bool,
+        /// V0.2 M0.16.2: re-write every shipped team's seed
+        /// (`~/.ccteam/teams/<name>/team.yaml` + `~/.ccteam/<phase_dir>/*.md`)
+        /// from the in-binary bundle. `force=false` preserves operator
+        /// hand-edits; pair with `--force` to clobber. Useful after a
+        /// ccteam upgrade ships schema-additive team.yaml fields.
+        #[arg(long, default_value_t = false)]
+        reset_shipped_teams: bool,
     },
 }
 
@@ -236,6 +245,7 @@ fn main() -> Result<()> {
             install_meta_agent,
             install_mcp,
             install_memory_bridge,
+            reset_shipped_teams,
         } => run_doctor(commands::DoctorOptions {
             install_recommended_agents,
             dry_run,
@@ -245,6 +255,7 @@ fn main() -> Result<()> {
             install_meta_agent,
             install_mcp,
             install_memory_bridge,
+            reset_shipped_teams,
         }),
     }
 }
@@ -301,6 +312,22 @@ fn run_hook(cmd: HookCommand) -> Result<()> {
 fn run_start(tick_seconds: u64, skip_tool_check: bool) -> Result<()> {
     init_tracing();
     let paths = CcteamPaths::from_env()?;
+
+    // V0.2 M0.16.2: self-heal shipped team seeds on every daemon
+    // start. force=false skips existing files so operator hand-edits
+    // are preserved; the call still ensures `~/.ccteam/teams/<name>/team.yaml`
+    // exists for every shipped team (dev / product-research /
+    // meta-agent) — without this, a fresh install missing `ccteam init`
+    // would leave `is_evergreen("meta-agent") == false` and the
+    // dispatcher would fall into the phase-DAG path.
+    if let Err(err) = ccteam_core::write_all_global_team_templates(&paths.root, false) {
+        tracing::warn!(
+            error = %err,
+            root = %paths.root.display(),
+            "ccteam start: could not seed shipped team templates; \
+             run `ccteam doctor --reset-shipped-teams` if teams are missing",
+        );
+    }
 
     if !paths.phases_dir().exists() {
         eprintln!(

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -75,17 +75,21 @@ pub use subskill::{
 };
 pub use state::{Parallelism, PhaseHistoryEntry, PhaseState, ProjectState};
 pub use team::{
-    CriticDimensionSpec, CriticStrictness, EscalateGrammarExtension, EscalateRoute,
+    CostPolicy, CriticDimensionSpec, CriticStrictness, EscalateGrammarExtension, EscalateRoute,
     RetroFieldKind, RetroFieldSpec, TeamSpec,
 };
 pub use templates::{
-    current_ccteam_bin, project_phase_filename, render_project_settings, team_bundle,
+    current_ccteam_bin, project_phase_filename, render_project_settings,
     write_all_global_team_templates, write_global_helper_templates,
     write_global_phase_templates, write_project_phase_templates,
     write_project_phase_templates_for_team, write_project_settings, SettingsEnv,
-    TeamTemplateBundle, HELPER_TEMPLATES, PHASE_TEMPLATES, PROJECT_SETTINGS_JSON,
-    TEAM_BUNDLES,
+    HELPER_TEMPLATES, PHASE_TEMPLATES, PROJECT_SETTINGS_JSON,
 };
+// V0.2 §6.4 candidate 3: TEAM_BUNDLES / team_bundle / TeamTemplateBundle
+// are no longer exported. They remain `pub(crate)` as the in-binary
+// seed source for `write_all_global_team_templates`; runtime code paths
+// outside ccteam-core query disk (`<global_dir>/teams/<name>/team.yaml`)
+// instead.
 pub use tmux::{pid_is_alive, session_name_for_slug, tmux_available, TmuxSession};
 pub use tool_surface::{
     disable_tool_surface_bootstrap_for_tests, ensure_skills_placeholders,

--- a/crates/ccteam-core/src/memory_bridge.rs
+++ b/crates/ccteam-core/src/memory_bridge.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+use crate::team::TeamSpec;
 use crate::tool_surface::user_claude_dir;
 
 const DEV_TEMPLATE: &str = include_str!("templates/memory_bridge_dev.md");
@@ -33,13 +34,72 @@ const CANONICAL_MARKED_BLOCK: &str = "<!-- ccteam-managed:lessons begin -->\n\
 (Empty until first retro. Phase prompts append lessons here using `Edit`.)\n\
 <!-- ccteam-managed:lessons end -->";
 
-/// Teams whose lessons file the bridge ships. Keep in lock-step with
-/// `teams/<name>.yaml` — every team consuming `retro_schema` needs a
-/// matching rules file or its retro phase has nowhere to `Edit`.
-const TEAMS: &[(&str, &str)] = &[
-    ("dev", DEV_TEMPLATE),
-    ("product-research", PRODUCT_RESEARCH_TEMPLATE),
-];
+/// V0.2 §6.4 candidate 3: which teams need a memory bridge is now
+/// disk-driven. Scan `<global_dir>/teams/<name>/team.yaml`; any team
+/// with a non-empty `retro_schema` gets a `~/.claude/rules/ccteam-lessons-<name>.md`
+/// scaffold. Shipped teams (dev / product-research) keep their richer
+/// embedded templates; user-authored teams fall back to a generic
+/// scaffold built from the team description.
+fn discover_bridge_teams(global_dir: &Path) -> Vec<(String, String)> {
+    let teams_dir = global_dir.join("teams");
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(&teams_dir) {
+        Ok(e) => e,
+        Err(_) => return out, // ~/.ccteam/teams/ not yet seeded
+    };
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let yaml = entry.path().join("team.yaml");
+        if !yaml.exists() {
+            continue;
+        }
+        let spec = match TeamSpec::load(&yaml) {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::warn!(
+                    path = %yaml.display(),
+                    error = %err,
+                    "memory_bridge: skipping team with malformed team.yaml",
+                );
+                continue;
+            }
+        };
+        if spec.retro_schema.is_empty() {
+            continue;
+        }
+        let body = lookup_bridge_template(&spec);
+        out.push((spec.name, body));
+    }
+    out
+}
+
+/// Map a team to its bridge file body. Shipped teams use the curated
+/// `memory_bridge_<name>.md` template; user-authored teams get a
+/// generic scaffold derived from the team's description so a fresh
+/// `ccteam team publish` immediately has somewhere for retros to
+/// `Edit` cross-project lessons into.
+fn lookup_bridge_template(spec: &TeamSpec) -> String {
+    match spec.name.as_str() {
+        "dev" => DEV_TEMPLATE.to_string(),
+        "product-research" => PRODUCT_RESEARCH_TEMPLATE.to_string(),
+        _ => generic_bridge_template(spec),
+    }
+}
+
+fn generic_bridge_template(spec: &TeamSpec) -> String {
+    let description = if spec.description.trim().is_empty() {
+        format!("`{}` team", spec.name)
+    } else {
+        spec.description.trim().to_string()
+    };
+    format!(
+        "---\ndescription: cross-project memory for {description}. Appended by retro phases at session end; only the marker block is ccteam-managed.\nactivation:\n  paths:\n    - ~/projects/{name}-*\n---\n\n# Lessons learned ({name} team)\n\n(Empty until first retro. Phase prompts append lessons here using `Edit`.)\n\n<!-- ccteam-managed:lessons begin -->\n<!-- ccteam-managed:lessons end -->\n",
+        description = description,
+        name = spec.name,
+    )
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InstallMemoryBridgeOptions {
@@ -70,17 +130,25 @@ pub enum MemoryBridgeAction {
     },
 }
 
-/// Install both team lessons files into `~/.claude/rules/`.
+/// Install lessons files for every team with a non-empty
+/// `retro_schema` into `~/.claude/rules/`. Teams are discovered by
+/// scanning `<global_dir>/teams/` (V0.2 §6.4 candidate 3 — formerly a
+/// hardcoded `const TEAMS` lock-stepped with the in-binary
+/// TEAM_BUNDLES).
 pub fn install_memory_bridge(
+    global_dir: &Path,
     opts: InstallMemoryBridgeOptions,
 ) -> Result<Vec<MemoryBridgeReport>> {
     let claude = user_claude_dir().context("resolve ~/.claude/")?;
-    install_into(&claude, opts)
+    install_into(global_dir, &claude, opts)
 }
 
-/// Test-injectable variant: write under `<claude_dir>/rules/...` so unit
-/// tests can point at a tempdir without mutating `$HOME/.claude/`.
+/// Test-injectable variant: write under `<claude_dir>/rules/...` so
+/// unit tests can point at a tempdir without mutating `$HOME/.claude/`.
+/// `global_dir` is the equivalent of `~/.ccteam/` — `teams/<name>/team.yaml`
+/// underneath it drives which teams get a bridge.
 pub fn install_into(
+    global_dir: &Path,
     claude_dir: &Path,
     opts: InstallMemoryBridgeOptions,
 ) -> Result<Vec<MemoryBridgeReport>> {
@@ -89,13 +157,14 @@ pub fn install_into(
         std::fs::create_dir_all(&rules_dir)
             .with_context(|| format!("create {}", rules_dir.display()))?;
     }
-    let mut reports = Vec::with_capacity(TEAMS.len());
-    for (team, template) in TEAMS {
+    let teams = discover_bridge_teams(global_dir);
+    let mut reports = Vec::with_capacity(teams.len());
+    for (team, template) in &teams {
         let target = rules_dir.join(format!("ccteam-lessons-{team}.md"));
         let action = install_one(&target, template, opts)
             .with_context(|| format!("install memory bridge for team {team}"))?;
         reports.push(MemoryBridgeReport {
-            team: (*team).to_string(),
+            team: team.clone(),
             target,
             action,
         });
@@ -190,11 +259,23 @@ mod tests {
         std::fs::read_to_string(path).unwrap()
     }
 
+    /// Seed shipped team yamls under `<tmp>/ccteam-home/teams/<name>/`
+    /// so `install_into(global, claude, ...)` finds dev / product-research
+    /// during the disk scan introduced in V0.2 §6.4 candidate 3.
+    /// Returns `(global_dir, claude_dir)` — claude_dir is `<tmp>/`,
+    /// matching the historical layout the per-test assertions expect.
+    fn seed(tmp: &tempfile::TempDir) -> (PathBuf, PathBuf) {
+        let global = tmp.path().join("ccteam-home");
+        crate::templates::write_all_global_team_templates(&global, true).unwrap();
+        (global, tmp.path().to_path_buf())
+    }
+
     #[test]
     fn install_creates_both_lessons_files_with_intact_markers() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
         let reports =
-            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         assert_eq!(reports.len(), 2);
         for r in &reports {
             assert_eq!(r.action, MemoryBridgeAction::Wrote);
@@ -214,13 +295,14 @@ mod tests {
     #[test]
     fn install_idempotent_when_files_present_and_intact() {
         let tmp = tempfile::TempDir::new().unwrap();
-        install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        let (global, claude) = seed(&tmp);
+        install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         // Capture baseline content (including default empty marked block body).
         let dev_target = tmp.path().join("rules/ccteam-lessons-dev.md");
         let baseline = read(&dev_target);
 
         let reports2 =
-            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         for r in &reports2 {
             assert_eq!(r.action, MemoryBridgeAction::AlreadyPresent);
         }
@@ -232,7 +314,8 @@ mod tests {
     fn install_preserves_lessons_written_between_markers() {
         // Simulate a retro phase having edited the marked block.
         let tmp = tempfile::TempDir::new().unwrap();
-        install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+        let (global, claude) = seed(&tmp);
+        install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         let dev_target = tmp.path().join("rules/ccteam-lessons-dev.md");
         let with_lessons = read(&dev_target).replace(
             "(Empty until first retro. Phase prompts append lessons here using `Edit`.)",
@@ -241,7 +324,7 @@ mod tests {
         std::fs::write(&dev_target, &with_lessons).unwrap();
 
         let reports =
-            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         assert_eq!(reports[0].action, MemoryBridgeAction::AlreadyPresent);
         let after = read(&dev_target);
         assert!(after.contains("Rust 1.78 + tokio"), "lessons clobbered");
@@ -251,6 +334,7 @@ mod tests {
     #[test]
     fn install_repairs_missing_markers_and_keeps_user_content() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
         let rules_dir = tmp.path().join("rules");
         std::fs::create_dir_all(&rules_dir).unwrap();
         let target = rules_dir.join("ccteam-lessons-dev.md");
@@ -262,7 +346,7 @@ mod tests {
         .unwrap();
 
         let reports =
-            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         assert_eq!(reports[0].action, MemoryBridgeAction::RepairedMarkedSection);
         let after = read(&target);
         assert!(after.contains("# manually authored notes"));
@@ -273,6 +357,7 @@ mod tests {
     #[test]
     fn install_repairs_duplicated_marker_blocks() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
         let rules_dir = tmp.path().join("rules");
         std::fs::create_dir_all(&rules_dir).unwrap();
         let target = rules_dir.join("ccteam-lessons-dev.md");
@@ -284,7 +369,7 @@ mod tests {
         std::fs::write(&target, &dup).unwrap();
 
         let reports =
-            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         assert_eq!(reports[0].action, MemoryBridgeAction::RepairedMarkedSection);
         let after = read(&target);
         assert!(marked_section_intact(&after));
@@ -296,6 +381,7 @@ mod tests {
     #[test]
     fn install_repairs_unbalanced_begin_marker() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
         let rules_dir = tmp.path().join("rules");
         std::fs::create_dir_all(&rules_dir).unwrap();
         let target = rules_dir.join("ccteam-lessons-dev.md");
@@ -306,7 +392,7 @@ mod tests {
         std::fs::write(&target, &body).unwrap();
 
         let reports =
-            install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
         assert_eq!(reports[0].action, MemoryBridgeAction::RepairedMarkedSection);
         let after = read(&target);
         assert!(marked_section_intact(&after));
@@ -320,18 +406,63 @@ mod tests {
     #[test]
     fn dry_run_reports_actions_without_touching_disk() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
         let opts = InstallMemoryBridgeOptions { dry_run: true };
-        let reports = install_into(tmp.path(), opts).unwrap();
+        let reports = install_into(&global, &claude, opts).unwrap();
         for r in &reports {
             assert_eq!(r.action, MemoryBridgeAction::DryRun { would_write: true });
             assert!(!r.target.exists(), "dry-run wrote {}", r.target.display());
         }
         // Now install for real; second dry-run should report no-op.
-        install_into(tmp.path(), InstallMemoryBridgeOptions::default()).unwrap();
-        let reports2 = install_into(tmp.path(), opts).unwrap();
+        install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
+        let reports2 = install_into(&global, &claude, opts).unwrap();
         for r in &reports2 {
             assert_eq!(r.action, MemoryBridgeAction::DryRun { would_write: false });
         }
+    }
+
+    #[test]
+    fn install_skips_team_when_retro_schema_is_empty() {
+        // V0.2 §6.4 candidate 3: meta-agent ships with `retro_schema: []`,
+        // so the disk-scan path must NOT install a bridge for it. Also
+        // verifies the discovery is data-driven — adding a team.yaml
+        // with retro_schema produces a bridge without touching ccteam-core.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
+        let reports =
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
+        assert!(
+            reports.iter().all(|r| r.team != "meta-agent"),
+            "meta-agent has empty retro_schema and must not get a bridge: {:?}",
+            reports.iter().map(|r| &r.team).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn install_picks_up_user_authored_team_via_disk_scan() {
+        // V0.2 §6.4 candidate 3 — the team registry is now disk-driven.
+        // A user-authored team.yaml with non-empty retro_schema gets a
+        // bridge (with the generic fallback template) without ccteam-core
+        // changes.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (global, claude) = seed(&tmp);
+        let custom_dir = global.join("teams").join("custom");
+        std::fs::create_dir_all(&custom_dir).unwrap();
+        std::fs::write(
+            custom_dir.join("team.yaml"),
+            "name: custom\ndescription: A user-authored team\nphase_dir: phases-custom\nretro_schema:\n  - field: outcomes\n    description: Things observed\n",
+        )
+        .unwrap();
+        let reports =
+            install_into(&global, &claude, InstallMemoryBridgeOptions::default()).unwrap();
+        let custom = reports
+            .iter()
+            .find(|r| r.team == "custom")
+            .expect("custom team bridge missing");
+        assert_eq!(custom.action, MemoryBridgeAction::Wrote);
+        let body = read(&custom.target);
+        assert!(body.contains("ccteam-managed:lessons begin"));
+        assert!(body.contains("custom"));
     }
 
     #[test]

--- a/crates/ccteam-core/src/meta_agent.rs
+++ b/crates/ccteam-core/src/meta_agent.rs
@@ -6,13 +6,18 @@
 //! project requests via `ccteam new`, monitors active projects, and
 //! routes inbox/outbox messages.
 //!
-//! Two design rules locked by `docs/development-plan.md` §3 M1:
+//! Two design rules:
 //!
-//! 1. **Hardcoded `team == "meta-agent"` branch**: meta-agent behavior
-//!    (event loop, no phase DAG, never terminal) doesn't fit the phase-DAG
-//!    team contract; M3.4 may revisit. M1 wires a single `if state.team
-//!    == META_TEAM_NAME` branch in the orchestrator (see
-//!    `Orchestrator::process_project`).
+//! 1. **Evergreen flag, not hardcoded branch** (V0.2 §6.4 candidate 5):
+//!    meta-agent behavior (event loop, no phase DAG, never terminal,
+//!    no per-project cost cap) is declared in
+//!    `teams/meta-agent.yaml` via `evergreen: true` + `cost_policy:
+//!    {kind: none}`. The orchestrator dispatches off these flags
+//!    (`Orchestrator::is_evergreen` / `cost_policy`) — any
+//!    user-authored evergreen team (e.g. V0.3 watchdog / reviewer
+//!    agents) takes the same code path. The
+//!    `Orchestrator::process_meta_project` call still drives the
+//!    actual session lifecycle.
 //! 2. **Role prompt template lives in-binary**: shipped as
 //!    `include_str!`, rendered at bootstrap time with the user handle
 //!    interpolated. Anything fancier (hot-reload, per-user templates)
@@ -28,10 +33,13 @@ use crate::paths::CcteamPaths;
 use crate::projects::{bootstrap_project, slugify};
 use crate::state::ProjectState;
 
-/// Special team string the orchestrator uses to dispatch the
-/// meta-agent state machine instead of the phase-DAG one. Hardcoded
-/// for M1; M3.4 may turn it into a `TeamSpec` flag (see
-/// development-plan §3 M1 lock #4).
+/// Canonical team name for the user-facing NL dispatcher session.
+/// V0.2 §6.4 candidate 5: behavior is now driven by
+/// `teams/meta-agent.yaml.evergreen: true` rather than a string
+/// comparison in the orchestrator. This const remains as the slug
+/// passed to `bootstrap_project` so meta-agent's state.json says
+/// `team: meta-agent` and the orchestrator looks up its TeamSpec by
+/// the same key.
 pub const META_TEAM_NAME: &str = "meta-agent";
 
 /// tmux session prefix for meta-agent sessions. The full name is

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -29,7 +29,9 @@ use crate::cost::{self, CostLevel};
 use crate::dag::Dag;
 use crate::auto_loop::{self, AutoLoopState};
 use crate::inbox::{InboxMessage, SessionMailbox};
-use crate::meta_agent::META_TEAM_NAME;
+// `META_TEAM_NAME` is no longer referenced from orchestrator after
+// V0.2 §6.4 candidate 5 — evergreen-team behavior dispatches off
+// `TeamSpec::evergreen` / `cost_policy` flags instead.
 use crate::paths::CcteamPaths;
 use crate::phases::{PhaseTemplate, SubSkillTrigger};
 use crate::progress;
@@ -253,6 +255,13 @@ impl Orchestrator {
     /// refuses to start in a known-bad state instead of silently
     /// routing through agent_team / multi_session paths that aren't
     /// implemented yet.
+    ///
+    /// **Pure load** — no side effects on `~/.ccteam/`. Production
+    /// callers seed shipped templates via `ccteam start` /
+    /// `ccteam init` / `ccteam doctor --reset-shipped-teams` before
+    /// constructing the orchestrator (V0.2 M0.16.2 — keeps tests
+    /// from picking up stray shipped teams when they construct an
+    /// Orchestrator against an empty tempdir).
     pub fn new(paths: CcteamPaths, config: OrchestratorConfig) -> Result<Self> {
         let teams = load_team_runtimes(&paths)?;
         if !config.skip_tool_check {
@@ -283,6 +292,9 @@ impl Orchestrator {
                 golden_rules: Vec::new(),
                 phase_dir: "phases".into(),
                 verdict_schema: Vec::new(),
+                evergreen: false,
+                cost_policy: crate::team::CostPolicy::default(),
+                claude_md_template: String::new(),
             },
             templates: Vec::new(),
             dag: Dag::from_templates(&[])?,
@@ -322,6 +334,28 @@ impl Orchestrator {
     /// Iterate every registered team. Used by `ccteam doctor` and tests.
     pub fn teams(&self) -> impl Iterator<Item = &TeamRuntime> {
         self.teams.values()
+    }
+
+    /// V0.2 §6.4 candidate 5: declarative replacement for
+    /// `state.team == META_TEAM_NAME` branches. Evergreen sessions
+    /// bypass phase-DAG advance, cost hard-kill, and stall warnings.
+    /// An unknown team (no runtime registered) defaults to `false` —
+    /// matching the historical behavior where only meta-agent fell
+    /// into the special branch and everything else ran the regular
+    /// phase-DAG path.
+    pub(crate) fn is_evergreen(&self, team: &str) -> bool {
+        self.team_runtime(team)
+            .is_some_and(|t| t.spec.evergreen)
+    }
+
+    /// V0.2 §6.4 candidate 5: cost policy lookup. Defaults to
+    /// `KillAt(None)` (the historical behavior — hard-kill at
+    /// `state.hard_kill_threshold_usd`) for any unknown team so
+    /// dropping a team.yaml without `cost_policy:` keeps M3 semantics.
+    pub(crate) fn cost_policy(&self, team: &str) -> crate::team::CostPolicy {
+        self.team_runtime(team)
+            .map(|t| t.spec.cost_policy)
+            .unwrap_or_default()
     }
 
     pub fn paths(&self) -> &CcteamPaths {
@@ -547,12 +581,13 @@ impl Orchestrator {
     /// Mutates + persists `state.claude_pid` whenever a new session is
     /// born. Skipped silently for terminal projects.
     pub fn ensure_session(&self, slug: &str, state: &mut ProjectState) -> Result<()> {
-        // Meta-agent sessions never reach a terminal phase state and the
-        // dag check below would skip them — guard meta-agent first so it
-        // always tries to come up.
-        let is_meta = state.team == META_TEAM_NAME;
+        // Evergreen sessions never reach a terminal phase state and the
+        // dag check below would skip them — guard evergreen first so it
+        // always tries to come up. (§6.4 candidate 5 declarative replacement
+        // for the prior `state.team == META_TEAM_NAME` literal.)
+        let is_evergreen = self.is_evergreen(&state.team);
         let team_dag = self.team_runtime(&state.team).map(|t| &t.dag);
-        if !is_meta && team_dag.is_some_and(|d| d.is_terminal_state(state)) {
+        if !is_evergreen && team_dag.is_some_and(|d| d.is_terminal_state(state)) {
             return Ok(());
         }
         let session = TmuxSession::from_name(state.tmux_session.clone());
@@ -604,12 +639,12 @@ impl Orchestrator {
     /// DispatchPhase chain so a phase boundary doesn't take two ticks
     /// to act on. The loop iteration cap is a paranoia guard.
     ///
-    /// Meta-agent projects (`team == META_TEAM_NAME`) bypass the phase
-    /// DAG entirely — they're event-loop sessions, not phase-DAG ones —
-    /// and only get `ensure_session` lifecycle handling. See
-    /// `process_meta_project` for that path.
+    /// Evergreen projects (`team.yaml.evergreen: true`) bypass the
+    /// phase DAG entirely — they're event-loop sessions, not phase-DAG
+    /// ones — and only get `ensure_session` lifecycle handling. See
+    /// `process_meta_project` for that path. (§6.4 candidate 5.)
     pub fn process_project(&self, slug: &str, mut state: ProjectState) -> Result<ProjectState> {
-        if state.team == META_TEAM_NAME {
+        if self.is_evergreen(&state.team) {
             return self.process_meta_project(slug, state);
         }
         // Resolve the project's team runtime. Unknown team in
@@ -1031,7 +1066,11 @@ impl Orchestrator {
         slug: &str,
         mut state: ProjectState,
     ) -> Result<ProjectState> {
-        debug_assert_eq!(state.team, META_TEAM_NAME);
+        debug_assert!(
+            self.is_evergreen(&state.team),
+            "process_meta_project called on non-evergreen team `{}`",
+            state.team,
+        );
         self.ensure_session(slug, &mut state)?;
         if let Err(err) = self.process_session_inbox(slug, &state) {
             tracing::warn!(slug, error = %err, "meta inbox processing failed");
@@ -1137,14 +1176,16 @@ impl Orchestrator {
         Ok(())
     }
 
-    /// Count regular (non-meta) projects whose tmux session is
-    /// currently driving a phase (`InFlight` or `AutoLocked`). The
-    /// concurrency gate (`MAX_CONCURRENT_PROJECTS`) compares this to
-    /// the cap so over-the-limit idle projects wait their turn.
-    pub fn count_active_regular(projects: &[(String, ProjectState)]) -> usize {
+    /// Count phase-DAG projects whose tmux session is currently
+    /// driving a phase (`InFlight` or `AutoLocked`). The concurrency
+    /// gate (`MAX_CONCURRENT_PROJECTS`) compares this to the cap so
+    /// over-the-limit idle projects wait their turn. Evergreen sessions
+    /// are excluded — they're permanent fixtures in the User
+    /// Interaction Layer, not phase-DAG workers (§6.4 candidate 5).
+    pub fn count_active_regular(&self, projects: &[(String, ProjectState)]) -> usize {
         projects
             .iter()
-            .filter(|(_, s)| s.team != META_TEAM_NAME)
+            .filter(|(_, s)| !self.is_evergreen(&s.team))
             .filter(|(_, s)| {
                 matches!(s.phase_state, PhaseState::InFlight | PhaseState::AutoLocked)
             })
@@ -1209,7 +1250,7 @@ impl Orchestrator {
 
     async fn poll_tick(&self, tick_count: u64) -> Result<()> {
         let projects = self.discover_projects()?;
-        let active_regular = Self::count_active_regular(&projects);
+        let active_regular = self.count_active_regular(&projects);
         let total_templates: usize =
             self.teams.values().map(|t| t.templates.len()).sum();
         tracing::debug!(
@@ -1236,12 +1277,15 @@ impl Orchestrator {
                 None => continue, // hard-kill terminated this project
             };
 
-            if state.team == META_TEAM_NAME {
+            if self.is_evergreen(&state.team) {
+                // Evergreen sessions skip the concurrency cap — they're
+                // permanent fixtures in the User Interaction Layer
+                // (§6.4 candidate 5).
                 if let Err(err) = self.process_project(&slug, state) {
                     tracing::error!(
                         slug,
                         error = format!("{err:#}"),
-                        "meta tick failed",
+                        "evergreen tick failed",
                     );
                 }
                 continue;
@@ -1296,11 +1340,15 @@ impl Orchestrator {
         slug: &str,
         mut state: ProjectState,
     ) -> Result<Option<ProjectState>> {
-        // Meta-agent sessions are evergreen and don't fit "hard kill on
-        // budget" semantics — their cost is the user's running tab, not
-        // a per-project budget. M1 lets them through; M4 may want a
-        // separate ladder when conversation continuity (M4.6) lands.
-        if state.team == META_TEAM_NAME {
+        use crate::team::CostPolicy;
+        // V0.2 §6.4 candidate 5: declarative cost policy per team.
+        // `CostPolicy::None` (evergreen meta-agent) bypasses entirely.
+        // `CostPolicy::Track` logs soft / mid warnings but never kills.
+        // `CostPolicy::KillAt(threshold)` is the historical dev /
+        // product-research path; `threshold = None` falls back to
+        // `state.hard_kill_threshold_usd` (default $200 from M1).
+        let policy = self.cost_policy(&state.team);
+        if matches!(policy, CostPolicy::None) {
             return Ok(Some(state));
         }
         if self
@@ -1324,7 +1372,19 @@ impl Orchestrator {
                 cost::COST_MID_WARN_USD,
             ),
             CostLevel::HardKill => {
-                let hard = state.hard_kill_threshold_usd;
+                if matches!(policy, CostPolicy::Track) {
+                    // Track policy: log + return, never kill.
+                    tracing::error!(
+                        slug,
+                        cost = state.cost_used_usd,
+                        "cost over hard threshold but team policy is `track`; logging only",
+                    );
+                    return Ok(Some(state));
+                }
+                let hard = match policy {
+                    CostPolicy::KillAt(Some(team_override)) => team_override,
+                    _ => state.hard_kill_threshold_usd,
+                };
                 tracing::error!(
                     slug,
                     cost = state.cost_used_usd,
@@ -1371,11 +1431,12 @@ impl Orchestrator {
     }
 
     fn warn_if_stalled(&self, slug: &str, state: &ProjectState, now: chrono::DateTime<Utc>) {
-        // Meta-agent sessions sit idle by design (waiting for the next
+        // Evergreen sessions sit idle by design (waiting for the next
         // NL message) — stall semantics don't apply. dag.is_terminal_state
         // would also return false for them since they have no phase
-        // history, so guard explicitly.
-        if state.team == META_TEAM_NAME {
+        // history, so guard explicitly. (§6.4 candidate 5 declarative
+        // replacement.)
+        if self.is_evergreen(&state.team) {
             return;
         }
         let team = self.team_runtime(&state.team);
@@ -1605,28 +1666,42 @@ fn load_team_runtimes(paths: &CcteamPaths) -> Result<HashMap<String, TeamRuntime
             let spec = TeamSpec::load(&yaml).with_context(|| {
                 format!("load team.yaml at {}", yaml.display())
             })?;
-            let phase_dir = paths.root.join(&spec.phase_dir);
-            if !phase_dir.exists() {
-                tracing::warn!(
-                    team = %spec.name,
-                    phase_dir = %phase_dir.display(),
-                    "team registered but phase_dir is missing; \
-                     run `ccteam init` to populate templates",
-                );
-                continue;
-            }
-            let templates = load_phase_templates(&phase_dir)?;
-            for t in &templates {
-                t.validate_m0().with_context(|| {
-                    format!(
-                        "team `{}` phase template `{}` failed M0 validation",
-                        spec.name, t.name,
-                    )
+            // V0.2 §6.4 candidate 5: evergreen teams (meta-agent) ship
+            // an empty phase set — they're event-loop sessions, not
+            // phase-DAG ones. Skip the phase_dir presence check + the
+            // template load; the resulting TeamRuntime carries an
+            // empty templates Vec and an empty DAG, which `decide_tick`
+            // handles via early NoOp.
+            let (templates, dag) = if spec.evergreen {
+                let dag = Dag::from_templates(&[]).with_context(|| {
+                    format!("team `{}` build empty phase DAG", spec.name)
                 })?;
-            }
-            let dag = Dag::from_templates(&templates).with_context(|| {
-                format!("team `{}` build phase DAG", spec.name)
-            })?;
+                (Vec::new(), dag)
+            } else {
+                let phase_dir = paths.root.join(&spec.phase_dir);
+                if !phase_dir.exists() {
+                    tracing::warn!(
+                        team = %spec.name,
+                        phase_dir = %phase_dir.display(),
+                        "team registered but phase_dir is missing; \
+                         run `ccteam init` to populate templates",
+                    );
+                    continue;
+                }
+                let templates = load_phase_templates(&phase_dir)?;
+                for t in &templates {
+                    t.validate_m0().with_context(|| {
+                        format!(
+                            "team `{}` phase template `{}` failed M0 validation",
+                            spec.name, t.name,
+                        )
+                    })?;
+                }
+                let dag = Dag::from_templates(&templates).with_context(|| {
+                    format!("team `{}` build phase DAG", spec.name)
+                })?;
+                (templates, dag)
+            };
             teams.insert(
                 spec.name.clone(),
                 TeamRuntime {
@@ -1662,6 +1737,9 @@ fn load_team_runtimes(paths: &CcteamPaths) -> Result<HashMap<String, TeamRuntime
                     golden_rules: Vec::new(),
                     phase_dir: "phases".into(),
                     verdict_schema: Vec::new(),
+                    evergreen: false,
+                    cost_policy: crate::team::CostPolicy::default(),
+                    claude_md_template: String::new(),
                 };
                 teams.insert(
                     "dev".into(),

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -1343,7 +1343,6 @@ impl Orchestrator {
         use crate::team::CostPolicy;
         // V0.2 §6.4 candidate 5: declarative cost policy per team.
         // `CostPolicy::None` (evergreen meta-agent) bypasses entirely.
-        // `CostPolicy::Track` logs soft / mid warnings but never kills.
         // `CostPolicy::KillAt(threshold)` is the historical dev /
         // product-research path; `threshold = None` falls back to
         // `state.hard_kill_threshold_usd` (default $200 from M1).
@@ -1372,15 +1371,6 @@ impl Orchestrator {
                 cost::COST_MID_WARN_USD,
             ),
             CostLevel::HardKill => {
-                if matches!(policy, CostPolicy::Track) {
-                    // Track policy: log + return, never kill.
-                    tracing::error!(
-                        slug,
-                        cost = state.cost_used_usd,
-                        "cost over hard threshold but team policy is `track`; logging only",
-                    );
-                    return Ok(Some(state));
-                }
                 let hard = match policy {
                     CostPolicy::KillAt(Some(team_override)) => team_override,
                     _ => state.hard_kill_threshold_usd,

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -179,22 +179,47 @@ pub fn bootstrap_project(
     Ok(project_dir)
 }
 
-/// Build the `<project>/CLAUDE.md` body for `team`. dev keeps its
-/// historical "no git push, tests must pass" wording; product-research
-/// gets a research-specific contract; unknown teams get a generic
-/// shell that doesn't bake in dev or research assumptions.
+/// Build the `<project>/CLAUDE.md` body for `team`. V0.2 §6.4
+/// candidate 2: the per-team body lives in `team.yaml.claude_md_template`,
+/// not in a `match team` branch in ccteam-core. Templates contain the
+/// literal placeholders `{slug}` / `{team}`, substituted here.
+///
+/// Lookup precedence:
+/// 1. The shipped `TEAM_BUNDLES` entry's `team.yaml.claude_md_template`
+///    (parsed lazily from the embedded yaml).
+/// 2. A generic body that doesn't bake in dev / research assumptions —
+///    used for unknown teams (user-authored without a template) and as
+///    a safety net if the shipped yaml fails to parse.
+///
+/// The body is written verbatim; teams that want richer templating
+/// (eg. `--config` style placeholder selection) should fill in
+/// values before storing the template, since runtime substitution is
+/// limited to the two slots the template author can rely on.
 fn render_project_claude_md(slug: &str, team: &str) -> String {
-    match team {
-        "dev" => format!(
-            "# CLAUDE.md (auto-managed by ccteam)\n\n## 项目上下文\n- slug: {slug}\n- team: dev\n- 用户原始需求: 见 .ccteam/spec.md\n\n## 工作约定\n- 不要交互式询问。所有决策已在 .ccteam/plan-eng.md 中。\n- 测试不过不算完成。\n\n## 不做的事\n- 不要 git push(被 hook 拦截)\n- 不要修改 .ccteam/ 之外的元数据\n",
-        ),
-        "product-research" => format!(
-            "# CLAUDE.md (auto-managed by ccteam)\n\n## 项目上下文\n- slug: {slug}\n- team: product-research\n- 用户原始需求: 见 .ccteam/spec.md\n\n## 工作约定\n- 不写代码,只产研究报告。\n- 至少 3 个独立信息源,**不要编造数据**;不确定时标 \"未确认\"。\n- 决策走 outbox(`async` 模式)或 AskUserQuestion,**不要**自行假设关键事实。\n\n## 不做的事\n- 不要修改 .ccteam/ 之外的元数据。\n- 不要在 verdict 之前下定论 — 让 phase DAG 走完。\n- 不要把 dev 的 \"测试不过不算完成\" 套用到本项目;研究报告的 done 是 verdict.md 写出 + rationale.md 自洽。\n",
-        ),
-        _ => format!(
-            "# CLAUDE.md (auto-managed by ccteam)\n\n## 项目上下文\n- slug: {slug}\n- team: {team}\n- 用户原始需求: 见 .ccteam/spec.md\n\n## 工作约定\n- 跟随该 team 的 phase 模板指示。\n- 不要修改 .ccteam/ 之外的元数据。\n",
-        ),
-    }
+    let template = team_bundle(team)
+        .and_then(|b| crate::team::TeamSpec::parse(b.team_yaml).ok())
+        .filter(|spec| !spec.claude_md_template.trim().is_empty())
+        .map(|spec| spec.claude_md_template);
+    let body = match template {
+        Some(t) => t,
+        None => generic_claude_md_template().to_string(),
+    };
+    body.replace("{slug}", slug).replace("{team}", team)
+}
+
+/// Fallback body for teams without an explicit `claude_md_template`.
+/// Carries no team-specific contract — phase markdown owns that.
+fn generic_claude_md_template() -> &'static str {
+    "# CLAUDE.md (auto-managed by ccteam)\n\
+     \n\
+     ## 项目上下文\n\
+     - slug: {slug}\n\
+     - team: {team}\n\
+     - 用户原始需求: 见 .ccteam/spec.md\n\
+     \n\
+     ## 工作约定\n\
+     - 跟随该 team 的 phase 模板指示。\n\
+     - 不要修改 .ccteam/ 之外的元数据。\n"
 }
 
 /// Parse the embedded phase templates for `team` into a
@@ -769,6 +794,52 @@ mod tests {
         // must not clobber the user edit.
         bootstrap_project(&paths, "demo2", "another request", "dev").unwrap();
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "USER EDIT\n");
+    }
+
+    // ---------------- V0.2 M0.16.3: claude_md_template ----------------
+
+    #[test]
+    fn render_project_claude_md_uses_dev_template_with_substitution() {
+        let body = render_project_claude_md("dev-build-todo", "dev");
+        assert!(body.contains("# CLAUDE.md (auto-managed by ccteam)"));
+        assert!(body.contains("- slug: dev-build-todo"));
+        assert!(body.contains("- team: dev"));
+        // dev-specific contract from the template body must land verbatim.
+        assert!(body.contains("测试不过不算完成"));
+        assert!(body.contains("不要 git push"));
+    }
+
+    #[test]
+    fn render_project_claude_md_uses_product_research_template_with_substitution() {
+        let body = render_project_claude_md("product-research-recipe-ai", "product-research");
+        assert!(body.contains("- slug: product-research-recipe-ai"));
+        assert!(body.contains("- team: product-research"));
+        // product-research-specific contract: no code, source diversity.
+        assert!(body.contains("不写代码"));
+        assert!(body.contains("3 个独立信息源"));
+    }
+
+    #[test]
+    fn render_project_claude_md_falls_back_to_generic_for_unknown_team() {
+        let body = render_project_claude_md("custom-foo-1", "custom-team");
+        // Generic body has no dev-specific or research-specific clauses.
+        assert!(body.contains("- slug: custom-foo-1"));
+        assert!(body.contains("- team: custom-team"));
+        assert!(!body.contains("测试不过不算完成"));
+        assert!(!body.contains("不写代码"));
+        assert!(body.contains("跟随该 team 的 phase 模板指示"));
+    }
+
+    #[test]
+    fn render_project_claude_md_falls_back_to_generic_when_template_field_empty() {
+        // meta-agent ships with an empty `claude_md_template` (the role
+        // prompt overwrites the file via a different path), so the
+        // generic body is the right fallback. This guards against
+        // accidentally writing "" as the body.
+        let body = render_project_claude_md("rob-meta", "meta-agent");
+        assert!(!body.is_empty());
+        assert!(body.contains("- slug: rob-meta"));
+        assert!(body.contains("- team: meta-agent"));
     }
 
     #[test]

--- a/crates/ccteam-core/src/team.rs
+++ b/crates/ccteam-core/src/team.rs
@@ -148,6 +148,48 @@ pub enum EscalateRoute {
     Abort,
 }
 
+/// V0.2 §6.4 candidate 5: cost-handling policy. Replaces the
+/// hardcoded `if state.team == META_TEAM_NAME { skip }` branch in
+/// `enforce_cost_thresholds` with a declarative per-team flag. Three
+/// variants cover the cases in flight:
+///
+/// - `None` — no cost tracking, no warnings, no kill. Used by
+///   evergreen teams (meta-agent) where "cost" is the user's running
+///   tab, not a per-project budget.
+/// - `Track` — log soft / mid warnings but never hard-kill. Reserved
+///   for future "long-running but observable" teams (V0.3+ may use
+///   this for watchdog / reviewer agents).
+/// - `KillAt(usd)` — current dev / product-research behavior: soft +
+///   mid warnings, hard-kill the tmux session when
+///   `state.cost_used_usd > usd`. The threshold is per-team, not
+///   per-project, so a team author sets a sensible default and the
+///   orchestrator uses it unless `state.hard_kill_threshold_usd`
+///   overrides at the project level.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "threshold_usd")]
+pub enum CostPolicy {
+    /// No tracking, no warnings, no kill. Evergreen sessions
+    /// (meta-agent) — cost is the user's running tab, not a per-project
+    /// budget.
+    None,
+    /// Soft + mid warnings only. Never hard-kills.
+    Track,
+    /// Soft + mid warnings + hard-kill at threshold. Default for
+    /// regular phase-DAG teams. Falls back to
+    /// `state.hard_kill_threshold_usd` (default $200) when this
+    /// variant's threshold is `None`.
+    KillAt(Option<f64>),
+}
+
+impl Default for CostPolicy {
+    fn default() -> Self {
+        // Phase-DAG teams default to the historical KillAt path so a
+        // team.yaml that omits `cost_policy` keeps M3 behavior intact.
+        // Evergreen teams (meta-agent) override to `None`.
+        Self::KillAt(None)
+    }
+}
+
 /// `team.yaml` — the team-level config. M3.1 shipped name /
 /// description / retro_schema; M3.2 adds the five fields below so the
 /// orchestrator can route phases / ESCALATE prefixes / golden-rule
@@ -203,6 +245,38 @@ pub struct TeamSpec {
     /// dev currently leaves this empty.
     #[serde(default)]
     pub verdict_schema: Vec<String>,
+
+    // ---------------- V0.2 M0.16 fields (§6.4 candidate 5) ----------------
+    /// Evergreen sessions never reach a phase-DAG terminal state and
+    /// don't follow the AdvancePhase / DispatchPhase loop — they're
+    /// event-loop sessions waiting for inbox messages. The orchestrator
+    /// dispatches them through `process_meta_project` instead of
+    /// `process_project`. Defaults to false so phase-DAG teams behave
+    /// unchanged.
+    ///
+    /// Replaces `if state.team == META_TEAM_NAME` branches in
+    /// `process_project` / `count_active_regular` / `tick`. Any
+    /// user-authored team can opt in (e.g. V0.3 watchdog / reviewer
+    /// agents) without ccteam-core changes.
+    #[serde(default)]
+    pub evergreen: bool,
+
+    /// Cost-handling policy (§6.4 candidate 5). Defaults to
+    /// `KillAt(None)` so phase-DAG teams keep current behavior;
+    /// evergreen teams (meta-agent) opt to `None`. See `CostPolicy`
+    /// for variant semantics.
+    #[serde(default)]
+    pub cost_policy: CostPolicy,
+
+    /// Auto-managed `<project>/CLAUDE.md` body. Replaces the hardcoded
+    /// `match team` in `projects::render_project_claude_md` (§6.2
+    /// candidate 2). `{slug}` and `{team}` placeholders are substituted
+    /// at bootstrap time; everything else lands verbatim.
+    ///
+    /// Empty string keeps a generic fallback body so a team.yaml
+    /// without `claude_md_template` still bootstraps.
+    #[serde(default)]
+    pub claude_md_template: String,
 }
 
 impl TeamSpec {
@@ -436,6 +510,9 @@ mod tests {
             golden_rules: Vec::new(),
             phase_dir: "phases".into(),
             verdict_schema: Vec::new(),
+            evergreen: false,
+            cost_policy: CostPolicy::default(),
+            claude_md_template: String::new(),
         };
         let yaml = serde_yaml::to_string(&original).unwrap();
         let parsed = TeamSpec::parse(&yaml).unwrap();
@@ -649,6 +726,71 @@ mod tests {
         assert!(spec.escalate_grammar_extensions.is_empty());
         assert!(spec.golden_rules.is_empty());
         assert!(spec.verdict_schema.is_empty());
+    }
+
+    // ---------------- V0.2 M0.16 fields (§6.4 candidate 5) ----------------
+
+    #[test]
+    fn m016_evergreen_defaults_false_and_cost_policy_kill_at_none() {
+        let spec = TeamSpec::parse("name: dev\n").unwrap();
+        assert!(!spec.evergreen);
+        assert_eq!(spec.cost_policy, CostPolicy::KillAt(None));
+    }
+
+    #[test]
+    fn m016_evergreen_round_trips() {
+        let src = concat!(
+            "name: meta-agent\n",
+            "evergreen: true\n",
+            "cost_policy:\n",
+            "  kind: none\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert!(spec.evergreen);
+        assert_eq!(spec.cost_policy, CostPolicy::None);
+    }
+
+    #[test]
+    fn m016_cost_policy_track_round_trips() {
+        let src = concat!(
+            "name: x\n",
+            "cost_policy:\n",
+            "  kind: track\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert_eq!(spec.cost_policy, CostPolicy::Track);
+    }
+
+    #[test]
+    fn m016_cost_policy_kill_at_with_threshold_round_trips() {
+        let src = concat!(
+            "name: x\n",
+            "cost_policy:\n",
+            "  kind: kill_at\n",
+            "  threshold_usd: 200.0\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert_eq!(spec.cost_policy, CostPolicy::KillAt(Some(200.0)));
+    }
+
+    #[test]
+    fn m016_claude_md_template_default_is_empty_string() {
+        let spec = TeamSpec::parse("name: dev\n").unwrap();
+        assert!(spec.claude_md_template.is_empty());
+    }
+
+    #[test]
+    fn m016_claude_md_template_round_trips() {
+        let src = concat!(
+            "name: dev\n",
+            "claude_md_template: |\n",
+            "  # CLAUDE.md\n",
+            "  slug: {slug}\n",
+            "  team: {team}\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert!(spec.claude_md_template.contains("{slug}"));
+        assert!(spec.claude_md_template.contains("{team}"));
     }
 
     #[test]

--- a/crates/ccteam-core/src/team.rs
+++ b/crates/ccteam-core/src/team.rs
@@ -150,21 +150,25 @@ pub enum EscalateRoute {
 
 /// V0.2 §6.4 candidate 5: cost-handling policy. Replaces the
 /// hardcoded `if state.team == META_TEAM_NAME { skip }` branch in
-/// `enforce_cost_thresholds` with a declarative per-team flag. Three
-/// variants cover the cases in flight:
+/// `enforce_cost_thresholds` with a declarative per-team flag. Two
+/// variants cover the cases V0.2 has consumers for:
 ///
 /// - `None` — no cost tracking, no warnings, no kill. Used by
 ///   evergreen teams (meta-agent) where "cost" is the user's running
 ///   tab, not a per-project budget.
-/// - `Track` — log soft / mid warnings but never hard-kill. Reserved
-///   for future "long-running but observable" teams (V0.3+ may use
-///   this for watchdog / reviewer agents).
 /// - `KillAt(usd)` — current dev / product-research behavior: soft +
 ///   mid warnings, hard-kill the tmux session when
 ///   `state.cost_used_usd > usd`. The threshold is per-team, not
 ///   per-project, so a team author sets a sensible default and the
 ///   orchestrator uses it unless `state.hard_kill_threshold_usd`
 ///   overrides at the project level.
+///
+/// PRD §6.4 originally listed a third `Track` variant (warn but
+/// don't kill) for V0.3 watchdog agents. Dropped on review (PR #15
+/// 2026-05-07 fixup): V0.3 will define the watchdog cost behavior
+/// concretely (warn thresholds, soft-warn factor, etc.) — adding
+/// `Track` then with real consumers beats shipping a marker variant
+/// today.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind", content = "threshold_usd")]
 pub enum CostPolicy {
@@ -172,8 +176,6 @@ pub enum CostPolicy {
     /// (meta-agent) — cost is the user's running tab, not a per-project
     /// budget.
     None,
-    /// Soft + mid warnings only. Never hard-kills.
-    Track,
     /// Soft + mid warnings + hard-kill at threshold. Default for
     /// regular phase-DAG teams. Falls back to
     /// `state.hard_kill_threshold_usd` (default $200) when this
@@ -748,17 +750,6 @@ mod tests {
         let spec = TeamSpec::parse(src).unwrap();
         assert!(spec.evergreen);
         assert_eq!(spec.cost_policy, CostPolicy::None);
-    }
-
-    #[test]
-    fn m016_cost_policy_track_round_trips() {
-        let src = concat!(
-            "name: x\n",
-            "cost_policy:\n",
-            "  kind: track\n",
-        );
-        let spec = TeamSpec::parse(src).unwrap();
-        assert_eq!(spec.cost_policy, CostPolicy::Track);
     }
 
     #[test]

--- a/crates/ccteam-core/src/templates.rs
+++ b/crates/ccteam-core/src/templates.rs
@@ -67,29 +67,44 @@ const PRODUCT_RESEARCH_PHASE_TEMPLATES: &[(&str, &str)] = &[
 ];
 
 /// Embedded `team.yaml` files keyed by team name. M3.4 ships dev +
-/// product-research. `ccteam init` writes these to
-/// `~/.ccteam/teams/<name>/team.yaml`. The orchestrator reads them at
-/// startup to resolve `phase_dir`, registered ESCALATE prefixes, and
-/// (eventually) team-wide golden rules.
+/// product-research; V0.2 M0.16 adds meta-agent (evergreen). `ccteam
+/// init` writes these to `~/.ccteam/teams/<name>/team.yaml`. The
+/// orchestrator reads them at startup to resolve `phase_dir`,
+/// registered ESCALATE prefixes, the V0.2 `evergreen` / `cost_policy`
+/// flags, and (eventually) team-wide golden rules.
 const DEV_TEAM_YAML: &str = include_str!("../../../teams/dev.yaml");
 const PRODUCT_RESEARCH_TEAM_YAML: &str =
     include_str!("../../../teams/product-research.yaml");
+const META_AGENT_TEAM_YAML: &str = include_str!("../../../teams/meta-agent.yaml");
+
+/// Empty phase set for evergreen teams (meta-agent). The orchestrator
+/// builds a `Dag::from_templates(&[])` for these, which `decide_tick`
+/// short-circuits to `NoOp`. `process_meta_project` runs the
+/// alternative event-loop path instead.
+const META_AGENT_PHASE_TEMPLATES: &[(&str, &str)] = &[];
 
 /// One team's compile-time bundle: a `team.yaml` body + the phase
 /// markdowns to stamp into the project's `<project>/.ccteam/phases/`
 /// dir on `ccteam new`. Looking up by team name keeps every
 /// per-team artifact in one place — adding a team is a config change.
+///
+/// V0.2 §6.4 candidate 3: `pub(crate)` — runtime code paths now read
+/// disk (`~/.ccteam/teams/<name>/team.yaml`); this struct is only
+/// the in-binary seed source for `write_all_global_team_templates`
+/// and the bootstrap-time helpers in `projects.rs`.
 #[derive(Debug, Clone, Copy)]
-pub struct TeamTemplateBundle {
+pub(crate) struct TeamTemplateBundle {
     pub team_yaml: &'static str,
     pub phases: &'static [(&'static str, &'static str)],
 }
 
-/// Per-team template registry. `bootstrap_project`,
-/// `write_global_phase_templates`, and `Orchestrator::new` consult
-/// this. Adding a new team = add an entry here + author its YAML +
-/// markdowns; ccteam-core changes nothing else.
-pub const TEAM_BUNDLES: &[(&str, TeamTemplateBundle)] = &[
+/// In-binary seed source for shipped teams. **Not** a runtime
+/// registry — production lookups walk `~/.ccteam/teams/<name>/team.yaml`
+/// (see `Orchestrator::team_runtime` /
+/// `memory_bridge::discover_bridge_teams`). Adding a new shipped team
+/// = add an entry here + author its YAML + markdowns; user-authored
+/// teams skip this entirely (V0.2 M0.22 team factory).
+pub(crate) const TEAM_BUNDLES: &[(&str, TeamTemplateBundle)] = &[
     (
         "dev",
         TeamTemplateBundle {
@@ -104,12 +119,21 @@ pub const TEAM_BUNDLES: &[(&str, TeamTemplateBundle)] = &[
             phases: PRODUCT_RESEARCH_PHASE_TEMPLATES,
         },
     ),
+    (
+        "meta-agent",
+        TeamTemplateBundle {
+            team_yaml: META_AGENT_TEAM_YAML,
+            phases: META_AGENT_PHASE_TEMPLATES,
+        },
+    ),
 ];
 
-/// Resolve a team's compile-time bundle. Returns `None` for unknown
-/// teams so callers can fall back to "no embedded templates" — useful
-/// for user-authored teams that live entirely on disk.
-pub fn team_bundle(team: &str) -> Option<TeamTemplateBundle> {
+/// Resolve a shipped team's compile-time seed bundle. Returns `None`
+/// for unknown teams so callers fall back to "no embedded templates" —
+/// the right behavior for user-authored teams that live entirely on
+/// disk. V0.2 §6.4 candidate 3: `pub(crate)` — only bootstrap-time
+/// callers in ccteam-core may use this.
+pub(crate) fn team_bundle(team: &str) -> Option<TeamTemplateBundle> {
     TEAM_BUNDLES
         .iter()
         .find_map(|(name, bundle)| (*name == team).then_some(*bundle))
@@ -237,17 +261,16 @@ pub fn write_project_phase_templates(project_dir: &Path) -> Result<()> {
 }
 
 /// M3.3: write the project-local phase templates for `team` under
-/// `<project_dir>/.ccteam/phases/`. The `meta-agent` team has no
-/// phase set (event-loop session); for it this is a no-op so meta
-/// project bootstrap doesn't fail with "unknown team".
+/// `<project_dir>/.ccteam/phases/`. Evergreen teams (e.g. meta-agent)
+/// ship an empty phase set — the loop body is a no-op for them, so
+/// the function returns successfully without ever creating the
+/// `phases/` directory. (V0.2 §6.4 candidate 5 — declarative "no
+/// phases" via empty bundle, replacing the prior `team ==
+/// META_TEAM_NAME` literal.)
 pub fn write_project_phase_templates_for_team(
     project_dir: &Path,
     team: &str,
 ) -> Result<()> {
-    if team == crate::meta_agent::META_TEAM_NAME {
-        // Meta-agent has no DAG; skip the phase write entirely.
-        return Ok(());
-    }
     let bundle = team_bundle(team).ok_or_else(|| {
         anyhow!(
             "no embedded phase templates for team `{team}` — \
@@ -256,6 +279,12 @@ pub fn write_project_phase_templates_for_team(
              to TEAM_BUNDLES in templates.rs"
         )
     })?;
+    if bundle.phases.is_empty() {
+        // Evergreen / phase-less team — skip the directory creation
+        // so we don't litter empty `.ccteam/phases/` dirs across
+        // event-loop project trees.
+        return Ok(());
+    }
     let dir = project_dir.join(".ccteam").join("phases");
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create {}", dir.display()))?;
@@ -308,17 +337,21 @@ pub fn write_all_global_team_templates(global_dir: &Path, force: bool) -> Result
         let spec = TeamSpec::parse(bundle.team_yaml).with_context(|| {
             format!("embedded team.yaml for `{name}` does not match TeamSpec schema")
         })?;
-        // Phase markdowns → <global>/<phase_dir>/<NN-name>.md.
-        let phase_dir = global_dir.join(&spec.phase_dir);
-        std::fs::create_dir_all(&phase_dir)
-            .with_context(|| format!("create {}", phase_dir.display()))?;
-        for (filename, body) in bundle.phases {
-            let path = phase_dir.join(filename);
-            if path.exists() && !force {
-                continue;
+        // Phase markdowns → <global>/<phase_dir>/<NN-name>.md. Skip
+        // the directory creation for evergreen / phase-less teams so
+        // we don't leave empty placeholder dirs around.
+        if !bundle.phases.is_empty() {
+            let phase_dir = global_dir.join(&spec.phase_dir);
+            std::fs::create_dir_all(&phase_dir)
+                .with_context(|| format!("create {}", phase_dir.display()))?;
+            for (filename, body) in bundle.phases {
+                let path = phase_dir.join(filename);
+                if path.exists() && !force {
+                    continue;
+                }
+                std::fs::write(&path, body)
+                    .with_context(|| format!("write {}", path.display()))?;
             }
-            std::fs::write(&path, body)
-                .with_context(|| format!("write {}", path.display()))?;
         }
         // team.yaml → <global>/teams/<name>/team.yaml.
         let team_dir = global_dir.join("teams").join(name);

--- a/crates/ccteam-core/tests/m1_meta_dispatch_test.rs
+++ b/crates/ccteam-core/tests/m1_meta_dispatch_test.rs
@@ -15,9 +15,9 @@ use std::time::Duration;
 use ccteam_core::tmux::{tmux_available, TmuxSession};
 use ccteam_core::{
     bootstrap_meta_project, bootstrap_project, disable_tool_surface_bootstrap_for_tests,
-    inbox_filename, write_global_phase_templates, CcteamPaths, InboxFrontMatter, InboxMessage,
-    Orchestrator, OrchestratorConfig, PhaseState, ProjectState, SessionMailbox,
-    MAX_CONCURRENT_PROJECTS, META_TEAM_NAME,
+    inbox_filename, write_all_global_team_templates, write_global_phase_templates, CcteamPaths,
+    InboxFrontMatter, InboxMessage, Orchestrator, OrchestratorConfig, PhaseState, ProjectState,
+    SessionMailbox, MAX_CONCURRENT_PROJECTS, META_TEAM_NAME,
 };
 use chrono::Utc;
 use tempfile::TempDir;
@@ -45,8 +45,37 @@ fn write_solo_phases(paths: &CcteamPaths) {
     write_global_phase_templates(&paths.root, true).unwrap();
 }
 
+/// Seed every shipped team (`teams/<name>/team.yaml`) so
+/// `Orchestrator::new`'s `load_team_runtimes` registers them. Tests
+/// exercising the V0.2 evergreen flag (meta-agent dispatched off
+/// `TeamSpec::evergreen` rather than a string compare) need this.
+fn seed_all_teams(paths: &CcteamPaths) {
+    write_all_global_team_templates(&paths.root, true).unwrap();
+}
+
+/// Build an `Orchestrator` with all shipped teams seeded so
+/// `count_active_regular` / `is_evergreen` work for meta-agent.
+fn orch_with_all_teams(paths: &CcteamPaths) -> Orchestrator {
+    seed_all_teams(paths);
+    Orchestrator::new(
+        paths.clone(),
+        OrchestratorConfig {
+            ready_timeout: Duration::from_secs(5),
+            post_ready_warmup: Duration::from_millis(0),
+            skip_tool_check: true,
+            ..OrchestratorConfig::default()
+        },
+    )
+    .unwrap()
+}
+
 #[test]
 fn count_active_regular_excludes_meta_team() {
+    isolation();
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    let orch = orch_with_all_teams(&paths);
+
     let mut a = ProjectState::initial("p-1".into());
     a.phase_state = PhaseState::InFlight;
     let mut b = ProjectState::initial("p-2".into());
@@ -62,7 +91,7 @@ fn count_active_regular_excludes_meta_team() {
         ("p-3".into(), idle),
         ("rob-meta".into(), meta),
     ];
-    assert_eq!(Orchestrator::count_active_regular(&projects), 2);
+    assert_eq!(orch.count_active_regular(&projects), 2);
 }
 
 #[test]
@@ -189,7 +218,9 @@ fn meta_project_skips_phase_dispatch() {
     isolation();
     let tmp = TempDir::new().unwrap();
     let paths = fresh_paths(&tmp);
-    write_solo_phases(&paths);
+    // V0.2 §6.4 candidate 5: seed every shipped team so meta-agent's
+    // `evergreen: true` flag drives the dispatch.
+    seed_all_teams(&paths);
     // Per-test user handle so concurrent tmux session names don't collide.
     let user = format!("rob-skip-{}", std::process::id());
     let report = bootstrap_meta_project(&paths, &user).unwrap();
@@ -244,6 +275,11 @@ fn meta_project_skips_phase_dispatch() {
 
 #[test]
 fn poll_tick_caps_active_regular_projects_at_three() {
+    isolation();
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    let orch = orch_with_all_teams(&paths);
+
     // We don't actually want to spin tmux for 5 projects in a unit
     // test, so we exercise the budget arithmetic directly. The pure
     // counter is the load-bearing assertion; the dispatch path itself
@@ -264,7 +300,7 @@ fn poll_tick_caps_active_regular_projects_at_three() {
         ("q1".into(), q1),
         ("q2".into(), q2),
     ];
-    let active = Orchestrator::count_active_regular(&projects);
+    let active = orch.count_active_regular(&projects);
     assert_eq!(active, 3);
     let budget = MAX_CONCURRENT_PROJECTS.saturating_sub(active);
     assert_eq!(
@@ -282,7 +318,12 @@ fn meta_context_reset_appends_progress_summary_to_claude_md() {
     isolation();
     let tmp = TempDir::new().unwrap();
     let paths = fresh_paths(&tmp);
-    write_solo_phases(&paths);
+    // V0.2 §6.4 candidate 5: seed every shipped team so meta-agent's
+    // `evergreen: true` flag is loadable when Orchestrator::new walks
+    // ~/.ccteam/teams/. Without this, `is_evergreen("meta-agent")`
+    // returns false and `process_project` skips the meta dispatch
+    // path entirely.
+    seed_all_teams(&paths);
     let user = format!("rob-reset-{}", std::process::id());
     let report = bootstrap_meta_project(&paths, &user).unwrap();
 
@@ -338,6 +379,11 @@ fn meta_context_reset_appends_progress_summary_to_claude_md() {
 
 #[test]
 fn meta_project_does_not_consume_concurrency_budget() {
+    isolation();
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    let orch = orch_with_all_teams(&paths);
+
     let mut a = ProjectState::initial("p1".into());
     a.phase_state = PhaseState::InFlight;
     let mut b = ProjectState::initial("p2".into());
@@ -350,9 +396,9 @@ fn meta_project_does_not_consume_concurrency_budget() {
         ("p2".into(), b),
         ("rob-meta".into(), meta),
     ];
-    assert_eq!(Orchestrator::count_active_regular(&projects), 2);
+    assert_eq!(orch.count_active_regular(&projects), 2);
     assert!(
-        MAX_CONCURRENT_PROJECTS - Orchestrator::count_active_regular(&projects) > 0,
+        MAX_CONCURRENT_PROJECTS - orch.count_active_regular(&projects) > 0,
         "meta should leave at least one budget slot",
     );
 }

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -36,6 +36,21 @@ F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭),分布:
 | **N/A 已是领域无关** | 2 | F14, F19(M3 docs sweep 后)|
 | **已修复** | 18 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)|
 
+### V0.2 §6 反模式候选状态(prd-v0-2.md)
+
+PRD V0.2 §6 列了 8 条 ccteam-core 反模式候选清理任务,跟 F-finding
+独立编号但同源(都是"领域字面量泄漏到 core"):
+
+| 候选 | 描述 | 状态 |
+|---|---|---|
+| 1 + 8 | 协议关键字 `PHASE_DONE` / `ESCALATE` 三处镜像 → 单一 source | M0.18 待做 |
+| 2 | `render_project_claude_md` `match team` 写死 | **2026-05-07 关闭(M0.16.3,本 PR)** |
+| 3 | `TEAM_BUNDLES` 编译时常量 → seed-only | **2026-05-07 关闭(M0.16.2,本 PR)** |
+| 5 | meta-agent `if team == META_TEAM_NAME` 5 处分叉 | **2026-05-07 关闭(M0.16.1,本 PR)** |
+| 7 | `RECOMMENDED_AGENTS` ln -sf 8 plugin agent | M0.20 待做 |
+| 4 | `golden_rules` layered merge | V0.3 deferred |
+| 6 | `pre_trust_project` 写 `~/.claude.json` | V0.3 deferred |
+
 **剩余 P0 关键路径**:**只剩 F1**(`auto_loop` 字段已在 phase YAML 里加了
 [M3.1],orchestrator 仍按 `FIX_PHASE_NAME` 字符串触发 `FixLoopState`——需
 切到读 `template.auto_loop`)。完成后 ccteam-core 可彻底放弃 "fix" 这个名字。

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -576,7 +576,7 @@ confidence: 0.0-1.0
 
 ---
 
-### 5.5 `team.yaml` 团队配置(M3.1 / M3.2 / M3.3+)
+### 5.5 `team.yaml` 团队配置(M3.1 / M3.2 / M3.3 / V0.2 M0.16+)
 
 每个团队一份 `team.yaml`,落 `~/.ccteam/teams/<name>/team.yaml`。
 
@@ -587,6 +587,10 @@ confidence: 0.0-1.0
   按 `phase_dir` 加载 phases,每团队建 `TeamRuntime { spec, templates, dag }`
 - **M3.4** ✅ product-research 团队入仓(`teams/product-research.yaml` +
   `phases-product-research/`)
+- **V0.2 M0.16** ✅ 加 `evergreen` / `cost_policy` / `claude_md_template` —
+  替代 `if state.team == META_TEAM_NAME` / `match team` ccteam-core 分叉
+  (PRD §6.4 candidate 5 + §6.2 candidate 2);新增 `teams/meta-agent.yaml`
+  作 evergreen 范例;`memory_bridge` 团队列表改成扫盘(PRD §6.4 candidate 3)
 
 ```yaml
 # ~/.ccteam/teams/product-research/team.yaml — 完整字段示例
@@ -625,6 +629,22 @@ retro_schema:
   - field: market_signals
     description: Top market signals collected
     kind: list                            # 默认 list。可选 text(单段叙述)
+
+# V0.2 M0.16 — evergreen 标记 + cost 政策(PRD §6.4 candidate 5)。
+# 默认 evergreen=false / cost_policy=KillAt(None)(沿用 M3 行为)。
+# meta-agent / V0.3 watchdog / reviewer agent 应设 evergreen=true +
+# cost_policy={kind: none}。
+evergreen: false
+cost_policy:
+  kind: kill_at        # none | track | kill_at
+  threshold_usd: ~     # KillAt(None) 回退到 state.hard_kill_threshold_usd
+
+# V0.2 M0.16 — auto-managed `<project>/CLAUDE.md` body。{slug} / {team}
+# bootstrap 时替换。空字符串走通用 fallback(不烧 dev / research 假设)。
+# Replaces ccteam-core::projects::render_project_claude_md 的 match team。
+claude_md_template: |
+  # CLAUDE.md (auto-managed by ccteam)
+  ...
 ```
 
 **校验**(`TeamSpec::validate` 在 parse 时执行):
@@ -636,6 +656,12 @@ retro_schema:
 - `golden_rules[*]` 必须 `cmd | pattern` 二选一(同 phase YAML)
 - `verdict_schema[*]` 非空
 - `critic_dimensions[*].name` 非空、唯一
+- V0.2 M0.16:`evergreen` / `cost_policy` / `claude_md_template` 都 serde-default,
+  现存 yaml 不需 migration;`evergreen=true` 团队走
+  `Orchestrator::process_meta_project`(事件循环 + 上下文重置),
+  `phase_dir` 不需存在;`cost_policy=None` 跳过 cost 阶梯;
+  `cost_policy=KillAt(threshold)` 用 yaml 阈值覆盖
+  `state.hard_kill_threshold_usd`
 
 **实现位置**:`crates/ccteam-core/src/team.rs`(`TeamSpec` / `RetroFieldSpec` /
 `RetroFieldKind` / `CriticDimensionSpec` / `CriticStrictness` /

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -636,7 +636,7 @@ retro_schema:
 # cost_policy={kind: none}。
 evergreen: false
 cost_policy:
-  kind: kill_at        # none | track | kill_at
+  kind: kill_at        # none | kill_at
   threshold_usd: ~     # KillAt(None) 回退到 state.hard_kill_threshold_usd
 
 # V0.2 M0.16 — auto-managed `<project>/CLAUDE.md` body。{slug} / {team}

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -246,9 +246,11 @@ reviewer agent 同样会是常驻角色。这类 team 的 `team.yaml` 设
 **红线**:`Orchestrator` / `process_project` / `enforce_cost_thresholds` /
 `warn_if_stalled` / `count_active_regular` 全部用 `is_evergreen(team)` 查
 TeamSpec.evergreen,**不许**回到 `state.team == META_TEAM_NAME` 字面量
-分叉(strategic doc §3 ccteam-core 红线)。`cost_policy` 三种 variant
-(`None` / `Track` / `KillAt(Option<f64>)`)的语义在
-[interfaces.md §5.5](./interfaces.md#55-teamyaml-团队配置m31--m32--m33--v02-m016) 详述。
+分叉(strategic doc §3 ccteam-core 红线)。`cost_policy` 两种 variant
+(`None` / `KillAt(Option<f64>)`)的语义在
+[interfaces.md §5.5](./interfaces.md#55-teamyaml-团队配置m31--m32--m33--v02-m016) 详述
+(PRD §6.4 草稿曾列第三个 `Track` variant 给 V0.3 watchdog,review 时删 —
+V0.3 真要 cost 追踪不杀时再定义具体行为)。
 
 `teams/meta-agent.yaml` 是首个 evergreen 范例,V0.2 起作为 shipped seed
 随 binary 发布;`Orchestrator::new` / `ccteam start` / `ccteam doctor

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -231,6 +231,29 @@ inbox
 
 orchestrator 重启时：`tmux has-session` + `kill -0 <claude_pid>` 双重校验。session 还在 → 续接；进程不在 → 走 §6.1 的"极端情况——session 必须重启"路径用 `--resume` 恢复对话历史。
 
+#### 3.2.1 Evergreen 团队(V0.2 §6.4 candidate 5)
+
+某些团队不走 phase DAG —— meta-agent 是事件循环 session,V0.3 watchdog /
+reviewer agent 同样会是常驻角色。这类 team 的 `team.yaml` 设
+`evergreen: true` + `cost_policy: {kind: none}` 后,orchestrator 会:
+
+- `process_project` 早返,转到 `process_meta_project`(inbox drain +
+  context reset,§6.9)
+- `enforce_cost_thresholds` 跳过整个 cost 阶梯
+- `warn_if_stalled` 跳过 stall 警告(idle 是常态)
+- 不计入 `MAX_CONCURRENT_PROJECTS` 配额
+
+**红线**:`Orchestrator` / `process_project` / `enforce_cost_thresholds` /
+`warn_if_stalled` / `count_active_regular` 全部用 `is_evergreen(team)` 查
+TeamSpec.evergreen,**不许**回到 `state.team == META_TEAM_NAME` 字面量
+分叉(strategic doc §3 ccteam-core 红线)。`cost_policy` 三种 variant
+(`None` / `Track` / `KillAt(Option<f64>)`)的语义在
+[interfaces.md §5.5](./interfaces.md#55-teamyaml-团队配置m31--m32--m33--v02-m016) 详述。
+
+`teams/meta-agent.yaml` 是首个 evergreen 范例,V0.2 起作为 shipped seed
+随 binary 发布;`Orchestrator::new` / `ccteam start` / `ccteam doctor
+--reset-shipped-teams` 都会把它写到 `~/.ccteam/teams/meta-agent/team.yaml`。
+
 ### 3.3 Phase Pipeline（短期对标 gstack-auto）
 
 每个 phase 是一个 markdown 文件 + YAML front matter（抄 Symphony 的 WORKFLOW.md 形态）。**完整字段定义、9 个 phase 列表、Seed verdict 输出格式 → [interfaces.md §5](./interfaces.md#5-phase-模板-schema)**。

--- a/teams/dev.yaml
+++ b/teams/dev.yaml
@@ -2,6 +2,26 @@ name: dev
 description: Software development team
 phase_dir: phases
 
+# V0.2 §6.4 candidate 2 — auto-managed `<project>/CLAUDE.md` body.
+# `{slug}` and `{team}` get substituted at bootstrap time; everything
+# else lands verbatim. Replaces the prior `match team { "dev" => ... }`
+# branch in projects::render_project_claude_md.
+claude_md_template: |
+  # CLAUDE.md (auto-managed by ccteam)
+
+  ## 项目上下文
+  - slug: {slug}
+  - team: dev
+  - 用户原始需求: 见 .ccteam/spec.md
+
+  ## 工作约定
+  - 不要交互式询问。所有决策已在 .ccteam/plan-eng.md 中。
+  - 测试不过不算完成。
+
+  ## 不做的事
+  - 不要 git push(被 hook 拦截)
+  - 不要修改 .ccteam/ 之外的元数据
+
 # dev's `golden_rules` is intentionally empty in M3.2: the existing
 # fix-loop (M0) + per-phase `golden_rules` declared inside individual
 # phase markdown already cover dev's hard quality gates. Adding stubs

--- a/teams/meta-agent.yaml
+++ b/teams/meta-agent.yaml
@@ -1,0 +1,37 @@
+name: meta-agent
+description: User-facing NL dispatcher session. Long-running event loop, no phase DAG.
+
+# V0.2 §6.4 candidate 5 — declarative replacement for the old
+# `if state.team == META_TEAM_NAME` branches in orchestrator.rs.
+# Evergreen sessions never reach a phase-DAG terminal state and are
+# dispatched through process_meta_project (inbox drain + context
+# reset) rather than the AdvancePhase / DispatchPhase loop.
+evergreen: true
+
+# Cost is the user's running tab here, not a per-project budget —
+# the soft / mid / hard ladder doesn't apply. `none` skips cost
+# tracking entirely.
+cost_policy:
+  kind: none
+
+# Phase markdown directory — declared for schema completeness even
+# though meta-agent ships no phase templates (phase set is empty).
+# load_team_runtimes treats `evergreen: true` as exempt from the
+# phase_dir-must-exist check.
+phase_dir: phases-meta-agent
+
+# Auto-managed CLAUDE.md template (M0.16.3) — body lives in
+# crates/ccteam-core/src/templates/meta_agent_role.md so the
+# meta-agent's role prompt stays the source of truth for the
+# session's CLAUDE.md. `claude_md_template` is left empty so
+# bootstrap_meta_project keeps owning the CLAUDE.md write path
+# (renders the role prompt instead of using the team's template).
+claude_md_template: ""
+
+# No retro / critic / escalate-grammar / verdict — meta-agent is a
+# session, not a phase pipeline.
+retro_schema: []
+critic_dimensions: []
+escalate_grammar_extensions: []
+golden_rules: []
+verdict_schema: []

--- a/teams/product-research.yaml
+++ b/teams/product-research.yaml
@@ -2,6 +2,28 @@ name: product-research
 description: Product research team — should we build this idea?
 phase_dir: phases-product-research
 
+# V0.2 §6.4 candidate 2 — auto-managed `<project>/CLAUDE.md` body.
+# `{slug}` and `{team}` get substituted at bootstrap time. Replaces
+# the prior `match team { "product-research" => ... }` branch in
+# projects::render_project_claude_md.
+claude_md_template: |
+  # CLAUDE.md (auto-managed by ccteam)
+
+  ## 项目上下文
+  - slug: {slug}
+  - team: product-research
+  - 用户原始需求: 见 .ccteam/spec.md
+
+  ## 工作约定
+  - 不写代码,只产研究报告。
+  - 至少 3 个独立信息源,**不要编造数据**;不确定时标 "未确认"。
+  - 决策走 outbox(`async` 模式)或 AskUserQuestion,**不要**自行假设关键事实。
+
+  ## 不做的事
+  - 不要修改 .ccteam/ 之外的元数据。
+  - 不要在 verdict 之前下定论 — 让 phase DAG 走完。
+  - 不要把 dev 的 "测试不过不算完成" 套用到本项目;研究报告的 done 是 verdict.md 写出 + rationale.md 自洽。
+
 # Phase that produces a verdict markdown (interfaces §5.3 schema).
 # `verdict.md` PASS/CONCERN/REJECT/CLARIFY drives downstream decisions.
 verdict_schema:


### PR DESCRIPTION
## Summary

Closes V0.2 PRD §6.4 candidate 5 (M0.16.1), §6.4 candidate 3 (M0.16.2), and §6.2 candidate 2 (M0.16.3). Implements `dev-plan-v0-2.md` M0.16 (anti-pattern foundation).

This is the first PR in the V0.2 series. It clears the team-name-literal red-line violations in `ccteam-core` so M0.17 (team layout), M0.20 (plugin pipeline) and M0.22 (team factory) can build cleanly on a foundation that no longer hardcodes team names in branches.

### M0.16.1 — TeamSpec evergreen + cost_policy flags
- Adds `evergreen: bool`, `cost_policy: CostPolicy {None | Track | KillAt(Option<f64>)}`, `claude_md_template: String` (all serde-default) to `TeamSpec`
- Replaces six \`if state.team == META_TEAM_NAME\` branches in \`orchestrator.rs\` with \`is_evergreen(team)\` / \`cost_policy(team)\` lookups (lines 553/612/1147/1239/1303/1378 + the 1034 debug_assert)
- Ships \`teams/meta-agent.yaml\` (\`evergreen: true\`, \`cost_policy: {kind: none}\`) as a seed bundle so the new flag is loadable at orchestrator startup

### M0.16.2 — TEAM_BUNDLES → seed-only (not registry)
- \`TEAM_BUNDLES\` / \`team_bundle()\` / \`TeamTemplateBundle\` drop from public API to \`pub(crate)\` — they remain the in-binary seed source for \`write_all_global_team_templates\` only. Runtime team lookups walk \`~/.ccteam/teams/<name>/team.yaml\`.
- \`memory_bridge::TEAMS\` const replaced with \`discover_bridge_teams(global_dir)\` that scans disk for teams with non-empty \`retro_schema\`. Generic fallback template covers user-authored teams.
- New \`ccteam doctor --reset-shipped-teams [--force]\` flag re-stamps shipped seeds (force=false preserves operator hand-edits).
- \`ccteam new\` and \`ccteam start\` self-heal seeds defensively so a fresh install no longer requires explicit \`ccteam init\`.

### M0.16.3 — render_project_claude_md template-ize
- \`teams/dev.yaml\` and \`teams/product-research.yaml\` gain \`claude_md_template:\` body content
- \`projects::render_project_claude_md\` deletes the \`match team\` branches; reads template from the parsed team.yaml and substitutes \`{slug}\` / \`{team}\` placeholders. Generic body fallback for unknown teams.

## ⚠ Open question for review

**CostPolicy enum** has 3 variants per PRD §6.4 (\`None\` / \`Track\` / \`KillAt(Option<f64>)\`). M0.16 only exercises \`None\` (meta-agent) and \`KillAt\` (dev / product-research). \`Track\` is reserved for V0.3 watchdog-style teams that want to log cost without a hard kill. If the team prefers fewer variants now, drop \`Track\` — it's easy to re-add when V0.3 lands.

## Tests

- 369 baseline → **384 passing (+15 new)**, 0 failures.
- Clippy unchanged (10 pre-existing warnings, 0 new).
- Coverage:
  - \`team.rs\`: 6 new tests for evergreen / cost_policy round-trips / claude_md_template defaults
  - \`memory_bridge.rs\`: 2 new tests for the disk-scan path (skip empty \`retro_schema\`, pick up user-authored team)
  - \`projects.rs\`: 4 new tests for \`render_project_claude_md\` template substitution + generic fallback
  - \`commands.rs\`: 3 new tests for \`--reset-shipped-teams\` + \`run_new\` self-heal
- Added \`env_lock()\` Mutex to serialize \`CLAUDE_CONFIG_HOME\`-mutating tests in \`commands::tests\` (M0.16.2 widened the timing window for a pre-existing flake)

## Red-line check (CLAUDE.md §三)

- \`grep -rE '\"(dev|product-research|meta-agent)\"' crates/ccteam-core/src/\` → only legit hits (META_TEAM_NAME const owner, TEAM_BUNDLES seed entries, state.json serde default, tests, doc comments)
- \`grep -rn 'state\\.team == META_TEAM_NAME' crates/ccteam-core/src/\` → **0 hits** (replaced with \`is_evergreen\` + \`cost_policy\` lookups)
- \`grep -rn 'match team {' crates/ccteam-core/src/projects.rs\` → **0 hits**
- 5+ META_TEAM_NAME branches identified in PRD §6.4 candidate 5: all replaced

## Documentation synced (per dev-plan §12 matrix)

- [x] \`docs/interfaces.md §5.5\` — team.yaml schema gains \`evergreen\` / \`cost_policy\` / \`claude_md_template\`
- [x] \`docs/tech-design.md §3.2.1\` — new "Evergreen 团队" subsection documents \`is_evergreen\` / \`cost_policy\` dispatch
- [x] \`docs/dev-coupling-audit.md\` — V0.2 §6 candidate status table; candidates 2/3/5 marked closed (2026-05-07)

## Test plan

- [x] Run \`cargo test --workspace\` — 384 passing
- [x] Run \`cargo clippy --workspace --all-targets\` — no new warnings
- [x] Verify \`grep -rn 'state.team == META_TEAM_NAME' crates/ccteam-core/src/\` returns 0
- [x] Verify \`grep -rn 'match team {' crates/ccteam-core/src/projects.rs\` returns 0
- [x] Manually verify \`teams/meta-agent.yaml\` parses as a TeamSpec with evergreen=true
- [ ] Reviewer: confirm the 3-variant CostPolicy enum is the right choice (vs. 2 variants — drop Track until V0.3 needs it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)