### PR TITLE
M0.19: self-loop default-on + AskUserQuestion intercept

### DIFF
--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -218,6 +218,11 @@ enum HookCommand {
     /// SessionStart hook: write the `<project>/.ccteam/ready` marker.
     /// M0.10 extends this to bridge a pre-reset progress summary.
     LoadContext,
+    /// V0.2 M0.19.3 PreToolUse hook for `AskUserQuestion`. Returns a
+    /// `permissionDecision: deny` so the assistant routes through the
+    /// outbox / clarify protocol instead of synchronously waiting on
+    /// an offline user.
+    InterceptAsk,
 }
 
 fn main() -> Result<()> {
@@ -342,17 +347,34 @@ fn run_hook(cmd: HookCommand) -> Result<()> {
         }
         HookCommand::ParsePhaseEnd => {
             let decision = ccteam_hooks::parse_phase_end(&paths, &stdin)?;
-            if let ccteam_hooks::ParseDecision::Block { reason } = decision {
-                let json = serde_json::json!({
-                    "decision": "block",
-                    "reason": reason,
-                });
-                println!("{}", serde_json::to_string(&json)?);
+            match decision {
+                ccteam_hooks::ParseDecision::Continue => Ok(()),
+                ccteam_hooks::ParseDecision::Block { reason } => {
+                    let json = serde_json::json!({
+                        "decision": "block",
+                        "reason": reason,
+                    });
+                    println!("{}", serde_json::to_string(&json)?);
+                    Ok(())
+                }
+                ccteam_hooks::ParseDecision::BlockMissingOutput { stderr } => {
+                    // V0.2 M0.19: exit 2 + stderr is the Stop hook
+                    // contract Claude Code interprets as a blocking
+                    // system message (`hooks.ts:2784-2805`). The
+                    // assistant is forced to re-prompt with the
+                    // stderr text injected.
+                    eprintln!("{stderr}");
+                    std::process::exit(2);
+                }
             }
-            Ok(())
         }
         HookCommand::CostAccumulate => ccteam_hooks::cost_accumulate(&paths, &stdin),
         HookCommand::LoadContext => ccteam_hooks::load_context(&paths, &stdin),
+        HookCommand::InterceptAsk => {
+            let decision = ccteam_hooks::intercept_ask_decision();
+            println!("{}", serde_json::to_string(&decision)?);
+            Ok(())
+        }
     }
 }
 

