### PR TITLE
M0.20: plugin pipeline cleanup — drop ln -sf, use enabledPlugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,4 +107,5 @@
 - **跨 session 协作时见到主仓 dirty 状态** → `git stash push -m "<owner-session> WIP"` 再切,别盲目 `git checkout -- .`
 - **改了 `ccteam-core` 公共 API**(如 `pick_unused_slug` 签名)→ grep 全 caller(包括 tests / mcp_serve.rs / commands.rs)
 - **F22 后 slug 带 team 前缀**:`run_new` test 期望 `dev-<base>` 而非 `<base>`;改新 slug 路径时验证 rules `paths:` 还匹配
+- **V0.1 → V0.2 升级一次性迁移**:M0.20 后 plugin agent 通过 spawned session `enabledPlugins` 启用,不再 ln -sf 进 `~/.claude/agents/`。V0.1 用户首次升级 V0.2 时跑 `ccteam doctor --migrate-recommended-agents` 清理旧 ln -sf(只删 ccteam 自己创建的 marketplace symlink,用户手写 agent 不动)
 - **本文件不超过 250 行** — CLAUDE.md 越长 cache 越贵,Claude 越忽略(best-practices §4.1 + §8)

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -11,12 +11,11 @@ use serde_json::{json, Map, Value};
 
 use ccteam_core::{
     bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
-    link_recommended_agents, pick_unused_slug, user_claude_dir,
+    migrate_recommended_agent_symlinks, pick_unused_slug, user_claude_dir,
     write_all_global_team_templates, write_global_helper_templates,
-    write_global_phase_templates, AgentLinkAction, AgentLinkReport, CcteamPaths,
-    InstallSkillOptions, LinkOptions, MetaBootstrapReport, OutboxEventKind, OutboxMessage,
-    PhaseHistoryEntry, PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
-    SkillInstallAction, TeamSpec,
+    write_global_phase_templates, CcteamPaths, InstallSkillOptions, MetaBootstrapReport,
+    MigrationReport, OutboxEventKind, OutboxMessage, PhaseHistoryEntry, PhaseState,
+    PhaseTemplate, ProjectState, SessionMailbox, SkillInstallAction, TeamSpec,
     ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES, PHASE_TEMPLATES,
 };
 use ccteam_core::tmux::TmuxSession;
