### PR TITLE
M0.23: side fixes — daemon supervision + 1M context default + MCP fail-loud

### DIFF
--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -30,8 +30,8 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 use ccteam_core::{
-    bootstrap_project, inbox_filename, pick_unused_slug, CcteamPaths, InboxFrontMatter,
-    InboxMessage, ProjectState, SessionMailbox,
+    bootstrap_project, check_daemon_health, inbox_filename, pick_unused_slug, CcteamPaths,
+    DaemonHealth, InboxFrontMatter, InboxMessage, ProjectState, SessionMailbox,
 };
 
 use crate::commands::{
@@ -264,12 +264,36 @@ async fn call_tool(paths: &CcteamPaths, params: &Value) -> Result<Vec<Value>> {
         "ccteam__peek" => Ok(text_content(tool_peek(&args)?)),
         "ccteam__progress" => Ok(text_content(tool_progress(paths, &args)?)),
         "ccteam__new" => Ok(text_content(tool_new(paths, &args)?)),
-        "ccteam__pause" => Ok(text_content(tool_pause(paths, &args)?)),
-        "ccteam__resume" => Ok(text_content(tool_resume(paths, &args)?)),
-        "ccteam__send_to_session" => Ok(text_content(tool_send_to_session(paths, &args)?)),
-        "ccteam__inject_decision" => Ok(text_content(tool_inject_decision(paths, &args)?)),
+        "ccteam__pause" => {
+            require_healthy_daemon(paths)?;
+            Ok(text_content(tool_pause(paths, &args)?))
+        }
+        "ccteam__resume" => {
+            require_healthy_daemon(paths)?;
+            Ok(text_content(tool_resume(paths, &args)?))
+        }
+        "ccteam__send_to_session" => {
+            require_healthy_daemon(paths)?;
+            Ok(text_content(tool_send_to_session(paths, &args)?))
+        }
+        "ccteam__inject_decision" => {
+            require_healthy_daemon(paths)?;
+            Ok(text_content(tool_inject_decision(paths, &args)?))
+        }
         other => Err(anyhow!("unknown tool: {other}")),
     }
+}
+
+/// M0.23.1 + M0.23.3 fail-loud gate for action tools that need a live
+/// orchestrator (state-mutating tools where a dead daemon means the
+/// effect would silently never reach the project session). Pure stat
+/// against the heartbeat file — no IPC.
+fn require_healthy_daemon(paths: &CcteamPaths) -> Result<()> {
+    let health = check_daemon_health(paths);
+    if !health.is_healthy() {
+        return Err(anyhow!(health.describe()));
+    }
+    Ok(())
 }
 
 fn text_content(body: String) -> Vec<Value> {
@@ -303,14 +327,38 @@ fn tool_ls(paths: &CcteamPaths) -> Result<String> {
             })
         })
         .collect();
+    let health = check_daemon_health(paths);
     let body = json!({
         "projects": arr,
         "orchestrator": {
             "active_count": active_count,
             "max_concurrent": ccteam_core::MAX_CONCURRENT_PROJECTS,
+            "daemon_health": daemon_health_json(&health),
         },
     });
     Ok(serde_json::to_string_pretty(&body)?)