--- a/crates/ccteam-core/src/phases.rs
+++ b/crates/ccteam-core/src/phases.rs
@@ -198,7 +198,13 @@ pub struct PhaseTemplate {
     /// Mechanism is phase-name-agnostic — dev's `fix` phase sets it
     /// true, research's `04-primary` data-collection phase will also
     /// set it true.
-    #[serde(default)]
+    ///
+    /// V0.2 M0.19: default flipped to `true`. Every phase self-loops
+    /// unless its yaml explicitly opts out with `auto_loop: false`.
+    /// Pairs with the Stop-hook self-loop fallback (parse_phase_end
+    /// exits 2 + stderr when neither PHASE_DONE / ESCALATE / outbox
+    /// fired) so phases can never silently halt the orchestrator.
+    #[serde(default = "default_auto_loop")]
     pub auto_loop: bool,
 
     /// Iteration cap when `auto_loop = true`. Defaults to 3 so existing
@@ -277,6 +283,14 @@ pub struct PhaseTemplate {
 
 fn default_auto_loop_max_iterations() -> u32 {
     DEFAULT_AUTO_LOOP_MAX_ITERATIONS
+}
+
+/// V0.2 M0.19: phases self-loop unless explicitly opted out. The Stop
+/// hook re-injects the same prompt up to `auto_loop_max_iterations`
+/// times (default 3) until the assistant emits the phase's
+/// `completion_signal` (default `PHASE_DONE: <name>`).
+fn default_auto_loop() -> bool {
+    true
 }
 
 fn default_max_clarify_rounds() -> u32 {
@@ -539,7 +553,12 @@ mod tests {
     }
 
     #[test]
-    fn auto_loop_defaults_to_false_when_omitted() {
+    fn auto_loop_defaults_to_true_when_omitted() {
+        // V0.2 M0.19: phases self-loop by default. A yaml that omits
+        // the field gets `auto_loop: true` + the synthesized
+        // `PHASE_DONE: <name>` completion signal so the Stop hook can
+        // re-inject up to `auto_loop_max_iterations` times until the
+        // assistant emits the signal.
         let src = concat!(
             "---\n",
             "name: implement\n",
@@ -548,10 +567,29 @@ mod tests {
             "body\n",
         );
         let t = PhaseTemplate::parse(src).unwrap();
-        assert!(!t.auto_loop);
+        assert!(t.auto_loop);
         assert_eq!(t.auto_loop_max_iterations, 3);
         assert!(t.completion_signal.is_empty());
-        // Validation passes — auto_loop=false ignores the empty signal.
+        // effective_completion_signal() falls back to PHASE_DONE: <name>.
+        assert_eq!(t.effective_completion_signal(), "PHASE_DONE: implement");
+        t.validate_m0().unwrap();
+    }
+
+    #[test]
+    fn auto_loop_explicit_false_opts_out() {
+        // Some phase yamls (e.g. evergreen meta-agent stubs, ad-hoc
+        // diagnostic phases) may want to skip the ralph-loop. Explicit
+        // `auto_loop: false` continues to disable it.
+        let src = concat!(
+            "---\n",
+            "name: kickoff\n",
+            "parallelism: solo\n",
+            "auto_loop: false\n",
+            "---\n",
+            "body\n",
+        );
+        let t = PhaseTemplate::parse(src).unwrap();
+        assert!(!t.auto_loop);
         t.validate_m0().unwrap();
     }
 

--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -501,7 +501,9 @@ mod tests {
 
     #[test]
     fn inject_prompt_auto_loop_segment_emitted_only_when_auto_loop_true() {
-        let t_off = parse_template("name: x\nparallelism: solo");
+        // V0.2 M0.19: `auto_loop` defaults to `true`, so an "off"
+        // template must opt out explicitly.
+        let t_off = parse_template("name: x\nparallelism: solo\nauto_loop: false");
         let off = build_phase_prompt_for_template(&t_off, &[]);
         assert!(!off.contains("auto_loop=true"));
 

--- a/crates/ccteam-core/src/team.rs
+++ b/crates/ccteam-core/src/team.rs
@@ -975,6 +975,31 @@ mod tests {
         assert!(format!("{err:#}").contains("dup"));
     }
 
+    // ---------------- V0.2 M0.19.4 forbid_ask_user_question ----------------
+
+    #[test]
+    fn m019_forbid_ask_user_question_rule_loads_as_prompt_directive() {
+        // Shape every shipped team.yaml uses to enforce the self-loop
+        // protocol: a `protocol` rule with `enforce: prompt_directive`
+        // whose `directive` text rides into every phase's inject prompt.
+        let src = concat!(
+            "name: dev\n",
+            "golden_rules:\n",
+            "  protocol:\n",
+            "    - rule_id: forbid_ask_user_question\n",
+            "      enforce: prompt_directive\n",
+            "      directive: '禁用 AskUserQuestion / 纯文本问句。改写 .ccteam/outbox/clarify-<ts>.md。'\n",
+        );
+        let spec = TeamSpec::parse(src).unwrap();
+        assert_eq!(spec.golden_rules.protocol.len(), 1);
+        let rule = &spec.golden_rules.protocol[0];
+        assert_eq!(rule.rule_id, "forbid_ask_user_question");
+        assert_eq!(rule.enforce, GoldenRuleEnforcement::PromptDirective);
+        assert!(rule.directive.as_deref().unwrap().contains("AskUserQuestion"));
+        // It's a prompt-only rule, not a cmd-check.
+        assert!(spec.golden_rules.as_cmd_check_rules().is_empty());
+    }
+
     #[test]
     fn m32_verdict_schema_round_trips() {
         let src = concat!(

--- a/crates/ccteam-core/src/templates.rs
+++ b/crates/ccteam-core/src/templates.rs
@@ -460,6 +460,27 @@ mod tests {
     }
 
     #[test]
+    fn template_pre_tool_use_intercepts_ask_user_question() {
+        // V0.2 M0.19.3: PreToolUse must carry a second matcher-bound
+        // entry for `AskUserQuestion` so the hook can deny the call
+        // before the assistant blocks waiting on an offline user.
+        let body = render_project_settings(
+            Path::new("/usr/local/bin/ccteam"),
+            &SettingsEnv::default(),
+            &EnabledPluginsSetting::default(),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let entries = v["hooks"]["PreToolUse"].as_array().unwrap();
+        let intercept = entries
+            .iter()
+            .find(|e| e.get("matcher").and_then(|m| m.as_str()) == Some("AskUserQuestion"))
+            .expect("PreToolUse must have an AskUserQuestion matcher entry");
+        let cmd = intercept["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(cmd, "/usr/local/bin/ccteam hook intercept-ask");
+    }
+
+    #[test]
     fn template_session_start_uses_absolute_ccteam_path() {
         let body = render_project_settings(
             Path::new("/usr/local/bin/ccteam"),

--- a/crates/ccteam-core/src/templates/settings.json
+++ b/crates/ccteam-core/src/templates/settings.json
@@ -36,6 +36,12 @@
         "hooks": [
           {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append PreToolUse", "async": true}
         ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {"type": "command", "command": "__CCTEAM_BIN__ hook intercept-ask", "timeout": 5}
+        ]
       }
     ],
     "PostToolUse": [

--- a/crates/ccteam-hooks/src/intercept_ask.rs
+++ b/crates/ccteam-hooks/src/intercept_ask.rs
@@ -1,0 +1,81 @@
+//! `ccteam hook intercept-ask` — PreToolUse hook for `AskUserQuestion`.
+//!
+//! V0.2 M0.19.3 (PRD §2.4 / alignment-review §3.2). The phase
+//! self-loop's Stop-hook fallback can't catch `AskUserQuestion`
+//! because that tool blocks the assistant turn synchronously — Stop
+//! never fires while the model waits for an answer. The PreToolUse
+//! hook intercepts the call before the wait and returns a structured
+//! `permissionDecision: deny` so Claude Code feeds the deny reason
+//! back into the conversation. The assistant is then forced to route
+//! through the outbox / clarify protocol instead.
+//!
+//! Wire-up:
+//!
+//! ```json
+//! "PreToolUse": [{
+//!   "matcher": "AskUserQuestion",
+//!   "hooks": [{"type": "command", "command": "<ccteam-bin> hook intercept-ask"}]
+//! }]
+//! ```
+//!
+//! Output schema (Claude Code `hooks.ts:608-625`):
+//!
+//! ```json
+//! {
+//!   "hookSpecificOutput": {
+//!     "hookEventName": "PreToolUse",
+//!     "permissionDecision": "deny",
+//!     "permissionDecisionReason": "<reason>"
+//!   }
+//! }
+//! ```
+
+use serde_json::{json, Value};
+
+/// The deny reason the assistant sees inline. Kept bilingual + short
+/// so a single re-prompt fits well within Claude Code's tool-error
+/// budget.
+const DENY_REASON: &str = "本 phase 应自决,不能用 AskUserQuestion 阻塞等待用户。\
+                           询问用户的唯一合法出口是写 .ccteam/outbox/clarify-<ts>.md,\
+                           Stop hook 后写 PHASE_DONE_PENDING。";
+
+/// Build the Claude Code PreToolUse hook decision JSON. Pure — the
+/// CLI dispatcher prints whatever this returns to stdout.
+pub fn intercept_ask_decision() -> Value {
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": DENY_REASON,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_targets_pre_tool_use_with_deny() {
+        let v = intercept_ask_decision();
+        let outer = v
+            .get("hookSpecificOutput")
+            .expect("payload has hookSpecificOutput");
+        assert_eq!(
+            outer.get("hookEventName").and_then(|s| s.as_str()),
+            Some("PreToolUse"),
+        );
+        assert_eq!(
+            outer.get("permissionDecision").and_then(|s| s.as_str()),
+            Some("deny"),
+        );
+        let reason = outer
+            .get("permissionDecisionReason")
+            .and_then(|s| s.as_str())
+            .expect("reason present");
+        assert!(
+            reason.contains("outbox"),
+            "deny reason must steer the assistant to outbox: {reason}",
+        );
+    }
+}

--- a/crates/ccteam-hooks/src/lib.rs
+++ b/crates/ccteam-hooks/src/lib.rs
@@ -8,12 +8,16 @@
 //! and §6.2 / §6.3 (per-hook responsibilities).
 
 pub mod cost;
+pub mod intercept_ask;
 pub mod load_context;
 pub mod parse_phase_end;
 pub mod progress;
 pub mod transcript;
 
 pub use cost::cost_accumulate;
+pub use intercept_ask::intercept_ask_decision;
 pub use load_context::load_context;
-pub use parse_phase_end::{parse_phase_end, EscalateKind, ParseDecision, ParsedEscalate};
+pub use parse_phase_end::{
+    needs_attention_outbox_path, parse_phase_end, EscalateKind, ParseDecision, ParsedEscalate,
+};
 pub use progress::progress_append;

--- a/crates/ccteam-hooks/src/parse_phase_end.rs
+++ b/crates/ccteam-hooks/src/parse_phase_end.rs
@@ -1,6 +1,6 @@
 //! `ccteam hook parse-phase-end` — Stop hook handler.
 //!
-//! Two responsibilities, in order:
+//! Three responsibilities, in order:
 //!
 //! 1. **Fix-loop ralph-loop pattern** (M0.12, tech-design §3.5). If the
 //!    project has a `<project>/.ccteam/auto-loop.state.md`, this hook
@@ -14,20 +14,34 @@
 //!    non-empty line of the latest assistant message starts with
 //!    `PHASE_DONE:` → `phase_done` event; `ESCALATE:` → `escalate`
 //!    event.
+//!
+//! 3. **V0.2 M0.19 self-loop fallback** (PRD §2.2 / alignment-review
+//!    §3.1). A phase ended without producing any of the three legal
+//!    outputs — no `PHASE_DONE` / `ESCALATE` in the assistant text and
+//!    no fresh outbox file under `<project>/.ccteam/outbox/`. The hook
+//!    returns exit 2 + stderr so Claude Code re-injects a coercive
+//!    "phase 未正常收尾" prompt and the assistant is forced to pick a
+//!    legal output. On the second entry (`stop_hook_active: true`)
+//!    the hook stops blocking and writes `needs_attention.outbox.json`
+//!    so the watchdog (M0.21) can surface it to the user.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use chrono::{SecondsFormat, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde_json::{json, Value};
 
 use ccteam_core::auto_loop::{self, AutoLoopDecision};
-use ccteam_core::{progress::append_event, slug_from_project_dir, CcteamPaths};
+use ccteam_core::{
+    progress::{append_event, read_all_events},
+    slug_from_project_dir, CcteamPaths,
+};
 
 use crate::transcript::{last_assistant_message, message_text};
 
 /// Result of running `parse_phase_end`. The CLI dispatcher emits the
-/// Claude Code Stop hook decision JSON when this is `Block`.
+/// Claude Code Stop hook decision JSON when this is `Block`, and exits
+/// 2 with the carried stderr message when this is `BlockMissingOutput`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParseDecision {
     /// Default: don't block; let claude continue exiting.
@@ -35,6 +49,13 @@ pub enum ParseDecision {
     /// Block the Stop and re-feed `reason` as the next user prompt
     /// (ralph-loop / fix-cycle).
     Block { reason: String },
+    /// V0.2 M0.19: phase ended with none of the three legal outputs
+    /// (PHASE_DONE / ESCALATE / outbox). The dispatcher prints `stderr`
+    /// to fd 2 and exits with code 2. Claude Code interprets exit 2 +
+    /// stderr as a blocking system message and re-prompts the model
+    /// with the stderr text (`hooks.ts:2784-2805`). The next Stop entry
+    /// carries `stop_hook_active: true` and we won't recurse.
+    BlockMissingOutput { stderr: String },
 }
 
 pub fn parse_phase_end(paths: &CcteamPaths, stdin: &Value) -> Result<ParseDecision> {
@@ -150,17 +171,200 @@ pub fn parse_phase_end(paths: &CcteamPaths, stdin: &Value) -> Result<ParseDecisi
 
     if let Some(event) = event {
         append_event(&progress_path, &event)?;
-    } else {
-        // Hook fired but found no sigil. Log to stderr at debug level so
-        // the operator can confirm the hook was reached even when no
-        // event was emitted — silent zero-exit is otherwise hard to
-        // diagnose in production runs.
-        eprintln!(
-            "[ccteam parse-phase-end] no PHASE_DONE/ESCALATE in last_text (head: {:?})",
-            last_text.lines().rev().take(3).collect::<Vec<_>>(),
-        );
+        return Ok(ParseDecision::Continue);
     }
-    Ok(ParseDecision::Continue)
+
+    // V0.2 M0.19 self-loop fallback. The phase ended with neither a
+    // PHASE_DONE/ESCALATE sigil in the assistant text nor an active
+    // ralph-loop state file. Check whether the assistant at least wrote
+    // a fresh outbox file (the third legal output); if so, this is a
+    // legitimate user-decision pause and we let the orchestrator route
+    // it. Otherwise the phase has silently halted — fail loud.
+    let phase_started_at = phase_started_at(&progress_path)?;
+    let outbox_dir = cwd_path.join(".ccteam").join("outbox");
+    let fresh_outbox = fresh_outbox_files(&outbox_dir, phase_started_at)?;
+
+    if !fresh_outbox.is_empty() {
+        // Decision pause is legitimate; the orchestrator's existing
+        // outbox / decisions queue path takes over from here.
+        return Ok(ParseDecision::Continue);
+    }
+
+    // No legal output produced. Decide between exit-2 (first Stop) and
+    // append-needs-attention (second Stop, recursion guard).
+    let stop_hook_active = stdin
+        .get("stop_hook_active")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if stop_hook_active {
+        // L3 fail-safe per PRD §2.3: do not block again, just record
+        // the stall so the watchdog surfaces it. Claude Code carries
+        // `stop_hook_active: true` on the second Stop entry so a phase
+        // that keeps producing nothing won't loop forever.
+        let pane_tail = capture_pane_tail(&slug, 30);
+        write_needs_attention_outbox(
+            cwd_path,
+            &slug,
+            &last_text,
+            pane_tail.as_deref(),
+        )?;
+        return Ok(ParseDecision::Continue);
+    }
+
+    eprintln!(
+        "[ccteam parse-phase-end] phase未产出 PHASE_DONE/ESCALATE/outbox 任一 (head: {:?})",
+        last_text.lines().rev().take(3).collect::<Vec<_>>(),
+    );
+    Ok(ParseDecision::BlockMissingOutput {
+        stderr: SELF_LOOP_FALLBACK_MESSAGE.to_string(),
+    })
+}
+
+/// V0.2 M0.19: stderr text Claude Code injects back into the model
+/// when this hook returns exit 2. Kept short so a single re-prompt
+/// fits well within Claude Code's blockingError budget.
+const SELF_LOOP_FALLBACK_MESSAGE: &str =
+    "phase 未正常收尾。请输出 PHASE_DONE: <phase> / ESCALATE: <reason> / 写 .ccteam/outbox/clarify-<ts>.md 三者之一。\
+     直接询问用户的纯文本问句不会被人看见,只会触发本次提示重发。";
+
+/// Walk progress.jsonl for the most recent `phase_inject` event and
+/// return its `ts` timestamp. The Stop hook treats this as the lower
+/// bound for "outbox file written by *this* phase". `None` (no
+/// `phase_inject` yet) means the phase started before progress was
+/// initialized — treat every outbox file as fresh.
+fn phase_started_at(progress_path: &Path) -> Result<Option<DateTime<Utc>>> {
+    if !progress_path.exists() {
+        return Ok(None);
+    }
+    let events = read_all_events(progress_path)?;
+    for event in events.iter().rev() {
+        let kind = event.get("event").and_then(|s| s.as_str()).unwrap_or("");
+        if kind == "phase_inject" {
+            let ts = event.get("ts").and_then(|s| s.as_str()).unwrap_or("");
+            return Ok(DateTime::parse_from_rfc3339(ts)
+                .map(|d| d.with_timezone(&Utc))
+                .ok());
+        }
+    }
+    Ok(None)
+}
+
+/// Return the basenames of outbox files created or modified after
+/// `since`. `since: None` collects every outbox file. The Stop hook
+/// uses this to detect the third legal phase output.
+fn fresh_outbox_files(
+    outbox_dir: &Path,
+    since: Option<DateTime<Utc>>,
+) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(outbox_dir) {
+        Ok(it) => it,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(out);
+        }
+        Err(err) => {
+            return Err(err.into());
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        if !name.ends_with(".md") {
+            continue;
+        }
+        let recognised = ["clarify-", "escalation-", "reply-"]
+            .iter()
+            .any(|prefix| name.starts_with(prefix));
+        if !recognised {
+            continue;
+        }
+        if let Some(min) = since {
+            let stale = entry
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| DateTime::<Utc>::from(t) < min)
+                .unwrap_or(false);
+            if stale {
+                continue;
+            }
+        }
+        out.push(name);
+    }
+    Ok(out)
+}
+
+/// Capture the last `n` lines of the project's tmux pane. Returns
+/// `None` if tmux isn't installed, the session is missing, or the
+/// invocation otherwise fails. The captured text only ever lands in
+/// `needs_attention.outbox.json` as user-facing surface info — never
+/// parsed by the orchestrator's state machine (see CLAUDE.md
+/// "永不解析 tmux 终端输出" red line).
+fn capture_pane_tail(slug: &str, lines: usize) -> Option<String> {
+    let session = format!("ccteam-{slug}");
+    let output = std::process::Command::new("tmux")
+        .args([
+            "capture-pane",
+            "-p",
+            "-t",
+            &session,
+            "-S",
+            &format!("-{lines}"),
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim_end().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// V0.2 M0.19 L3 fail-safe: write `<project>/.ccteam/needs_attention.outbox.json`
+/// with the most recent assistant message + pane tail. The watchdog
+/// (M0.21) reads it and surfaces it to the user. Idempotent — the file
+/// is always overwritten with the latest snapshot.
+fn write_needs_attention_outbox(
+    cwd: &Path,
+    slug: &str,
+    last_assistant_message: &str,
+    pane_tail: Option<&str>,
+) -> Result<()> {
+    let dir = cwd.join(".ccteam");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("needs_attention.outbox.json");
+    let body = json!({
+        "schema_version": 1,
+        "ts": now_rfc3339(),
+        "slug": slug,
+        "reason": "stop_hook_active recursion guard tripped — phase produced no PHASE_DONE/ESCALATE/outbox over two consecutive Stop entries",
+        "last_assistant_message": last_assistant_message,
+        "pane_tail": pane_tail.unwrap_or(""),
+    });
+    let pretty = serde_json::to_string_pretty(&body)?;
+    std::fs::write(&path, pretty)?;
+    Ok(())
+}
+
+/// Path the L3 fail-safe writes when the Stop hook recurses. Exposed
+/// so tests + the watchdog (M0.21) can locate it without re-deriving
+/// the layout.
+pub fn needs_attention_outbox_path(cwd: &Path) -> PathBuf {
+    cwd.join(".ccteam").join("needs_attention.outbox.json")
 }
 
 /// Structured ESCALATE grammar (interfaces §4.1.1). Pure string-prefix

--- a/crates/ccteam-hooks/tests/hooks_test.rs
+++ b/crates/ccteam-hooks/tests/hooks_test.rs
@@ -371,7 +371,12 @@ fn cost_accumulate_handles_claude_code_2x_schema() {
 }
 
 #[test]
-fn parse_phase_end_silent_when_no_sigil() {
+fn parse_phase_end_returns_block_missing_output_when_no_sigil_no_outbox() {
+    // V0.2 M0.19: Stop hook fallback. The phase wrote nothing legal —
+    // no PHASE_DONE / ESCALATE in the assistant text, no outbox file,
+    // and no `stop_hook_active` recursion guard. The hook returns
+    // BlockMissingOutput so the dispatcher exits 2 and stderr is
+    // re-injected by Claude Code.
     let fx = Fixture::new("bookmark-mgr-a3f9");
     fx.write_transcript(&[assistant_message(
         "Just a plain answer with no terminal sigil.",
@@ -382,11 +387,18 @@ fn parse_phase_end_silent_when_no_sigil() {
         "transcript_path": fx.transcript_path,
     });
 
-    parse_phase_end(&fx.paths, &stdin).unwrap();
+    let decision = parse_phase_end(&fx.paths, &stdin).unwrap();
+    match decision {
+        ccteam_hooks::ParseDecision::BlockMissingOutput { stderr } => {
+            assert!(stderr.contains("PHASE_DONE"), "stderr: {stderr}");
+            assert!(stderr.contains("outbox"), "stderr: {stderr}");
+        }
+        other => panic!("expected BlockMissingOutput, got {other:?}"),
+    }
     let p = fx.paths.progress_jsonl(&fx.slug);
     assert!(
         !p.exists(),
-        "no progress.jsonl should be created when there is no terminal sigil",
+        "no progress event should be appended when phase produced nothing legal",
     );
 }
 
@@ -558,4 +570,170 @@ fn progress_append_errors_when_state_json_absent() {
         msg.contains("state.json"),
         "expected state.json read failure, got: {msg}",
     );
+}
+
+// ---------------- V0.2 M0.19 self-loop fallback ----------------
+
+#[test]
+fn parse_phase_end_continues_when_phase_wrote_outbox_clarify() {
+    // V0.2 M0.19: a phase that ended in a user-decision pause writes
+    // .ccteam/outbox/clarify-<ts>.md as one of the three legal outputs.
+    // The Stop hook must NOT block — the orchestrator's existing
+    // decisions queue path takes over.
+    let fx = Fixture::new("bookmark-mgr-a3f9");
+    fx.write_transcript(&[assistant_message(
+        "Need a sec — written .ccteam/outbox/clarify-2026-05-08-001.md.",
+        None,
+    )]);
+    let outbox = fx.project_dir.join(".ccteam").join("outbox");
+    std::fs::create_dir_all(&outbox).unwrap();
+    std::fs::write(
+        outbox.join("clarify-2026-05-08-001.md"),
+        "---\nschema_version: 1\nevent_kind: clarify\n---\n\nq?",
+    )
+    .unwrap();
+    let stdin = json!({
+        "cwd": fx.project_dir,
+        "transcript_path": fx.transcript_path,
+    });
+
+    let decision = parse_phase_end(&fx.paths, &stdin).unwrap();
+    assert_eq!(decision, ccteam_hooks::ParseDecision::Continue);
+}
+
+#[test]
+fn parse_phase_end_appends_needs_attention_when_stop_hook_active_recurses() {
+    // V0.2 M0.19 L3: second Stop entry carries `stop_hook_active: true`.
+    // The hook must not block again (recursion guard) and instead drop
+    // a `needs_attention.outbox.json` so the watchdog (M0.21) can
+    // surface the stall to the user.
+    let fx = Fixture::new("bookmark-mgr-a3f9");
+    fx.write_transcript(&[assistant_message(
+        "I'll keep waiting for clarity.",
+        None,
+    )]);
+    let stdin = json!({
+        "cwd": fx.project_dir,
+        "transcript_path": fx.transcript_path,
+        "stop_hook_active": true,
+    });
+
+    let decision = parse_phase_end(&fx.paths, &stdin).unwrap();
+    assert_eq!(decision, ccteam_hooks::ParseDecision::Continue);
+
+    let outbox = ccteam_hooks::needs_attention_outbox_path(&fx.project_dir);
+    assert!(outbox.exists(), "needs_attention.outbox.json must be written");
+    let body: Value = serde_json::from_slice(&std::fs::read(&outbox).unwrap()).unwrap();
+    assert_eq!(body["schema_version"], 1);
+    assert_eq!(body["slug"], "bookmark-mgr-a3f9");
+    assert!(body["last_assistant_message"]
+        .as_str()
+        .unwrap()
+        .contains("waiting"));
+}
+
+#[test]
+fn parse_phase_end_ignores_stale_outbox_from_previous_phase() {
+    // Simulate: previous phase wrote clarify-A.md, then orchestrator
+    // dispatched the next phase (phase_inject ts in progress.jsonl);
+    // current phase ended with no new output. The Stop hook must NOT
+    // treat the stale file as a fresh output — it should fall to
+    // BlockMissingOutput so the assistant gets re-prompted.
+    let fx = Fixture::new("bookmark-mgr-a3f9");
+    let outbox = fx.project_dir.join(".ccteam").join("outbox");
+    std::fs::create_dir_all(&outbox).unwrap();
+    let stale = outbox.join("clarify-old-phase.md");
+    std::fs::write(&stale, "old").unwrap();
+
+    // Backdate the stale file so phase_inject's ts is "later".
+    let early = std::time::SystemTime::UNIX_EPOCH
+        + std::time::Duration::from_secs(1_700_000_000);
+    let f = std::fs::File::options().write(true).open(&stale).unwrap();
+    f.set_times(std::fs::FileTimes::new().set_modified(early)).unwrap();
+
+    let progress_path = fx.paths.progress_jsonl(&fx.slug);
+    std::fs::create_dir_all(progress_path.parent().unwrap()).unwrap();
+    // phase_inject at "now" — well after the backdated outbox file.
+    let later = chrono::Utc::now().to_rfc3339();
+    std::fs::write(
+        &progress_path,
+        format!(
+            "{}\n",
+            json!({"event": "phase_inject", "phase": "implement", "ts": later})
+        ),
+    )
+    .unwrap();
+
+    fx.write_transcript(&[assistant_message("done thinking", None)]);
+    let stdin = json!({
+        "cwd": fx.project_dir,
+        "transcript_path": fx.transcript_path,
+    });
+    let decision = parse_phase_end(&fx.paths, &stdin).unwrap();
+    assert!(matches!(
+        decision,
+        ccteam_hooks::ParseDecision::BlockMissingOutput { .. }
+    ));
+}
+
+#[test]
+fn parse_phase_end_treats_legacy_outbox_files_as_fresh_when_no_phase_inject() {
+    // No phase_inject event in progress.jsonl yet (e.g. project just
+    // bootstrapped) → the hook can't compute a "since" cutoff. It
+    // must still treat any pre-existing outbox file as legitimate and
+    // keep returning Continue.
+    let fx = Fixture::new("bookmark-mgr-a3f9");
+    fx.write_transcript(&[assistant_message(
+        "see clarify file",
+        None,
+    )]);
+    let outbox = fx.project_dir.join(".ccteam").join("outbox");
+    std::fs::create_dir_all(&outbox).unwrap();
+    std::fs::write(outbox.join("clarify-pre-existing.md"), "body").unwrap();
+    let stdin = json!({
+        "cwd": fx.project_dir,
+        "transcript_path": fx.transcript_path,
+    });
+    let decision = parse_phase_end(&fx.paths, &stdin).unwrap();
+    assert_eq!(decision, ccteam_hooks::ParseDecision::Continue);
+}
+
+#[test]
+fn parse_phase_end_does_not_recurse_after_first_block_missing_output() {
+    // Second-entry contract: stop_hook_active=true short-circuits to
+    // append + Continue, never to BlockMissingOutput. Otherwise the
+    // assistant could oscillate between Stop entries forever.
+    let fx = Fixture::new("bookmark-mgr-a3f9");
+    fx.write_transcript(&[assistant_message("still nothing", None)]);
+    let stdin = json!({
+        "cwd": fx.project_dir,
+        "transcript_path": fx.transcript_path,
+        "stop_hook_active": true,
+    });
+    let decision = parse_phase_end(&fx.paths, &stdin).unwrap();
+    assert!(matches!(
+        decision,
+        ccteam_hooks::ParseDecision::Continue
+    ));
+}
+
+#[test]
+fn intercept_ask_decision_returns_deny_with_outbox_reason() {
+    // V0.2 M0.19.3: pure unit shape — the decision JSON must carry a
+    // `permissionDecision: deny` and the reason must steer the
+    // assistant toward the outbox protocol.
+    let v = ccteam_hooks::intercept_ask_decision();
+    assert_eq!(
+        v["hookSpecificOutput"]["hookEventName"].as_str(),
+        Some("PreToolUse"),
+    );
+    assert_eq!(
+        v["hookSpecificOutput"]["permissionDecision"].as_str(),
+        Some("deny"),
+    );
+    let reason = v["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .unwrap();
+    assert!(reason.contains("outbox"));
+    assert!(reason.contains("AskUserQuestion"));
 }

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -818,6 +818,12 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
         "hooks": [
           {"type": "command", "command": "ccteam hook progress-append PreToolUse", "async": true}
         ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {"type": "command", "command": "ccteam hook intercept-ask", "timeout": 5}
+        ]
       }
     ],
     "PostToolUse": [
@@ -857,14 +863,67 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 | Hook | 作用 |
 |---|---|
 | `SessionStart` | 写 ready 标记;append `session_start` 事件 |
-| `Stop` | 解析最后一行 `PHASE_DONE` / `ESCALATE`;append `Stop` 事件(idle 信号);若 fix-loop.state.md 存在则按 ralph-loop 范式拦截重喂 |
+| `Stop` | 解析最后一行 `PHASE_DONE` / `ESCALATE`;append `Stop` 事件(idle 信号);若 fix-loop.state.md 存在按 ralph-loop 范式拦截重喂;**V0.2 M0.19**:三档兜底——前两档都没命中且 outbox 没新文件 → exit 2 + stderr 强制续聊,`stop_hook_active=true` 时写 `needs_attention.outbox.json` 不再 block |
 | `Notification:idle_prompt` | claude 显式等待用户输入 → idle 信号 |
 | `Notification:permission_prompt` | 不应出现(`--dangerously-skip-permissions` 兜底);出现说明配置失效 |
-| `PreToolUse` | append 工具调用事件;活跃信号(stall 检测反向判断) |
+| `PreToolUse`(通用) | append 工具调用事件;活跃信号(stall 检测反向判断) |
+| `PreToolUse(matcher: AskUserQuestion)` | **V0.2 M0.19.3**:`ccteam hook intercept-ask` 返回 `permissionDecision: deny`,assistant 改写 outbox。机制详见 `docs/v0-2-claude-code-alignment-review.md` §3.2 |
 | `PostToolUse`(通用) | append 事件;`cost-accumulate.sh` 累加 token / cost 到 `state.json` |
 | `PostToolUse(Bash matcher)` | 拦截危险命令(`git push` / `rm -rf /` / deploy 脚本) |
 | `SubagentStop` | 子 agent 退出(仅 Agent Teams phase 内相关) |
 | `SessionEnd` | claude 进程退出 → orchestrator 知道 reset 完成 vs crash |
+
+#### 6.2.1 `parse-phase-end` 状态机(V0.2 M0.19 三档兜底)
+
+```
+Stop fires
+  │
+  ▼
+auto-loop.state.md 存在?
+  │ yes ──→ 读 state,decide()
+  │           │
+  │           ├─ Reinject → ParseDecision::Block { reason }(stdout JSON)
+  │           └─ AllowExit + 撞顶 → emit escalate;Continue
+  │ no
+  ▼
+last_assistant_message 末行 PHASE_DONE / ESCALATE?
+  │ yes ──→ append 对应 progress 事件;Continue
+  │ no
+  ▼
+<project>/.ccteam/outbox/ 有 phase_inject ts 之后的 clarify-* / escalation-* / reply-*?
+  │ yes ──→ Continue(orchestrator 决策队列接力)
+  │ no
+  ▼
+stop_hook_active == true?
+  │ yes ──→ 写 needs_attention.outbox.json;Continue(L3 fail-safe 防递归)
+  │ no  ──→ ParseDecision::BlockMissingOutput { stderr }
+            (CLI dispatcher 写 stderr,exit 2;Claude Code 把 stderr 当 blockingError 注入下一轮)
+```
+
+`needs_attention.outbox.json` schema:
+
+```json
+{
+  "schema_version": 1,
+  "ts": "<RFC3339>",
+  "slug": "<slug>",
+  "reason": "stop_hook_active recursion guard tripped — phase produced no PHASE_DONE/ESCALATE/outbox over two consecutive Stop entries",
+  "last_assistant_message": "<原始末段 assistant 文本>",
+  "pane_tail": "<tmux capture-pane 末 30 行;仅 surface 给用户,不参与 orchestrator 状态机>"
+}
+```
+
+`ccteam hook intercept-ask` 返回的 PreToolUse 决策(`hooks.ts:608-625`):
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "本 phase 应自决,不能用 AskUserQuestion ... 改写 .ccteam/outbox/clarify-<ts>.md ..."
+  }
+}
+```
 
 ### 6.3 `cost-accumulate` 子命令工作原理
 

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -398,6 +398,24 @@ test-run phase
 
 **禁止静默重试**：fix loop 撞 3 次顶绝不静默重置——这是 ccteam 区别于"AI 永远说没事"的承诺。
 
+#### V0.2 M0.19 — auto_loop default-on + Stop hook self-loop fallback
+
+**`PhaseTemplate.auto_loop` 默认 `true`**：每个 phase 自循环,撞 `auto_loop_max_iterations`(默认 3)顶才 escalate。phase yaml 显式 `auto_loop: false` 才 opt-out(evergreen 桥接 / ad-hoc diagnostic phase 用)。`completion_signal` 留空时 `effective_completion_signal()` 回退到 `PHASE_DONE: <phase-name>`,因此 phase yaml 不需要重复声明协议字面量。
+
+**Stop hook 三档兜底**(`crates/ccteam-hooks/src/parse_phase_end.rs`):
+
+1. **Auto-loop reinject**:`<project>/.ccteam/auto-loop.state.md` 存在 → 按 ralph-loop 范式重喂 prompt,撞顶时 emit escalate 事件。
+2. **PHASE_DONE / ESCALATE 解析**:assistant 末行匹配协议关键字 → 写 progress 事件,Continue。
+3. **Self-loop fallback**(V0.2 新增):前两档都没命中,且 `<project>/.ccteam/outbox/` 没有本 phase 内的 `clarify-* / escalation-* / reply-*` 新文件 → 区分两种情形:
+   - **第一次进入**(`stop_hook_active` 为 false / 缺):返回 exit 2 + stderr `phase 未正常收尾,请输出 PHASE_DONE / ESCALATE / 写 outbox 之一`。Claude Code 把 stderr 当 blockingError 注入下一轮(`hooks.ts:2784-2805`),assistant 被强制重选合法出口。
+   - **第二次进入**(`stop_hook_active` 为 true,L3 fail-safe):写 `<project>/.ccteam/needs_attention.outbox.json`(含 `last_assistant_message` + `tmux capture-pane` 末 30 行),不再 block。watchdog(M0.21)读这个文件 surface 给用户。
+
+**关键约束**:第三档**不**让 ccteam orchestrator 主动 send-keys 续 loop;Claude Code 自己接管循环。orchestrator 只在 progress.jsonl 出现 phase_done / escalate 事件时换 phase。`tmux capture-pane` 输出**只**写进 needs_attention 文件作为给用户看的 surface,不参与状态机决策(沿用"主路径不解析终端输出"红线)。
+
+#### V0.2 M0.19.3 — PreToolUse 拦截 AskUserQuestion
+
+`AskUserQuestion` 是 LLM 内部同步阻塞,Stop hook 不会触发。bootstrap 写 `<project>/.claude/settings.json` 时配 `PreToolUse` matcher `AskUserQuestion`,跑 `ccteam hook intercept-ask` 返回 `permissionDecision: deny`(reason 指引去 outbox)。LLM 收到 deny 立即改写 outbox。pair 的 prompt-layer 软约束在 team.yaml `golden_rules.protocol.forbid_ask_user_question` —— inject prompt 把 directive 文字写进协议红线段(progress.rs `build_phase_prompt_for_template_with_team`)。
+
 ### 3.6 三层防御协议（Defense in Depth）
 
 替代旧方案中"人持续在场审查"的能力，用三层独立机制保证质量与方向不偏（呼应痛点 11）：
@@ -1185,6 +1203,19 @@ fi
 ```
 
 `/btw`（by the way）是 Claude Code 内建命令——把消息塞到"待办"，不打断当前推理，claude 完成手头的事后会处理。这一条命令就是注入失败的全部解法，**不**做超时重试 / capture-pane 解析 / kill-restart 多层兜底。
+
+#### V0.2 M0.19 — auto_loop default-on 后的 phase 完结路径
+
+`auto_loop` 默认 `true`(§3.5)后,phase 退出路径只有四种合法形态(orchestrator / Stop hook 都按这套识别):
+
+| 出口 | 触发 | progress 事件 | 后续 |
+|---|---|---|---|
+| `PHASE_DONE: <phase>` | assistant 末行匹配 | `phase_done` | orchestrator 换下一 phase |
+| `PHASE_DONE_PENDING — ...` | assistant 末行匹配 | `phase_done_pending` + `open_decisions` | orchestrator 看 outbox / 静等 |
+| `ESCALATE: <prefix> <reason>` | assistant 末行匹配 | `escalate` | orchestrator 走 escalate 路由 |
+| `<project>/.ccteam/outbox/clarify-*.md` | phase 在 phase_inject ts 之后写新文件 | (无) | orchestrator 决策队列接力 |
+
+**没产出三种合法出口任一 → Stop hook fallback 接管**:第一次 Stop 返回 exit 2 + stderr 强制 LLM 续聊,第二次 (`stop_hook_active=true`) 写 `<project>/.ccteam/needs_attention.outbox.json` 让 watchdog(M0.21)接力 surface 给用户。**永远不出现"silent halt"**——即使 LLM 反复输出纯文本问句,撞 cycle cap 也会硬 escalate。
 
 ### 6.10 Sub-skill 自动调度（替人编排 plugin）
 

--- a/teams/dev/team.yaml
+++ b/teams/dev/team.yaml
@@ -22,14 +22,18 @@ claude_md_template: |
   - 不要 git push(被 hook 拦截)
   - 不要修改 .ccteam/ 之外的元数据
 
-# dev's `golden_rules` is intentionally empty in M3.2: the existing
-# fix-loop (M0) + per-phase `golden_rules` declared inside individual
-# phase markdown already cover dev's hard quality gates. Adding stubs
-# here without a real consumer would make the team-wide vs phase-level
-# precedence rule harder to read. M3.4 reverse-engineering note (open
-# question 4.1, plan §5): leave empty until product-research has
-# proven the team-wide default pattern is worth landing for dev.
-golden_rules: []
+# V0.2 M0.19.4: enforce the self-loop protocol via prompt directive.
+# `forbid_ask_user_question` rides into every phase's inject prompt as
+# a hard constraint — the assistant is steered to write
+# .ccteam/outbox/clarify-<ts>.md instead of synchronously blocking on
+# AskUserQuestion / nat-text questions. PreToolUse hook
+# (`ccteam hook intercept-ask`) is the matching deterministic guard.
+golden_rules:
+  protocol:
+    - rule_id: forbid_ask_user_question
+      enforce: prompt_directive
+      directive: "禁用 AskUserQuestion / 纯文本问句。询问用户唯一合法出口是写 .ccteam/outbox/clarify-<ts>.md(配 PHASE_DONE_PENDING 或 ESCALATE NEED_USER_INPUT)。"
+  domain: []
 
 # critic_dimensions empty — M5 will populate (strategic doc §A inv 1).
 critic_dimensions: []

--- a/teams/meta-agent/team.yaml
+++ b/teams/meta-agent/team.yaml
@@ -34,5 +34,15 @@ claude_md_template: ""
 retro_schema: []
 critic_dimensions: []
 escalate_grammar_extensions: []
-golden_rules: []
 verdict_schema: []
+
+# V0.2 M0.19.4: meta-agent has no phase pipeline but the same
+# self-loop protocol applies to its dispatcher prompt — every
+# AskUserQuestion attempt has to route through the outbox so an
+# offline user never freezes the long-running session.
+golden_rules:
+  protocol:
+    - rule_id: forbid_ask_user_question
+      enforce: prompt_directive
+      directive: "禁用 AskUserQuestion / 纯文本问句。询问用户唯一合法出口是写 .ccteam/outbox/clarify-<ts>.md(配 PHASE_DONE_PENDING 或 ESCALATE NEED_USER_INPUT)。"
+  domain: []

--- a/teams/product-research/team.yaml
+++ b/teams/product-research/team.yaml
@@ -49,11 +49,18 @@ escalate_grammar_extensions:
     target_phase: kickoff
     reason: "no sustainable differentiation found; revert to kickoff so the user can rethink the brief from a different angle"
 
-# Team-wide golden_rules default. Phase YAML's golden_rules takes
-# priority — phases declaring their own ignore these. Empty for now;
-# product-research has no team-wide hard quality bars (each phase
-# declares its own where applicable).
-golden_rules: []
+# V0.2 M0.19.4: enforce the self-loop protocol via prompt directive.
+# `forbid_ask_user_question` rides into every phase's inject prompt as
+# a hard constraint — the assistant is steered to write
+# .ccteam/outbox/clarify-<ts>.md instead of synchronously blocking on
+# AskUserQuestion / nat-text questions. PreToolUse hook
+# (`ccteam hook intercept-ask`) is the matching deterministic guard.
+golden_rules:
+  protocol:
+    - rule_id: forbid_ask_user_question
+      enforce: prompt_directive
+      directive: "禁用 AskUserQuestion / 纯文本问句。询问用户唯一合法出口是写 .ccteam/outbox/clarify-<ts>.md(配 PHASE_DONE_PENDING 或 ESCALATE NEED_USER_INPUT)。"
+  domain: []
 
 # Critic dimensions — data form only in M3; M5 will read these.
 # Empty here per the plan §5 M3 design notes (4.2): research / dev


### PR DESCRIPTION
## Summary

Closes **V0.2 M0.19** (`docs/dev-plan-v0-2.md §5`) — phase auto-loop becomes the default, Stop hook self-loops via exit-2 (no orchestrator send-keys), and AskUserQuestion is intercepted at PreToolUse.

1. **M0.19.1 auto_loop default-on** — `PhaseTemplate.auto_loop` defaults to `true`; phase yamls explicitly setting `auto_loop: false` keep opting out (covered by `auto_loop_explicit_false_opts_out`).
2. **M0.19.2 Stop hook self-loop** — `parse-phase-end` scans `.ccteam/` for phase_done / escalate / outbox; if all three missing and `stop_hook_active != true`, exits 2 + writes stderr → Claude Code feeds stderr back to LLM, LLM continues. **Recursion guard**: on `stop_hook_active == true`, appends `.ccteam/needs_attention.outbox.json` (with `last_assistant_message` + `tmux capture-pane` last 30 lines) and exits 0 — no orchestrator send-keys involvement.
3. **M0.19.3 PreToolUse AskUserQuestion intercept** — `bootstrap_project` writes `.claude/settings.json` with PreToolUse matcher: AskUserQuestion → `ccteam-hooks intercept-ask`, returning `permissionDecision: deny` + reason "本 phase 应自决,改写 outbox". LLM redirects to outbox.
4. **M0.19.4 `forbid_ask_user_question` golden rule** — added as `protocol.*.enforce: prompt_directive` in dev / product-research / meta-agent team.yaml; injected verbatim into phase prompts via M0.18's protocol/domain rule pipeline.

## Maps to

- PRD: `docs/prd-v0-2.md §2 + §2.4`
- Design: `docs/v0-2-claude-code-alignment-review.md §3.1 (Stop hook self-loop) + §3.2 (PreToolUse intercept)`
- Dev plan: `docs/dev-plan-v0-2.md §5`

## Test results

| Item | Before | After |
|---|---|---|
| `cargo test --workspace` | 441 / 0 | **451 / 0** (+10 net) |
| `cargo clippy --workspace --all-targets` warnings | 10 | **10** (0 new) |

New tests:
- 2 phase yaml: `auto_loop_defaults_to_true_when_omitted`, `auto_loop_explicit_false_opts_out`
- 6 parse-phase-end state machine: block-missing-output, outbox clarify continues, stop_hook_active recurses, legacy outbox treated as fresh when no phase inject, stale outbox ignored, no recurse after first block
- 2 intercept-ask: decision deny + outbox reason (lib + integration)
- 1 settings.json template: PreToolUse intercepts AskUserQuestion
- 1 team.yaml: forbid_ask_user_question loads as prompt_directive

## Red-line grep

- `\bdev\b|\bproduct-research\b|\bmeta-agent\b` in `crates/ccteam-core/src/`: +2 vs main, both in `///` doc comments / test fixture YAML — no new behavior literals.
- `PHASE_DONE|ESCALATE:` in `crates/ccteam-core/src/`: production count unchanged (3 hits, identical to M0.18 baseline); +5 new hits all in test asserts / doc comments.

## Documentation sync

- [x] `docs/tech-design.md` §3.5 — added "V0.2 M0.19 — auto_loop default-on + Stop hook self-loop fallback" + "M0.19.3 PreToolUse 拦截 AskUserQuestion".
- [x] `docs/tech-design.md` §6.9 — added "M0.19 — auto_loop default-on 后的 phase 完结路径" (4-output table).
- [x] `docs/interfaces.md` §6.1 — `.claude/settings.json` template gains PreToolUse matcher.
- [x] `docs/interfaces.md` §6.2 — Hook 用途表 added intercept-ask + Stop hook V0.2 三档兜底.
- [x] `docs/interfaces.md` §6.2.1 — new section: parse-phase-end state machine ASCII + needs_attention.outbox.json schema + intercept-ask decision JSON.

## ⚠ Open questions for review

1. **`stop_hook_active` field name** — implementation reads `stdin["stop_hook_active"].as_bool()` per alignment-review §3.1 / PRD §2.2 source citation. If actual Claude Code field name differs (camelCase, etc.), the recursion guard never trips and the hook would loop. **Worth a smoke-test with a real spawned project before V0.2 ship.**
2. **`ccteam-hooks intercept-ask` binary path** — settings.json template uses `__CCTEAM_BIN__` placeholder substituted to absolute path at bootstrap time (re-uses existing M0.4 mechanism); no PATH dependency.
3. **auto_loop default-on backward compat** — only `06-fix.md` previously opted in; everything else now self-loops. `effective_completion_signal()` synthesizes `PHASE_DONE: <name>` so the loop exits on first PHASE_DONE — no regression for templates whose body emits PHASE_DONE. Phase yamls explicitly `auto_loop: false` keep opting out.
4. **Stop hook tmux capture** — `tmux capture-pane -p -t ccteam-<slug>` runs from hook subprocess; non-tmux contexts return None → fail-safe still writes `needs_attention.outbox.json` with empty `pane_tail`. Per CLAUDE.md red-line, tmux text only lands as user-surface info; orchestrator never reads it.
5. **`forbid_ask_user_question` mechanism** — kept as `enforce: prompt_directive` in M0.18's `protocol/domain` rule schema rather than a dedicated boolean field, to keep ccteam-core data-driven (no special-casing rule_id in code).

## Test plan

- [ ] `cargo test --workspace` passes (451 / 0)
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] Manual: spawn project, induce phase end without PHASE_DONE / ESCALATE / outbox → first Stop hook exits 2, LLM receives stderr reminder, second Stop hook writes needs_attention.outbox
- [ ] Manual: phase prompt induces AskUserQuestion → PreToolUse intercept denies, LLM writes outbox
- [ ] Manual: confirm `stop_hook_active` field name in real Claude Code Stop hook payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)