@@ -601,7 +600,6 @@ fn ellipsize(s: &str, max: usize) -> String {
 /// `--install-skill` automatically).
 #[derive(Debug, Clone, Default)]
 pub struct DoctorOptions {
-    pub install_recommended_agents: bool,
     pub dry_run: bool,
     pub force: bool,
     pub tool_surface: bool,
@@ -631,28 +629,33 @@ pub struct DoctorOptions {
     /// `ESCALATE:`) without failing — those drift in over time and a
     /// fail-loud check would block the orchestrator.
     pub validate_team: Option<String>,
+    /// V0.2 M0.20: remove stale `~/.claude/agents/<name>.md` symlinks
+    /// the M0.5 `--install-recommended-agents` path used to create.
+    /// One-time cleanup for users upgrading from V0.1 to the plugin-
+    /// pipeline-based path. Idempotent — no-op when no marketplace
+    /// symlinks remain.
+    pub migrate_recommended_agents: bool,
 }
 
 /// `ccteam doctor` dispatch. Returns a human-readable report so unit
 /// tests don't need to capture stdout.
 pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
-    let any_mode = opts.install_recommended_agents
-        || opts.tool_surface
+    let any_mode = opts.tool_surface
         || opts.install_skill
         || opts.install_meta_agent.is_some()
         || opts.install_mcp
         || opts.install_memory_bridge
         || opts.reset_shipped_teams
-        || opts.validate_team.is_some();
+        || opts.validate_team.is_some()
+        || opts.migrate_recommended_agents;
     if !any_mode {
         return Ok(String::from(
             "ccteam doctor: pass at least one mode flag.\n\
              \n\
              modes:\n  \
-             --install-recommended-agents [--dry-run] [--force]\n      \
-             ln -sf 8 plugin agents into ~/.claude/agents/ (M0.5.5).\n  \
              --tool-surface\n      \
-             cross-check phase templates' tools_required against current reachability (M0.5.6).\n  \
+             cross-check phase templates' tools_required against current reachability — \
+             plugin-pipeline-aware (V0.2 M0.20).\n  \
              --install-skill [--force]\n      \
              write ~/.claude/skills/ccteam-control/SKILL.md (M1.8).\n  \
              --install-meta-agent <user-handle>\n      \
@@ -664,13 +667,12 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
              --reset-shipped-teams [--force]\n      \
              re-seed shipped team templates (~/.ccteam/teams/<name>/team.yaml + ~/.ccteam/<phase_dir>/*.md) from the in-binary bundle. Without --force, operator hand-edits are preserved; with --force, every shipped file is overwritten (V0.2 M0.16.2).\n  \
              --validate-team <name>\n      \
-             load + validate one team's team.yaml + phase markdown set (V0.2 M0.18.5). Reports per-phase frontmatter health, IO contract consistency between adjacent phases, and warns on body-level protocol-keyword residue.\n",
+             load + validate one team's team.yaml + phase markdown set (V0.2 M0.18.5). Reports per-phase frontmatter health, IO contract consistency between adjacent phases, and warns on body-level protocol-keyword residue.\n  \
+             --migrate-recommended-agents [--dry-run]\n      \
+             remove stale ~/.claude/agents/<name>.md symlinks left by the V0.1 ln -sf path. One-time cleanup after upgrading to V0.2 plugin pipeline (V0.2 M0.20).\n",
         ));
     }
     let mut out = String::new();
-    if opts.install_recommended_agents {
-        out.push_str(&render_install_recommended_agents_report(&opts)?);
-    }
     if opts.tool_surface {
         out.push_str(&render_tool_surface_report(paths)?);
     }
@@ -694,6 +696,9 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     }
     if let Some(team) = &opts.validate_team {
         out.push_str(&render_validate_team_report(paths, team)?);
+    }
+    if opts.migrate_recommended_agents {
+        out.push_str(&render_migrate_recommended_agents_report(&opts)?);
     }
     Ok(out)
 }
@@ -1092,66 +1097,51 @@ fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> R
     Ok(out)
 }
 
-fn render_install_recommended_agents_report(opts: &DoctorOptions) -> Result<String> {
-    let reports = link_recommended_agents(LinkOptions {
-        force: opts.force,
-        dry_run: opts.dry_run,
-    })?;
+fn render_migrate_recommended_agents_report(opts: &DoctorOptions) -> Result<String> {
+    let claude = user_claude_dir()?;
+    let reports = migrate_recommended_agent_symlinks(&claude, opts.dry_run)?;
     let mut out = String::new();
     out.push_str(if opts.dry_run {
-        "ccteam doctor --install-recommended-agents (dry-run)\n"
+        "ccteam doctor --migrate-recommended-agents (dry-run)\n"
     } else {
-        "ccteam doctor --install-recommended-agents\n"
+        "ccteam doctor --migrate-recommended-agents\n"
     });
     out.push('\n');
-    let mut all_ok = true;
+    if reports.is_empty() {
+        out.push_str(
+            "  no stale ccteam-managed symlinks found under ~/.claude/agents/ — nothing to do.\n",
+        );
+        return Ok(out);
+    }
     for r in &reports {
-        out.push_str(&render_agent_link_line(r));
-        if !r.action.is_ok() {
-            all_ok = false;
-        }
+        out.push_str(&render_migration_line(r, opts.dry_run));
     }
     out.push('\n');
-    if !all_ok {
-        out.push_str(
-            "some agents skipped — pass --force to overwrite user files, or install \
-             claude-plugins-official for missing sources.\n",
-        );
-    } else if opts.dry_run {
+    if opts.dry_run {
         out.push_str(
             "no changes made (--dry-run). drop the flag to apply.\n",
         );
     } else {
-        out.push_str("all 8 plugin agents reachable via Task(subagent_type=...)\n");
+        out.push_str(&format!(
+            "removed {} stale symlink(s); spawned project sessions now resolve plugin agents \
+             through the in-memory plugin pipeline (V0.2 M0.20).\n",
+            reports.len(),
+        ));
     }
     Ok(out)
 }
 
-fn render_agent_link_line(r: &AgentLinkReport) -> String {
-    let action_label = format_action_label(&r.action);
+fn render_migration_line(r: &MigrationReport, dry_run: bool) -> String {
+    let label = if dry_run { "would remove" } else { "removed" };
     format!(
-        "  {:<28} {:<28} {}\n",
-        r.agent.filename, action_label, r.target.display(),
+        "  {:<28} {:<14} -> {}\n",
+        r.target
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("?"),
+        label,
+        r.previous_link.display(),
     )
-}
-
-fn format_action_label(action: &AgentLinkAction) -> String {
-    use AgentLinkAction::*;
-    match action {
-        Linked => "linked".into(),
-        AlreadyLinked => "already-linked".into(),
-        Replaced { previous_target } => {
-            format!("replaced (was -> {})", previous_target.display())
-        }
-        Kept { previous_target } => {
-            format!("kept foreign link (was -> {}; use --force to replace)", previous_target.display())
-        }
-        SkippedUserFile => "skipped (user file)".into(),
-        SkippedSourceMissing { source } => {
-            format!("skipped (source missing: {})", source.display())
-        }
-        DryRun { would } => format!("would: {}", format_action_label(would)),
-    }
 }
 
 fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
@@ -1918,12 +1908,12 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         let body = run_doctor(&paths, DoctorOptions::default()).unwrap();
-        assert!(body.contains("install-recommended-agents"));
         assert!(body.contains("tool-surface"));
         assert!(body.contains("install-skill"));
         assert!(body.contains("install-meta-agent"));
         assert!(body.contains("install-memory-bridge"));
         assert!(body.contains("validate-team"), "got: {body}");
+        assert!(body.contains("migrate-recommended-agents"), "got: {body}");
     }
 
     #[test]
@@ -2005,14 +1995,6 @@ mod tests {
         let skill_path = tmp.path().join("skills/ccteam-control/SKILL.md");
         assert!(skill_path.is_file());
         std::env::remove_var("CLAUDE_CONFIG_HOME");
-    }
-
-    #[test]
-    fn format_action_label_renders_dry_run_clearly() {
-        let label = format_action_label(&AgentLinkAction::DryRun {
-            would: Box::new(AgentLinkAction::Linked),
-        });
-        assert_eq!(label, "would: linked");
     }
 
     // ---------------- V0.2 M0.16.2: shipped-team seed regen ----------------

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -51,8 +51,9 @@ enum Command {
         #[arg(long, value_name = "SECONDS", default_value_t = 30)]
         tick_seconds: u64,
         /// Skip the M0.5.3 phase tools_required check at startup.
-        /// Use when an old project on disk needs `ccteam doctor
-        /// --install-recommended-agents` first.
+        /// Use when an old project on disk has phase YAML referencing
+        /// a plugin agent whose plugin isn't installed yet (run
+        /// `claude /plugin add <id>` first).
         #[arg(long, default_value_t = false)]
         skip_tool_check: bool,
     },
@@ -113,22 +114,17 @@ enum Command {
     Stop,
     /// Health checks + tool-surface maintenance.
     Doctor {
-        /// Backfill ~/.claude/agents/<name>.md symlinks for the eight
-        /// recommended plugin agents (M0.5.5). Idempotent. User-authored
-        /// agent files are preserved unless --force is given.
-        #[arg(long, default_value_t = false)]
-        install_recommended_agents: bool,
         /// Print + return what would happen without touching the
         /// filesystem.
         #[arg(long, default_value_t = false)]
         dry_run: bool,
-        /// Replace user-authored agent files with the plugin link.
-        /// Use cautiously.
+        /// Overwrite operator hand-edits (memory bridge / shipped team
+        /// seeds). Use cautiously.
         #[arg(long, default_value_t = false)]
         force: bool,
         /// Cross-check every shipped phase template's tools_required
-        /// against the live tool surface and print a markdown report
-        /// (M0.5.6).
+        /// against the live tool surface (plugin pipeline + user
+        /// agents/skills + MCP servers) and print a markdown report.
         #[arg(long, default_value_t = false)]
         tool_surface: bool,
         /// Install the `ccteam-control` skill at
@@ -172,6 +168,15 @@ enum Command {
         /// `--validate-team dev`).
         #[arg(long, value_name = "TEAM")]
         validate_team: Option<String>,
+        /// V0.2 M0.20: remove stale `~/.claude/agents/<name>.md`
+        /// symlinks left by the V0.1 `--install-recommended-agents`
+        /// path. Spawned project sessions now resolve plugin agents
+        /// through Claude Code's in-memory plugin pipeline via
+        /// `enabledPlugins` in `<project>/.claude/settings.json`, so
+        /// these symlinks are obsolete. Idempotent — no-op when no
+        /// marketplace symlinks remain.
+        #[arg(long, default_value_t = false)]
+        migrate_recommended_agents: bool,
     },
     /// V0.2 M0.18.6: render the orchestrator's per-phase inject
     /// prompt (frontmatter-driven) plus the `@`-referenced phase
@@ -265,7 +270,6 @@ fn main() -> Result<()> {
         }
         Command::Stop => run_stop(),
         Command::Doctor {
-            install_recommended_agents,
             dry_run,
             force,
             tool_surface,
@@ -275,8 +279,8 @@ fn main() -> Result<()> {
             install_memory_bridge,
             reset_shipped_teams,
             validate_team,
+            migrate_recommended_agents,
         } => run_doctor(commands::DoctorOptions {
-            install_recommended_agents,
             dry_run,
             force,
             tool_surface,
@@ -286,6 +290,7 @@ fn main() -> Result<()> {
             install_memory_bridge,
             reset_shipped_teams,
             validate_team,
+            migrate_recommended_agents,
         }),
         Command::Phase { cmd } => run_phase(cmd),
     }

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod memory_bridge;
 pub mod skill;
 pub mod paths;
 pub mod phases;
+pub mod plugin_resolution;
 pub mod progress;
 pub mod projects;
 pub mod stall;
@@ -88,8 +89,9 @@ pub use templates::{
     current_ccteam_bin, project_phase_filename, render_project_settings,
     write_all_global_team_templates, write_global_helper_templates,
     write_global_phase_templates, write_project_phase_templates,
-    write_project_phase_templates_for_team, write_project_settings, SettingsEnv,
-    HELPER_TEMPLATES, PHASE_TEMPLATES, PROJECT_SETTINGS_JSON,
+    write_project_phase_templates_for_team, write_project_settings,
+    EnabledPluginsSetting, SettingsEnv, HELPER_TEMPLATES, PHASE_TEMPLATES,
+    PROJECT_SETTINGS_JSON,
 };
 // V0.2 §6.4 candidate 3: TEAM_BUNDLES / team_bundle / TeamTemplateBundle
 // are no longer exported. They remain `pub(crate)` as the in-binary
@@ -97,13 +99,13 @@ pub use templates::{
 // outside ccteam-core query disk (`<global_dir>/teams/<name>/team.yaml`)
 // instead.
 pub use tmux::{pid_is_alive, session_name_for_slug, tmux_available, TmuxSession};
+pub use plugin_resolution::{
+    lookup_plugin_agent, plugins_to_enable, PluginAgent, KNOWN_PLUGIN_AGENTS,
+};
 pub use tool_surface::{
     disable_tool_surface_bootstrap_for_tests, ensure_skills_placeholders,
-    link_recommended_agents, link_recommended_agents_for_phases,
-    link_recommended_agents_for_phases_into, link_recommended_agents_into, missing_tools,
-    user_claude_dir, AgentLinkAction, AgentLinkReport, LinkOptions, MissingTool,
-    RecommendedAgent, ToolSurfaceSnapshot, ToolsRequired, BUILTIN_SUBAGENTS,
-    RECOMMENDED_AGENTS,
+    migrate_recommended_agent_symlinks, missing_tools, user_claude_dir, MigrationReport,
+    MissingTool, ToolSurfaceSnapshot, ToolsRequired, BUILTIN_SUBAGENTS,
 };
 
 /// Crate version, identical to the workspace package version.

--- a/crates/ccteam-core/src/plugin_resolution.rs
+++ b/crates/ccteam-core/src/plugin_resolution.rs
@@ -1,0 +1,188 @@
+//! Static map from `subagent_type` (the bare name a phase YAML's
+//! `tools_required.subagents` lists, eg `code-reviewer`) to the plugin
+//! that ships it (`pr-review-toolkit@claude-plugins-official`).
+//!
+//! Used by `bootstrap_project` to compute the `enabledPlugins` set
+//! written into the spawned project's `<project>/.claude/settings.json`,
+//! and by the tool-surface validator + `ccteam doctor --tool-surface`
+//! to decide whether a phase's declared subagent dependency is
+//! reachable through Claude Code's in-memory plugin pipeline (V0.2 §6.5
+//! candidate 7 / review §2.2). Replaces the M0.5 `RECOMMENDED_AGENTS`
+//! ln -sf protocol — Claude Code's plugin pipeline auto-namespaces
+//! plugin agents as `<plugin>:<name>` once the plugin is enabled, so
+//! ccteam-core no longer has to symlink each agent file into
+//! `~/.claude/agents/`.
+//!
+//! The map is intentionally static for V0.2 — V0.3 will add a runtime
+//! discovery pass over `~/.claude/plugins/marketplaces/<mkt>/plugins/`
+//! that picks up any plugin shipping `<plugin>/agents/<name>.md`.
+
+use std::path::{Path, PathBuf};
+
+/// One plugin agent ccteam phase YAML can reference by its bare name
+/// in `tools_required.subagents`. Maps that bare name to the plugin
+/// that ships it so `bootstrap_project` knows which `<plugin>@<mkt>`
+/// to enable in the project's `.claude/settings.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PluginAgent {
+    /// The bare `subagent_type` phase YAML lists (no namespace prefix).
+    pub subagent: &'static str,
+    /// The plugin directory name under
+    /// `<claude_dir>/plugins/marketplaces/<marketplace>/plugins/`.
+    pub plugin: &'static str,
+    /// The marketplace directory name.
+    pub marketplace: &'static str,
+    /// Path inside the plugin to the agent file (relative).
+    pub relpath: &'static str,
+}
+
+impl PluginAgent {
+    /// `enabledPlugins` map key (`<plugin>@<marketplace>`).
+    pub fn plugin_id(&self) -> String {
+        format!("{}@{}", self.plugin, self.marketplace)
+    }
+
+    /// Absolute path to the plugin's agent file.
+    pub fn source_path(&self, claude_dir: &Path) -> PathBuf {
+        claude_dir
+            .join("plugins")
+            .join("marketplaces")
+            .join(self.marketplace)
+            .join("plugins")
+            .join(self.plugin)
+            .join(self.relpath)
+    }
+}
+
+/// V0.2 static plugin-agent map. Same eight `claude-plugins-official`
+/// agents previously hard-symlinked by `RECOMMENDED_AGENTS`; expressed
+/// here as data the plugin-pipeline writer + reachability checker both
+/// consume.
+pub const KNOWN_PLUGIN_AGENTS: &[PluginAgent] = &[
+    PluginAgent {
+        subagent: "code-reviewer",
+        plugin: "pr-review-toolkit",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/code-reviewer.md",
+    },
+    PluginAgent {
+        subagent: "silent-failure-hunter",
+        plugin: "pr-review-toolkit",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/silent-failure-hunter.md",
+    },
+    PluginAgent {
+        subagent: "pr-test-analyzer",
+        plugin: "pr-review-toolkit",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/pr-test-analyzer.md",
+    },
+    PluginAgent {
+        subagent: "type-design-analyzer",
+        plugin: "pr-review-toolkit",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/type-design-analyzer.md",
+    },
+    PluginAgent {
+        subagent: "comment-analyzer",
+        plugin: "pr-review-toolkit",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/comment-analyzer.md",
+    },
+    PluginAgent {
+        subagent: "code-architect",
+        plugin: "feature-dev",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/code-architect.md",
+    },
+    PluginAgent {
+        subagent: "code-explorer",
+        plugin: "feature-dev",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/code-explorer.md",
+    },
+    PluginAgent {
+        subagent: "code-simplifier",
+        plugin: "code-simplifier",
+        marketplace: "claude-plugins-official",
+        relpath: "agents/code-simplifier.md",
+    },
+];
+
+/// Look up a bare `subagent_type` in the static map. Returns `None`
+/// for built-ins (`general-purpose`, `Explore`, …) and user-authored
+/// agents that ccteam doesn't ship a plugin for.
+pub fn lookup_plugin_agent(subagent: &str) -> Option<&'static PluginAgent> {
+    KNOWN_PLUGIN_AGENTS.iter().find(|a| a.subagent == subagent)
+}
+
+/// Compute the `enabledPlugins` map (`<plugin>@<mkt>` → `true`) a
+/// spawned project session needs to wire the plugin pipeline for every
+/// subagent the team's phase YAML declares. Bare names with no entry
+/// in [`KNOWN_PLUGIN_AGENTS`] are ignored — they're either built-ins
+/// (no enable needed) or user-authored agents the operator drops into
+/// `~/.claude/agents/` themselves.
+pub fn plugins_to_enable<'a, I: IntoIterator<Item = &'a str>>(
+    subagents: I,
+) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    for name in subagents {
+        if let Some(a) = lookup_plugin_agent(name) {
+            out.insert(a.plugin_id());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_plugin_agents_has_eight_distinct_subagents() {
+        assert_eq!(KNOWN_PLUGIN_AGENTS.len(), 8);
+        let mut names: Vec<&str> =
+            KNOWN_PLUGIN_AGENTS.iter().map(|a| a.subagent).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), 8);
+    }
+
+    #[test]
+    fn plugin_id_renders_plugin_at_marketplace() {
+        let cr = lookup_plugin_agent("code-reviewer").unwrap();
+        assert_eq!(cr.plugin_id(), "pr-review-toolkit@claude-plugins-official");
+    }
+
+    #[test]
+    fn lookup_returns_none_for_builtin() {
+        assert!(lookup_plugin_agent("general-purpose").is_none());
+        assert!(lookup_plugin_agent("Explore").is_none());
+    }
+
+    #[test]
+    fn plugins_to_enable_dedups_and_skips_unknown() {
+        let set = plugins_to_enable([
+            "code-reviewer",
+            "silent-failure-hunter", // same plugin as code-reviewer
+            "code-architect",
+            "general-purpose", // built-in, skipped
+            "user-authored",   // unknown, skipped
+        ]);
+        let mut v: Vec<&String> = set.iter().collect();
+        v.sort();
+        assert_eq!(
+            v,
+            vec![
+                &"feature-dev@claude-plugins-official".to_string(),
+                &"pr-review-toolkit@claude-plugins-official".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn plugins_to_enable_empty_when_no_plugin_subagents() {
+        let set = plugins_to_enable(["general-purpose", "Explore"]);
+        assert!(set.is_empty());
+    }
+}

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -9,15 +9,14 @@ use chrono::{SecondsFormat, Utc};
 use serde_json::{Map, Value};
 
 use crate::paths::CcteamPaths;
+use crate::plugin_resolution::{lookup_plugin_agent, plugins_to_enable};
 use crate::state::ProjectState;
 use crate::templates::{
     team_bundle, write_global_helper_templates, write_project_phase_templates_for_team,
-    write_project_settings,
+    write_project_settings, EnabledPluginsSetting,
 };
 use crate::phases::PhaseTemplate;
-use crate::tool_surface::{
-    link_recommended_agents_for_phases_into, user_claude_dir, AgentLinkAction, LinkOptions,
-};
+use crate::tool_surface::user_claude_dir;
 
 /// Slugify a free-text project request: keep `[a-z0-9]`, collapse other
 /// runs to `-`, trim, lower-case, and cap at 40 chars. When the cap
@@ -129,7 +128,13 @@ pub fn bootstrap_project(
     let state = ProjectState::initial_for_team(slug.to_string(), team.to_string());
     state.save(&paths.project_state(slug))?;
 
-    write_project_settings(&project_dir)?;
+    // V0.2 M0.20 (candidate 7): compute the spawned-session
+    // `enabledPlugins` set from the team's phase YAML
+    // `tools_required.subagents`, replacing the M0.5 ln -sf protocol.
+    let templates = load_phase_templates_for_bootstrap(team);
+    let enabled_plugins = compute_enabled_plugins(&templates);
+
+    write_project_settings(&project_dir, &enabled_plugins)?;
     write_project_phase_templates_for_team(&project_dir, team)?;
     // M2.4: ensure ~/.ccteam/templates/ has the helper templates so
     // any phase markdown's `@~/.ccteam/templates/<name>.md` reference
@@ -152,16 +157,13 @@ pub fn bootstrap_project(
         );
     }
 
-    // M0.5.1 / M0.5.2 / M2.1: register plugin agents under
-    // ~/.claude/agents/ (recommended set + every sub_skill plugin agent
-    // referenced in phase YAML) and pre-create the skills placeholder
-    // directories. Both must be done **before** the orchestrator's
-    // ensure_session triggers `tmux new-session`, since Claude Code
-    // scans agents/ once at session start (claude-code-tool-surface.md
-    // §1.2.5/6) and attaches the SKILL.md watcher only to dirs that
-    // exist at startup (§1.2.4). bootstrap_project runs in `ccteam
-    // new`, well before the daemon's ensure_session.
-    let templates = load_phase_templates_for_bootstrap(team);
+    // V0.2 M0.20: pre-create the skills placeholder dirs and warn on
+    // any phase-declared subagent whose plugin source isn't on disk.
+    // Plugin pipeline activation lives in the spawned project's
+    // .claude/settings.json `enabledPlugins` (written above) — Claude
+    // Code's in-memory plugin loader reads it at session start and
+    // namespaces each agent as `<plugin>:<name>` automatically. No more
+    // ln -sf into ~/.claude/agents/ (replaces the M0.5 protocol).
     if let Err(err) = setup_tool_surface(&project_dir, &templates) {
         tracing::warn!(
             project_dir = %project_dir.display(),
@@ -330,23 +332,60 @@ fn resolve_claude_json_path_from_env(
     Ok(h.join(".claude.json"))
 }
 
-/// Symlink the `RECOMMENDED_AGENTS` set + every plugin agent named in
-/// `templates`' `sub_skills` into `~/.claude/agents/`, then pre-create
-/// the global + project-local skills placeholder dirs. See the call
-/// site in `bootstrap_project` for the timing constraint.
+/// Compute the `enabledPlugins` map a spawned project's
+/// `.claude/settings.json` needs by walking every phase template's
+/// `tools_required.subagents` (and any sub_skill referencing a plugin
+/// agent) and resolving each name through
+/// [`crate::plugin_resolution::lookup_plugin_agent`]. Built-ins and
+/// user-authored agent names produce no plugin entries.
 ///
-/// **Test isolation**: tests that call `bootstrap_project` but don't
-/// want to mutate the developer's real `~/.claude/` should set the
-/// env var `CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP=1` (or set
-/// `CLAUDE_CONFIG_HOME` to a tempdir and let it run). Production
-/// never sets the disable flag, so the only way for the symlinks to
-/// land is through bootstrap_project.
+/// V0.2 M0.20 — replaces the M0.5 `RECOMMENDED_AGENTS` ln -sf logic.
+fn compute_enabled_plugins(templates: &[PhaseTemplate]) -> EnabledPluginsSetting {
+    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for t in templates {
+        for s in &t.tools_required.subagents {
+            names.insert(s.clone());
+        }
+        // sub_skills referencing `<mkt>:<plugin>/agents/<name>.md` carry
+        // the same plugin dependency even when the bare subagent name
+        // isn't listed in tools_required (M2.1 contract).
+        for spec in &t.sub_skills {
+            if let Some(bare) = parse_subskill_subagent_name(&spec.skill) {
+                names.insert(bare);
+            }
+        }
+    }
+    let plugin_ids = plugins_to_enable(names.iter().map(String::as_str));
+    EnabledPluginsSetting { plugin_ids }
+}
+
+/// Extract the bare agent name from a sub_skill `skill:` reference of
+/// the form `<marketplace>:<plugin>/agents/<name>.md`. Returns `None`
+/// for hook scripts (`.py`, `.sh`) or non-agent paths.
+fn parse_subskill_subagent_name(skill: &str) -> Option<String> {
+    let (_market, rest) = skill.split_once(':')?;
+    if !rest.contains("/agents/") || !rest.ends_with(".md") {
+        return None;
+    }
+    let filename = rest.rsplit('/').next()?;
+    Some(filename.strip_suffix(".md").unwrap_or(filename).to_string())
+}
+
+/// Pre-create the project-local + global skills placeholder dirs and
+/// log a warning for any phase-declared subagent whose plugin source
+/// isn't installed under `~/.claude/plugins/marketplaces/`.
 ///
-/// The project-local `<project>/.claude/skills/` placeholder is
-/// created unconditionally — it lives under `project_dir` (a
-/// tempdir during tests) and carries no global-pollution risk.
+/// Plugin agents are no longer ln -sf'd here (V0.2 M0.20) — Claude
+/// Code's in-memory plugin pipeline reads `enabledPlugins` from the
+/// spawned project's `.claude/settings.json` and namespaces each agent
+/// as `<plugin>:<name>`. Skills directory pre-creation still matters
+/// because Claude Code's SKILL.md watcher only attaches to dirs that
+/// exist at session start (§1.2.4).
+///
+/// **Test isolation**: tests that call `bootstrap_project` without
+/// caring about `~/.claude/` set `CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP=1`
+/// (or redirect `CLAUDE_CONFIG_HOME` to a tempdir).
 fn setup_tool_surface(project_dir: &Path, templates: &[PhaseTemplate]) -> Result<()> {
-    // Project-local placeholder always created — see doc comment.
     let project_skills = project_dir.join(".claude").join("skills");
     std::fs::create_dir_all(&project_skills)
         .with_context(|| format!("create {}", project_skills.display()))?;
@@ -361,52 +400,42 @@ fn setup_tool_surface(project_dir: &Path, templates: &[PhaseTemplate]) -> Result
         return Ok(());
     }
     let claude = user_claude_dir()?;
-    let reports = link_recommended_agents_for_phases_into(
-        &claude,
-        templates,
-        LinkOptions::default(),
-    )?;
-    for r in &reports {
-        match &r.action {
-            AgentLinkAction::Linked => tracing::info!(
-                agent = r.agent.filename,
-                target = %r.target.display(),
-                "linked plugin agent into ~/.claude/agents/",
-            ),
-            AgentLinkAction::AlreadyLinked => tracing::debug!(
-                agent = r.agent.filename,
-                "plugin agent symlink already in place",
-            ),
-            AgentLinkAction::Replaced { previous_target } => tracing::info!(
-                agent = r.agent.filename,
-                previous = %previous_target.display(),
-                "replaced foreign symlink with plugin source (force=true)",
-            ),
-            AgentLinkAction::Kept { previous_target } => tracing::warn!(
-                agent = r.agent.filename,
-                previous = %previous_target.display(),
-                "agent symlink points elsewhere — `Task(subagent_type=...)` will hit the foreign target. \
-                 run `ccteam doctor --install-recommended-agents --force` to replace.",
-            ),
-            AgentLinkAction::SkippedUserFile => tracing::warn!(
-                agent = r.agent.filename,
-                target = %r.target.display(),
-                "user-authored agent file at target; not overwriting (use `ccteam doctor --install-recommended-agents --force` to replace)",
-            ),
-            AgentLinkAction::SkippedSourceMissing { source } => tracing::warn!(
-                agent = r.agent.filename,
-                source = %source.display(),
-                "plugin source missing — install claude-plugins-official to enable this agent",
-            ),
-            AgentLinkAction::DryRun { .. } => {}
-        }
-    }
-    // Global ~/.claude/skills/ — only when not in test-disable mode
-    // (covered above). Project-local skills dir was already created
-    // unconditionally at function entry.
     let global_skills = claude.join("skills");
     std::fs::create_dir_all(&global_skills)
         .with_context(|| format!("create {}", global_skills.display()))?;
+
+    let mut declared: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for t in templates {
+        for s in &t.tools_required.subagents {
+            declared.insert(s.clone());
+        }
+        for spec in &t.sub_skills {
+            if let Some(bare) = parse_subskill_subagent_name(&spec.skill) {
+                declared.insert(bare);
+            }
+        }
+    }
+    for name in &declared {
+        let Some(agent) = lookup_plugin_agent(name) else {
+            continue;
+        };
+        let src = agent.source_path(&claude);
+        if src.is_file() {
+            tracing::debug!(
+                subagent = %name,
+                plugin = %agent.plugin_id(),
+                "plugin agent source present; spawned session enables plugin via enabledPlugins",
+            );
+        } else {
+            tracing::warn!(
+                subagent = %name,
+                plugin = %agent.plugin_id(),
+                source = %src.display(),
+                "plugin source missing — run `claude /plugin add {}` so phase markdown's Task(subagent_type=...) resolves",
+                agent.plugin_id(),
+            );
+        }
+    }
     Ok(())
 }
 

--- a/crates/ccteam-core/src/templates.rs
+++ b/crates/ccteam-core/src/templates.rs
@@ -200,12 +200,29 @@ pub struct SettingsEnv {
     pub ccteam_projects_root: Option<String>,
 }
 
+/// Optional `enabledPlugins` map for the rendered settings.json. V0.2
+/// M0.20: spawned project sessions enable each plugin a phase's
+/// `tools_required.subagents` resolves to (via `plugin_resolution`) so
+/// Claude Code's in-memory plugin pipeline auto-namespaces the agent
+/// without ccteam-core ln -sf'ing into `~/.claude/agents/`.
+///
+/// Each entry is the `<plugin>@<marketplace>` key Claude Code's plugin
+/// pipeline expects.
+#[derive(Debug, Default, Clone)]
+pub struct EnabledPluginsSetting {
+    pub plugin_ids: std::collections::BTreeSet<String>,
+}
+
 /// Render `PROJECT_SETTINGS_JSON` with `__CCTEAM_BIN__` replaced by the
-/// given absolute binary path and `extra_env` merged into the top-level
-/// `env` block. Validates that the rewritten body is still valid JSON
-/// so a path with shell-hostile characters can't silently corrupt the
-/// settings file.
-pub fn render_project_settings(ccteam_bin: &Path, extra_env: &SettingsEnv) -> Result<String> {
+/// given absolute binary path, `extra_env` merged into the top-level
+/// `env` block, and `enabled` written under `enabledPlugins`. Validates
+/// that the rewritten body is still valid JSON so a path with
+/// shell-hostile characters can't silently corrupt the settings file.
+pub fn render_project_settings(
+    ccteam_bin: &Path,
+    extra_env: &SettingsEnv,
+    enabled: &EnabledPluginsSetting,
+) -> Result<String> {
     let bin = ccteam_bin
         .to_str()
         .ok_or_else(|| anyhow!("ccteam binary path not valid UTF-8: {}", ccteam_bin.display()))?;
@@ -228,16 +245,29 @@ pub fn render_project_settings(ccteam_bin: &Path, extra_env: &SettingsEnv) -> Re
             );
         }
     }
+    if !enabled.plugin_ids.is_empty() {
+        let mut map = serde_json::Map::new();
+        for id in &enabled.plugin_ids {
+            map.insert(id.clone(), Value::Bool(true));
+        }
+        v.as_object_mut()
+            .ok_or_else(|| anyhow!("settings.json root is not an object"))?
+            .insert("enabledPlugins".into(), Value::Object(map));
+    }
     serde_json::to_string_pretty(&v).context("serialize rendered settings.json")
 }
 
 /// Write `<project_dir>/.claude/settings.json` with hook commands
-/// pointing at the running ccteam binary by absolute path **and** the
-/// effective `CCTEAM_HOME` / `CCTEAM_PROJECTS_ROOT` baked into `env` so
-/// hook subprocesses don't depend on tmux env propagation. Creates the
-/// parent dir if missing. Idempotent — overwrites any prior render so
-/// re-running after a ccteam upgrade refreshes paths.
-pub fn write_project_settings(project_dir: &Path) -> Result<()> {
+/// pointing at the running ccteam binary by absolute path, the
+/// effective `CCTEAM_HOME` / `CCTEAM_PROJECTS_ROOT` baked into `env`,
+/// and the spawned-session `enabledPlugins` set. Creates the parent
+/// dir if missing. Idempotent — overwrites any prior render so
+/// re-running after a ccteam upgrade refreshes paths and the
+/// plugin set.
+pub fn write_project_settings(
+    project_dir: &Path,
+    enabled: &EnabledPluginsSetting,
+) -> Result<()> {
     let dir = project_dir.join(".claude");
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create {}", dir.display()))?;
@@ -247,7 +277,7 @@ pub fn write_project_settings(project_dir: &Path) -> Result<()> {
         ccteam_home: std::env::var("CCTEAM_HOME").ok(),
         ccteam_projects_root: std::env::var("CCTEAM_PROJECTS_ROOT").ok(),
     };
-    let body = render_project_settings(&bin, &extra)?;
+    let body = render_project_settings(&bin, &extra, enabled)?;
     std::fs::write(&path, body)
         .with_context(|| format!("write {}", path.display()))?;
     Ok(())
@@ -404,9 +434,12 @@ mod tests {
 
     #[test]
     fn template_is_valid_json_with_expected_hook_keys() {
-        let body =
-            render_project_settings(Path::new("/usr/local/bin/ccteam"), &SettingsEnv::default())
-                .unwrap();
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &SettingsEnv::default(),
+            &EnabledPluginsSetting::default(),
+        )
+        .unwrap();
         let v: serde_json::Value =
             serde_json::from_str(&body).expect("rendered template must be valid JSON");
         let hooks = v["hooks"].as_object().expect("hooks object");
@@ -428,9 +461,12 @@ mod tests {
 
     #[test]
     fn template_session_start_uses_absolute_ccteam_path() {
-        let body =
-            render_project_settings(Path::new("/usr/local/bin/ccteam"), &SettingsEnv::default())
-                .unwrap();
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &SettingsEnv::default(),
+            &EnabledPluginsSetting::default(),
+        )
+        .unwrap();
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         let entries = v["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap();
         let cmds: Vec<&str> = entries
@@ -506,6 +542,7 @@ mod tests {
         let err = render_project_settings(
             Path::new("/tmp/has\"quote/ccteam"),
             &SettingsEnv::default(),
+            &EnabledPluginsSetting::default(),
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("characters"));
@@ -517,7 +554,12 @@ mod tests {
             ccteam_home: Some("/tmp/sandbox/home".into()),
             ccteam_projects_root: Some("/tmp/sandbox/projects".into()),
         };
-        let body = render_project_settings(Path::new("/usr/local/bin/ccteam"), &env).unwrap();
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &env,
+            &EnabledPluginsSetting::default(),
+        )
+        .unwrap();
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["env"]["CCTEAM_HOME"], "/tmp/sandbox/home");
         assert_eq!(v["env"]["CCTEAM_PROJECTS_ROOT"], "/tmp/sandbox/projects");
@@ -527,10 +569,47 @@ mod tests {
 
     #[test]
     fn render_project_settings_omits_env_when_default() {
-        let body =
-            render_project_settings(Path::new("/usr/local/bin/ccteam"), &SettingsEnv::default())
-                .unwrap();
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &SettingsEnv::default(),
+            &EnabledPluginsSetting::default(),
+        )
+        .unwrap();
         let v: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert!(v["env"]["CCTEAM_HOME"].is_null());
+    }
+
+    #[test]
+    fn render_project_settings_omits_enabled_plugins_when_empty() {
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &SettingsEnv::default(),
+            &EnabledPluginsSetting::default(),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(v.get("enabledPlugins").is_none());
+    }
+
+    #[test]
+    fn render_project_settings_writes_enabled_plugins_when_present() {
+        let mut enabled = EnabledPluginsSetting::default();
+        enabled
+            .plugin_ids
+            .insert("pr-review-toolkit@claude-plugins-official".into());
+        enabled
+            .plugin_ids
+            .insert("feature-dev@claude-plugins-official".into());
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &SettingsEnv::default(),
+            &enabled,
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let map = v["enabledPlugins"].as_object().expect("enabledPlugins object");
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["pr-review-toolkit@claude-plugins-official"], true);
+        assert_eq!(map["feature-dev@claude-plugins-official"], true);
     }
 }

--- a/crates/ccteam-core/src/tool_surface.rs
+++ b/crates/ccteam-core/src/tool_surface.rs
@@ -1,23 +1,16 @@
-//! Tool-surface foundation (M0.5). Makes Claude Code's plugin agents
-//! and skills callable from inside ccteam-managed long sessions.
+//! Tool-surface foundation. Validates phase YAML's
+//! `tools_required` (subagents / skills / MCP servers) against what's
+//! reachable on this machine.
 //!
-//! Two artifacts shipped here:
-//!
-//! 1. `RECOMMENDED_AGENTS` — the eight `claude-plugins-official` plugin
-//!    agents that ccteam phase markdown is allowed to invoke via
-//!    `Task(subagent_type=…)`. Plugin agents do **not** auto-register
-//!    in Claude Code's `Task` namespace just because the plugin is
-//!    installed (per `docs/claude-code-tool-surface.md` §1.1.2 / §1.2.5);
-//!    we have to symlink each `<plugin>/agents/<name>.md` into
-//!    `~/.claude/agents/` **before** the tmux session starts, since
-//!    Claude Code scans that directory at session start and never again.
-//!
-//! 2. `ensure_skills_placeholders` — pre-creates the global and
-//!    project-local skills directories (even empty) so Claude Code's
-//!    live SKILL.md monitor (§1.2.4) attaches at session start. Without
-//!    this, "lazy-inject a skill mid-session" silently fails.
-//!
-//! Pure-ish: file-system mutations only; no orchestrator side effects.
+//! V0.2 M0.20 (candidate 7) replaces the M0.5 `RECOMMENDED_AGENTS`
+//! ln -sf protocol with Claude Code's in-memory plugin pipeline:
+//! `bootstrap_project` writes `enabledPlugins` into the spawned
+//! project's `.claude/settings.json`, Claude Code namespaces plugin
+//! agents as `<plugin>:<name>` automatically, and ccteam-core no
+//! longer touches `~/.claude/agents/`. The reachability check here
+//! walks the plugin pipeline (via [`plugin_resolution`]) plus
+//! `~/.claude/agents/` (operator's user-authored customs) plus
+//! `~/.claude/skills/` (user skills) plus plugin-shipped skills.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -25,280 +18,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 
-/// One recommended plugin agent we link into `~/.claude/agents/`.
-///
-/// `filename` is the basename used inside `~/.claude/agents/` and the
-/// `subagent_type` Claude Code will accept (e.g. `code-reviewer.md` →
-/// `Task(subagent_type="code-reviewer")`). `plugin` is the
-/// `claude-plugins-official` plugin directory name; `relpath` is the
-/// path inside that plugin to the agent file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct RecommendedAgent {
-    pub filename: &'static str,
-    pub plugin: &'static str,
-    pub relpath: &'static str,
-}
-
-impl RecommendedAgent {
-    /// `subagent_type` Claude Code accepts for `Task(subagent_type=…)`,
-    /// derived from `filename` (drop trailing `.md`).
-    pub fn subagent_type(&self) -> &'static str {
-        self.filename.strip_suffix(".md").unwrap_or(self.filename)
-    }
-
-    /// Absolute path to the plugin's agent file under
-    /// `<claude_dir>/plugins/marketplaces/claude-plugins-official/plugins/`.
-    pub fn source_path(&self, claude_dir: &Path) -> PathBuf {
-        claude_dir
-            .join("plugins")
-            .join("marketplaces")
-            .join("claude-plugins-official")
-            .join("plugins")
-            .join(self.plugin)
-            .join(self.relpath)
-    }
-}
-
-/// The eight plugin agents `bootstrap_project` symlinks into
-/// `~/.claude/agents/`. Source list: `docs/claude-code-tool-surface.md`
-/// §6.2 (kept identical so the doctor cross-check is straightforward).
-pub const RECOMMENDED_AGENTS: &[RecommendedAgent] = &[
-    RecommendedAgent {
-        filename: "code-reviewer.md",
-        plugin: "pr-review-toolkit",
-        relpath: "agents/code-reviewer.md",
-    },
-    RecommendedAgent {
-        filename: "silent-failure-hunter.md",
-        plugin: "pr-review-toolkit",
-        relpath: "agents/silent-failure-hunter.md",
-    },
-    RecommendedAgent {
-        filename: "pr-test-analyzer.md",
-        plugin: "pr-review-toolkit",
-        relpath: "agents/pr-test-analyzer.md",
-    },
-    RecommendedAgent {
-        filename: "type-design-analyzer.md",
-        plugin: "pr-review-toolkit",
-        relpath: "agents/type-design-analyzer.md",
-    },
-    RecommendedAgent {
-        filename: "comment-analyzer.md",
-        plugin: "pr-review-toolkit",
-        relpath: "agents/comment-analyzer.md",
-    },
-    RecommendedAgent {
-        filename: "code-architect.md",
-        plugin: "feature-dev",
-        relpath: "agents/code-architect.md",
-    },
-    RecommendedAgent {
-        filename: "code-explorer.md",
-        plugin: "feature-dev",
-        relpath: "agents/code-explorer.md",
-    },
-    RecommendedAgent {
-        filename: "code-simplifier.md",
-        plugin: "code-simplifier",
-        relpath: "agents/code-simplifier.md",
-    },
-];
-
-/// What `link_recommended_agents_into` did for one agent. Surfaced so
-/// `ccteam doctor --install-recommended-agents` can render a per-agent
-/// status line.
-///
-/// The `Kept` vs `Replaced` split matters: a foreign symlink left
-/// in place (Kept) means `Task(subagent_type=…)` will hit the user's
-/// stale target, **not** the plugin source we wanted; only `Replaced`
-/// (force=true) actually leaves the registration in a usable state.
-/// `is_ok` reflects this so the doctor verdict doesn't lie.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AgentLinkAction {
-    /// Created a fresh symlink target → source.
-    Linked,
-    /// A symlink already pointed at our source; no-op.
-    AlreadyLinked,
-    /// Symlink existed and pointed *elsewhere*. We removed it and
-    /// replaced it with our source (force=true). Now correct.
-    Replaced { previous_target: PathBuf },
-    /// Symlink existed and pointed *elsewhere*. force=false, so we
-    /// left it alone. The slot is **not** wired to our plugin source —
-    /// `Task(subagent_type=…)` will still hit the wrong target.
-    Kept { previous_target: PathBuf },
-    /// A regular file existed at the target; skipped to preserve user
-    /// authorship. `force=true` would replace it instead.
-    SkippedUserFile,
-    /// Source file is missing under the plugins dir; skipped. The user
-    /// likely uninstalled the plugin (or the marketplace path differs).
-    SkippedSourceMissing { source: PathBuf },
-    /// Would-be no-op in `--dry-run` mode.
-    DryRun { would: Box<AgentLinkAction> },
-}
-
-impl AgentLinkAction {
-    /// True if this action made (or would make) the symlink point at
-    /// our plugin source. Used by the `bootstrap` and `doctor` paths
-    /// to decide overall success. **Excludes** `Kept` because that
-    /// leaves a foreign symlink in place.
-    pub fn is_ok(&self) -> bool {
-        match self {
-            AgentLinkAction::Linked
-            | AgentLinkAction::AlreadyLinked
-            | AgentLinkAction::Replaced { .. } => true,
-            AgentLinkAction::DryRun { would } => would.is_ok(),
-            AgentLinkAction::Kept { .. }
-            | AgentLinkAction::SkippedUserFile
-            | AgentLinkAction::SkippedSourceMissing { .. } => false,
-        }
-    }
-}
-
-/// One per-agent line in the report.
-#[derive(Debug, Clone)]
-pub struct AgentLinkReport {
-    pub agent: RecommendedAgent,
-    pub target: PathBuf,
-    pub action: AgentLinkAction,
-}
-
-/// `link_recommended_agents` policy knob.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct LinkOptions {
-    /// Replace user-authored regular files / symlinks pointing
-    /// elsewhere. Default false: keep user files and warn instead.
-    pub force: bool,
-    /// Print + return what *would* happen but don't touch the
-    /// filesystem. Used by `ccteam doctor --install-recommended-agents
-    /// --dry-run`.
-    pub dry_run: bool,
-}
-
-/// Symlink every `RECOMMENDED_AGENTS` entry from its plugin source into
-/// `<claude_dir>/agents/`. Test seam — production callers go through
-/// [`link_recommended_agents`] which resolves `claude_dir` from
-/// `dirs::home_dir()`.
-pub fn link_recommended_agents_into(
-    claude_dir: &Path,
-    opts: LinkOptions,
-) -> Result<Vec<AgentLinkReport>> {
-    let agents_dir = claude_dir.join("agents");
-    if !opts.dry_run {
-        std::fs::create_dir_all(&agents_dir)
-            .with_context(|| format!("create {}", agents_dir.display()))?;
-    }
-
-    let mut out = Vec::with_capacity(RECOMMENDED_AGENTS.len());
-    for agent in RECOMMENDED_AGENTS {
-        let source = agent.source_path(claude_dir);
-        let target = agents_dir.join(agent.filename);
-        let action = link_one_agent(&source, &target, opts)?;
-        out.push(AgentLinkReport {
-            agent: *agent,
-            target,
-            action,
-        });
-    }
-    Ok(out)
-}
-
-fn link_one_agent(
-    source: &Path,
-    target: &Path,
-    opts: LinkOptions,
-) -> Result<AgentLinkAction> {
-    if !source.exists() {
-        return Ok(AgentLinkAction::SkippedSourceMissing {
-            source: source.to_path_buf(),
-        });
-    }
-
-    let inner = if let Some(existing) = read_symlink_safe(target)? {
-        if existing == source {
-            AgentLinkAction::AlreadyLinked
-        } else if opts.force {
-            if !opts.dry_run {
-                std::fs::remove_file(target).with_context(|| {
-                    format!("remove existing symlink {}", target.display())
-                })?;
-                symlink_file(source, target)?;
-            }
-            AgentLinkAction::Replaced {
-                previous_target: existing,
-            }
-        } else {
-            AgentLinkAction::Kept {
-                previous_target: existing,
-            }
-        }
-    } else if target.exists() {
-        if opts.force {
-            if !opts.dry_run {
-                std::fs::remove_file(target).with_context(|| {
-                    format!("remove user file {}", target.display())
-                })?;
-                symlink_file(source, target)?;
-            }
-            AgentLinkAction::Linked
-        } else {
-            AgentLinkAction::SkippedUserFile
-        }
-    } else {
-        if !opts.dry_run {
-            symlink_file(source, target)?;
-        }
-        AgentLinkAction::Linked
-    };
-
-    Ok(if opts.dry_run {
-        AgentLinkAction::DryRun {
-            would: Box::new(inner),
-        }
-    } else {
-        inner
-    })
-}
-
-/// Resolve a symlink at `path` to its absolute target if (and only if)
-/// `path` is a symlink. Returns `Ok(None)` for regular files / missing
-/// paths so the caller can branch on those separately.
-fn read_symlink_safe(path: &Path) -> Result<Option<PathBuf>> {
-    let meta = match std::fs::symlink_metadata(path) {
-        Ok(m) => m,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(err)
-                .with_context(|| format!("symlink_metadata {}", path.display()));
-        }
-    };
-    if !meta.file_type().is_symlink() {
-        return Ok(None);
-    }
-    let raw = std::fs::read_link(path)
-        .with_context(|| format!("read_link {}", path.display()))?;
-    let resolved = if raw.is_absolute() {
-        raw
-    } else {
-        path.parent()
-            .map(|p| p.join(&raw))
-            .unwrap_or(raw)
-    };
-    Ok(Some(resolved))
-}
-
-#[cfg(unix)]
-fn symlink_file(source: &Path, target: &Path) -> Result<()> {
-    std::os::unix::fs::symlink(source, target)
-        .with_context(|| format!("symlink {} → {}", target.display(), source.display()))
-}
-
-#[cfg(not(unix))]
-fn symlink_file(_source: &Path, _target: &Path) -> Result<()> {
-    Err(anyhow!(
-        "ccteam tool-surface symlinks are not supported on this platform yet",
-    ))
-}
+use crate::plugin_resolution::{lookup_plugin_agent, KNOWN_PLUGIN_AGENTS};
 
 /// Resolve the user's `~/.claude/` directory (where Claude Code scans
 /// `agents/` and `skills/`). Honors `CLAUDE_CONFIG_HOME` for testing.
@@ -311,125 +31,11 @@ pub fn user_claude_dir() -> Result<PathBuf> {
     Ok(home.join(".claude"))
 }
 
-/// Production entry point: resolve `~/.claude/` and call
-/// [`link_recommended_agents_into`].
-pub fn link_recommended_agents(opts: LinkOptions) -> Result<Vec<AgentLinkReport>> {
-    let claude_dir = user_claude_dir()?;
-    link_recommended_agents_into(&claude_dir, opts)
-}
-
-/// M2.1 extension: like [`link_recommended_agents_into`] but also
-/// walks every phase template's `sub_skills` list, parses any
-/// `claude-plugins-official:<plugin>/agents/<name>.md` reference, and
-/// links the plugin source into `<claude_dir>/agents/<name>.md` —
-/// even if the agent isn't in [`RECOMMENDED_AGENTS`]. Result is the
-/// union of "8 hardcoded recommended" + "everything phase YAML asks
-/// for", deduplicated by target filename.
-///
-/// Tools_required.subagents are *not* auto-linked here — they're a
-/// names-only list with no source-path information; the operator is
-/// responsible for placing custom agents under `~/.claude/agents/`.
-/// The orchestrator's startup tool-surface check (M0.5.3) catches
-/// the missing case with a fix-hint.
-pub fn link_recommended_agents_for_phases_into(
-    claude_dir: &Path,
-    templates: &[crate::phases::PhaseTemplate],
-    opts: LinkOptions,
-) -> Result<Vec<AgentLinkReport>> {
-    let mut reports = link_recommended_agents_into(claude_dir, opts)?;
-
-    let agents_dir = claude_dir.join("agents");
-    if !opts.dry_run {
-        std::fs::create_dir_all(&agents_dir)
-            .with_context(|| format!("create {}", agents_dir.display()))?;
-    }
-
-    let mut seen: BTreeSet<&str> = reports.iter().map(|r| r.agent.filename).collect();
-    for template in templates {
-        for spec in &template.sub_skills {
-            let Some((source, leaked_filename)) =
-                parse_official_plugin_subagent(&spec.skill)
-            else {
-                continue;
-            };
-            if seen.contains(leaked_filename) {
-                continue;
-            }
-            // Link target stays under <claude_dir>/agents/, same as
-            // RECOMMENDED_AGENTS.
-            let abs_source = claude_dir
-                .join("plugins")
-                .join("marketplaces")
-                .join("claude-plugins-official")
-                .join("plugins")
-                .join(&source);
-            let target = agents_dir.join(leaked_filename);
-            let action = link_one_agent(&abs_source, &target, opts)?;
-            reports.push(AgentLinkReport {
-                // Build a synthetic RecommendedAgent — the report
-                // type is shared with the hardcoded path; we only
-                // need enough for the operator to read.
-                agent: RecommendedAgent {
-                    filename: Box::leak(leaked_filename.to_string().into_boxed_str()),
-                    plugin: Box::leak(plugin_part(&source).to_string().into_boxed_str()),
-                    relpath: Box::leak(rel_part(&source).to_string().into_boxed_str()),
-                },
-                target,
-                action,
-            });
-            seen.insert(Box::leak(leaked_filename.to_string().into_boxed_str()));
-        }
-    }
-    Ok(reports)
-}
-
-/// Production entry: resolve `~/.claude/` then call the phase-aware
-/// variant. Used by `bootstrap_project` so every project-creation
-/// path stages every plugin agent the templates declare.
-pub fn link_recommended_agents_for_phases(
-    templates: &[crate::phases::PhaseTemplate],
-    opts: LinkOptions,
-) -> Result<Vec<AgentLinkReport>> {
-    let claude_dir = user_claude_dir()?;
-    link_recommended_agents_for_phases_into(&claude_dir, templates, opts)
-}
-
-/// Parse `claude-plugins-official:<plugin>/agents/<name>.md`. Returns
-/// `(plugin/agents/<name>.md, <name>.md)` — the first component is
-/// joined under `plugins/marketplaces/claude-plugins-official/plugins/`
-/// for the abs source path, the second is the basename used under
-/// `<claude_dir>/agents/`.
-fn parse_official_plugin_subagent(skill: &str) -> Option<(String, &str)> {
-    let rest = skill.strip_prefix("claude-plugins-official:")?;
-    // Only auto-link when the relative path looks like an agent file.
-    // sub_skills can also reference hooks (.sh / .py) which Claude Code
-    // doesn't load via Task — those should not become symlinks under
-    // ~/.claude/agents/.
-    if !rest.contains("/agents/") || !rest.ends_with(".md") {
-        return None;
-    }
-    let filename = rest.rsplit('/').next()?;
-    Some((rest.to_string(), filename))
-}
-
-fn plugin_part(rest: &str) -> &str {
-    rest.split('/').next().unwrap_or(rest)
-}
-
-fn rel_part(rest: &str) -> &str {
-    let mut parts = rest.splitn(2, '/');
-    parts.next();
-    parts.next().unwrap_or(rest)
-}
-
 /// Test-only helper: set `CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP=1` so
 /// any subsequent `bootstrap_project` call in the same process
 /// no-ops the `~/.claude/` mutation. Use from a once-init at the top
 /// of test files that exercise `bootstrap_project` but don't care
 /// about tool-surface side effects.
-///
-/// Safe across parallel test threads (env var write is atomic on
-/// Linux); idempotent because it's one fixed value.
 pub fn disable_tool_surface_bootstrap_for_tests() {
     std::env::set_var("CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP", "1");
 }
@@ -450,14 +56,17 @@ pub fn ensure_skills_placeholders(claude_dir: &Path, project_dir: &Path) -> Resu
 /// Tools a phase markdown declares it needs at runtime. Validated
 /// against [`ToolSurfaceSnapshot`] at orchestrator startup so a phase
 /// that asks for `Task(subagent_type="code-reviewer")` fails fast if
-/// the agent file is missing under `~/.claude/agents/`.
+/// neither the plugin shipping it is enabled nor a user-authored
+/// `~/.claude/agents/code-reviewer.md` exists.
 ///
 /// Schema: `docs/interfaces.md` §5.1.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ToolsRequired {
     /// `subagent_type` strings (e.g. `code-reviewer`, `general-purpose`).
     /// Five built-ins are always reachable and don't need to be listed,
-    /// but listing them is harmless.
+    /// but listing them is harmless. Plugin-shipped agents resolve via
+    /// [`crate::plugin_resolution`] and require the plugin to be
+    /// enabled in the spawned project's `enabledPlugins`.
     #[serde(default)]
     pub subagents: Vec<String>,
     /// Skill names callable via the `Skill` tool. Resolved against
@@ -465,9 +74,7 @@ pub struct ToolsRequired {
     /// `skills/<name>/SKILL.md`.
     #[serde(default)]
     pub skills: Vec<String>,
-    /// MCP server names from `~/.claude.json` `mcpServers` keys
-    /// (and any plugin `.mcp.json` once M2 lands plugin-aware
-    /// MCP discovery).
+    /// MCP server names from `~/.claude.json` `mcpServers` keys.
     #[serde(default)]
     pub mcp: Vec<String>,
 }
@@ -494,6 +101,11 @@ pub const BUILTIN_SUBAGENTS: &[&str] = &[
 /// What's actually reachable on the current machine. Built once at
 /// orchestrator startup and used to validate every phase template's
 /// `tools_required`.
+///
+/// For plugin-shipped agents the snapshot indexes both the bare name
+/// (`code-reviewer`) and the namespaced one (`pr-review-toolkit:code-reviewer`)
+/// — phase YAML can use either form, and the namespaced form survives
+/// when two plugins ship a `code-simplifier`-style collision.
 #[derive(Debug, Clone, Default)]
 pub struct ToolSurfaceSnapshot {
     pub subagents: BTreeSet<String>,
@@ -509,10 +121,14 @@ impl ToolSurfaceSnapshot {
     }
 
     /// Build a snapshot by reading the filesystem under `claude_dir`
-    /// (`~/.claude/`). MCP servers come from `<claude_dir>/.claude.json`
-    /// or `<claude_dir>/mcp_servers.json` when present. Plugin-supplied
-    /// skills are pulled from
-    /// `<claude_dir>/plugins/marketplaces/*/plugins/*/skills/<name>/`.
+    /// (`~/.claude/`).
+    ///
+    /// Plugin-shipped subagents are picked up from
+    /// [`KNOWN_PLUGIN_AGENTS`] when their plugin source file exists
+    /// under `<claude_dir>/plugins/marketplaces/<mkt>/plugins/<plugin>/agents/<name>.md`.
+    /// User-authored agents from `<claude_dir>/agents/<name>.md` still
+    /// resolve (operator escape hatch). Skills and MCP servers come
+    /// from the same paths as before.
     pub fn scan(claude_dir: &Path) -> Result<Self> {
         let mut subagents: BTreeSet<String> = BUILTIN_SUBAGENTS
             .iter()
@@ -521,7 +137,22 @@ impl ToolSurfaceSnapshot {
         let mut skills: BTreeSet<String> = BTreeSet::new();
         let mut mcp: BTreeSet<String> = BTreeSet::new();
 
-        // ~/.claude/agents/<name>.md → subagent_type "<name>"
+        // Plugin-shipped subagents (V0.2 M0.20 — replaces the prior
+        // ~/.claude/agents/ ln -sf scan). A plugin agent counts as
+        // reachable iff its source file exists on disk; the project
+        // session's `enabledPlugins` decides which plugins actually
+        // load, but the source file existing is a necessary condition
+        // either way.
+        for agent in KNOWN_PLUGIN_AGENTS {
+            if agent.source_path(claude_dir).is_file() {
+                subagents.insert(agent.subagent.to_string());
+                subagents.insert(format!("{}:{}", agent.plugin, agent.subagent));
+            }
+        }
+
+        // ~/.claude/agents/<name>.md → subagent_type "<name>". Operator
+        // escape hatch for custom agents that aren't shipped by any
+        // plugin. ccteam-core no longer writes here (V0.2 M0.20).
         let agents_dir = claude_dir.join("agents");
         if let Ok(entries) = std::fs::read_dir(&agents_dir) {
             for e in entries.flatten() {
@@ -616,8 +247,13 @@ impl MissingTool {
     pub fn fix_hint(&self) -> String {
         match self {
             MissingTool::Subagent(name) => {
-                if RECOMMENDED_AGENTS.iter().any(|a| a.subagent_type() == name) {
-                    "run `ccteam doctor --install-recommended-agents` to symlink the plugin agent".into()
+                if let Some(a) = lookup_plugin_agent(name) {
+                    format!(
+                        "install plugin `{}` (e.g. `claude /plugin add {}`); \
+                         spawned project sessions enable it via `enabledPlugins` automatically",
+                        a.plugin_id(),
+                        a.plugin_id(),
+                    )
                 } else {
                     format!(
                         "drop `{name}.md` into ~/.claude/agents/ (custom agent), or remove it from `tools_required.subagents`"
@@ -692,144 +328,81 @@ fn collect_mcp_from(path: &Path, out: &mut BTreeSet<String>) {
     }
 }
 
+/// Remove every `~/.claude/agents/<name>.md` symlink whose target
+/// resolves into `<claude_dir>/plugins/marketplaces/`. Surfaced for
+/// `ccteam doctor --migrate-recommended-agents` so V0.1 users with
+/// the old M0.5 ln -sf protocol can clean up stale links once they
+/// upgrade to V0.2's plugin pipeline.
+///
+/// Regular files (operator-authored agents) and symlinks pointing
+/// outside the marketplace tree are preserved. Returns the report so
+/// the doctor command can render per-agent status; `dry_run=true`
+/// reports without touching the filesystem.
+pub fn migrate_recommended_agent_symlinks(
+    claude_dir: &Path,
+    dry_run: bool,
+) -> Result<Vec<MigrationReport>> {
+    let agents_dir = claude_dir.join("agents");
+    let marketplaces_root = claude_dir.join("plugins").join("marketplaces");
+    let mut out: Vec<MigrationReport> = Vec::new();
+    let entries = match std::fs::read_dir(&agents_dir) {
+        Ok(e) => e,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("read_dir {}", agents_dir.display()));
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if !meta.file_type().is_symlink() {
+            continue;
+        }
+        let raw = match std::fs::read_link(&path) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let resolved = if raw.is_absolute() {
+            raw.clone()
+        } else {
+            path.parent()
+                .map(|p| p.join(&raw))
+                .unwrap_or_else(|| raw.clone())
+        };
+        if !resolved.starts_with(&marketplaces_root) {
+            continue;
+        }
+        if !dry_run {
+            std::fs::remove_file(&path)
+                .with_context(|| format!("remove {}", path.display()))?;
+        }
+        out.push(MigrationReport {
+            target: path,
+            previous_link: raw,
+            removed: !dry_run,
+        });
+    }
+    Ok(out)
+}
+
+/// One symlink the migrate command found / removed.
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    /// `<claude_dir>/agents/<name>.md` whose stale ln -sf was found.
+    pub target: PathBuf,
+    /// What the symlink pointed at (relative or absolute, as stored).
+    pub previous_link: PathBuf,
+    /// `false` for `dry_run=true` runs.
+    pub removed: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn fake_claude_dir(tmp: &tempfile::TempDir) -> PathBuf {
-        let dir = tmp.path().join(".claude");
-        // Stage all 8 plugin agent files so link_one_agent finds sources.
-        for agent in RECOMMENDED_AGENTS {
-            let src = agent.source_path(&dir);
-            std::fs::create_dir_all(src.parent().unwrap()).unwrap();
-            std::fs::write(&src, format!("# stub for {}\n", agent.filename)).unwrap();
-        }
-        dir
-    }
-
-    #[test]
-    fn recommended_set_has_eight_distinct_filenames() {
-        assert_eq!(RECOMMENDED_AGENTS.len(), 8);
-        let mut names: Vec<&str> = RECOMMENDED_AGENTS.iter().map(|a| a.filename).collect();
-        names.sort();
-        names.dedup();
-        assert_eq!(names.len(), 8, "filenames must be unique under ~/.claude/agents/");
-    }
-
-    #[test]
-    fn subagent_type_drops_md_suffix() {
-        let a = RECOMMENDED_AGENTS[0];
-        assert_eq!(a.filename, "code-reviewer.md");
-        assert_eq!(a.subagent_type(), "code-reviewer");
-    }
-
-    #[test]
-    fn link_recommended_agents_creates_eight_symlinks() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let claude = fake_claude_dir(&tmp);
-
-        let reports = link_recommended_agents_into(&claude, LinkOptions::default()).unwrap();
-        assert_eq!(reports.len(), 8);
-        for r in &reports {
-            assert_eq!(r.action, AgentLinkAction::Linked, "{:?}", r);
-            let meta = std::fs::symlink_metadata(&r.target).unwrap();
-            assert!(meta.file_type().is_symlink());
-        }
-    }
-
-    #[test]
-    fn link_recommended_agents_is_idempotent() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let claude = fake_claude_dir(&tmp);
-
-        link_recommended_agents_into(&claude, LinkOptions::default()).unwrap();
-        let reports = link_recommended_agents_into(&claude, LinkOptions::default()).unwrap();
-        for r in reports {
-            assert_eq!(r.action, AgentLinkAction::AlreadyLinked, "{:?}", r);
-        }
-    }
-
-    #[test]
-    fn link_recommended_agents_skips_user_authored_file_without_force() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let claude = fake_claude_dir(&tmp);
-        let agents = claude.join("agents");
-        std::fs::create_dir_all(&agents).unwrap();
-        let user_file = agents.join("code-reviewer.md");
-        std::fs::write(&user_file, "USER VERSION").unwrap();
-
-        let reports = link_recommended_agents_into(&claude, LinkOptions::default()).unwrap();
-        let cr = reports
-            .iter()
-            .find(|r| r.agent.filename == "code-reviewer.md")
-            .unwrap();
-        assert_eq!(cr.action, AgentLinkAction::SkippedUserFile);
-        // User file untouched.
-        assert_eq!(std::fs::read_to_string(&user_file).unwrap(), "USER VERSION");
-    }
-
-    #[test]
-    fn link_recommended_agents_force_replaces_user_file() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let claude = fake_claude_dir(&tmp);
-        let agents = claude.join("agents");
-        std::fs::create_dir_all(&agents).unwrap();
-        let user_file = agents.join("code-reviewer.md");
-        std::fs::write(&user_file, "USER VERSION").unwrap();
-
-        link_recommended_agents_into(&claude, LinkOptions { force: true, dry_run: false })
-            .unwrap();
-        let meta = std::fs::symlink_metadata(&user_file).unwrap();
-        assert!(meta.file_type().is_symlink(), "force should replace user file");
-    }
-
-    #[test]
-    fn link_recommended_agents_skips_when_source_missing() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let claude = tmp.path().join(".claude"); // do NOT pre-stage sources
-
-        let reports = link_recommended_agents_into(&claude, LinkOptions::default()).unwrap();
-        for r in reports {
-            assert!(
-                matches!(r.action, AgentLinkAction::SkippedSourceMissing { .. }),
-                "expected SkippedSourceMissing, got {:?}",
-                r.action,
-            );
-        }
-        // No symlinks created.
-        let agents = claude.join("agents");
-        if agents.exists() {
-            let count = std::fs::read_dir(&agents).unwrap().count();
-            assert_eq!(count, 0, "should not create any symlinks when sources missing");
-        }
-    }
-
-    #[test]
-    fn link_recommended_agents_dry_run_no_filesystem_writes() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let claude = fake_claude_dir(&tmp);
-        let agents_dir = claude.join("agents");
-
-        let reports = link_recommended_agents_into(
-            &claude,
-            LinkOptions { force: false, dry_run: true },
-        )
-        .unwrap();
-        for r in reports {
-            assert!(
-                matches!(r.action, AgentLinkAction::DryRun { .. }),
-                "expected DryRun, got {:?}",
-                r.action,
-            );
-            assert!(
-                !r.target.exists(),
-                "dry_run must not create {}",
-                r.target.display(),
-            );
-        }
-        // Even the parent agents dir shouldn't be created in dry-run.
-        assert!(!agents_dir.exists(), "agents dir should not be auto-created in dry-run");
-    }
 
     #[test]
     fn ensure_skills_placeholders_creates_both_dirs() {
@@ -870,7 +443,7 @@ mod tests {
         let claude = tmp.path().join(".claude");
         // user-authored agent
         std::fs::create_dir_all(claude.join("agents")).unwrap();
-        std::fs::write(claude.join("agents/code-reviewer.md"), "# stub").unwrap();
+        std::fs::write(claude.join("agents/user-custom.md"), "# stub").unwrap();
         // user-authored skill
         std::fs::create_dir_all(claude.join("skills/my-skill")).unwrap();
         std::fs::write(claude.join("skills/my-skill/SKILL.md"), "# stub").unwrap();
@@ -881,15 +454,33 @@ mod tests {
         std::fs::write(plugin_skill.join("SKILL.md"), "# stub").unwrap();
 
         let snap = ToolSurfaceSnapshot::scan(&claude).unwrap();
-        assert!(snap.has_subagent("code-reviewer"));
+        assert!(snap.has_subagent("user-custom"));
         assert!(snap.has_skill("my-skill"));
         assert!(snap.has_skill("plug-skill"));
     }
 
     #[test]
+    fn snapshot_picks_up_plugin_subagent_via_in_memory_pipeline() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        // Stage the source file the way claude-plugins-official lays
+        // out on disk after `claude /plugin add`.
+        let src = claude
+            .join("plugins/marketplaces/claude-plugins-official/plugins/pr-review-toolkit/agents/code-reviewer.md");
+        std::fs::create_dir_all(src.parent().unwrap()).unwrap();
+        std::fs::write(&src, "# code-reviewer\n").unwrap();
+
+        let snap = ToolSurfaceSnapshot::scan(&claude).unwrap();
+        // Reachable under both bare and namespaced forms.
+        assert!(snap.has_subagent("code-reviewer"));
+        assert!(snap.has_subagent("pr-review-toolkit:code-reviewer"));
+        // Other plugin agents whose source isn't staged don't leak in.
+        assert!(!snap.has_subagent("code-architect"));
+    }
+
+    #[test]
     fn snapshot_reads_mcp_from_claude_json() {
         let tmp = tempfile::TempDir::new().unwrap();
-        // Layout: <home>/.claude/ for claude_dir, <home>/.claude.json sibling
         let claude = tmp.path().join(".claude");
         std::fs::create_dir_all(&claude).unwrap();
         std::fs::write(
@@ -940,13 +531,83 @@ mod tests {
     }
 
     #[test]
-    fn missing_tool_fix_hint_recommends_doctor_for_recommended_agents() {
+    fn fix_hint_for_known_plugin_agent_names_plugin_id() {
         let m = MissingTool::Subagent("code-reviewer".into());
         let h = m.fix_hint();
-        assert!(h.contains("ccteam doctor"), "got: {h}");
+        assert!(
+            h.contains("pr-review-toolkit@claude-plugins-official"),
+            "got: {h}",
+        );
+        assert!(h.contains("plugin"), "got: {h}");
+    }
 
-        let m2 = MissingTool::Subagent("user-custom".into());
-        let h2 = m2.fix_hint();
-        assert!(h2.contains("custom agent"), "got: {h2}");
+    #[test]
+    fn fix_hint_for_unknown_subagent_points_at_user_agents_dir() {
+        let m = MissingTool::Subagent("user-custom".into());
+        let h = m.fix_hint();
+        assert!(h.contains("custom agent"), "got: {h}");
+        assert!(h.contains("~/.claude/agents/"), "got: {h}");
+    }
+
+    #[test]
+    fn migrate_returns_empty_when_no_agents_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let reports = migrate_recommended_agent_symlinks(&claude, false).unwrap();
+        assert!(reports.is_empty());
+    }
+
+    #[test]
+    fn migrate_removes_only_marketplace_symlinks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let agents = claude.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        // Stage a plugin source file.
+        let plugin_src = claude.join(
+            "plugins/marketplaces/claude-plugins-official/plugins/pr-review-toolkit/agents/code-reviewer.md",
+        );
+        std::fs::create_dir_all(plugin_src.parent().unwrap()).unwrap();
+        std::fs::write(&plugin_src, "# stub").unwrap();
+        // ccteam-style symlink -> marketplace
+        let stale = agents.join("code-reviewer.md");
+        std::os::unix::fs::symlink(&plugin_src, &stale).unwrap();
+        // Operator-authored regular file (must survive)
+        let user_file = agents.join("user-custom.md");
+        std::fs::write(&user_file, "# operator").unwrap();
+        // Operator symlink to a non-marketplace path (must survive)
+        let foreign_target = tmp.path().join("foreign.md");
+        std::fs::write(&foreign_target, "# foreign").unwrap();
+        let foreign_link = agents.join("foreign.md");
+        std::os::unix::fs::symlink(&foreign_target, &foreign_link).unwrap();
+
+        let reports = migrate_recommended_agent_symlinks(&claude, false).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert!(reports[0].removed);
+        assert!(!stale.exists());
+        // Survivors:
+        assert!(user_file.exists());
+        assert!(foreign_link.symlink_metadata().unwrap().file_type().is_symlink());
+    }
+
+    #[test]
+    fn migrate_dry_run_does_not_remove() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let agents = claude.join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        let plugin_src = claude.join(
+            "plugins/marketplaces/claude-plugins-official/plugins/pr-review-toolkit/agents/code-reviewer.md",
+        );
+        std::fs::create_dir_all(plugin_src.parent().unwrap()).unwrap();
+        std::fs::write(&plugin_src, "# stub").unwrap();
+        let stale = agents.join("code-reviewer.md");
+        std::os::unix::fs::symlink(&plugin_src, &stale).unwrap();
+
+        let reports = migrate_recommended_agent_symlinks(&claude, true).unwrap();
+        assert_eq!(reports.len(), 1);
+        assert!(!reports[0].removed);
+        // Dry-run preserves the symlink.
+        assert!(stale.symlink_metadata().unwrap().file_type().is_symlink());
     }
 }

--- a/crates/ccteam-core/tests/templates_test.rs
+++ b/crates/ccteam-core/tests/templates_test.rs
@@ -2,7 +2,8 @@
 //! `.claude/settings.json` under a tempdir-rooted project.
 
 use ccteam_core::{
-    write_global_helper_templates, write_project_settings, HELPER_TEMPLATES,
+    write_global_helper_templates, write_project_settings, EnabledPluginsSetting,
+    HELPER_TEMPLATES,
 };
 use tempfile::TempDir;
 
@@ -11,7 +12,7 @@ fn write_project_settings_creates_dot_claude_dir_and_valid_json() {
     let tmp = TempDir::new().unwrap();
     let project = tmp.path().join("acme");
 
-    write_project_settings(&project).unwrap();
+    write_project_settings(&project, &EnabledPluginsSetting::default()).unwrap();
 
     let path = project.join(".claude").join("settings.json");
     assert!(path.exists(), "settings.json should exist after rendering");
@@ -26,13 +27,31 @@ fn write_project_settings_is_idempotent() {
     let tmp = TempDir::new().unwrap();
     let project = tmp.path().join("acme");
 
-    write_project_settings(&project).unwrap();
+    write_project_settings(&project, &EnabledPluginsSetting::default()).unwrap();
     let first = std::fs::read(project.join(".claude/settings.json")).unwrap();
 
-    write_project_settings(&project).unwrap();
+    write_project_settings(&project, &EnabledPluginsSetting::default()).unwrap();
     let second = std::fs::read(project.join(".claude/settings.json")).unwrap();
 
     assert_eq!(first, second, "rerun must produce identical bytes");
+}
+
+#[test]
+fn write_project_settings_writes_enabled_plugins_when_subagents_declared() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("acme");
+
+    let mut enabled = EnabledPluginsSetting::default();
+    enabled
+        .plugin_ids
+        .insert("pr-review-toolkit@claude-plugins-official".into());
+    write_project_settings(&project, &enabled).unwrap();
+
+    let bytes =
+        std::fs::read(project.join(".claude/settings.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let map = v["enabledPlugins"].as_object().expect("enabledPlugins object");
+    assert_eq!(map["pr-review-toolkit@claude-plugins-official"], true);
 }
 
 // -------------- M2.4: helper template global writer --------------

--- a/crates/ccteam-core/tests/tool_surface_e2e_test.rs
+++ b/crates/ccteam-core/tests/tool_surface_e2e_test.rs
@@ -1,16 +1,15 @@
-//! M0.5.7 — end-to-end regression for the tool-surface foundation.
+//! Tool-surface foundation regression. V0.2 M0.20 replaces the M0.5
+//! `~/.claude/agents/` ln -sf protocol with Claude Code's in-memory
+//! plugin pipeline:
 //!
-//! Acceptance: a freshly bootstrapped project must come up under
-//! orchestrator startup even when its phase markdown declares
-//! `tools_required: subagents: [code-reviewer]`. The bootstrap path
-//! is responsible for ln -sf'ing the agent file before
-//! `Orchestrator::new`'s tool-surface validator runs.
-//!
-//! We exercise the full chain — bootstrap_project (which calls
-//! setup_tool_surface internally) → orchestrator construction with
-//! the real `tools_required` from `phases/03-implement.md` — under
-//! an isolated `CLAUDE_CONFIG_HOME` pointed at a tempdir so the test
-//! doesn't depend on the developer's `~/.claude/` state.
+//!   1. `bootstrap_project` writes `enabledPlugins` into the spawned
+//!      project's `.claude/settings.json`, derived from each phase
+//!      YAML's `tools_required.subagents` via `plugin_resolution`.
+//!   2. The orchestrator's tool-surface validator passes when the
+//!      plugin source file exists under
+//!      `~/.claude/plugins/marketplaces/<mkt>/plugins/<plugin>/agents/<name>.md`.
+//!   3. `Task(subagent_type=...)` resolves at runtime through the
+//!      plugin pipeline (Claude Code namespaces it as `<plugin>:<name>`).
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -20,10 +19,9 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use ccteam_core::{
-    bootstrap_project, decide_tick_from_events, dev_dag,
-    link_recommended_agents_for_phases_into, progress, slugify, AgentLinkAction, CcteamPaths,
-    LinkOptions, Orchestrator, OrchestratorConfig, PhaseState, PhaseTemplate, ProjectState,
-    TickAction, RECOMMENDED_AGENTS,
+    bootstrap_project, decide_tick_from_events, dev_dag, plugins_to_enable, progress, slugify,
+    CcteamPaths, KNOWN_PLUGIN_AGENTS, Orchestrator, OrchestratorConfig, PhaseState,
+    PhaseTemplate, ProjectState, TickAction,
 };
 
 /// Several tests in this file mutate `CLAUDE_CONFIG_HOME`, which is a
@@ -54,23 +52,21 @@ impl Drop for ScopedClaude<'_> {
     }
 }
 
+/// Stage every shipped plugin agent's source file under the in-memory
+/// plugin pipeline path layout. Mirrors what `claude /plugin add
+/// claude-plugins-official` writes after marketplace fetch.
 fn stage_plugin_sources(claude_dir: &Path) {
-    for agent in RECOMMENDED_AGENTS {
+    for agent in KNOWN_PLUGIN_AGENTS {
         let src = agent.source_path(claude_dir);
         std::fs::create_dir_all(src.parent().unwrap()).unwrap();
-        std::fs::write(&src, format!("# stub for {}\n", agent.filename)).unwrap();
+        std::fs::write(&src, format!("# stub for {}\n", agent.subagent)).unwrap();
     }
 }
 
 fn write_global_phases_with_implement(phases_dir: &Path) {
     std::fs::create_dir_all(phases_dir).unwrap();
-    // The shipped 03-implement.md declares tools_required:[code-reviewer]
-    // — we read it from disk so this test breaks loudly if anyone
-    // weakens the declaration.
     let implement_src = include_str!("../../../teams/dev/phases/03-implement.md");
     std::fs::write(phases_dir.join("03-implement.md"), implement_src).unwrap();
-    // Plus a minimal plan-eng so the orchestrator has more than one
-    // template to validate.
     let plan_eng = concat!(
         "---\n",
         "name: plan-eng\n",
@@ -83,8 +79,6 @@ fn write_global_phases_with_implement(phases_dir: &Path) {
 
 #[test]
 fn shipped_implement_phase_declares_code_reviewer_subagent() {
-    // Sentinel: catch a future commit that strips the tools_required
-    // declaration from 03-implement.md without intending to.
     let body = include_str!("../../../teams/dev/phases/03-implement.md");
     let template = PhaseTemplate::parse(body).unwrap();
     assert!(
@@ -104,13 +98,12 @@ fn shipped_implement_phase_declares_code_reviewer_subagent() {
     );
 }
 
-/// Full M0.5.7 chain:
-///   1. set CLAUDE_CONFIG_HOME → tempdir/claude
-///   2. stage all 8 plugin agent source files there
-///   3. bootstrap_project (ln -sf 8 agents into <claude>/agents/)
-///   4. write the *real* shipped implement.md to phases dir
-///   5. Orchestrator::new — tool-surface validator must pass because
-///      bootstrap_project just registered code-reviewer
+/// V0.2 M0.20 chain:
+///   1. CLAUDE_CONFIG_HOME → tempdir/claude
+///   2. stage every plugin agent source file (simulates plugin install)
+///   3. bootstrap_project writes enabledPlugins to settings.json
+///   4. orchestrator's tool-surface validator passes via the plugin
+///      pipeline reachability check
 #[test]
 fn fresh_project_passes_tool_surface_validator_for_shipped_implement() {
     let tmp = TempDir::new().unwrap();
@@ -126,22 +119,29 @@ fn fresh_project_passes_tool_surface_validator_for_shipped_implement() {
     write_global_phases_with_implement(&paths.phases_dir());
 
     let slug = slugify("review smoke");
-    bootstrap_project(&paths, &slug, "review smoke", "dev").unwrap();
+    let project_dir = bootstrap_project(&paths, &slug, "review smoke", "dev").unwrap();
 
-    // Confirm bootstrap actually placed the symlink — this is the
-    // M0.5.1 + M0.5.3 contract.
-    let target = claude_dir.join("agents").join("code-reviewer.md");
-    assert!(
-        target.exists(),
-        "bootstrap_project must ln -sf code-reviewer.md into {}",
-        target.display(),
-    );
-    let meta = std::fs::symlink_metadata(&target).unwrap();
-    assert!(meta.file_type().is_symlink());
+    // V0.2 M0.20 contract: the spawned project's settings.json carries
+    // enabledPlugins for the plugin shipping each declared subagent
+    // (instead of an ln -sf into ~/.claude/agents/).
+    let settings = project_dir.join(".claude/settings.json");
+    let v: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&settings).unwrap()).unwrap();
+    let enabled = v["enabledPlugins"]
+        .as_object()
+        .expect("enabledPlugins must be present when team declares plugin subagents");
+    assert_eq!(enabled["pr-review-toolkit@claude-plugins-official"], true);
 
-    // The validator is what would otherwise fail loudly. Construction
-    // succeeding with default config (skip_tool_check=false) is the
-    // acceptance.
+    // No ln -sf into ~/.claude/agents/ — V0.2 M0.20 deletes that path.
+    let agents_dir = claude_dir.join("agents");
+    if agents_dir.exists() {
+        let count = std::fs::read_dir(&agents_dir).unwrap().count();
+        assert_eq!(
+            count, 0,
+            "ccteam-core no longer writes ~/.claude/agents/ — found {count} entries",
+        );
+    }
+
     let orch = Orchestrator::new(paths, OrchestratorConfig::default()).unwrap();
     assert_eq!(orch.templates().len(), 2);
     let names: Vec<&str> = orch.templates().iter().map(|t| t.name.as_str()).collect();
@@ -149,11 +149,8 @@ fn fresh_project_passes_tool_surface_validator_for_shipped_implement() {
     assert!(names.contains(&"plan-eng"));
 }
 
-/// SubagentStop appears *after* phase_done in real Claude Code 2.x
-/// (subagent shutdown happens after the parent turn's Stop hook
-/// fires). Our state machine must still advance — confirmed in
-/// `progress::latest_terminal_event_for_phase` unit tests, but worth
-/// re-asserting at the orchestrator decision level for M0.5.7.
+/// SubagentStop appears *after* phase_done in real Claude Code 2.x —
+/// the state machine must still advance.
 #[test]
 fn implement_phase_advances_when_subagent_done_lands_after_phase_done() {
     let tmp = TempDir::new().unwrap();
@@ -165,16 +162,11 @@ fn implement_phase_advances_when_subagent_done_lands_after_phase_done() {
     let project_dir = paths.project_dir(slug);
     std::fs::create_dir_all(project_dir.join(".ccteam")).unwrap();
 
-    // State: implement is in-flight after a code-reviewer Task launch.
     let mut state = ProjectState::initial(slug.into());
     state.current_phase = "implement".into();
     state.phase_state = PhaseState::InFlight;
     state.save(&paths.project_state(slug)).unwrap();
 
-    // Simulate the production event sequence: phase_inject (impl
-    // started), the code-reviewer subagent's PreToolUse / PostToolUse,
-    // then parse-phase-end's phase_done, then a trailing SubagentStop
-    // for the code-reviewer.
     let progress_path = paths.progress_jsonl(slug);
     let events = [
         json!({"event": "phase_inject", "phase": "implement"}),
@@ -186,7 +178,6 @@ fn implement_phase_advances_when_subagent_done_lands_after_phase_done() {
             "phase": "implement",
             "ts": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
         }),
-        // Real Claude Code 2.1.x flushes SubagentStop *after* Stop.
         json!({"event": "SubagentStop", "subagent_type": "code-reviewer"}),
     ];
     for e in &events {
@@ -206,16 +197,13 @@ fn implement_phase_advances_when_subagent_done_lands_after_phase_done() {
     );
 }
 
-/// Negative case: if bootstrap is skipped (no symlink + no fallback),
-/// orchestrator startup must reject with a fix hint. This locks in
-/// the "fail loud, never silently silent-fail" contract.
+/// Negative case: when the plugin source isn't installed, orchestrator
+/// startup must reject with a fix hint pointing at the plugin id.
 #[test]
 fn missing_code_reviewer_fails_orchestrator_construction_with_fix_hint() {
     let tmp = TempDir::new().unwrap();
     let claude_dir = tmp.path().join("claude-empty");
     std::fs::create_dir_all(&claude_dir).unwrap();
-    // Note: we deliberately do NOT stage plugin sources, so no link
-    // bootstrap can produce.
 
     let _claude_guard = ScopedClaude::set(&claude_dir);
 
@@ -225,8 +213,6 @@ fn missing_code_reviewer_fails_orchestrator_construction_with_fix_hint() {
     };
     write_global_phases_with_implement(&paths.phases_dir());
 
-    // Bootstrap will warn (source missing) but not fail. The
-    // orchestrator validator is what we expect to fail loudly.
     let slug = slugify("missing reviewer");
     bootstrap_project(&paths, &slug, "missing reviewer", "dev").unwrap();
 
@@ -237,98 +223,59 @@ fn missing_code_reviewer_fails_orchestrator_construction_with_fix_hint() {
         "error must name the missing subagent, got: {msg}",
     );
     assert!(
-        msg.contains("ccteam doctor"),
-        "error must include the fix hint, got: {msg}",
+        msg.contains("pr-review-toolkit@claude-plugins-official"),
+        "error must include the plugin id fix hint, got: {msg}",
     );
 }
 
-/// M2.1: phase YAML's `sub_skills` reference plugin agents that may
-/// not be in the hardcoded RECOMMENDED_AGENTS set. The phase-aware
-/// linker walks each template's sub_skills and ln -sfs the plugin
-/// source so `Task(subagent_type=...)` finds the agent at session
-/// start.
+/// V0.2 M0.20: phase YAML's sub_skill referencing a plugin agent via
+/// `<marketplace>:<plugin>/agents/<name>.md` propagates the same plugin
+/// dependency into `enabledPlugins` even when the bare name isn't
+/// listed in `tools_required.subagents`.
 #[test]
-fn link_phase_subagents_picks_up_sub_skill_plugin_agent() {
-    let tmp = TempDir::new().unwrap();
-    let claude_dir = tmp.path().join("claude");
-    stage_plugin_sources(&claude_dir);
-    // Stage an extra plugin agent that isn't in RECOMMENDED_AGENTS, so
-    // the test proves the extension does more than the hardcoded
-    // recommended set.
-    let custom = claude_dir
-        .join("plugins/marketplaces/claude-plugins-official/plugins/custom-toolkit/agents/custom-reviewer.md");
-    std::fs::create_dir_all(custom.parent().unwrap()).unwrap();
-    std::fs::write(&custom, "# custom-reviewer stub\n").unwrap();
-
-    let _guard = ScopedClaude::set(&claude_dir);
-
-    // Phase template with one sub_skill referencing the custom agent.
+fn enabled_plugins_picks_up_sub_skill_plugin_agent() {
     let body = concat!(
         "---\n",
         "name: review\n",
         "parallelism: solo\n",
         "sub_skills:\n",
-        "  - skill: claude-plugins-official:custom-toolkit/agents/custom-reviewer.md\n",
+        "  - skill: claude-plugins-official:pr-review-toolkit/agents/code-reviewer.md\n",
         "    trigger: phase_done\n",
-        "    output_to: .ccteam/custom-review.md\n",
+        "    output_to: .ccteam/code-review.md\n",
         "---\n",
         "body\n",
     );
     let template = PhaseTemplate::parse(body).unwrap();
 
-    let reports =
-        link_recommended_agents_for_phases_into(&claude_dir, &[template], LinkOptions::default())
-            .unwrap();
-
-    // Must include the 8 hardcoded agents *and* the new one.
-    assert_eq!(
-        reports.len(),
-        RECOMMENDED_AGENTS.len() + 1,
-        "expected {} reports, got {}",
-        RECOMMENDED_AGENTS.len() + 1,
-        reports.len(),
+    // The bare subagent name extracted from the sub_skill path resolves
+    // through plugin_resolution.
+    let plugin_ids = plugins_to_enable(["code-reviewer"]);
+    assert!(
+        plugin_ids.contains("pr-review-toolkit@claude-plugins-official"),
+        "code-reviewer must resolve to pr-review-toolkit@claude-plugins-official",
     );
-    let custom_report = reports
-        .iter()
-        .find(|r| r.agent.filename == "custom-reviewer.md")
-        .expect("custom-reviewer plugin agent must appear in reports");
-    assert_eq!(custom_report.action, AgentLinkAction::Linked);
-    assert!(claude_dir
-        .join("agents/custom-reviewer.md")
-        .symlink_metadata()
-        .unwrap()
-        .file_type()
-        .is_symlink());
+    // Sentinel: the parsed template still carries the sub_skill reference
+    // verbatim so bootstrap_project sees it.
+    assert_eq!(template.sub_skills.len(), 1);
+    assert!(
+        template.sub_skills[0].skill.contains("code-reviewer.md"),
+        "sub_skill must keep the agent path intact",
+    );
 }
 
-/// Sub-skill referencing a hook script (`.sh`) instead of an agent
-/// must NOT be auto-linked into `~/.claude/agents/` — only `.md`
-/// files under `<plugin>/agents/` count as Task-callable subagents.
+/// Plugin name lookup table covers every shipped phase YAML's known
+/// subagent so a fresh project's enabledPlugins isn't empty by accident
+/// for the dev / product-research teams.
 #[test]
-fn link_phase_subagents_skips_non_agent_sub_skill_paths() {
-    let tmp = TempDir::new().unwrap();
-    let claude_dir = tmp.path().join("claude");
-    stage_plugin_sources(&claude_dir);
-
-    let _guard = ScopedClaude::set(&claude_dir);
-
-    let body = concat!(
-        "---\n",
-        "name: ship\n",
-        "parallelism: solo\n",
-        "sub_skills:\n",
-        "  - skill: claude-plugins-official:security-guidance/hooks/security_reminder_hook.py\n",
-        "    trigger: phase_start\n",
-        "    output_to: .ccteam/precheck.md\n",
-        "---\n",
-    );
-    let template = PhaseTemplate::parse(body).unwrap();
-
-    let reports =
-        link_recommended_agents_for_phases_into(&claude_dir, &[template], LinkOptions::default())
-            .unwrap();
-    // Just the 8 hardcoded — the .py hook is not eligible for Task
-    // dispatch, so no extra link.
-    assert_eq!(reports.len(), RECOMMENDED_AGENTS.len());
+fn known_subagents_resolve_to_official_marketplace_plugins() {
+    let plugin_ids: Vec<String> = plugins_to_enable([
+        "code-reviewer",
+        "code-architect",
+        "code-simplifier",
+    ])
+    .into_iter()
+    .collect();
+    assert!(plugin_ids.contains(&"pr-review-toolkit@claude-plugins-official".to_string()));
+    assert!(plugin_ids.contains(&"feature-dev@claude-plugins-official".to_string()));
+    assert!(plugin_ids.contains(&"code-simplifier@claude-plugins-official".to_string()));
 }
-

--- a/docs/claude-code-tool-surface.md
+++ b/docs/claude-code-tool-surface.md
@@ -83,13 +83,16 @@ command 触发后的特殊上下文里可调,**不进全局 Task subagent 注册
 
 | 方案 | 怎么做 | 评价 |
 |---|---|---|
-| A. 安装到全局 agents 目录 | `cp <plugin>/agents/code-reviewer.md ~/.claude/agents/` 后,所有 claude session 的 `Task(subagent_type="code-reviewer")` 都能调 | ✅ 推荐;ccteam M1 `bootstrap_project` 应该批量做这件事 |
+| A. 启用 in-memory plugin pipeline | spawned session 的 `<project>/.claude/settings.json` 写 `enabledPlugins: {"<plugin>@<mkt>": true}`,Claude Code 自动 namespace `<plugin>:<name>`,phase markdown 用裸名仍可调 | ✅ V0.2 M0.20 起的官方路径;ccteam `bootstrap_project` 自动据 phase YAML 写 |
 | B. `@文件引用` + general-purpose 执行 | phase markdown 里写 "请用 Task(subagent_type='general-purpose'),把 `@~/.claude/plugins/.../agents/code-reviewer.md` 的内容当作 system prompt,review 当前 diff" | ✅ 零安装,但每次都走 general-purpose,损失了 plugin agent 的 model / color / tools 配置 |
 | C. orchestrator send-keys 触发 slash command | tmux send-keys `/review-pr <args>`,plugin 自己的 prompt body 在 TUI 上下文里能调它的私有 agent | ⚠️ 阻塞长会话当前 turn,只适合 phase 边界 |
 
-**ccteam 的设计选择**:M0 用方案 B(零安装,文档先行);M1 在 `bootstrap_project`
-里加方案 A 的批量复制(`ccteam doctor --install-recommended-agents`);方案 C
-留给 director-claude(通道 3)在跨 phase 路由时调用。
+**ccteam 的设计选择**:V0.2 M0.20 起 `bootstrap_project` 用方案 A
+(`enabledPlugins` 写到 spawned session 的 settings.json,plugin pipeline
+自动加载 + namespace);**V0.1 的 ln -sf 路径已删除**,旧 ccteam 用户用
+`ccteam doctor --migrate-recommended-agents` 一次性清理 `~/.claude/agents/`
+里残留的 ccteam 创建的 symlink。方案 B 仍然作为零安装兜底;方案 C 留给
+director-claude(通道 3)在跨 phase 路由时调用。
 
 #### 1.1.4 验证示例(无需任何 plugin,直接可跑)
 
@@ -129,8 +132,10 @@ Task(subagent_type="code-reviewer", description="review HEAD diff",
      prompt="Review the unstaged diff against CLAUDE.md guidelines.")
 ```
 
-ccteam 项目用 plugin agent 的步骤见 §6.2(必须先 ln -sf 到 `~/.claude/agents/`
-才能 Task 调,不是装 plugin 就能用)。
+ccteam 项目从 V0.2 M0.20 起靠 in-memory plugin pipeline 调用 plugin agent
+(详见 §6.2):`bootstrap_project` 把依赖的 plugin 写进
+`<project>/.claude/settings.json` 的 `enabledPlugins` 字段,Claude Code
+session 启动时 plugin pipeline 自动加载,**不再 ln -sf 到 `~/.claude/agents/`**。
 
 ---
 
@@ -207,20 +212,25 @@ Claude Code 对 `~/.claude/skills/`、项目 `.claude/skills/`、`--add-dir`
 
 **最终结论**:
 - Skill 的 SKILL.md 文件**实时监听**,中途加生效(§1.2.4)
-- `~/.claude/agents/<name>.md` **会话启动时一次性扫描**,**中途加不生效**;但 startup 时已存在的 agent 文件**正常被识别**——所以 M1 `bootstrap_project` 在 `tmux new-session` 之前 ln -sf 这条路**完全可行**(已实测确认)
+- `~/.claude/agents/<name>.md` **会话启动时一次性扫描**,**中途加不生效**;
+  V0.1 ccteam 靠 startup 前 ln -sf 这条路曾经可行,**V0.2 M0.20 改走
+  in-memory plugin pipeline**(`enabledPlugins` 写到 spawned session
+  的 settings.json,Claude Code session 启动时一次性加载 enabled plugin)
+  —— ccteam-core 不再写 `~/.claude/agents/`
 
-#### 1.2.6 给 ccteam M1 `bootstrap_project` 的强约束
+#### 1.2.6 给 ccteam `bootstrap_project` 的强约束
 
-既然 agent 必须 startup 前注册,`bootstrap_project` 的执行顺序必须是:
+agent / plugin 必须 startup 前注册,`bootstrap_project` 的执行顺序必须是:
 
 ```
 ccteam new <brief>
   ├─ 1. 创建 ~/projects/<slug>/ 目录与子目录
   ├─ 2. 写 spec.md / CLAUDE.md / phase 模板 / settings.json
+  │       (含 `enabledPlugins`,V0.2 M0.20)
   ├─ 3. 写 ~/.claude.json 的 hasTrustDialogAccepted
-  ├─ 4. **ln -sf 推荐 plugin agents 到 ~/.claude/agents/**(M1 新增)
-  ├─ 5. mkdir -p ~/.claude/skills/ <project>/.claude/skills/(占位让监听挂上)
-  └─ 6. 由 orchestrator ensure_session 触发 tmux new-session(claude TUI 启动)
+  ├─ 4. mkdir -p ~/.claude/skills/ <project>/.claude/skills/(占位让监听挂上)
+  └─ 5. 由 orchestrator ensure_session 触发 tmux new-session(claude TUI 启动,
+        plugin pipeline 加载 enabledPlugins 并 namespace 每个 plugin agent)
 ```
 
 第 4 步**必须**在第 6 步之前;第 5 步是为了让 skill 后续懒注入能命中
@@ -424,15 +434,16 @@ ESCALATE 语法节、phase 模板里的 ESCALATE 写法示例。M0 不需要,先
 
 | 决策类型 | 谁来 | 前置条件 |
 |---|---|---|
-| 当前 phase 里要不要调 code-reviewer / code-simplifier | 通道 1(长会话内 Claude 自决) | agent 文件已 ln 到 `~/.claude/agents/`(见 §6.2) |
+| 当前 phase 里要不要调 code-reviewer / code-simplifier | 通道 1(长会话内 Claude 自决) | spawned session settings.json 有 `enabledPlugins` 启用对应 plugin(见 §6.2) |
 | 要不要 `/exit` reset / `/reload-plugins` | 通道 2(orchestrator,看 cost / context 阈值机械触发) | — |
 | 下一 phase 走 fix 还是 ship,要不要 inject `/review-pr` 等 TUI 命令 | 通道 3(director-claude) | M1+ |
 
-**重要的架构后果**:Plugin agent 不是"装了 plugin 就能调"——必须额外做一步
-agents 目录注册才进通道 1。这意味着:**ccteam M1 的 `bootstrap_project`
-必须把 §6.2 那段 ln -sf 加进去**,否则所有"phase 让模型自己调 code-reviewer"
-的设计在产出项目里都跑不通,只能 fallback 到通道 3 的 send-keys `/review-pr`。
-这条已记入 development-plan(M1.x)。
+**重要的架构后果**:Plugin agent 不是"装了 plugin 就能调"——spawned project
+session 必须显式 enable plugin pipeline 才进通道 1。**V0.2 M0.20 起
+`bootstrap_project` 自动据 phase YAML `tools_required.subagents` 写
+`enabledPlugins` 到 `<project>/.claude/settings.json`**,session 启动时
+plugin pipeline 加载 + namespace,phase markdown 用 `Task(subagent_type=...)`
+即可调。否则只能 fallback 到通道 3 的 send-keys `/review-pr`。
 
 ### 3.4 与 sub_skills 的边界(M2)
 
@@ -461,44 +472,31 @@ sub_skills 是 phase front matter 里**声明式**指定的 plugin 触发,固定
 | `claude-code-guide` | Claude Code 内置 | Claude Code 用法咨询 |
 | `statusline-setup` | Claude Code 内置 | 配置 status line |
 
-### 6.2 想做 plugin 级别 review / simplify / 架构方案 — 必须做安装步骤
+### 6.2 想做 plugin 级别 review / simplify / 架构方案 — 用 plugin pipeline
 
 `pr-review-toolkit` / `feature-dev` / `code-simplifier` 等 plugin 里的 agent
-**装了 plugin 也不能直接 Task 调**(见 §1.1.2)。要在 ccteam 自治调用,
-需要在 ccteam `bootstrap_project`(或一次性手工)里执行下面这步:
+**装了 plugin 也不能直接 Task 调**(见 §1.1.2),除非 enable plugin pipeline。
+ccteam V0.2 M0.20 起走**官方 in-memory plugin pipeline 路径**——不再 ln -sf。
 
-```bash
-# 把 plugin agent 文件软链/拷到全局 agents 目录,Claude Code 会扫这里
-# 自动注册成 subagent_type。
-# 显式列出每个文件 —— **不要用 pr-review-toolkit/agents/*.md 这种 glob**:
-# 该目录下也有 code-simplifier.md,会跟下面 code-simplifier plugin 的同名文
-# 件抢同一个 ~/.claude/agents/code-simplifier.md target,后写盖前写,得到
-# 哪个版本不确定。
-mkdir -p ~/.claude/agents
-PLUGIN_ROOT=~/.claude/plugins/marketplaces/claude-plugins-official/plugins
-for src in \
-  "$PLUGIN_ROOT/pr-review-toolkit/agents/code-reviewer.md" \
-  "$PLUGIN_ROOT/pr-review-toolkit/agents/silent-failure-hunter.md" \
-  "$PLUGIN_ROOT/pr-review-toolkit/agents/pr-test-analyzer.md" \
-  "$PLUGIN_ROOT/pr-review-toolkit/agents/type-design-analyzer.md" \
-  "$PLUGIN_ROOT/pr-review-toolkit/agents/comment-analyzer.md" \
-  "$PLUGIN_ROOT/feature-dev/agents/code-architect.md" \
-  "$PLUGIN_ROOT/feature-dev/agents/code-explorer.md" \
-  "$PLUGIN_ROOT/code-simplifier/agents/code-simplifier.md"
-do
-  ln -sf "$src" "$HOME/.claude/agents/$(basename "$src")"
-done
+**ccteam 自治调用**:`bootstrap_project` 写 `<project>/.claude/settings.json`
+时,根据 phase YAML `tools_required.subagents` 解析出依赖的 Claude Code plugin
+(静态映射表:`crates/ccteam-core/src/plugin_resolution.rs`),写入
+`enabledPlugins`:
+
+```jsonc
+{
+  "enabledPlugins": {
+    "pr-review-toolkit@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true
+  }
+}
 ```
 
-(`code-simplifier` 取自 `code-simplifier` plugin 的版本——它是该 plugin 的
-正主;`pr-review-toolkit` 里的 `code-simplifier.md` 是该 plugin 内部使用的
-副本,生产代码 M0.5.1 实测 reviewer catch 了这个重名 target 冲突,显式枚举
-是正确做法。)
-
-之后用 `Task(subagent_type="probe-XXX")` 探当前可用列表 —— 应该多出
-`code-reviewer`、`code-architect`、`code-explorer`、`code-simplifier`、
-`silent-failure-hunter`、`pr-test-analyzer`、`type-design-analyzer`、
-`comment-analyzer`。
+Claude Code session 启动时 plugin pipeline 自动加载 enabled plugin,
+**namespace 加 `<plugin>:` 前缀**(eg `pr-review-toolkit:code-reviewer`);
+phase markdown 用裸名 `Task(subagent_type="code-reviewer")` 仍然可调,
+plugin pipeline 自匹配。
 
 | 来源 plugin | agent 文件 → subagent_type | ccteam 用例 |
 |---|---|---|
@@ -511,13 +509,19 @@ done
 | `pr-review-toolkit` | `comment-analyzer` | review phase |
 | `code-simplifier` | `code-simplifier` | review 后打磨 |
 
-**ccteam 路线图**:M1 起 `bootstrap_project` 在 `tmux new-session` **之前**
-自动做 ln -sf(执行顺序见 §1.2.6);可单独通过 `ccteam doctor
---install-recommended-agents` 给老项目补做。在 M1 落地前,phase 模板用
-§1.1.3 方案 B(`@文件引用` + Task general-purpose)兜底。
+**用户需先装上游 plugin**:`claude /plugin add pr-review-toolkit@claude-plugins-official`
+(以及 `feature-dev` / `code-simplifier`)——**只一次,装在 user level
+(`~/.claude/plugins/marketplaces/`)**。spawned project session 通过
+`enabledPlugins` 启用 plugin pipeline,不需要每个项目重装。
 
-**关键约束**(已实测确认):agent 文件必须在 claude session 启动时已存在 ——
-中途 ln -sf 不生效(§1.2.5)。这条不能违反。
+**V0.1 → V0.2 升级**:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf
+是 ccteam-core 自己写的,V0.2 起停止维护。一次性清理:
+`ccteam doctor --migrate-recommended-agents [--dry-run]`(只删 ccteam
+当年创建的 marketplace symlink,操作员手写文件保留)。
+
+**关键约束**(plugin pipeline 替代 ln -sf 后仍然成立):enabledPlugins
+必须在 session 启动时已写好——orchestrator 在 `tmux new-session` **之前**
+完成 `bootstrap_project`(执行顺序见 §1.2.6),然后启动 session 才能正确加载。
 
 ### 6.3 推荐挂的 hook(plugin 提供)
 
@@ -543,7 +547,7 @@ done
 | 引用某个文件让模型读 | `@.ccteam/spec.md` |
 | 引用 plugin 里某个 agent 文件让模型按里面规程办 | `@~/.claude/plugins/marketplaces/claude-plugins-official/plugins/feature-dev/agents/code-architect.md` |
 | 让模型主动 launch subagent(默认 5 个) | "请使用 Task 工具,subagent_type='general-purpose'/'Explore'/'Plan'/'claude-code-guide'/'statusline-setup',..." |
-| 让模型主动 launch plugin subagent(必须先 §6.2 ln -sf) | "请使用 Task 工具,subagent_type='code-reviewer',..." |
+| 让模型主动 launch plugin subagent(必须先 §6.2 enable plugin pipeline) | "请使用 Task 工具,subagent_type='code-reviewer',..." |
 | 模型按 plugin agent 规程办但不显式调 subagent | "请读 `@~/.claude/plugins/.../agents/code-reviewer.md`,严格按其指引 review 当前 diff" |
 | 让模型用 skill | "请使用 Skill 工具调用 <name> skill" |
 | 让模型用 MCP tool | "请使用 mcp__\<server>__\<tool> 工具,..." |
@@ -566,8 +570,8 @@ done
 
 | 现象 | 根因 | 对策 |
 |---|---|---|
-| phase markdown 写 "请 `/review`",模型却没有动作 | 模型摸不到 slash command | 改为 "请用 Task 工具调 code-reviewer subagent" + §6.2 安装 |
-| `Task(subagent_type="code-reviewer")` 报 "Agent type not found, Available: general-purpose, Explore, Plan, claude-code-guide, statusline-setup" | **装了 plugin 不等于 Task 能调它的 agent**(plugin agent 文件不进 Task 全局注册表) | 跑 §6.2 那段 ln -sf,把 plugin agent 文件链到 `~/.claude/agents/`;或临时用方案 B(`@文件引用` + Task general-purpose) |
+| phase markdown 写 "请 `/review`",模型却没有动作 | 模型摸不到 slash command | 改为 "请用 Task 工具调 code-reviewer subagent" + §6.2 plugin pipeline 启用 |
+| `Task(subagent_type="code-reviewer")` 报 "Agent type not found, Available: general-purpose, Explore, Plan, claude-code-guide, statusline-setup" | **装了 plugin 不等于 Task 能调它的 agent**(spawned session 没启用 plugin pipeline) | spawned session 的 `<project>/.claude/settings.json` 加 `enabledPlugins: {"<plugin>@<mkt>": true}`(ccteam V0.2 M0.20 自动做);旧 ccteam 用户跑 `ccteam doctor --migrate-recommended-agents` 清理残留 ln -sf;临时兜底用方案 B(`@文件引用` + Task general-purpose) |
 | `Skill(skill="review-pr")` 报 InputValidationError | `review-pr` 是 plugin 的 slash command 不是 Skill;`commands/<name>.md` 文件不被 Skill 工具识别 | 这条只能走通道 2(orchestrator send-keys `/review-pr`),phase markdown 别让模型自己调 |
 | `Skill(skill="X")` 报 InputValidationError | skill 名字写错 / 当前会话没加载到 system-reminder 列表 | §1.2.2 的探针实测当前可调 skill |
 | `mcp__foo__bar` 报工具不存在 | MCP server 没连 | 检查项目 `.mcp.json` + `ccteam doctor` |

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -43,11 +43,11 @@ PRD V0.2 §6 列了 8 条 ccteam-core 反模式候选清理任务,跟 F-finding
 
 | 候选 | 描述 | 状态 |
 |---|---|---|
-| 1 + 8 | 协议关键字 `PHASE_DONE` / `ESCALATE` 三处镜像 → 单一 source | **2026-05-08 关闭(M0.18,本 PR):inject prompt template + frontmatter `completion_signal` / `escalate_grammar_ref` 单一 source;phase markdown 正文清理协议关键词;`build_phase_prompt_for_template` 是唯一 protocol literal 拼装位置;详 `docs/phase-prompt-architecture.md`** |
+| 1 + 8 | 协议关键字 `PHASE_DONE` / `ESCALATE` 三处镜像 → 单一 source | **2026-05-08 关闭(M0.18):inject prompt template + frontmatter `completion_signal` / `escalate_grammar_ref` 单一 source;phase markdown 正文清理协议关键词;`build_phase_prompt_for_template` 是唯一 protocol literal 拼装位置;详 `docs/phase-prompt-architecture.md`** |
 | 2 | `render_project_claude_md` `match team` 写死 | **2026-05-07 关闭(M0.16.3)** |
 | 3 | `TEAM_BUNDLES` 编译时常量 → seed-only | **2026-05-07 关闭(M0.16.2)** |
 | 5 | meta-agent `if team == META_TEAM_NAME` 5 处分叉 | **2026-05-07 关闭(M0.16.1)** |
-| 7 | `RECOMMENDED_AGENTS` ln -sf 8 plugin agent | M0.20 待做 |
+| 7 | `RECOMMENDED_AGENTS` ln -sf 8 plugin agent | **2026-05-08 关闭(M0.20)** — 改 in-memory plugin pipeline,`bootstrap_project` 写 `enabledPlugins` 到 spawned session settings.json;`ccteam doctor --migrate-recommended-agents` 清理 V0.1 残留 ln -sf |
 | 4 | `golden_rules` layered merge | V0.3 deferred |
 | 6 | `pre_trust_project` 写 `~/.claude.json` | V0.3 deferred |
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -599,13 +599,15 @@ confidence: 0.0-1.0
 
 | 子字段 | 名字来源 | "可达"判定 |
 |---|---|---|
-| `subagents` | `Task(subagent_type="<name>")` | `~/.claude/agents/<name>.md` 存在(不要列内置五个,但列了无害) |
+| `subagents` | `Task(subagent_type="<name>")` | (V0.2 M0.20)plugin pipeline 解析:`crates/ccteam-core/src/plugin_resolution.rs::KNOWN_PLUGIN_AGENTS` 命中 + 对应 plugin source 文件存在;或 `~/.claude/agents/<name>.md` 用户自写文件存在;或内置五个之一 |
 | `skills` | `Skill(skill="<name>")` | `~/.claude/skills/<name>/SKILL.md` 或 `~/.claude/plugins/marketplaces/*/plugins/*/skills/<name>/SKILL.md` 存在 |
 | `mcp` | `mcp__<name>__<tool>` 工具前缀 | `~/.claude.json` 或 `~/.claude/mcp_servers.json` 的 `mcpServers` 含此 key |
 
-实测背景:plugin 装了 plugin 不等于 plugin agent 进 Task 注册表 —— 必须 ln -sf 到 `~/.claude/agents/` 才行(详见 [docs/claude-code-tool-surface.md §1.1.2 / §1.2.5](./claude-code-tool-surface.md))。所以 `tools_required.subagents` 列 `code-reviewer` 而 `~/.claude/agents/code-reviewer.md` 不存在 → orchestrator 拒绝启动并给出 `ccteam doctor --install-recommended-agents` 修复命令。
+实测背景:plugin 装了 plugin 不等于 plugin agent 进 Task 注册表 —— spawned session 必须启用 plugin pipeline(V0.2 M0.20)。`bootstrap_project` 写 `<project>/.claude/settings.json` 时,根据 `tools_required.subagents` 解析 plugin 依赖,自动写入 `enabledPlugins: {"<plugin>@<mkt>": true}`;Claude Code session 启动时 plugin pipeline 加载 + 自动 namespace `<plugin>:<name>`,phase markdown 用裸名 `Task(subagent_type="code-reviewer")` 仍可调。`tools_required.subagents` 列 `code-reviewer` 而 plugin source 又不在 `~/.claude/plugins/marketplaces/` → orchestrator 拒绝启动并提示装 plugin(`claude /plugin add pr-review-toolkit@claude-plugins-official`)。
 
-`bootstrap_project` 已在 §1.2 项目创建路径里自动 ln -sf 八个推荐 agent + 占位 skills 目录,所以 happy path 上模板要的工具默认都有;只有用户手工编辑模板加了非推荐工具时才会触发本节的校验失败。
+`bootstrap_project` 已在 §1.2 项目创建路径里自动写 `enabledPlugins` + 占位 skills 目录,所以 happy path 上模板要的工具默认都有;只有用户手工编辑模板加了非推荐工具时才会触发本节的校验失败。
+
+V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `ccteam doctor --migrate-recommended-agents` 一次性清理。
 
 ---
 
@@ -1168,12 +1170,12 @@ ccteam kick <slug>                     # 软重启项目 session(claude --resume
 # ccteam 不提供 memory 子命令(无自建索引,无东西可 rebuild)。
 ccteam config edit                                # 改全局配置
 ccteam doctor                                     # 体检:列出可用 mode flags
-ccteam doctor --install-recommended-agents        # M0.5.5 ln -sf 8 个 plugin agent
-ccteam doctor --tool-surface                      # M0.5.6 phase tools_required 交叉表
+ccteam doctor --tool-surface                      # phase tools_required 交叉表(plugin pipeline 感知,V0.2 M0.20)
 ccteam doctor --install-skill                     # M1.8 写 ccteam-control skill
 ccteam doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
 ccteam doctor --install-mcp                       # M2.5 在 ~/.claude.json 注册 mcpServers.ccteam(详见 §12)
 ccteam doctor --install-memory-bridge             # M4.2 写 ~/.claude/rules/ccteam-lessons-{dev,product-research}.md 占位 + paths frontmatter scope
+ccteam doctor --migrate-recommended-agents        # V0.2 M0.20 一次性清理 V0.1 ln -sf 残留 (~/.claude/agents/ 下指向 marketplace 的 symlink)
 ccteam hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
                                                   # subcmd ∈ {progress-append, parse-phase-end,
                                                   # cost-accumulate, load-context, block-push}

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -545,7 +545,7 @@ dumb router。这条贯彻到底,避免 Symphony 多层 agent 反模式
 |---|---|---|
 | 生命周期 | 永不 terminal,跟用户 ccteam 实例同寿 | ship / abort 即终态 |
 | 行为模式 | 事件循环(等输入→处理→等输入)| phase DAG(plan-eng → ... → ship) |
-| 主要工具 | `ccteam-control` skill(已 ship,M1.8)/ `ccteam-mcp`(已 ship,M2.8)/ 跨项目 lessons(已 ship,M4 走 `~/.claude/rules/` + auto-memory)| 项目级文件操作 / 内嵌 plugin agents(已 ship,M0.5 ln -sf) |
+| 主要工具 | `ccteam-control` skill(已 ship,M1.8)/ `ccteam-mcp`(已 ship,M2.8)/ 跨项目 lessons(已 ship,M4 走 `~/.claude/rules/` + auto-memory)| 项目级文件操作 / 内嵌 plugin agents(已 ship,V0.2 M0.20 改走 `enabledPlugins` 写到 `<project>/.claude/settings.json`,Claude Code in-memory plugin pipeline 自动 namespace `<plugin>:<name>`,不再 ln -sf 进 `~/.claude/agents/`) |
 | context reset | 60% 阈值时桥接 CLAUDE.md(M0.10 已 ship);跨项目记忆通过 `~/.claude/rules/ccteam-lessons-<user>-meta.md` 滚动累积(M4 路径,无独立 conversation-log) | 60% 阈值时把当前 phase 进度写 CLAUDE.md(已 ship,M0.10) |
 | 用户 attach | `tmux attach -t ccteam-meta-<user>`,直接 NL 对话 | `tmux attach -t ccteam-<team>-<slug>`,可介入项目执行 |
 
@@ -974,6 +974,30 @@ agent（本节）= 在 phase 内或后台**并行**跑的 multi-agent；sub-skil
 完整 tool schema 与协议见 [interfaces.md §12](./interfaces.md#12-ccteam-mcp-mcp-server-m2)。**M0 / M1 走 CLI `--format json` 兜底路径**——用户的 claude 用 Bash 工具调即可;M2 后 MCP 路径作为首选,CLI 仍然保留作为脚本化入口。
 
 **实现形态**:`ccteam-mcp` 与 `ccteam-core` 同 crate(workspace 内 lib + 多 binary),通过 `ccteam mcp-serve` 子命令暴露——读写同一份 state.json / progress.jsonl,**为将来 `ccteam tui`(未 ship,M4.9) / `ccteam serve` web 前端(backlog)预留同一状态读写 API**。三种前端共用 `ccteam-core` lib API(详见 §3.8 前端层小节),MCP 只是把这套 API 套上 MCP wire protocol 给外部 LLM 消费。
+
+#### Plugin pipeline(V0.2 M0.20,候选 7)
+
+**Spawned project session 启 plugin agent 走 `enabledPlugins` 路径,不再 ln -sf 进 `~/.claude/agents/`**。
+
+`bootstrap_project` 写 `<project>/.claude/settings.json` 时,根据 team 的 phase YAML
+`tools_required.subagents` + `sub_skills` 解析依赖的 Claude Code plugin
+(eg `code-reviewer` → `pr-review-toolkit@claude-plugins-official`),写入
+`enabledPlugins: {"<plugin>@<mkt>": true}`。Claude Code session 启动时
+in-memory plugin pipeline 加载 enabled plugin,**自动加 `<plugin>:` namespace**
+(eg `pr-review-toolkit:code-reviewer`);phase markdown 用裸名
+`Task(subagent_type="code-reviewer")` 仍然可调,plugin pipeline 自匹配。
+
+- 静态映射表:`crates/ccteam-core/src/plugin_resolution.rs`
+  (`KNOWN_PLUGIN_AGENTS` const,8 个 `claude-plugins-official` agent;V0.3 改运行时发现)
+- doctor `--tool-surface` 校验:`enabledPlugins` 引用的 plugin source 文件
+  存在于 `~/.claude/plugins/marketplaces/<mkt>/plugins/<plugin>/agents/<name>.md`
+- doctor `--migrate-recommended-agents`:一次性清理 V0.1 留下的
+  `~/.claude/agents/` ln -sf(只删指向 marketplace 的 symlink,
+  操作员手写文件保留)
+
+**ccteam-core 不再写 `~/.claude/agents/`**——M4 红线"零检索 + 不写程序读 memory 文件"
+扩展到 plugin pipeline:plugin 装载交还 Claude Code 官方 in-memory pipeline,
+ccteam 只声明依赖。
 
 ### 6.5 项目级 CLAUDE.md（每项目自动生成）
 


### PR DESCRIPTION
## Summary

Closes **V0.2 M0.20** (`docs/dev-plan-v0-2.md §6` / candidate 7) — replace the M0.5 `~/.claude/agents/<name>.md` ln -sf path with the official Claude Code plugin pipeline:

1. **Delete `RECOMMENDED_AGENTS` const + `link_recommended_agents_for_phases_into`** — no more program-level symlinks into `~/.claude/agents/`.
2. **Spawned project session writes `enabledPlugins`** — `bootstrap_project` writes the project's `.claude/settings.json` with `enabledPlugins` derived from phase YAML `tools_required.subagents` via the new static map in `crates/ccteam-core/src/plugin_resolution.rs`.
3. **Doctor changes** — replaces `--install-recommended-agents` with `--migrate-recommended-agents` (one-shot cleanup of V0.1 ln -sf state); subagent reachability check now resolves `enabledPlugins` rather than asserting symlinks.
4. **Migration** — V0.1 users run `ccteam doctor --migrate-recommended-agents` once; only ccteam-managed marketplace symlinks are removed; user-authored agents preserved.

## Maps to

- PRD: `docs/prd-v0-2.md §6.5 (候选 7)` + alignment review §2.2
- Dev plan: `docs/dev-plan-v0-2.md §6`
- Audit: closes candidate 7 in `docs/dev-coupling-audit.md`

## Test results

| Item | Before | After |
|---|---|---|
| `cargo test --workspace` | 393 / 0 | **399 / 0** (+6 net; ~24 new tests, replaced/removed older ln -sf-specific tests) |
| `cargo clippy --workspace --all-targets` | 10 warnings | **10** (0 new) |

New coverage: 5 unit tests in `plugin_resolution.rs`, 13 in `tool_surface.rs` (snapshot picks up plugin pipeline + user agents, fix_hint variants, migrate happy/dry-run/no-op), 6 e2e in `tool_surface_e2e_test.rs` (bootstrap writes enabledPlugins, no ln -sf created, missing-plugin error names plugin_id, sub_skill resolution), 3 in `templates_test.rs`, 2 in `commands.rs` for `--migrate-recommended-agents`.

## Red-line grep

- `grep -rE "RECOMMENDED_AGENTS|link_recommended_agents" crates/`: **4 hits, all in `//!` / `///` doc comments** explaining what was replaced. No code references.

## Documentation sync

- [x] `docs/tech-design.md` §6.4 — added "Plugin pipeline (V0.2 M0.20, 候选 7)" subsection; fixed §3.8 table cell.
- [x] `docs/claude-code-tool-surface.md` — rewrote §6.2 from ln -sf bash block to enabledPlugins JSON + plugin install instructions; updated §1.1.2 / §1.2.5 / §1.2.6 / §3.3 / §6.5 / appendix to reference plugin pipeline. "必须 ln -sf" 段已删.
- [x] `docs/dev-coupling-audit.md` — closed candidate 7 with M0.20 stamp.
- [x] `docs/interfaces.md` (bonus) — §5.4 `tools_required` reachability table updated; §10.6 maintenance commands list reflects `--migrate-recommended-agents`.

## ⚠ Open questions for review

1. **Inference map completeness** — `KNOWN_PLUGIN_AGENTS` mirrors V0.1's hardcoded 8-agent list (the `claude-plugins-official` set). Subagents not in the map fall through to "user-authored" path (must exist in `~/.claude/agents/<name>.md`). **V0.3 should switch to runtime discovery** by walking `~/.claude/plugins/marketplaces/*/plugins/*/agents/` so adding a new official agent doesn't require a ccteam release.
2. **Migration UX visibility** — `--migrate-recommended-agents` is mentioned in doctor help text but not in release notes / CLAUDE.md. Worth surfacing more loudly when V0.2 ships.
3. **Phase YAML naming form** — V0.1 phase markdown uses bare names (`tools_required.subagents: [code-reviewer]`); the snapshot indexes both bare + namespaced (`pr-review-toolkit:code-reviewer`) forms so existing YAML still works. M0.18 owns whether to migrate phase markdown to namespaced form.
4. **Two plugins, same agent name** — preserved V0.1's canonical mapping (`code-simplifier` from the `code-simplifier` plugin, not `pr-review-toolkit`'s internal copy). If a user manually enables both, namespaced lookup still resolves.

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] Manual: V0.1 user runs `ccteam doctor --migrate-recommended-agents` → 8 ccteam ln -sf removed
- [ ] Manual: new project's `Task(subagent_type="code-reviewer")` still spawns (via plugin pipeline)
- [ ] Manual: `~/.claude/agents/` after fresh ccteam project creation contains no ccteam ln -sf

🤖 Generated with [Claude Code](https://claude.com/claude-code)