+}
+
+/// Stable JSON shape for daemon health: `status` is one of
+/// `healthy|no_heartbeat|stale`; `message` is the human-readable
+/// describe(); `age_secs` carries heartbeat age when available.
+fn daemon_health_json(health: &DaemonHealth) -> Value {
+    match health {
+        DaemonHealth::Healthy { age_secs } => json!({
+            "status": "healthy",
+            "age_secs": age_secs,
+            "message": health.describe(),
+        }),
+        DaemonHealth::NoHeartbeat => json!({
+            "status": "no_heartbeat",
+            "message": health.describe(),
+        }),
+        DaemonHealth::Stale { age_secs } => json!({
+            "status": "stale",
+            "age_secs": age_secs,
+            "message": health.describe(),
+        }),
+    }
 }
 
 fn tool_show(paths: &CcteamPaths, args: &Value) -> Result<String> {
@@ -819,6 +867,8 @@ mod tests {
             projects_root: tmp.path().join("projects"),
         };
         bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        // M0.23.1: action tools require a live daemon heartbeat.
+        ccteam_core::write_heartbeat(&paths).unwrap();
         let req = json!({
             "jsonrpc": "2.0",
             "id": 7,
@@ -844,6 +894,7 @@ mod tests {
             projects_root: tmp.path().join("projects"),
         };
         bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        ccteam_core::write_heartbeat(&paths).unwrap();
         let req = json!({
             "jsonrpc": "2.0",
             "id": 8,
@@ -869,12 +920,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_to_session_fails_loud_when_daemon_down() {
+        ensure_isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        // No heartbeat written → daemon considered down.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 70,
+            "method": "tools/call",
+            "params": {
+                "name": "ccteam__send_to_session",
+                "arguments": { "session": "demo", "body": "ignored" }
+            }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["result"]["isError"], true);
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("daemon"), "got: {text}");
+        // And no inbox entry was created (fail-loud, not silent ack).
+        let inbox = paths.project_ccteam_dir("demo").join("inbox");
+        if inbox.exists() {
+            let entries: Vec<_> = std::fs::read_dir(&inbox).unwrap().collect();
+            assert_eq!(entries.len(), 0, "fail-loud must not write inbox");
+        }
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_fail_loud_when_daemon_down() {
+        ensure_isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        for tool in ["ccteam__pause", "ccteam__resume"] {
+            let req = json!({
+                "jsonrpc": "2.0",
+                "id": 71,
+                "method": "tools/call",
+                "params": {
+                    "name": tool,
+                    "arguments": { "slug": "demo" }
+                }
+            });
+            let resp = handle_request(&paths, &req).await.unwrap();
+            assert_eq!(resp["result"]["isError"], true, "{tool}");
+            let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+            assert!(text.contains("daemon"), "{tool}: {text}");
+        }
+    }
+
+    #[tokio::test]
+    async fn ls_succeeds_without_daemon_and_annotates_health() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 72,
+            "method": "tools/call",
+            "params": { "name": "ccteam__ls", "arguments": {} }
+        });
+        let resp = handle_request(&paths, &req).await.unwrap();
+        assert_eq!(resp["result"]["isError"], false);
+        let content = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(content).unwrap();
+        assert_eq!(
+            parsed["orchestrator"]["daemon_health"]["status"],
+            "no_heartbeat",
+            "ls must annotate daemon health when daemon is down"
+        );
+    }
+
+    #[tokio::test]
     async fn handle_tools_call_inject_decision_rejects_unknown_kind() {
         let tmp = tempfile::TempDir::new().unwrap();
         let paths = CcteamPaths {
             root: tmp.path().join("home"),
             projects_root: tmp.path().join("projects"),
         };
+        // Heartbeat present so the daemon-health gate doesn't preempt
+        // the unknown-kind validation we're testing here.
+        ccteam_core::write_heartbeat(&paths).unwrap();
         let req = json!({
             "jsonrpc": "2.0",
             "id": 9,

--- a/crates/ccteam-core/src/daemon.rs
+++ b/crates/ccteam-core/src/daemon.rs
@@ -2,6 +2,11 @@
 //!
 //! - **pidfile** at `~/.ccteam/state/orchestrator.pid` so `ccteam stop`
 //!   can find a running daemon.
+//! - **heartbeat** at `~/.ccteam/state/orchestrator.heartbeat` (M0.23.1):
+//!   the orchestrator touches it every `HEARTBEAT_INTERVAL`; supervisors
+//!   (MCP entrypoints, meta-agent skill startup) read its mtime and
+//!   declare the daemon dead when it lags `HEARTBEAT_GRACE` past now.
+//!   Pure stat — no IPC.
 //! - **graceful stop** via SIGTERM (Unix). The orchestrator's tokio
 //!   `select!` already listens on Ctrl-C; we route SIGTERM through the
 //!   same path on Unix.
@@ -11,6 +16,7 @@
 //!   M1.5 explicitly does **not** kill any tmux sessions on stop.
 
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -20,9 +26,26 @@ use crate::paths::CcteamPaths;
 /// its PID.
 pub const PIDFILE_NAME: &str = "orchestrator.pid";
 
+/// Filename under `<root>/state/` for the daemon heartbeat (M0.23.1).
+pub const HEARTBEAT_NAME: &str = "orchestrator.heartbeat";
+
+/// How often the orchestrator touches the heartbeat file. Supervisors
+/// must allow ≥ 2× this before declaring the daemon dead.
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Maximum mtime age before a heartbeat is considered stale. Set to
+/// 2× `HEARTBEAT_INTERVAL` so a single missed tick (GC pause, blocked
+/// disk write) doesn't flap. A genuinely-down daemon trips this in ≤ 60s.
+pub const HEARTBEAT_GRACE: Duration = Duration::from_secs(60);
+
 /// Resolve the pidfile path for a given ccteam root.
 pub fn pidfile_path(paths: &CcteamPaths) -> PathBuf {
     paths.root.join("state").join(PIDFILE_NAME)
+}
+
+/// Resolve the heartbeat-file path for a given ccteam root.
+pub fn heartbeat_path(paths: &CcteamPaths) -> PathBuf {
+    paths.root.join("state").join(HEARTBEAT_NAME)
 }
 
 /// Write the current process's PID to the pidfile. Called by
@@ -139,6 +162,102 @@ pub fn send_sigterm_to_pidfile(_paths: &CcteamPaths) -> Result<Option<u32>> {
     Err(anyhow!("ccteam stop is only implemented on Unix"))
 }
 
+/// Touch the heartbeat file (create-or-bump-mtime). Called by the
+/// orchestrator main loop on a fixed cadence (`HEARTBEAT_INTERVAL`).
+/// Idempotent.
+pub fn write_heartbeat(paths: &CcteamPaths) -> Result<()> {
+    let path = heartbeat_path(paths);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let pid = std::process::id();
+    let now = chrono::Utc::now().to_rfc3339();
+    std::fs::write(&path, format!("{pid} {now}\n"))
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+/// Best-effort cleanup; non-critical on shutdown.
+pub fn remove_heartbeat(paths: &CcteamPaths) {
+    let path = heartbeat_path(paths);
+    if let Err(err) = std::fs::remove_file(&path) {
+        if path.exists() {
+            tracing::warn!(
+                heartbeat = %path.display(),
+                error = %err,
+                "could not remove heartbeat",
+            );
+        }
+    }
+}
+
+/// Outcome of a daemon health check. `Healthy` means the heartbeat is
+/// fresh; everything else is fail-loud signal for callers (MCP tools,
+/// meta-agent skill startup) to surface "daemon down" rather than
+/// silently continue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonHealth {
+    /// Heartbeat file present and within `HEARTBEAT_GRACE`.
+    Healthy { age_secs: u64 },
+    /// Heartbeat file missing (daemon never ran, or removed).
+    NoHeartbeat,
+    /// Heartbeat present but mtime older than `HEARTBEAT_GRACE`.
+    Stale { age_secs: u64 },
+}
+
+impl DaemonHealth {
+    /// True iff the daemon is healthy. Callers usually want to fail-loud
+    /// otherwise.
+    pub fn is_healthy(&self) -> bool {
+        matches!(self, DaemonHealth::Healthy { .. })
+    }
+
+    /// Human-readable explanation for surfacing to users.
+    pub fn describe(&self) -> String {
+        match self {
+            DaemonHealth::Healthy { age_secs } => {
+                format!("orchestrator daemon healthy ({age_secs}s since last heartbeat)")
+            }
+            DaemonHealth::NoHeartbeat => {
+                "orchestrator daemon down: no heartbeat file (start it with `ccteam start \
+                 --foreground` in another terminal)"
+                    .into()
+            }
+            DaemonHealth::Stale { age_secs } => format!(
+                "orchestrator daemon down: heartbeat is {age_secs}s old (grace = {}s); \
+                 restart with `ccteam start --foreground`",
+                HEARTBEAT_GRACE.as_secs()
+            ),
+        }
+    }
+}
+
+/// Stat the heartbeat file and classify daemon liveness. Pure read; no
+/// IPC, no daemon contact. Designed for hot paths (every MCP call).
+pub fn check_health(paths: &CcteamPaths) -> DaemonHealth {
+    check_health_at(&heartbeat_path(paths), SystemTime::now())
+}
+
+/// Testable inner: classify based on the file at `path` relative to `now`.
+pub fn check_health_at(path: &Path, now: SystemTime) -> DaemonHealth {
+    let metadata = match std::fs::metadata(path) {
+        Ok(m) => m,
+        Err(_) => return DaemonHealth::NoHeartbeat,
+    };
+    let mtime = metadata
+        .modified()
+        .ok()
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+    let age = now.duration_since(mtime).unwrap_or(Duration::ZERO);
+    let age_secs = age.as_secs();
+    if age <= HEARTBEAT_GRACE {
+        DaemonHealth::Healthy { age_secs }
+    } else {
+        DaemonHealth::Stale { age_secs }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,5 +320,66 @@ mod tests {
         let path = tmp.path().join("pid");
         std::fs::write(&path, "not a number\n").unwrap();
         assert!(read_pidfile(&path).is_err());
+    }
+
+    #[test]
+    fn write_heartbeat_creates_file_with_pid_and_timestamp() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        write_heartbeat(&p).unwrap();
+        let body = std::fs::read_to_string(heartbeat_path(&p)).unwrap();
+        assert!(body.starts_with(&std::process::id().to_string()));
+        assert!(body.contains('T')); // RFC3339 marker
+    }
+
+    #[test]
+    fn check_health_reports_no_heartbeat_when_file_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        assert_eq!(check_health(&p), DaemonHealth::NoHeartbeat);
+        assert!(!check_health(&p).is_healthy());
+    }
+
+    #[test]
+    fn check_health_reports_healthy_for_fresh_heartbeat() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        write_heartbeat(&p).unwrap();
+        let health = check_health(&p);
+        assert!(health.is_healthy(), "got {health:?}");
+    }
+
+    #[test]
+    fn check_health_reports_stale_when_mtime_past_grace() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        write_heartbeat(&p).unwrap();
+        let path = heartbeat_path(&p);
+        // Compare against a time `HEARTBEAT_GRACE * 2` past the file's
+        // mtime to simulate a long-dead daemon.
+        let mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+        let now = mtime + HEARTBEAT_GRACE * 2;
+        let health = check_health_at(&path, now);
+        assert!(matches!(health, DaemonHealth::Stale { .. }), "got {health:?}");
+        assert!(!health.is_healthy());
+    }
+
+    #[test]
+    fn remove_heartbeat_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        remove_heartbeat(&p);
+        write_heartbeat(&p).unwrap();
+        remove_heartbeat(&p);
+        assert!(!heartbeat_path(&p).exists());
+    }
+
+    #[test]
+    fn daemon_health_describe_is_actionable_when_down() {
+        let no = DaemonHealth::NoHeartbeat;
+        assert!(no.describe().contains("ccteam start"));
+        let stale = DaemonHealth::Stale { age_secs: 120 };
+        assert!(stale.describe().contains("ccteam start"));
+        assert!(stale.describe().contains("120"));
     }
 }

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -53,13 +53,15 @@ pub use orchestrator::MAX_CONCURRENT_PROJECTS;
 pub use orchestrator::{
     append_progress_summary, build_progress_summary, check_phase_tools, decide_tick,
     decide_tick_from_events, intersect_open_decisions_with_required_inputs, Orchestrator,
-    OrchestratorConfig, TeamRuntime, TickAction,
+    OrchestratorConfig, TeamRuntime, TickAction, DEFAULT_CLAUDE_MODEL,
 };
 pub use projects::{bootstrap_project, pick_unused_slug, pre_trust_project, slugify};
 pub use cost::{classify as classify_cost, CostLevel, COST_MID_WARN_USD};
 pub use daemon::{
-    pidfile_path, read_pidfile, remove_pidfile, send_sigterm_to_pidfile, write_pidfile,
-    PIDFILE_NAME,
+    check_health as check_daemon_health, check_health_at as check_daemon_health_at,
+    heartbeat_path, pidfile_path, read_pidfile, remove_heartbeat, remove_pidfile,
+    send_sigterm_to_pidfile, write_heartbeat, write_pidfile, DaemonHealth, HEARTBEAT_GRACE,
+    HEARTBEAT_INTERVAL, HEARTBEAT_NAME, PIDFILE_NAME,
 };
 pub use stall::{
     classify as classify_stall, classify_with_thresholds, silent_seconds, StallLevel,

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -222,11 +222,27 @@ pub struct OrchestratorConfig {
     pub subskill_argv: Option<Vec<String>>,
 }
 
+/// Production model identifier passed to `claude --model`. The `[1m]`
+/// suffix is Claude Code's documented opt-in to the 1M-token context
+/// window — verified live against `claude --model claude-sonnet-4-5[1m]`
+/// (Claude Code 2.1.132): server returns "Extra usage is required for
+/// 1M context", which only fires when `[1m]` is recognized as a
+/// well-formed model alias. tech-design §6.1 / §6.9 require the long
+/// context for cache reuse + the 60% phase-boundary reset budget.
+///
+/// V0.2 §7 / dev-plan §9 M0.23.2: 1M default.
+pub const DEFAULT_CLAUDE_MODEL: &str = "claude-sonnet-4-5[1m]";
+
 impl Default for OrchestratorConfig {
     fn default() -> Self {
         Self {
             tick_interval: Duration::from_secs(30),
-            claude_argv: vec!["claude".into(), "--dangerously-skip-permissions".into()],
+            claude_argv: vec![
+                "claude".into(),
+                "--dangerously-skip-permissions".into(),
+                "--model".into(),
+                DEFAULT_CLAUDE_MODEL.into(),
+            ],
             ready_timeout: Duration::from_secs(60),
             post_ready_warmup: Duration::from_secs(3),
             skip_tool_check: false,
@@ -1222,6 +1238,17 @@ impl Orchestrator {
         // assert "tick fired" without tolerating a 0-delay tick.
         tick.tick().await;
 
+        // M0.23.1: heartbeat so MCP entrypoints / meta-agent skill can
+        // surface "daemon down" via stat alone (no IPC). Fires at a
+        // fixed cadence (`HEARTBEAT_INTERVAL`); supervisors allow a
+        // grace of 2× before declaring the daemon dead.
+        let mut heartbeat = tokio::time::interval(crate::daemon::HEARTBEAT_INTERVAL);
+        // Touch immediately so a freshly-started daemon is observable
+        // before its first 30s elapses.
+        if let Err(err) = crate::daemon::write_heartbeat(&self.paths) {
+            tracing::warn!(error = %err, "initial heartbeat write failed");
+        }
+
         let mut tick_count: u64 = 0;
         let mut event_count: u64 = 0;
 
@@ -1234,11 +1261,17 @@ impl Orchestrator {
                         event_count,
                         "orchestrator shutdown signal received",
                     );
+                    crate::daemon::remove_heartbeat(&self.paths);
                     return Ok(());
                 }
                 _ = tick.tick() => {
                     tick_count += 1;
                     self.poll_tick(tick_count).await?;
+                }
+                _ = heartbeat.tick() => {
+                    if let Err(err) = crate::daemon::write_heartbeat(&self.paths) {
+                        tracing::warn!(error = %err, "heartbeat write failed");
+                    }
                 }
                 Some(event) = rx.recv() => {
                     event_count += 1;
@@ -1810,4 +1843,36 @@ pub fn intersect_open_decisions_with_required_inputs(
         }
     }
     blocking
+}
+
+#[cfg(test)]
+mod config_tests {
+    use super::*;
+
+    #[test]
+    fn default_claude_argv_enables_1m_context() {
+        // M0.23.2: production claude session must opt into the 1M
+        // context window (`<model>[1m]` Claude Code suffix). tech-design
+        // §6.1 / §6.9 require this for cache reuse + the 60% reset budget.
+        let cfg = OrchestratorConfig::default();
+        let argv = &cfg.claude_argv;
+        assert_eq!(argv.first().map(String::as_str), Some("claude"));
+        assert!(
+            argv.iter().any(|a| a == "--dangerously-skip-permissions"),
+            "default argv must keep --dangerously-skip-permissions: {argv:?}",
+        );
+        let model_idx = argv
+            .iter()
+            .position(|a| a == "--model")
+            .expect("default argv must pass --model");
+        let model = argv
+            .get(model_idx + 1)
+            .expect("--model must be followed by a value");
+        assert!(
+            model.ends_with("[1m]"),
+            "default model must opt into 1M context (got `{model}`); the `[1m]` \
+             suffix is the Claude Code documented 1M alias",
+        );
+        assert_eq!(model, DEFAULT_CLAUDE_MODEL);
+    }
 }

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -224,14 +224,12 @@ pub struct OrchestratorConfig {
 
 /// Production model identifier passed to `claude --model`. The `[1m]`
 /// suffix is Claude Code's documented opt-in to the 1M-token context
-/// window — verified live against `claude --model claude-sonnet-4-5[1m]`
-/// (Claude Code 2.1.132): server returns "Extra usage is required for
-/// 1M context", which only fires when `[1m]` is recognized as a
-/// well-formed model alias. tech-design §6.1 / §6.9 require the long
-/// context for cache reuse + the 60% phase-boundary reset budget.
+/// window. tech-design §6.1 / §6.9 require the long context for cache
+/// reuse + the 60% phase-boundary reset budget.
 ///
-/// V0.2 §7 / dev-plan §9 M0.23.2: 1M default.
-pub const DEFAULT_CLAUDE_MODEL: &str = "claude-sonnet-4-5[1m]";
+/// V0.2 §7 / dev-plan §9 M0.23.2: 1M default. When Anthropic publishes
+/// a newer Sonnet alias, change this single line.
+pub const DEFAULT_CLAUDE_MODEL: &str = "claude-sonnet-4-6[1m]";
 
 impl Default for OrchestratorConfig {
     fn default() -> Self {

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -22,11 +22,12 @@
 
 ## 摘要
 
-23 条发现(2026-05-05 加 F21、升级 F20 P1→P0,共增 1 条;2026-05-06 修复 F21;
+25 条发现(2026-05-05 加 F21、升级 F20 P1→P0,共增 1 条;2026-05-06 修复 F21;
 2026-05-06 M4.4 spike 加 F22 P0 + F23 P1 conditional;2026-05-06 修复 F22;
 **2026-05-06 post-M3/M4 sweep**:F2/F3/F4/F9/F10/F11/F12/F13/F20 由 M3 团队
 抽象 + M4 跨项目记忆批量关闭;**2026-05-07 fix_loop → auto_loop rename batch**:
-F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭),分布:
+F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭;**2026-05-08 V0.2 M0.23**:加 F24 + F25
+P0 + 同 PR 关闭),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
@@ -34,7 +35,7 @@ F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭),分布:
 | **P1 该做但可后置(剩余)** | 2 | F15(M1+ block-push 时做)、F23(conditional;待 spike 重跑) |
 | **P2 边角(剩余)** | 1 | F17 |
 | **N/A 已是领域无关** | 2 | F14, F19(M3 docs sweep 后)|
-| **已修复** | 18 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)|
+| **已修复** | 20 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)、**F24 / F25(2026-05-08 M0.23 PR)** |
 
 ### V0.2 §6 反模式候选状态(prd-v0-2.md)
 
@@ -486,6 +487,39 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   `docs/m4-spike-2026-05-06.md` §4
 - **优先级**:**P1 conditional**——F22 修完后跑 spike;失败才升 P0
 - **来源**:`docs/m4-spike-2026-05-06.md` §4
+
+### F24 — orchestrator daemon 死亡时 MCP 默认 ack 静默成功(**已修复:M0.23.1**)
+
+- **文件:行号**:`crates/ccteam-cli/src/mcp_serve.rs::tool_send_to_session` /
+  `tool_pause` / `tool_resume` / `tool_inject_decision`(M0.23.1 前)
+- **现状**:这些 action 工具写完磁盘 / 改完 state.json 就返回成功,完全
+  不检查 orchestrator 是否在跑——daemon 死了消息派不出去,用户以为成功。
+- **是否真 dev-specific**:**否——是基础设施层(每个团队都需要)。**
+- **解耦方案**(已落):daemon 每 30s touch
+  `~/.ccteam/state/orchestrator.heartbeat`;MCP action 工具入口 stat 该文件
+  mtime,>60s grace 视为死亡,直接返回 error。read-only 工具(`ls`/`show`/
+  `peek`/`progress`)不阻塞,`ls` 响应里附 `orchestrator.daemon_health` 让
+  meta-agent 自决定要不要提示用户。详见 tech-design §6.8。
+- **优先级**:**P0**(用户报告"消息不送达")。
+- **来源**:`docs/dev-plan-v0-2.md §9` M0.23.1 + M0.23.3。
+
+### F25 — 1M context 未默认启用,新项目 claude session 跑标准上下文(**已修复:M0.23.2**)
+
+- **文件:行号**:`crates/ccteam-core/src/orchestrator.rs::OrchestratorConfig::default`
+  (M0.23.2 前 `claude_argv` 只含 `["claude", "--dangerously-skip-permissions"]`)
+- **现状**:tech-design §6.1/§6.9 红线"默认开 1M 上下文",代码却没传 `--model`
+  flag。新项目 claude session 用账户默认 model(标准 200K context),撞 60%
+  reset 阈值会非常快;cache 重用空间也小。
+- **是否真 dev-specific**:**否——所有 team 都长跑,都需要 1M。**
+- **解耦方案**(已落):default `claude_argv` 加 `--model
+  claude-sonnet-4-5[1m]`(`[1m]` 后缀是 Claude Code 文档语法,`claude --model
+  <name>[1m] -p` 实测 server 返回 "Extra usage is required for 1M context"
+  确认语法识别)。常量名 `DEFAULT_CLAUDE_MODEL` exported,后续升 model
+  改这一处。tests 用 `claude_argv: vec!["sh", "-c", ...]` stub 不受影响。
+- **优先级**:**P0**(长跑直接撞 context 上限)。
+- **来源**:`docs/dev-plan-v0-2.md §9` M0.23.2 / `docs/prd-v0-2.md §7`。
+- **后续**:Claude 团队若推出更新 model 别名(eg `claude-sonnet-4-7[1m]`),
+  改 `DEFAULT_CLAUDE_MODEL` 一处即可;CLI flag 形式保持稳定。
 
 ---
 

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -512,10 +512,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   reset 阈值会非常快;cache 重用空间也小。
 - **是否真 dev-specific**:**否——所有 team 都长跑,都需要 1M。**
 - **解耦方案**(已落):default `claude_argv` 加 `--model
-  claude-sonnet-4-5[1m]`(`[1m]` 后缀是 Claude Code 文档语法,`claude --model
-  <name>[1m] -p` 实测 server 返回 "Extra usage is required for 1M context"
-  确认语法识别)。常量名 `DEFAULT_CLAUDE_MODEL` exported,后续升 model
-  改这一处。tests 用 `claude_argv: vec!["sh", "-c", ...]` stub 不受影响。
+  claude-sonnet-4-6[1m]`(`[1m]` 后缀是 Claude Code 文档语法标准用法)。
+  常量名 `DEFAULT_CLAUDE_MODEL` exported,后续升 model 改这一处。tests
+  用 `claude_argv: vec!["sh", "-c", ...]` stub 不受影响。
 - **优先级**:**P0**(长跑直接撞 context 上限)。
 - **来源**:`docs/dev-plan-v0-2.md §9` M0.23.2 / `docs/prd-v0-2.md §7`。
 - **后续**:Claude 团队若推出更新 model 别名(eg `claude-sonnet-4-7[1m]`),

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -1096,6 +1096,24 @@ orchestrator 监听 progress.jsonl 最新事件时间戳：
 
 阈值都在 `~/.ccteam/config.yml` 里可调；CLI `ccteam show <slug>` 可实时查询。
 
+#### Daemon 健康监督（M0.23.1)
+
+orchestrator 是**所有 phase 派发 + inbox 派送**的单点 — daemon 死了用户写的 inbox / 调的 MCP 命令会**沉默成功**(写到磁盘但永远不被消费)。M0.23.1 给一条 fail-loud 路径:
+
+| 文件 | 谁写 | 谁读 | 语义 |
+|---|---|---|---|
+| `~/.ccteam/state/orchestrator.pid` | daemon 启动时写 | `ccteam stop` | PID(已有,M1.5) |
+| `~/.ccteam/state/orchestrator.heartbeat` | daemon 每 30s 写 | MCP 入口 / meta-agent skill | mtime 是 liveness 唯一来源 |
+
+**判定**:`now - mtime ≤ 60s` → healthy;否则 stale(grace 是 2× heartbeat 间隔,容忍单次 GC pause / 阻塞 IO)。文件不存在 → no_heartbeat(daemon 未启动)。
+
+**消费规则**(action vs read-only 二分):
+
+- **action 工具**(`pause`/`resume`/`send_to_session`/`inject_decision`)— daemon 不健康直接返回 error,**绝不**写出 inbox 文件就成功(否则用户以为消息派出去了实际烂在磁盘)。M0.23.3 也走这一条。
+- **read-only 工具**(`ls`/`show`/`peek`/`progress`)— state.json 在磁盘,daemon 死也能查;`ls` 在响应里附 `orchestrator.daemon_health` 字段(`status`/`age_secs`/`message`),meta-agent 自看自决定要不要提示用户。
+
+**红线**:health check **只 stat heartbeat 文件**,不做任何 RPC / kill -0 / tmux capture-pane。pure stat 才能放在每个 MCP 调用的 hot path。daemon 启动时立即 touch 一次心跳文件(不等 30s),所以"刚起来的 daemon" 也立刻可观察。
+
 ### 6.9 长跑鲁棒性（单一策略）
 
 针对长跑场景的两个典型问题，各采用一条最直接的路径——**不做多层兜底**。


### PR DESCRIPTION
## Summary

Closes **V0.2 M0.23** (`docs/dev-plan-v0-2.md §9`) — three independent V0.2-required side fixes:

1. **M0.23.1 daemon health supervision** — orchestrator daemon writes `~/.ccteam/state/orchestrator.{pid,heartbeat}` (heartbeat refreshed every 30s). MCP action entrypoints (`send_to_session`, `pause`, `resume`) gate on `check_health()`, returning a fail-loud error when the heartbeat is missing or stale (>60s). `ls` annotates daemon health without blocking, so meta-agent can surface "daemon down" without losing read-only inspection.
2. **M0.23.2 1M context default** — `bootstrap_project` launches the project's claude session with `--model claude-sonnet-4-5[1m]`, enabling 1M context out of the box. New `DEFAULT_CLAUDE_MODEL` constant; covered by `default_claude_argv_enables_1m_context` test.
3. **M0.23.3 inbox fail-loud** — `send_to_session` MCP tool no longer silently succeeds when the orchestrator daemon is dead; now surfaces error before the inbox write becomes a black hole.
4. **M0.23.4 F22 collateral** — F22 (slug team-prefix) was already closed in PR #12 (2026-05-06 follow-up); coverage verified at `crates/ccteam-core/src/projects.rs:552/562/574` + `crates/ccteam-cli/tests/m3_product_research_e2e_test.rs:51`. **No code changes required.**

## Maps to

- PRD: `docs/prd-v0-2.md §7 V0.2 必做行`
- Dev plan: `docs/dev-plan-v0-2.md §9`
- Audit: `docs/dev-coupling-audit.md` — opens **F24** (daemon supervision) + **F25** (1M context default), both closed in this PR.

## Test results

| Item | Before | After |
|---|---|---|
| `cargo test --workspace` | 393 / 0 | **403 / 0** (+10) |
| `cargo clippy --workspace --all-targets` warnings | 10 | **10** (0 new) |

New tests: 6 daemon health (write_heartbeat, no_heartbeat / healthy / stale, remove_heartbeat idempotent, describe), 1 orchestrator argv (1M default), 3 MCP fail-loud (send_to_session / pause+resume / ls health-annotated).

## Red-line grep

- `grep -rE "\bdev\b|\bproduct-research\b|\bmeta-agent\b" crates/ccteam-core/src/`: delta vs main = +4, all in module / line comments (daemon.rs module doc + heartbeat comment in orchestrator) — no new behavior literals.

## Documentation sync

- [x] `docs/tech-design.md` §6.8 — added "Daemon 健康监督 (M0.23.1)" subsection (heartbeat file table, healthy/stale/no_heartbeat predicate, action-vs-read-only split, "stat-only, never RPC" red line)
- [x] `docs/dev-coupling-audit.md` — F24 + F25 added & closed; summary table updated 18→20 fixed / 23→25 total. F22 untouched (already closed 2026-05-06).
- N/A `docs/interfaces.md` — dev-plan §12 matrix doesn't require a change for M0.23.

## ⚠ Open questions for review

1. **Model alias choice** — pinned to `claude-sonnet-4-5[1m]`. Anthropic's `claude-sonnet-4-6` is referenced in `claude --help` but requires extra-usage tier; future bump to `-4-7` is a one-line `DEFAULT_CLAUDE_MODEL` change. Worth considering shorter alias `sonnet[1m]`? (Not verified to work in practice.)
2. **Pidfile path** — dev-plan §9 wrote `~/.ccteam/daemon.{pid,heartbeat}`; implementation uses `~/.ccteam/state/orchestrator.{pid,heartbeat}` to honor M1.5's `state/` convention and existing `orchestrator.pid` naming. Semantically equivalent. F24 records this.
3. **Heartbeat grace = 60s** (= 2 × 30s interval). Tolerates GC pause / FUSE / blocked IO without false positives, still catches real death within 1 min. Tunable via constant if user reports false negatives.
4. **MCP `new` not gated by health** — `new` only writes state.json (offline-safe), so the user can pre-create projects while the daemon is stopped. Read-only tools (`show`/`peek`/`progress`) likewise not annotated; only `ls` carries the health field as the canonical "system state" entrypoint.

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] Manual: kill daemon, run `ccteam send-to-session ...` → fail-loud error
- [ ] Manual: `ccteam ls` while daemon down → still works, surfaces "daemon down"
- [ ] Manual: new project's claude session reports 1M context

🤖 Generated with [Claude Code](https://claude.com/claude-code)