### PR TITLE
M0.22: team factory — author + publish ccteam teams as Claude Code plugins

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -718,12 +718,26 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
 ///    this as warn-not-fail by design).
 fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String> {
     use ccteam_core::{
-        default_user_staging_dir, resolve_team, TeamResolveContext, TEAM_SOURCES,
+        default_user_staging_dir, resolve_team, staging_dir_for, validate_staged_team,
+        TeamResolveContext, TEAM_SOURCES,
     };
 
     let mut out = format!("ccteam doctor --validate-team {team}\n\n");
     let user_staging = default_user_staging_dir();
     let ctx = TeamResolveContext::for_orchestrator(&paths.root, &user_staging);
+
+    // V0.2 M0.22.4: when a staged plugin tree exists at the user
+    // layer, run the plugin manifest checks before resolving the
+    // TeamSpec — operators authoring a team plugin want both the
+    // plugin schema findings and the phase IO findings in one report.
+    let staged = staging_dir_for(team, None);
+    if staged.join(".claude-plugin/plugin.json").exists() {
+        out.push_str("# Plugin manifest checks (staged tree)\n");
+        for line in validate_staged_team(&staged)? {
+            out.push_str(&format!("{line}\n"));
+        }
+        out.push('\n');
+    }
 
     let spec = match resolve_team(team, &ctx) {
         Ok(s) => {

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod commands;
 mod mcp_serve;
+mod team_factory_cli;
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -195,6 +196,14 @@ enum Command {
         #[command(subcommand)]
         cmd: WatchdogCommand,
     },
+    /// V0.2 M0.22: author + publish a ccteam team as a Claude Code
+    /// plugin. `init` scaffolds the staging tree under
+    /// `~/.config/ccteam/teams/<name>/`; `publish` links it into the
+    /// `ccteam-local` marketplace or pushes it to a GitHub repo.
+    Team {
+        #[command(subcommand)]
+        cmd: TeamCommand,
+    },
 }
 
 #[derive(Subcommand)]
@@ -227,6 +236,41 @@ enum PhaseCommand {
         team: String,
         /// Phase name (e.g. `implement`, not the prefixed filename).
         phase: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum TeamCommand {
+    /// Scaffold a new team plugin staging tree at
+    /// `~/.config/ccteam/teams/<name>/`. Creates plugin.json + team.yaml
+    /// + a starter phase + README. Idempotent.
+    Init {
+        /// Team / plugin name (ascii lower / digit / `-` / `_`).
+        name: String,
+        /// One-line plugin description.
+        #[arg(long, default_value = "")]
+        description: String,
+        /// Plugin manifest `author.name`. Required.
+        #[arg(long)]
+        author_name: String,
+        /// Plugin manifest `author.email` (optional).
+        #[arg(long)]
+        author_email: Option<String>,
+        /// Plugin manifest `version` (optional, eg `0.1.0`).
+        #[arg(long)]
+        version: Option<String>,
+    },
+    /// Publish a staged team. `--target local` symlinks staging into
+    /// `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`;
+    /// `--target github --repo <owner>/<name>` runs `gh repo create`
+    /// + push. Validates the staging tree before any side-effect.
+    Publish {
+        name: String,
+        #[arg(long, value_enum, default_value_t = team_factory_cli::PublishTargetArg::Local)]
+        target: team_factory_cli::PublishTargetArg,
+        /// `<owner>/<name>` repo coordinate (required for `--target github`).
+        #[arg(long)]
+        repo: Option<String>,
     },
 }
 
@@ -329,6 +373,7 @@ fn main() -> Result<()> {
         }),
         Command::Phase { cmd } => run_phase(cmd),
         Command::Watchdog { cmd } => run_watchdog(cmd),
+        Command::Team { cmd } => run_team(cmd),
     }
 }
 
@@ -341,6 +386,37 @@ fn run_watchdog(cmd: WatchdogCommand) -> Result<()> {
             }
             let handle = if push { user.as_deref() } else { None };
             let body = commands::run_watchdog_scan(&paths, format, handle)?;
+            print!("{body}");
+            Ok(())
+        }
+    }
+}
+
+fn run_team(cmd: TeamCommand) -> Result<()> {
+    match cmd {
+        TeamCommand::Init {
+            name,
+            description,
+            author_name,
+            author_email,
+            version,
+        } => {
+            let body = team_factory_cli::run_team_init(&team_factory_cli::TeamInitArgs {
+                name,
+                description,
+                author_name,
+                author_email,
+                version,
+            })?;
+            print!("{body}");
+            Ok(())
+        }
+        TeamCommand::Publish { name, target, repo } => {
+            let body = team_factory_cli::run_team_publish(&team_factory_cli::TeamPublishArgs {
+                name,
+                target,
+                repo,
+            })?;
             print!("{body}");
             Ok(())
         }

--- a/crates/ccteam-cli/src/team_factory_cli.rs
+++ b/crates/ccteam-cli/src/team_factory_cli.rs
@@ -1,0 +1,333 @@
+//! V0.2 M0.22 — `ccteam team {init,publish}` CLI handlers.
+//!
+//! `init` is intentionally lightweight: it stamps a single-phase
+//! starter staging tree (`<staging>/.claude-plugin/plugin.json` +
+//! `team.yaml` + `phases/01-intake.md` + `README.md`). The team author
+//! then either edits the staging files directly or runs the meta-agent
+//! `ccteam-team-author` skill, which interview-mode produces the same
+//! tree with N phases instead of one.
+//!
+//! `publish` calls `ccteam_core::publish_team` for the local target.
+//! The github target shells out to `gh repo create` + git push so
+//! the user's gh CLI authentication is the trust anchor — the factory
+//! does not embed any credentials.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use ccteam_core::{
+    init_team_staging, publish_team, staging_dir_for, validate_staged_team, InitReport,
+    PhaseScaffold, PluginAuthor, PluginManifest, PublishInput, PublishReport, PublishTarget,
+    TeamInitInput, TeamSpec,
+};
+
+/// `ccteam team init` arguments parsed from clap.
+#[derive(Debug, Clone)]
+pub struct TeamInitArgs {
+    pub name: String,
+    pub description: String,
+    pub author_name: String,
+    pub author_email: Option<String>,
+    pub version: Option<String>,
+}
+
+/// `ccteam team publish` arguments parsed from clap.
+#[derive(Debug, Clone)]
+pub struct TeamPublishArgs {
+    pub name: String,
+    pub target: PublishTargetArg,
+    pub repo: Option<String>,
+}
+
+/// CLI surface for the publish target. Keeps the clap enum decoupled
+/// from `ccteam_core::PublishTarget` so the core type can hold target-
+/// specific data without leaking into clap derives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum PublishTargetArg {
+    Local,
+    Github,
+}
+
+/// Run `ccteam team init <name>`. Writes the staging tree under
+/// `~/.config/ccteam/teams/<name>/` (or `$XDG_CONFIG_HOME/ccteam/...`).
+/// Returns a human-readable report so the binary entry point can
+/// print it.
+pub fn run_team_init(args: &TeamInitArgs) -> Result<String> {
+    let mut spec_yaml = format!("name: {}\n", args.name);
+    if !args.description.is_empty() {
+        spec_yaml.push_str(&format!("description: {}\n", args.description));
+    }
+    spec_yaml.push_str("phase_dir: phases\n");
+    let spec = TeamSpec::parse(&spec_yaml)
+        .with_context(|| format!("synthesize TeamSpec from `--name {}`", args.name))?;
+
+    let manifest = PluginManifest {
+        name: args.name.clone(),
+        description: args.description.clone(),
+        author: PluginAuthor {
+            name: args.author_name.clone(),
+            email: args.author_email.clone(),
+        },
+        version: args.version.clone(),
+    };
+
+    // Single starter phase. The team-author skill produces multi-phase
+    // teams via N init invocations / direct edit; the CLI default
+    // keeps the surface small and predictable.
+    let phases = vec![PhaseScaffold {
+        name: "intake",
+        task_summary: "interview the user, write `.ccteam/spec.md`.",
+        required_inputs: &[],
+        required_outputs: &[".ccteam/spec.md"],
+        auto_loop: true,
+    }];
+
+    let report: InitReport = init_team_staging(&TeamInitInput {
+        spec: &spec,
+        manifest: &manifest,
+        phases: &phases,
+        staging_root_override: None,
+    })?;
+    Ok(render_init_report(&report))
+}
+
+fn render_init_report(report: &InitReport) -> String {
+    let mut out = String::new();
+    out.push_str("ccteam team init\n\n");
+    out.push_str(&format!("  staging dir   {}\n", report.staging_dir.display()));
+    out.push_str(&format!(
+        "  manifest      {}\n",
+        report.manifest_path.display(),
+    ));
+    out.push_str(&format!(
+        "  team yaml     {}\n",
+        report.team_yaml_path.display(),
+    ));
+    out.push_str(&format!(
+        "  phases ({})  ", report.phase_paths.len(),
+    ));
+    out.push('\n');
+    for path in &report.phase_paths {
+        out.push_str(&format!("                {}\n", path.display()));
+    }
+    out.push_str(&format!("  README        {}\n\n", report.readme_path.display()));
+    out.push_str(
+        "next:\n  \
+         1. edit phases/*.md bodies to fill in domain detail.\n  \
+         2. ccteam doctor --validate-team <name> — checks plugin manifest + team.yaml.\n  \
+         3. ccteam team publish <name> --target local|github\n",
+    );
+    out
+}
+
+/// Run `ccteam team publish <name>`. For `--target github`, this
+/// validates staging + repo coordinate, then shells out to `gh repo
+/// create` + git plumbing. For `--target local`, it delegates to
+/// `ccteam_core::publish_team` (which symlinks staging into the
+/// ccteam-local marketplace).
+pub fn run_team_publish(args: &TeamPublishArgs) -> Result<String> {
+    let staging = staging_dir_for(&args.name, None);
+    let findings = validate_staged_team(&staging)?;
+    let mut out = String::new();
+    out.push_str("ccteam team publish\n\n");
+    for line in &findings {
+        out.push_str(&format!("  {line}\n"));
+    }
+    if findings.iter().any(|l| l.starts_with("[FAIL]")) {
+        bail!(
+            "ccteam team publish: validation failed — fix the [FAIL] lines above and re-run.",
+        );
+    }
+    match args.target {
+        PublishTargetArg::Local => {
+            let report = publish_team(&PublishInput {
+                team_name: &args.name,
+                target: PublishTarget::Local,
+                staging_root_override: None,
+                claude_dir_override: None,
+            })?;
+            out.push_str(&render_publish_report(&report));
+        }
+        PublishTargetArg::Github => {
+            let repo = args.repo.as_deref().ok_or_else(|| {
+                anyhow!(
+                    "ccteam team publish --target github requires --repo <owner>/<name>",
+                )
+            })?;
+            // Ensure the staging dir is otherwise OK before any network
+            // side-effects. Then shell out.
+            let _ = publish_team(&PublishInput {
+                team_name: &args.name,
+                target: PublishTarget::Github {
+                    repo: repo.to_string(),
+                },
+                staging_root_override: None,
+                claude_dir_override: None,
+            })?;
+            let url = github_publish_via_gh(&staging, repo)
+                .with_context(|| format!("publish staged team to github repo `{repo}`"))?;
+            out.push_str(&format!("  pushed → {url}\n"));
+            out.push_str(&format!(
+                "\nshare with: claude /plugin add {repo}\n",
+            ));
+        }
+    }
+    Ok(out)
+}
+
+fn render_publish_report(report: &PublishReport) -> String {
+    let mut out = String::new();
+    if let Some(link) = &report.local_link {
+        out.push_str(&format!("  linked → {}\n", link.display()));
+        out.push_str(
+            "\nshare with: tell the user the staging dir path; on their machine they install via\n  \
+             claude /plugin add <staging-path>\n  \
+             or copy/git-clone the staging tree into their ccteam-local marketplace.\n",
+        );
+    }
+    if let Some(url) = &report.github_url {
+        out.push_str(&format!("  pushed → {url}\n"));
+    }
+    out
+}
+
+/// Shell out to `gh` + `git` to create a GitHub repo and push the
+/// staging tree to it. Fail-loud (per task spec) when `gh` is missing
+/// / unauthenticated — the caller should see a clear pointer to
+/// `gh auth login`. Returns the resulting `https://github.com/<repo>`
+/// URL.
+fn github_publish_via_gh(staging: &Path, repo: &str) -> Result<String> {
+    if !command_exists("gh") {
+        bail!(
+            "gh CLI not found on PATH — install https://cli.github.com/ then run `gh auth login`",
+        );
+    }
+    let auth_status = Command::new("gh")
+        .args(["auth", "status"])
+        .output()
+        .context("invoke gh auth status")?;
+    if !auth_status.status.success() {
+        let stderr = String::from_utf8_lossy(&auth_status.stderr);
+        bail!(
+            "gh CLI is not authenticated; run `gh auth login` first.\n\
+             gh stderr:\n{stderr}",
+        );
+    }
+
+    // Ensure git history exists in the staging dir. The factory does
+    // not init git itself (staging may live alongside other ccteam
+    // metadata not part of the team plugin); we run `git init` here
+    // idempotently.
+    run_in(staging, "git", &["init", "-q"])?;
+    run_in(staging, "git", &["add", "-A"])?;
+    // `git commit` exits non-zero if the tree is clean; tolerate that.
+    let _ = Command::new("git")
+        .current_dir(staging)
+        .args(["commit", "-q", "-m", "initial team plugin commit"])
+        .status();
+
+    // Create the repo. `--source .` would push the cwd; we keep
+    // create + push separate so the failure mode (already exists,
+    // permission denied) is easier to attribute.
+    let create = Command::new("gh")
+        .current_dir(staging)
+        .args([
+            "repo",
+            "create",
+            repo,
+            "--public",
+            "--source",
+            ".",
+            "--remote",
+            "origin",
+            "--push",
+        ])
+        .output()
+        .context("invoke gh repo create")?;
+    if !create.status.success() {
+        let stderr = String::from_utf8_lossy(&create.stderr);
+        bail!(
+            "gh repo create failed.\nstderr:\n{stderr}",
+        );
+    }
+    Ok(format!("https://github.com/{repo}"))
+}
+
+fn run_in(dir: &Path, cmd: &str, args: &[&str]) -> Result<()> {
+    let output = Command::new(cmd)
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .with_context(|| format!("invoke {cmd} {}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "`{} {}` exited {}: {stderr}",
+            cmd,
+            args.join(" "),
+            output.status,
+        );
+    }
+    Ok(())
+}
+
+fn command_exists(cmd: &str) -> bool {
+    Command::new(cmd)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[allow(dead_code)] // V0.3 hook — surfaced as a public helper for tests.
+pub fn staging_path_for(name: &str) -> PathBuf {
+    staging_dir_for(name, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_init_report_includes_staging_dir() {
+        let report = InitReport {
+            staging_dir: PathBuf::from("/tmp/x"),
+            manifest_path: PathBuf::from("/tmp/x/.claude-plugin/plugin.json"),
+            team_yaml_path: PathBuf::from("/tmp/x/team.yaml"),
+            phase_paths: vec![PathBuf::from("/tmp/x/phases/01-intake.md")],
+            readme_path: PathBuf::from("/tmp/x/README.md"),
+        };
+        let body = render_init_report(&report);
+        assert!(body.contains("/tmp/x"));
+        assert!(body.contains("01-intake.md"));
+        assert!(body.contains("validate-team"));
+    }
+
+    #[test]
+    fn render_publish_report_local_includes_link_and_share_hint() {
+        let report = PublishReport {
+            target: PublishTarget::Local,
+            local_link: Some(PathBuf::from("/tmp/link")),
+            github_url: None,
+        };
+        let body = render_publish_report(&report);
+        assert!(body.contains("linked"));
+        assert!(body.contains("/plugin add"));
+    }
+
+    #[test]
+    fn render_publish_report_github_includes_url() {
+        let report = PublishReport {
+            target: PublishTarget::Github {
+                repo: "alice/example".into(),
+            },
+            local_link: None,
+            github_url: Some("https://github.com/alice/example".into()),
+        };
+        let body = render_publish_report(&report);
+        assert!(body.contains("alice/example"));
+        assert!(body.contains("https://"));
+    }
+}

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod stall;
 pub mod state;
 pub mod subskill;
 pub mod team;
+pub mod team_factory;
 pub mod team_resolver;
 pub mod templates;
 pub mod tmux;
@@ -47,9 +48,10 @@ pub use memory_bridge::{
     InstallMemoryBridgeOptions, MemoryBridgeAction, MemoryBridgeReport,
 };
 pub use skill::{
-    install_ccteam_control_skill, install_into as install_skill_into,
+    install_ccteam_control_skill, install_ccteam_team_author_skill,
+    install_into as install_skill_into, install_skill_body_into,
     InstallSkillOptions, InstallSkillReport, SkillInstallAction,
-    CCTEAM_CONTROL_SKILL_NAME,
+    CCTEAM_CONTROL_SKILL_NAME, CCTEAM_TEAM_AUTHOR_SKILL_NAME,
 };
 pub use orchestrator::MAX_CONCURRENT_PROJECTS;
 pub use orchestrator::{
@@ -83,6 +85,11 @@ pub use team::{
     CostPolicy, CriticDimensionSpec, CriticStrictness, DomainRule, EscalateGrammarExtension,
     EscalateRoute, GoldenRuleEnforcement, ProtocolRule, RetroFieldKind, RetroFieldSpec,
     TeamGoldenRules, TeamSpec,
+};
+pub use team_factory::{
+    init_team_staging, publish_team, staging_dir_for, validate_staged_team, InitReport,
+    PhaseScaffold, PluginAuthor, PluginManifest, PublishInput, PublishReport, PublishTarget,
+    TeamInitInput,
 };
 pub use team_resolver::{
     default_user_staging_dir, discover_team_names, resolve_team, save_team, TeamResolveContext,

--- a/crates/ccteam-core/src/skill.rs
+++ b/crates/ccteam-core/src/skill.rs
@@ -16,8 +16,18 @@ use crate::tool_surface::user_claude_dir;
 /// inside `~/.claude/skills/`.
 pub const CCTEAM_CONTROL_SKILL_NAME: &str = "ccteam-control";
 
+/// V0.2 M0.22.1 — `ccteam-team-author` skill name. Walks the
+/// meta-agent through the team-factory dialogue (phase list, tools,
+/// golden rules, retro / verdict schema, plugin metadata) before
+/// invoking `ccteam team init`.
+pub const CCTEAM_TEAM_AUTHOR_SKILL_NAME: &str = "ccteam-team-author";
+
 /// Embedded `SKILL.md` body. Written verbatim during install.
 const CCTEAM_CONTROL_SKILL_MD: &str = include_str!("templates/ccteam_control_skill.md");
+
+/// Embedded `SKILL.md` body for the team-author skill (V0.2 M0.22.1).
+const CCTEAM_TEAM_AUTHOR_SKILL_MD: &str =
+    include_str!("templates/ccteam_team_author_skill.md");
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InstallSkillOptions {
@@ -48,12 +58,42 @@ pub fn install_ccteam_control_skill(opts: InstallSkillOptions) -> Result<Install
     install_into(&claude, opts)
 }
 
+/// V0.2 M0.22.1: install the `ccteam-team-author` skill into
+/// `~/.claude/skills/ccteam-team-author/SKILL.md`. Same idempotent
+/// semantics as `install_ccteam_control_skill`.
+pub fn install_ccteam_team_author_skill(
+    opts: InstallSkillOptions,
+) -> Result<InstallSkillReport> {
+    let claude = user_claude_dir().context("resolve ~/.claude/")?;
+    install_skill_body_into(
+        &claude,
+        CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+        CCTEAM_TEAM_AUTHOR_SKILL_MD,
+        opts,
+    )
+}
+
 /// Test-injectable variant: write into `<claude_dir>/skills/...` so unit
 /// tests can point at a tempdir without mutating `$HOME/.claude/`.
 pub fn install_into(claude_dir: &Path, opts: InstallSkillOptions) -> Result<InstallSkillReport> {
-    let dir = claude_dir
-        .join("skills")
-        .join(CCTEAM_CONTROL_SKILL_NAME);
+    install_skill_body_into(
+        claude_dir,
+        CCTEAM_CONTROL_SKILL_NAME,
+        CCTEAM_CONTROL_SKILL_MD,
+        opts,
+    )
+}
+
+/// Shared idempotent writer used by both install_into (control) and
+/// the team-author install path. Skill name selects the `<claude_dir>/skills/<name>/`
+/// directory; body is the verbatim SKILL.md contents.
+pub fn install_skill_body_into(
+    claude_dir: &Path,
+    skill_name: &str,
+    body: &str,
+    opts: InstallSkillOptions,
+) -> Result<InstallSkillReport> {
+    let dir = claude_dir.join("skills").join(skill_name);
     let target = dir.join("SKILL.md");
     let exists = target.exists();
 
@@ -75,7 +115,7 @@ pub fn install_into(claude_dir: &Path, opts: InstallSkillOptions) -> Result<Inst
 
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create {}", dir.display()))?;
-    std::fs::write(&target, CCTEAM_CONTROL_SKILL_MD)
+    std::fs::write(&target, body)
         .with_context(|| format!("write {}", target.display()))?;
     Ok(InstallSkillReport {
         target,
@@ -140,5 +180,44 @@ mod tests {
             SkillInstallAction::DryRun { would_write: true },
         );
         assert!(!r.target.exists());
+    }
+
+    // ---------------- V0.2 M0.22.1 team-author skill ----------------
+
+    #[test]
+    fn team_author_skill_installs_under_ccteam_team_author_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let report = install_skill_body_into(
+            tmp.path(),
+            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+            CCTEAM_TEAM_AUTHOR_SKILL_MD,
+            InstallSkillOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(report.action, SkillInstallAction::Wrote);
+        let body = std::fs::read_to_string(&report.target).unwrap();
+        assert!(body.starts_with("---\n"));
+        assert!(body.contains("name: ccteam-team-author"));
+        assert!(body.contains("Capability index"));
+    }
+
+    #[test]
+    fn team_author_skill_install_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        install_skill_body_into(
+            tmp.path(),
+            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+            CCTEAM_TEAM_AUTHOR_SKILL_MD,
+            InstallSkillOptions::default(),
+        )
+        .unwrap();
+        let r2 = install_skill_body_into(
+            tmp.path(),
+            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+            CCTEAM_TEAM_AUTHOR_SKILL_MD,
+            InstallSkillOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(r2.action, SkillInstallAction::AlreadyPresent);
     }
 }

--- a/crates/ccteam-core/src/team_factory.rs
+++ b/crates/ccteam-core/src/team_factory.rs
@@ -1,0 +1,852 @@
+//! V0.2 M0.22 — Team factory: scaffold a Claude Code plugin from a
+//! `TeamSpec` so a user-authored team becomes a shareable artifact.
+//!
+//! Output layout (staging at `~/.config/ccteam/teams/<name>/`):
+//!
+//! ```text
+//! <staging>/
+//!   .claude-plugin/
+//!     plugin.json                  # Claude Code plugin manifest
+//!   team.yaml                      # ccteam team config (top-level
+//!                                  #   unknown field for plugin loader)
+//!   phases/
+//!     01-<phase-1>.md              # frontmatter + body template
+//!     ...
+//!   README.md                      # author / install pointer
+//! ```
+//!
+//! The factory does **not** write `agents/` / `commands/` /
+//! `hooks/hooks.json` / `.mcp.json`. Those are optional plugin
+//! conventions the team author can drop in by hand once the staging
+//! tree exists; `ccteam doctor --validate-team` accepts them when
+//! present and ignores them when absent.
+//!
+//! Why staging is separate from "published":
+//! - PRD §4 — staging is the user's draft; publish promotes it to a
+//!   marketplace (local symlink) or remote (github push). Two-stage
+//!   keeps `ccteam team init` cheap (no network) and `publish` strict
+//!   (validates first, fails loud if `gh` missing for github target).
+//!
+//! What rides as the plugin manifest:
+//! - `name` / `description` / `author` — strict Claude Code plugin
+//!   schema (plugin.json sample bodies inspected under
+//!   `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/*/.claude-plugin/plugin.json`
+//!   carry only those keys + occasional `version`).
+//! - `team.yaml` lives at the plugin root as a ccteam-private file. The
+//!   plugin loader's zod schema strips unknown root keys, so the
+//!   plugin loads cleanly; ccteam reads the file directly via
+//!   `team_resolver`. (alignment-review §2.7 confirms zod default
+//!   behaviour.)
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::team::TeamSpec;
+use crate::team_resolver::default_user_staging_dir;
+
+/// Claude Code plugin manifest fields the factory writes. Mirrors the
+/// schema observed in `claude-plugins-official` plugin.json files —
+/// `name` + `description` + `author { name, email? }`. `version` is
+/// optional but conventional (eg explanatory-output-style ships it).
+///
+/// The struct is **strict** on serialization (no unknown keys leak
+/// into plugin.json) but the on-disk schema validation is **lenient**
+/// — Claude Code's plugin loader strips unknown root fields by zod
+/// default (alignment-review §2.7), so older / future schema additions
+/// don't break ccteam.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginManifest {
+    pub name: String,
+    pub description: String,
+    pub author: PluginAuthor,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// `author` block in plugin.json. `email` is optional.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginAuthor {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+}
+
+impl PluginManifest {
+    /// Validate manifest fields the plugin loader cares about. Mirrors
+    /// the constraints on `team.yaml.name` (ascii lower / digit / `-`
+    /// / `_`) since the manifest name doubles as the plugin directory
+    /// + ccteam team name.
+    pub fn validate(&self) -> Result<()> {
+        if self.name.trim().is_empty() {
+            bail!("plugin.json: `name` must be non-empty");
+        }
+        if self
+            .name
+            .chars()
+            .any(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_'))
+        {
+            bail!(
+                "plugin.json: `name` must be ascii lower / digit / `-` / `_`; got `{}`",
+                self.name,
+            );
+        }
+        if self.description.trim().is_empty() {
+            bail!("plugin.json: `description` must be non-empty");
+        }
+        if self.author.name.trim().is_empty() {
+            bail!("plugin.json: `author.name` must be non-empty");
+        }
+        Ok(())
+    }
+}
+
+/// V0.2 M0.22.2 input for `init_team_staging`. The factory
+/// orchestrates the file layout; the caller (CLI / meta-agent skill)
+/// supplies the per-team data.
+#[derive(Debug, Clone)]
+pub struct TeamInitInput<'a> {
+    pub spec: &'a TeamSpec,
+    pub manifest: &'a PluginManifest,
+    /// Phase scaffolds to write under `phases/<NN>-<name>.md`. Order
+    /// drives both filename ordering (NN prefix from index) and
+    /// the on-disk DAG order. Empty list = evergreen team (no phases).
+    pub phases: &'a [PhaseScaffold<'a>],
+    /// `XDG_CONFIG_HOME` override for tests. None = real
+    /// `default_user_staging_dir()`.
+    pub staging_root_override: Option<&'a Path>,
+}
+
+/// One phase scaffold. The factory writes a phase markdown file with
+/// minimal frontmatter (the required keys for `PhaseTemplate::parse` +
+/// `validate_m0`) and a domain-task body template. Protocol literals
+/// (`PHASE_DONE: …` / `ESCALATE: …`) are deliberately absent from the
+/// body — V0.2 M0.18 keeps those inside the orchestrator's inject
+/// prompt only.
+#[derive(Debug, Clone)]
+pub struct PhaseScaffold<'a> {
+    pub name: &'a str,
+    /// Free-text one-liner. Renders inside the body's "## 任务" section.
+    pub task_summary: &'a str,
+    pub required_inputs: &'a [&'a str],
+    pub required_outputs: &'a [&'a str],
+    /// V0.2 M0.19 default `auto_loop: true`. Authors who want a phase
+    /// to run once and stop set this to false.
+    pub auto_loop: bool,
+}
+
+/// Outcome of `init_team_staging` — surfaces every file written so the
+/// CLI report can list them and tests can assert exact layout.
+#[derive(Debug, Clone)]
+pub struct InitReport {
+    pub staging_dir: PathBuf,
+    pub manifest_path: PathBuf,
+    pub team_yaml_path: PathBuf,
+    pub phase_paths: Vec<PathBuf>,
+    pub readme_path: PathBuf,
+}
+
+/// Resolve the staging dir for `team_name`. Honors
+/// `staging_root_override` for tests.
+pub fn staging_dir_for(team_name: &str, staging_root_override: Option<&Path>) -> PathBuf {
+    let root = match staging_root_override {
+        Some(p) => p.to_path_buf(),
+        None => default_user_staging_dir(),
+    };
+    root.join("teams").join(team_name)
+}
+
+/// V0.2 M0.22.2: write the staging tree for a new team. Idempotent —
+/// re-running with the same input produces the same files (overwrites).
+/// Strictly refuses to clobber an existing staging dir whose
+/// `.claude-plugin/plugin.json` carries a different `name`, since that
+/// indicates a different team's tree at the same path.
+pub fn init_team_staging(input: &TeamInitInput<'_>) -> Result<InitReport> {
+    input.manifest.validate().context("plugin manifest")?;
+    if input.spec.name != input.manifest.name {
+        bail!(
+            "team factory: spec.name `{}` != manifest.name `{}` — \
+             keep them in lock-step (the plugin directory uses manifest.name)",
+            input.spec.name,
+            input.manifest.name,
+        );
+    }
+    input.spec.validate().context("team.yaml spec")?;
+
+    let staging = staging_dir_for(&input.spec.name, input.staging_root_override);
+    if let Some(existing) = read_existing_manifest(&staging)? {
+        if existing.name != input.manifest.name {
+            bail!(
+                "team factory: {} already holds plugin `{}` — refusing to overwrite. \
+                 Delete or rename it before re-init.",
+                staging.display(),
+                existing.name,
+            );
+        }
+    }
+
+    let plugin_dir = staging.join(".claude-plugin");
+    std::fs::create_dir_all(&plugin_dir)
+        .with_context(|| format!("create {}", plugin_dir.display()))?;
+    let manifest_path = plugin_dir.join("plugin.json");
+    let manifest_body =
+        serde_json::to_string_pretty(input.manifest).context("serialize plugin.json")?;
+    std::fs::write(&manifest_path, format!("{manifest_body}\n"))
+        .with_context(|| format!("write {}", manifest_path.display()))?;
+
+    let team_yaml_path = staging.join("team.yaml");
+    let team_yaml_body =
+        serde_yaml::to_string(input.spec).context("serialize team.yaml")?;
+    std::fs::write(&team_yaml_path, team_yaml_body)
+        .with_context(|| format!("write {}", team_yaml_path.display()))?;
+
+    let phase_dir_name: &str = if input.spec.phase_dir.is_empty() {
+        "phases"
+    } else {
+        input.spec.phase_dir.as_str()
+    };
+    let phase_dir = staging.join(phase_dir_name);
+    std::fs::create_dir_all(&phase_dir)
+        .with_context(|| format!("create {}", phase_dir.display()))?;
+    let mut phase_paths = Vec::with_capacity(input.phases.len());
+    for (idx, scaffold) in input.phases.iter().enumerate() {
+        let filename = format!("{:02}-{}.md", idx + 1, scaffold.name);
+        let path = phase_dir.join(&filename);
+        std::fs::write(&path, render_phase_scaffold(scaffold))
+            .with_context(|| format!("write {}", path.display()))?;
+        phase_paths.push(path);
+    }
+
+    let readme_path = staging.join("README.md");
+    std::fs::write(&readme_path, render_readme(input))
+        .with_context(|| format!("write {}", readme_path.display()))?;
+
+    Ok(InitReport {
+        staging_dir: staging,
+        manifest_path,
+        team_yaml_path,
+        phase_paths,
+        readme_path,
+    })
+}
+
+fn read_existing_manifest(staging: &Path) -> Result<Option<PluginManifest>> {
+    let path = staging.join(".claude-plugin").join("plugin.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(&path)
+        .with_context(|| format!("read {}", path.display()))?;
+    let manifest: PluginManifest = serde_json::from_str(&body)
+        .with_context(|| format!("parse {}", path.display()))?;
+    Ok(Some(manifest))
+}
+
+/// Render one phase scaffold. Frontmatter carries only the required +
+/// commonly-tweaked fields; serde defaults handle everything else at
+/// parse time. Body has two sections (task summary + required outputs)
+/// and zero protocol literals.
+fn render_phase_scaffold(scaffold: &PhaseScaffold<'_>) -> String {
+    let mut yaml = String::new();
+    yaml.push_str("---\n");
+    yaml.push_str(&format!("name: {}\n", scaffold.name));
+    if !scaffold.required_inputs.is_empty() {
+        yaml.push_str("required_inputs:\n");
+        for input in scaffold.required_inputs {
+            yaml.push_str(&format!("  - {input}\n"));
+        }
+    }
+    if !scaffold.required_outputs.is_empty() {
+        yaml.push_str("required_outputs:\n");
+        for output in scaffold.required_outputs {
+            yaml.push_str(&format!("  - {output}\n"));
+        }
+    }
+    yaml.push_str("parallelism: solo\n");
+    yaml.push_str(&format!("auto_loop: {}\n", scaffold.auto_loop));
+    yaml.push_str("---\n\n");
+    yaml.push_str(&format!("# {}\n\n", scaffold.name));
+    yaml.push_str("## 任务\n\n");
+    yaml.push_str(scaffold.task_summary);
+    if !scaffold.task_summary.ends_with('\n') {
+        yaml.push('\n');
+    }
+    if !scaffold.required_outputs.is_empty() {
+        yaml.push_str("\n## 产出\n\n");
+        for output in scaffold.required_outputs {
+            yaml.push_str(&format!("- `{output}`\n"));
+        }
+    }
+    yaml.push_str(
+        "\n> 本文件由 ccteam team factory 生成。正文是任务描述,正文不写协议关键字\n\
+         > (`PHASE_DONE` / `ESCALATE` 由 orchestrator inject prompt 注入)。\n",
+    );
+    yaml
+}
+
+fn render_readme(input: &TeamInitInput<'_>) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("# {}\n\n", input.manifest.name));
+    s.push_str(&format!("{}\n\n", input.manifest.description));
+    s.push_str("## Install\n\n");
+    s.push_str("```bash\n");
+    s.push_str(&format!(
+        "ccteam team publish {} --target local\n",
+        input.manifest.name,
+    ));
+    s.push_str(&format!(
+        "claude /plugin enable {}@ccteam-local\n",
+        input.manifest.name,
+    ));
+    s.push_str("```\n\n");
+    s.push_str("## Phases\n\n");
+    if input.phases.is_empty() {
+        s.push_str("(no phases — evergreen team)\n");
+    } else {
+        for scaffold in input.phases {
+            s.push_str(&format!("- `{}` — {}\n", scaffold.name, scaffold.task_summary));
+        }
+    }
+    s.push('\n');
+    s.push_str("Authored via `ccteam team init`. Edit `phases/*.md` bodies to fill in domain detail.\n");
+    s
+}
+
+/// Publish target — selects between local marketplace symlink and a
+/// remote (github) push.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishTarget {
+    /// Symlink staging dir into
+    /// `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`.
+    Local,
+    /// Push to a new GitHub repo + return the URL. Caller supplies the
+    /// repo coordinates (`owner/name`); the factory shells out to
+    /// `gh repo create` + git push.
+    Github { repo: String },
+}
+
+/// Publish report — every path / URL touched.
+#[derive(Debug, Clone)]
+pub struct PublishReport {
+    pub target: PublishTarget,
+    /// Local install handle when target = Local
+    /// (`~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>`).
+    pub local_link: Option<PathBuf>,
+    /// Remote URL when target = Github.
+    pub github_url: Option<String>,
+}
+
+/// Options for `publish_team`. `claude_dir_override` and
+/// `git_runner_override` are test-injection points.
+#[derive(Debug, Clone)]
+pub struct PublishInput<'a> {
+    pub team_name: &'a str,
+    pub target: PublishTarget,
+    pub staging_root_override: Option<&'a Path>,
+    pub claude_dir_override: Option<&'a Path>,
+}
+
+/// V0.2 M0.22.3: publish a staged team. For Local target, link the
+/// staging tree into the ccteam-local marketplace. For Github, do not
+/// run the actual gh CLI from this function; the CLI command shell-runs
+/// the gh / git steps and uses this only to validate the staging dir
+/// exists. (Test boundary — the unit-tested function returns the
+/// expected paths; the CLI handles the side effects.)
+pub fn publish_team(input: &PublishInput<'_>) -> Result<PublishReport> {
+    let staging = staging_dir_for(input.team_name, input.staging_root_override);
+    if !staging.exists() {
+        bail!(
+            "ccteam team publish: staging dir {} not found — \
+             run `ccteam team init {}` first",
+            staging.display(),
+            input.team_name,
+        );
+    }
+    if !staging.join(".claude-plugin/plugin.json").exists() {
+        bail!(
+            "ccteam team publish: {} is not a complete plugin staging tree \
+             (missing .claude-plugin/plugin.json) — re-run `ccteam team init`",
+            staging.display(),
+        );
+    }
+
+    match &input.target {
+        PublishTarget::Local => {
+            let claude = match input.claude_dir_override {
+                Some(p) => p.to_path_buf(),
+                None => crate::tool_surface::user_claude_dir()?,
+            };
+            let marketplace_root = claude
+                .join("plugins")
+                .join("marketplaces")
+                .join("ccteam-local")
+                .join("plugins");
+            std::fs::create_dir_all(&marketplace_root).with_context(|| {
+                format!(
+                    "create ccteam-local marketplace dir {}",
+                    marketplace_root.display(),
+                )
+            })?;
+            let link = marketplace_root.join(input.team_name);
+            // Idempotent: remove any prior symlink before re-linking.
+            // Directory entries are not removed (avoid clobbering an
+            // unrelated team that happens to share the name).
+            match std::fs::symlink_metadata(&link) {
+                Ok(meta) if meta.file_type().is_symlink() => {
+                    std::fs::remove_file(&link).with_context(|| {
+                        format!("remove stale symlink {}", link.display())
+                    })?;
+                }
+                Ok(_) => bail!(
+                    "ccteam team publish: {} exists and is not a symlink — \
+                     refusing to overwrite",
+                    link.display(),
+                ),
+                Err(_) => {}
+            }
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&staging, &link).with_context(|| {
+                format!(
+                    "symlink {} -> {}",
+                    link.display(),
+                    staging.display(),
+                )
+            })?;
+            #[cfg(not(unix))]
+            std::fs::create_dir_all(&link).context("non-unix publish-local fallback")?;
+            ensure_marketplace_json(&claude)?;
+            Ok(PublishReport {
+                target: input.target.clone(),
+                local_link: Some(link),
+                github_url: None,
+            })
+        }
+        PublishTarget::Github { repo } => {
+            // Repo coordinate sanity check — `<owner>/<name>` shape so
+            // `gh repo create` doesn't fail with a confusing error.
+            if !repo.contains('/') || repo.split('/').count() != 2 {
+                bail!(
+                    "ccteam team publish --target github: --repo must be `<owner>/<name>`; got `{repo}`",
+                );
+            }
+            let url = format!("https://github.com/{repo}");
+            Ok(PublishReport {
+                target: input.target.clone(),
+                local_link: None,
+                github_url: Some(url),
+            })
+        }
+    }
+}
+
+/// Ensure `<claude>/plugins/marketplaces/ccteam-local/marketplace.json`
+/// exists with a minimal schema so `claude /plugin enable` finds the
+/// directory-source marketplace. Idempotent — overwrites a pre-existing
+/// `name: "ccteam-local"` file each call (safe — no user content).
+fn ensure_marketplace_json(claude_dir: &Path) -> Result<()> {
+    let path = claude_dir
+        .join("plugins")
+        .join("marketplaces")
+        .join("ccteam-local")
+        .join("marketplace.json");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let body = serde_json::json!({
+        "name": "ccteam-local",
+        "description": "ccteam team factory — local staging marketplace",
+    });
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&body)
+            .map_err(|e| anyhow!("serialize marketplace.json: {e}"))?,
+    )
+    .with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+/// V0.2 M0.22.4: validation pass over a staged team. Re-uses
+/// `TeamSpec::validate` and `PluginManifest::validate`, plus
+/// cross-checks the two `name` fields agree. Returns a list of
+/// human-readable findings (`[OK]` / `[WARN]` / `[FAIL]` lines) the
+/// caller can append to a doctor report. Empty Ok list = nothing
+/// found that warrants surfacing.
+pub fn validate_staged_team(staging: &Path) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    let manifest_path = staging.join(".claude-plugin").join("plugin.json");
+    if !manifest_path.exists() {
+        out.push(format!(
+            "[FAIL] missing plugin manifest at {}",
+            manifest_path.display(),
+        ));
+        return Ok(out);
+    }
+    let manifest_body = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    let manifest: PluginManifest = match serde_json::from_str(&manifest_body) {
+        Ok(m) => m,
+        Err(err) => {
+            out.push(format!("[FAIL] plugin.json parse: {err}"));
+            return Ok(out);
+        }
+    };
+    if let Err(err) = manifest.validate() {
+        out.push(format!("[FAIL] plugin.json: {err:#}"));
+    } else {
+        out.push(format!("[OK] plugin.json `name={}`", manifest.name));
+    }
+
+    let yaml_path = staging.join("team.yaml");
+    if !yaml_path.exists() {
+        out.push(format!(
+            "[FAIL] missing team.yaml at {}",
+            yaml_path.display(),
+        ));
+        return Ok(out);
+    }
+    let spec = match TeamSpec::load(&yaml_path) {
+        Ok(s) => s,
+        Err(err) => {
+            out.push(format!("[FAIL] team.yaml: {err:#}"));
+            return Ok(out);
+        }
+    };
+    out.push(format!("[OK] team.yaml `name={}`", spec.name));
+    if spec.name != manifest.name {
+        out.push(format!(
+            "[FAIL] team.yaml.name=`{}` != plugin.json.name=`{}` — \
+             keep them in lock-step",
+            spec.name, manifest.name,
+        ));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_spec() -> TeamSpec {
+        TeamSpec::parse(
+            "name: example\n\
+             description: example team\n\
+             phase_dir: phases\n",
+        )
+        .unwrap()
+    }
+
+    fn sample_manifest() -> PluginManifest {
+        PluginManifest {
+            name: "example".into(),
+            description: "example team plugin".into(),
+            author: PluginAuthor {
+                name: "tester".into(),
+                email: Some("t@example.com".into()),
+            },
+            version: Some("0.1.0".into()),
+        }
+    }
+
+    fn run_init(tmp: &TempDir) -> InitReport {
+        let spec = sample_spec();
+        let manifest = sample_manifest();
+        let phases = vec![
+            PhaseScaffold {
+                name: "kickoff",
+                task_summary: "interview the user, write `.ccteam/spec.md`.",
+                required_inputs: &[],
+                required_outputs: &[".ccteam/spec.md"],
+                auto_loop: true,
+            },
+            PhaseScaffold {
+                name: "build",
+                task_summary: "do the work; emit `.ccteam/build.md`.",
+                required_inputs: &[".ccteam/spec.md"],
+                required_outputs: &[".ccteam/build.md"],
+                auto_loop: true,
+            },
+        ];
+        init_team_staging(&TeamInitInput {
+            spec: &spec,
+            manifest: &manifest,
+            phases: &phases,
+            staging_root_override: Some(tmp.path()),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn init_writes_full_plugin_layout() {
+        let tmp = TempDir::new().unwrap();
+        let report = run_init(&tmp);
+        assert!(report.manifest_path.exists());
+        assert!(report.team_yaml_path.exists());
+        assert_eq!(report.phase_paths.len(), 2);
+        assert!(report.phase_paths[0].file_name().unwrap() == "01-kickoff.md");
+        assert!(report.phase_paths[1].file_name().unwrap() == "02-build.md");
+        assert!(report.readme_path.exists());
+    }
+
+    #[test]
+    fn init_writes_valid_plugin_manifest_json() {
+        let tmp = TempDir::new().unwrap();
+        let report = run_init(&tmp);
+        let body = std::fs::read_to_string(&report.manifest_path).unwrap();
+        let manifest: PluginManifest = serde_json::from_str(&body).unwrap();
+        assert_eq!(manifest.name, "example");
+        assert_eq!(manifest.author.name, "tester");
+        assert_eq!(manifest.version.as_deref(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn init_writes_team_yaml_at_plugin_root() {
+        let tmp = TempDir::new().unwrap();
+        let report = run_init(&tmp);
+        // team.yaml lives at root, NOT under .claude-plugin/, so the
+        // plugin loader's zod schema strips it as an unknown root file
+        // (alignment-review §2.7).
+        assert_eq!(
+            report.team_yaml_path.parent().unwrap(),
+            report.staging_dir,
+        );
+    }
+
+    #[test]
+    fn init_phase_body_excludes_protocol_literals() {
+        // V0.2 M0.18: phase markdown bodies must not carry PHASE_DONE /
+        // ESCALATE. Those are inject-prompt-only.
+        let tmp = TempDir::new().unwrap();
+        let report = run_init(&tmp);
+        for path in &report.phase_paths {
+            let body = std::fs::read_to_string(path).unwrap();
+            assert!(
+                !body.contains("PHASE_DONE:"),
+                "phase {} body has PHASE_DONE literal",
+                path.display(),
+            );
+            assert!(
+                !body.contains("ESCALATE:"),
+                "phase {} body has ESCALATE literal",
+                path.display(),
+            );
+        }
+    }
+
+    #[test]
+    fn init_phase_frontmatter_parses_back_into_phase_template() {
+        let tmp = TempDir::new().unwrap();
+        let report = run_init(&tmp);
+        for path in &report.phase_paths {
+            let template = crate::phases::PhaseTemplate::load(path).unwrap();
+            template.validate_m0().unwrap();
+        }
+    }
+
+    #[test]
+    fn init_team_yaml_round_trips_through_team_spec_load() {
+        let tmp = TempDir::new().unwrap();
+        let report = run_init(&tmp);
+        let reloaded = TeamSpec::load(&report.team_yaml_path).unwrap();
+        assert_eq!(reloaded.name, "example");
+    }
+
+    #[test]
+    fn init_refuses_to_overwrite_a_different_teams_staging_dir() {
+        let tmp = TempDir::new().unwrap();
+        let _ = run_init(&tmp);
+        // Tamper: rewrite the manifest with a different name.
+        let staging = staging_dir_for("example", Some(tmp.path()));
+        let manifest_path = staging.join(".claude-plugin/plugin.json");
+        let body = std::fs::read_to_string(&manifest_path).unwrap();
+        let mut manifest: PluginManifest = serde_json::from_str(&body).unwrap();
+        manifest.name = "intruder".into();
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let spec = sample_spec();
+        let new_manifest = sample_manifest();
+        let err = init_team_staging(&TeamInitInput {
+            spec: &spec,
+            manifest: &new_manifest,
+            phases: &[],
+            staging_root_override: Some(tmp.path()),
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("intruder"));
+    }
+
+    #[test]
+    fn init_rejects_mismatched_spec_and_manifest_names() {
+        let tmp = TempDir::new().unwrap();
+        let spec = sample_spec();
+        let mut manifest = sample_manifest();
+        manifest.name = "different-name".into();
+        let err = init_team_staging(&TeamInitInput {
+            spec: &spec,
+            manifest: &manifest,
+            phases: &[],
+            staging_root_override: Some(tmp.path()),
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("lock-step"));
+    }
+
+    #[test]
+    fn manifest_validate_rejects_invalid_name() {
+        let mut m = sample_manifest();
+        m.name = "Has Space".into();
+        let err = m.validate().unwrap_err();
+        assert!(format!("{err:#}").contains("ascii"));
+    }
+
+    #[test]
+    fn manifest_validate_rejects_empty_description() {
+        let mut m = sample_manifest();
+        m.description = "  ".into();
+        let err = m.validate().unwrap_err();
+        assert!(format!("{err:#}").contains("description"));
+    }
+
+    #[test]
+    fn manifest_validate_rejects_empty_author_name() {
+        let mut m = sample_manifest();
+        m.author.name = "".into();
+        let err = m.validate().unwrap_err();
+        assert!(format!("{err:#}").contains("author"));
+    }
+
+    #[test]
+    fn validate_staged_team_returns_ok_for_a_just_initted_team() {
+        let tmp = TempDir::new().unwrap();
+        let _report = run_init(&tmp);
+        let staging = staging_dir_for("example", Some(tmp.path()));
+        let findings = validate_staged_team(&staging).unwrap();
+        assert!(findings.iter().any(|l| l.starts_with("[OK] plugin.json")));
+        assert!(findings.iter().any(|l| l.starts_with("[OK] team.yaml")));
+        assert!(!findings.iter().any(|l| l.starts_with("[FAIL]")));
+    }
+
+    #[test]
+    fn validate_staged_team_flags_missing_manifest() {
+        let tmp = TempDir::new().unwrap();
+        let staging = tmp.path().join("orphan");
+        std::fs::create_dir_all(&staging).unwrap();
+        let findings = validate_staged_team(&staging).unwrap();
+        assert!(findings.iter().any(|l| l.contains("[FAIL] missing plugin manifest")));
+    }
+
+    #[test]
+    fn validate_staged_team_flags_name_mismatch_between_manifest_and_yaml() {
+        let tmp = TempDir::new().unwrap();
+        let _ = run_init(&tmp);
+        let staging = staging_dir_for("example", Some(tmp.path()));
+        // Tamper: rewrite team.yaml with a mismatched name.
+        std::fs::write(staging.join("team.yaml"), "name: drifted\n").unwrap();
+        let findings = validate_staged_team(&staging).unwrap();
+        assert!(
+            findings.iter().any(|l| l.starts_with("[FAIL]") && l.contains("lock-step")),
+            "got: {findings:?}",
+        );
+    }
+
+    #[test]
+    fn publish_local_creates_marketplace_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let _ = run_init(&tmp);
+        let claude = tmp.path().join("claude-home");
+        std::fs::create_dir_all(&claude).unwrap();
+        let report = publish_team(&PublishInput {
+            team_name: "example",
+            target: PublishTarget::Local,
+            staging_root_override: Some(tmp.path()),
+            claude_dir_override: Some(&claude),
+        })
+        .unwrap();
+        let link = report.local_link.expect("local target produces link");
+        assert!(link.exists());
+        // Symlink target = staging dir.
+        let canonical = std::fs::canonicalize(&link).unwrap();
+        let staging = staging_dir_for("example", Some(tmp.path()));
+        assert_eq!(canonical, std::fs::canonicalize(&staging).unwrap());
+        // marketplace.json exists under ccteam-local/.
+        let mkt = claude
+            .join("plugins/marketplaces/ccteam-local/marketplace.json");
+        assert!(mkt.exists());
+    }
+
+    #[test]
+    fn publish_local_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let _ = run_init(&tmp);
+        let claude = tmp.path().join("claude-home");
+        std::fs::create_dir_all(&claude).unwrap();
+        for _ in 0..2 {
+            publish_team(&PublishInput {
+                team_name: "example",
+                target: PublishTarget::Local,
+                staging_root_override: Some(tmp.path()),
+                claude_dir_override: Some(&claude),
+            })
+            .unwrap();
+        }
+        // Symlink survives the second pass.
+        let link = claude
+            .join("plugins/marketplaces/ccteam-local/plugins/example");
+        assert!(link.exists());
+    }
+
+    #[test]
+    fn publish_fails_loud_when_staging_missing() {
+        let tmp = TempDir::new().unwrap();
+        let claude = tmp.path().join("claude-home");
+        let err = publish_team(&PublishInput {
+            team_name: "ghost",
+            target: PublishTarget::Local,
+            staging_root_override: Some(tmp.path()),
+            claude_dir_override: Some(&claude),
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("staging dir"));
+    }
+
+    #[test]
+    fn publish_github_validates_repo_coordinate_shape() {
+        let tmp = TempDir::new().unwrap();
+        let _ = run_init(&tmp);
+        let err = publish_team(&PublishInput {
+            team_name: "example",
+            target: PublishTarget::Github {
+                repo: "missing-slash".into(),
+            },
+            staging_root_override: Some(tmp.path()),
+            claude_dir_override: None,
+        })
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("owner"));
+    }
+
+    #[test]
+    fn publish_github_returns_https_url() {
+        let tmp = TempDir::new().unwrap();
+        let _ = run_init(&tmp);
+        let report = publish_team(&PublishInput {
+            team_name: "example",
+            target: PublishTarget::Github {
+                repo: "alice/example".into(),
+            },
+            staging_root_override: Some(tmp.path()),
+            claude_dir_override: None,
+        })
+        .unwrap();
+        assert_eq!(
+            report.github_url.as_deref(),
+            Some("https://github.com/alice/example"),
+        );
+    }
+}

--- a/crates/ccteam-core/src/templates/ccteam_team_author_skill.md
+++ b/crates/ccteam-core/src/templates/ccteam_team_author_skill.md
@@ -1,0 +1,148 @@
+---
+name: ccteam-team-author
+description: |
+  Author a new ccteam team plugin via dialogue with the user. Use when
+  the user asks to create / design / scaffold a team, or wants to package
+  a custom phase pipeline as a Claude Code plugin. Primary consumer is
+  the ccteam meta-agent session — it walks the user through phase list,
+  tools, golden rules, retro schema, verdict schema, and plugin metadata,
+  then invokes `ccteam team init` / `ccteam team publish` to materialize
+  and share the result.
+allowed-tools: [Bash, Read, Write, Edit]
+---
+
+# ccteam-team-author
+
+ccteam ships two teams out of the box (`dev`, `product-research`). When
+the user wants a different workflow — code review only, market research
+only, custom multi-phase research, anything — author a new team. The
+factory produces a Claude Code plugin (with a ccteam `team.yaml` riding
+as a top-level unknown field) so the same artifact installs anywhere
+Claude Code runs.
+
+## Capability index
+
+| What you want | Bash command |
+|---|---|
+| Scaffold a team from interview answers | `ccteam team init <name> --description "…"` |
+| Validate a staged team | `ccteam doctor --validate-team <name>` |
+| Publish to local marketplace        | `ccteam team publish <name> --target local` |
+| Publish to GitHub                   | `ccteam team publish <name> --target github --repo <owner>/<name>` |
+| Inspect what was generated          | `ls ~/.config/ccteam/teams/<name>/` |
+
+Staging path: `~/.config/ccteam/teams/<name>/`. Layout mirrors a Claude
+Code plugin (`.claude-plugin/plugin.json` + `team.yaml` + `phases/` +
+optional `agents/` `commands/` `hooks/hooks.json` `.mcp.json`).
+
+## Typical workflow — interview the user, then scaffold
+
+The factory expects answers to a small set of questions before
+`ccteam team init` can produce a useful skeleton. Walk the user through
+them one at a time — do **not** dump every question in a single turn.
+
+### A) Plugin metadata
+
+1. Plugin / team `name` — must be ascii lowercase + `-` + digits.
+   Doubles as `team.yaml.name`.
+2. One-line `description` (shown in `ccteam ls --teams`,
+   `marketplace.json`).
+3. `author.name` (and optionally `author.email`).
+
+### B) Phase list
+
+1. How many phases? (Typical range 3 – 8.)
+2. For each phase, in order:
+   - `name` (kebab-case)
+   - one-line task description
+   - `required_inputs` (file paths under `.ccteam/`, eg `.ccteam/spec.md`)
+   - `required_outputs` (eg `.ccteam/<phase>.md`)
+   - `parallelism`: `solo` (default) — `agent_team` is M3+, rare
+   - `auto_loop`: should the assistant self-loop to retry until it emits
+     a completion signal? (Default: yes — V0.2 M0.19.)
+3. Optional: a `verdict` phase (writes `.ccteam/verdict.md` with
+   PASS / CONCERN / REJECT / CLARIFY) — research-style teams use this.
+
+### C) Tools each phase needs
+
+Per phase, ask: which subagents / skills / MCP servers does this phase
+invoke? (Common subagents: `code-reviewer`, `code-architect`,
+`code-explorer`, `silent-failure-hunter`.) The factory writes
+`tools_required:` for each phase; `ccteam doctor --validate-team` then
+cross-checks reachability.
+
+### D) Golden rules (team-wide)
+
+V0.2 split into `protocol` (orchestrator-enforced) and `domain`
+(prompt-only):
+
+- `protocol` with `enforce: cmd_check` — runs at phase boundary
+  (eg `cargo test --workspace`).
+- `protocol` with `enforce: prompt_directive` — text injected into every
+  phase's inject prompt. Default-include the `forbid_ask_user_question`
+  directive (V0.2 M0.19) — no team should let the assistant block on
+  AskUserQuestion.
+- `domain` — pure prompt guidance ("prefer small PRs", "no SQL string
+  interpolation").
+
+### E) Retro schema
+
+Fields the M4.1 retro phase will fill. Empty list = team has no retro.
+Fields are stable per team (renaming invalidates indexed history).
+Default for code teams: `tech_stack`, `pitfalls`, `successful_designs`,
+`do_not_do_again`.
+
+### F) Verdict schema (research / decision teams only)
+
+Phase names that emit `verdict.md` with PASS / CONCERN / REJECT /
+CLARIFY. Empty = team doesn't produce a verdict.
+
+### G) ESCALATE grammar extensions (optional)
+
+Team-specific ESCALATE prefixes the Stop hook should recognize. Each
+prefix has a `route`: `revert_to_phase` (with `target_phase`) /
+`need_user_input` / `abort`. Default = empty (the four built-in
+prefixes — `REVERT_TO_PHASE` / `NEED_USER_INPUT` / `ABORT` /
+`INSUFFICIENT_CLARIFICATION` — already cover most cases).
+
+## Decision principles
+
+- **One question at a time.** The user is collaborating with you in real
+  time; batching 7 questions into one turn loses signal. Walk through
+  A → G in order; let the user answer; move on.
+- **Defaults exist.** Each frontmatter / `team.yaml` field has a default.
+  When the user doesn't have a strong opinion, accept the default and
+  move on.
+- **Phase markdown bodies are user territory.** The factory writes a
+  domain-task template (1–2 sections); the user is encouraged to flesh
+  it out post-`init`. Do not write protocol literals (`PHASE_DONE: …` /
+  `ESCALATE: …`) into the body — those are inject-prompt territory only
+  (V0.2 M0.18).
+- **Validate before publishing.** Always run
+  `ccteam doctor --validate-team <name>` after `init` and before
+  `publish`. Fix any `[FAIL]`; surface `[WARN]` to the user.
+
+## Publish targets
+
+- `--target local` — link the staging dir to
+  `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`. The
+  user runs `claude /plugin enable <name>@ccteam-local` and the team
+  becomes available immediately. Share = give the staging path.
+- `--target github` — `gh repo create` + push. Output is a GitHub URL
+  the user can give to anyone; install side does
+  `claude /plugin add <owner>/<repo>` per Claude Code marketplace
+  conventions. Requires `gh auth login` first; the command fails loud
+  if `gh` is missing or unauthenticated.
+
+## What this skill cannot do
+
+- It cannot write phase markdown bodies for the user — those are domain
+  knowledge (the user's "what does this phase actually do"). The
+  factory writes a 5-line task-description template for each phase; the
+  user fills in the rest by editing the staging `phases/<name>.md`
+  files.
+- It cannot decide whether a team is needed — only the user knows their
+  workflow. If the request maps cleanly to `dev` or `product-research`,
+  use those instead.
+- It does not auto-install the plugin in any session. Publish writes the
+  artifact; the user enables it in each Claude Code session that wants
+  it (`/plugin enable`).

--- a/crates/ccteam-core/tests/team_factory_xdg_test.rs
+++ b/crates/ccteam-core/tests/team_factory_xdg_test.rs
@@ -1,0 +1,78 @@
+//! V0.2 M0.22 — env-mutating tests for the team factory's
+//! `default_user_staging_dir` resolution. Mutates `XDG_CONFIG_HOME` so
+//! it lives in its own integration test binary per CLAUDE.md §六
+//! ("env-mutating tests放 crates/*/tests/*.rs").
+
+use ccteam_core::{
+    init_team_staging, publish_team, staging_dir_for, validate_staged_team, PhaseScaffold,
+    PluginAuthor, PluginManifest, PublishInput, PublishTarget, TeamInitInput, TeamSpec,
+};
+use tempfile::TempDir;
+
+fn sample_input<'a>(
+    spec: &'a TeamSpec,
+    manifest: &'a PluginManifest,
+    phases: &'a [PhaseScaffold<'a>],
+) -> TeamInitInput<'a> {
+    TeamInitInput {
+        spec,
+        manifest,
+        phases,
+        staging_root_override: None,
+    }
+}
+
+#[test]
+fn xdg_config_home_drives_staging_dir_resolution() {
+    // Set XDG_CONFIG_HOME to a tmp path; staging dir must resolve
+    // beneath it. Pair with init/publish_local end-to-end so we trust
+    // both code paths against the resolved root.
+    let tmp = TempDir::new().unwrap();
+    let xdg = tmp.path().join("xdg");
+    std::env::set_var("XDG_CONFIG_HOME", &xdg);
+
+    let staging = staging_dir_for("xdg-test-team", None);
+    assert!(staging.starts_with(&xdg), "got: {}", staging.display());
+
+    let spec = TeamSpec::parse("name: xdg-test-team\nphase_dir: phases\n").unwrap();
+    let manifest = PluginManifest {
+        name: "xdg-test-team".into(),
+        description: "test".into(),
+        author: PluginAuthor {
+            name: "tester".into(),
+            email: None,
+        },
+        version: None,
+    };
+    let phases = vec![PhaseScaffold {
+        name: "intake",
+        task_summary: "do the thing.",
+        required_inputs: &[],
+        required_outputs: &[".ccteam/spec.md"],
+        auto_loop: true,
+    }];
+    let report = init_team_staging(&sample_input(&spec, &manifest, &phases)).unwrap();
+    assert!(report.staging_dir.starts_with(&xdg));
+    assert!(report.manifest_path.exists());
+
+    // Validate the staged tree end-to-end.
+    let findings = validate_staged_team(&staging).unwrap();
+    assert!(findings.iter().any(|l| l.starts_with("[OK] plugin.json")));
+    assert!(findings.iter().any(|l| l.starts_with("[OK] team.yaml")));
+
+    // Publish to a faux ~/.claude — exercises the symlink path against
+    // the XDG-resolved staging.
+    let claude = tmp.path().join("claude");
+    let publish = publish_team(&PublishInput {
+        team_name: "xdg-test-team",
+        target: PublishTarget::Local,
+        staging_root_override: None,
+        claude_dir_override: Some(&claude),
+    })
+    .unwrap();
+    let link = publish.local_link.unwrap();
+    let canonical = std::fs::canonicalize(&link).unwrap();
+    assert_eq!(canonical, std::fs::canonicalize(&staging).unwrap());
+
+    std::env::remove_var("XDG_CONFIG_HOME");
+}

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -725,6 +725,74 @@ claude_md_template: |
 `EscalateGrammarExtension` / `EscalateRoute`),通过 `ccteam_core::TeamSpec::load(path)`
 暴露。orchestrator 启动期扫描 + 加载在 `Orchestrator::new`(`load_team_runtimes`)。
 
+#### 5.5.1 Plugin manifest 兼容字段(V0.2 M0.22 team factory)
+
+工厂产物的 staging 树 (`~/.config/ccteam/teams/<name>/`) 是合法的
+**Claude Code plugin**,顶层布局:
+
+```text
+<staging>/
+  .claude-plugin/
+    plugin.json                       # Claude Code plugin manifest(严格 schema)
+  team.yaml                           # ccteam team 配置(plugin loader unknown,zod strip)
+  phases/
+    01-<phase>.md                     # 同 §5.1 frontmatter
+    ...
+  README.md
+  agents/      (可选,plugin 自带 subagent)
+  commands/    (可选)
+  skills/      (可选)
+  hooks/hooks.json   (可选)
+  .mcp.json    (可选,plugin 自带 MCP server)
+```
+
+`plugin.json` 字段集(借鉴 `~/.claude/plugins/marketplaces/claude-plugins-official/`
+所有实例的实际 schema):
+
+```json
+{
+  "name": "my-team",
+  "description": "Custom marketing-research team",
+  "author": {
+    "name": "Alice",
+    "email": "alice@example.com"
+  },
+  "version": "0.1.0"
+}
+```
+
+- **`name`** 必填,ascii lower / digit / `-` / `_`(与 `team.yaml.name`
+  一致;工厂在 `init_team_staging` 强制 lock-step)。doubles as plugin
+  目录名。
+- **`description`** 必填非空,一行。
+- **`author.name`** 必填非空。**`author.email`** 可选。
+- **`version`** 可选(`claude-plugins-official/explanatory-output-style`
+  ship,其他不 ship)。
+
+**ccteam 不写 plugin loader 的额外字段**(`hooks` / `mcpServers` /
+`enabledPlugins` / `userConfig` / `dependencies`)。这些是 Claude
+Code plugin 标准,工厂产物在需要时手工补齐(V0.2 不自动 emit;
+V0.3 candidate)。
+
+**`team.yaml` 在 plugin 根目录的去向**:Claude Code plugin loader
+读 `.claude-plugin/plugin.json` 时按 zod schema 校,unknown 顶级文件
+被忽略(默认 strip,见 `docs/v0-2-claude-code-alignment-review.md`
+§2.7)。`team.yaml` 不会污染 plugin 加载,ccteam 通过
+`team_resolver::resolve_team` 直接读。
+
+**校验**(`ccteam doctor --validate-team <name>`,M0.22.4 在 M0.18.5
+基础上扩展):
+1. `.claude-plugin/plugin.json` 解析 + `PluginManifest::validate`
+   (name / description / author.name 非空,name 字符集合法)
+2. `team.yaml` 解析 + `TeamSpec::validate`(同 §5.5)
+3. **`plugin.json.name` 必须等于 `team.yaml.name`** — 工厂强制
+   lock-step;手工编辑漂移 → `[FAIL]`
+
+**实现位置**:`crates/ccteam-core/src/team_factory.rs`(`PluginManifest` /
+`PluginAuthor` / `init_team_staging` / `validate_staged_team` /
+`publish_team`)。CLI 入口在 `crates/ccteam-cli/src/team_factory_cli.rs`
+`ccteam team {init,publish}`。
+
 ---
 
 ### 5.6 `decision_mode` 与 `max_clarify_rounds` 语义(M2.3+)

--- a/docs/team-factory-userguide.md
+++ b/docs/team-factory-userguide.md
@@ -1,0 +1,163 @@
+# Team Factory — User Guide (V0.2 M0.22)
+
+> Goal: ship a custom ccteam team as a Claude Code plugin, sharable via
+> a local marketplace symlink or a GitHub repo. This guide walks you
+> through the dialogue + commands. ~10 minutes.
+
+## When you want this
+
+- The user wants a workflow `dev` and `product-research` don't cover —
+  custom phases, custom golden rules, custom retro fields.
+- You want to share a team with another machine / another user — the
+  plugin format makes the artifact installable anywhere Claude Code
+  runs.
+
+## What you produce
+
+```text
+~/.config/ccteam/teams/<name>/         # staging tree (private)
+  .claude-plugin/plugin.json           # Claude Code plugin manifest
+  team.yaml                            # ccteam team config
+  phases/01-<phase>.md                 # phase markdown templates
+  README.md
+```
+
+After `publish --target local`, this tree gets symlinked into
+`~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`. After
+`publish --target github`, it gets pushed to a new repo as the
+sharable artifact.
+
+## Step 1 — interview the user (skill-driven)
+
+Inside any Claude Code session that has the `ccteam-team-author` skill
+installed (auto-installed by `ccteam doctor --install-skill --force`
+once shipped, or manually by the meta-agent):
+
+```bash
+# In a meta-agent session:
+"我想做个 marketing 团队,phase 跑 5 步"
+```
+
+The skill walks you through:
+
+1. plugin metadata (`name`, `description`, `author`)
+2. phase list (count + per-phase name / inputs / outputs / auto_loop)
+3. tools per phase (subagents / skills / MCP)
+4. golden rules (`protocol` cmd-check / prompt-directive, `domain`)
+5. retro schema (M4.1 retro fields)
+6. verdict schema (research-style teams only)
+7. ESCALATE grammar extensions (optional)
+
+One question at a time — the skill answers one user question per turn.
+
+## Step 2 — scaffold the staging tree
+
+The skill drives `ccteam team init` for you. The CLI direct path:
+
+```bash
+ccteam team init my-team \
+  --description "Custom marketing-research team" \
+  --author-name "Alice"
+```
+
+Result: a starter staging tree at `~/.config/ccteam/teams/my-team/`
+with a single `intake` phase. Edit the phase markdown bodies to
+fill in the actual domain task. **Do not** add `PHASE_DONE: …` /
+`ESCALATE: …` to the body text — those are inject-prompt-only (V0.2
+M0.18); the body is pure domain task description.
+
+## Step 3 — validate
+
+```bash
+ccteam doctor --validate-team my-team
+```
+
+Reads:
+- `[OK] plugin.json` — manifest schema OK
+- `[OK] team.yaml` — TeamSpec validate OK
+- per-phase `[OK]` / `[WARN]` lines (phase frontmatter + IO contract)
+- `[FAIL]` for anything broken
+
+Fix the `[FAIL]` lines before publishing.
+
+## Step 4 — publish
+
+### Local marketplace
+
+```bash
+ccteam team publish my-team --target local
+# Then in any Claude Code session:
+claude /plugin enable my-team@ccteam-local
+```
+
+The team is now available wherever Claude Code reads
+`~/.claude/plugins/marketplaces/`.
+
+### GitHub repo
+
+```bash
+gh auth login                                 # one-time
+ccteam team publish my-team \
+  --target github \
+  --repo alice/ccteam-marketing
+# Output:
+#   pushed → https://github.com/alice/ccteam-marketing
+#   share with: claude /plugin add alice/ccteam-marketing
+```
+
+The factory shells out to `gh repo create` + `git push`; it does not
+embed credentials. If `gh auth status` fails, the publish fails loud —
+re-run after `gh auth login`.
+
+## How it integrates with Claude Code
+
+The artifact is a **standard Claude Code plugin**. Claude Code's plugin
+loader reads:
+
+- `.claude-plugin/plugin.json` — strict schema (`name`, `description`,
+  `author`); ccteam additions (`team.yaml` at the plugin root) are
+  silently ignored by the loader (zod default `strip`).
+- `agents/` / `commands/` / `skills/` / `hooks/hooks.json` / `.mcp.json`
+  — auto-discovered when present. The factory does not write these by
+  default; the team author can drop them in by hand once the staging
+  tree exists.
+
+ccteam reads `team.yaml` directly via its own `team_resolver` — the
+file is invisible to Claude Code's plugin pipeline.
+
+## Limits in V0.2
+
+- The factory writes one starter phase. Multi-phase teams come from the
+  team-author skill dialogue (drives the same `init_team_staging`
+  primitive multiple times) or by hand-editing the staging tree.
+- Plugin `userConfig` (manifest field for "user fills these on enable")
+  is supported by Claude Code but the factory does not yet emit it.
+  Add by hand to `.claude-plugin/plugin.json` post-init.
+- Plugin `dependencies` (team-plugin-A depends on `code-reviewer@…`)
+  is supported by Claude Code; the factory does not yet emit it.
+  Add by hand post-init.
+- `--target github` requires `gh` CLI installed + authenticated.
+  V0.3 may add a pre-flight check earlier in the pipeline.
+
+## Troubleshooting
+
+| symptom | fix |
+|---|---|
+| `staging dir … not found` on publish | run `ccteam team init <name>` first |
+| `validation failed — fix the [FAIL] lines` | re-run `ccteam doctor --validate-team <name>` to see what broke |
+| `gh CLI not found` | install <https://cli.github.com>, then `gh auth login` |
+| `plugin.json` schema rejected by Claude Code | check `name` is ascii-lowercase / `-` / `_`, `description` non-empty, `author.name` non-empty |
+| team.yaml.name doesn't match plugin.json.name | the factory keeps them in lock-step — if you hand-edit, keep both consistent |
+
+## Reference
+
+- `crates/ccteam-core/src/team_factory.rs` — staging + publish + validate
+  primitives (unit-tested).
+- `crates/ccteam-cli/src/team_factory_cli.rs` — CLI handlers for
+  `ccteam team {init,publish}`.
+- `docs/tech-design.md` §6.12 — design decisions.
+- `docs/interfaces.md` §5.1 / §5.5 — phase frontmatter + team.yaml
+  schema (the factory writes these).
+- `docs/v0-2-claude-code-alignment-review.md` §2 — why we use the
+  Claude Code plugin format instead of inventing a ccteam-specific
+  packaging.

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -1333,6 +1333,58 @@ multi_session 项目内每个 sub-session 仍可独立选 `parallelism: agent_te
 - **子模块接口契约的形式化验证** = M5（M4.8 仅靠 review phase 跑测试 + 人审 contracts.md 满足度）
 - **跨子模块的 stop-the-world 重构** = M5（impl 中发现 contract 错时只能 escalate）
 
+### 6.12 Team factory(V0.2 M0.22 — 用户自定义 team 落地为 plugin)
+
+源自 PRD §4 + alignment-review §2。**复用 Claude Code plugin 格式,不发明 ccteam 私有打包**。
+
+#### 三阶段流水线
+
+```text
+            interview                 init                  publish
+meta-agent ───────────►  CLI/factory ───────►  staging ──────────────►  marketplace / GitHub
+  (skill)                              ~/.config/ccteam/teams/<name>/
+```
+
+1. **Interview** — 元 agent 跑 `ccteam-team-author` skill,跟用户对话收集 metadata(name / description / author)+ phase 列表 + tools + golden_rules + retro_schema + verdict_schema。一次一题,默认值能用就用。
+2. **Init** — `ccteam team init <name>` 落 staging 树到 `~/.config/ccteam/teams/<name>/`,内含:
+   - `.claude-plugin/plugin.json`(Claude Code plugin manifest 严格 schema:`name` / `description` / `author`)
+   - `team.yaml`(ccteam team 配置,作为 plugin 顶级 unknown 字段;zod 默认 strip,plugin pipeline 加载时忽略)
+   - `phases/<NN>-<phase>.md`(frontmatter + 正文领域模板;**正文不写 `PHASE_DONE:` / `ESCALATE:`**——M0.18 D 方案,协议关键字仅由 orchestrator inject prompt 注入)
+   - `README.md`
+3. **Publish** — `ccteam team publish <name> --target {local|github}`:
+   - `local`:软链 staging 到 `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`,产出 directory-source 标识 `<name>@ccteam-local`(用户 `claude /plugin enable` 启用)
+   - `github`:`gh repo create` + push,产出 GitHub URL(用户 `claude /plugin add <owner>/<repo>` 拉取)
+
+#### 关键设计决策
+
+- **不在 ccteam 自营 marketplace 注册中心**(alignment-review §2.3):用 Claude Code 已有的 `directory` source 作 `ccteam-local`,远程走 `gh repo` + `github` source。
+- **`team.yaml` 不走 plugin `settings` 注入**(alignment-review §2.7):plugin loader 只 allowlist `agent` key,其他 strip。改作 plugin 根目录顶级 unknown 文件,ccteam 自己读(`team_resolver`)。
+- **plugin manifest schema 借鉴 `claude-plugins-official`**:观察 `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/*/.claude-plugin/plugin.json` 实例,所有都只用 `name` / `description` / `author { name, email? }` + 偶有 `version`。`PluginManifest` struct 严格 serialize 这四个字段,反序列化 lenient(unknown 字段忽略,符合 zod default strip)。
+- **`enabledPlugins` 复用 M0.20 已 ship pipeline**:工厂产物的 `team.yaml` 声明依赖,`bootstrap_project` 写 `<project>/.claude/settings.json` 时由 `plugin_resolution` 推断。工厂自身不直接管理 plugin pipeline。
+- **doctor `--validate-team` 二档验证**(M0.22.4):
+  1. 已 ship 的 phase IO 契约 + frontmatter 校验(M0.18.5)
+  2. 新增 plugin manifest schema + name 一致性校验(M0.22.4),仅当 staging 树存在时触发
+
+#### 红线
+
+- ccteam-core 不出现 team 名字面量(M0.16 基线)— 工厂代码也不许;团队特定行为靠用户写的 `team.yaml`。
+- 工厂产物 phase markdown 正文不许写 `PHASE_DONE: <name>` / `ESCALATE: <prefix>` 关键字(M0.18 D 方案)。
+- 不 vendor `claude-plugins-official` — 工厂模板可写 `tools_required.subagents: [code-reviewer]` 引用 plugin agent,**不**把 plugin source 拷到工厂产物。
+- `--target github` 用户未 `gh auth login` → fail-loud,不试图绕过;不嵌入凭证。
+
+#### 实现位置
+
+- `crates/ccteam-core/src/team_factory.rs` — `init_team_staging` / `publish_team` / `validate_staged_team` 主路径;`PluginManifest` / `PhaseScaffold` / `PublishTarget` 数据类型。
+- `crates/ccteam-core/src/templates/ccteam_team_author_skill.md` — meta-agent 用的 dialogue skill。
+- `crates/ccteam-cli/src/team_factory_cli.rs` — `ccteam team init` / `ccteam team publish` CLI 包装。
+- `crates/ccteam-cli/src/commands.rs` — `--validate-team` 加 plugin manifest 段。
+- `docs/team-factory-userguide.md` — 用户实操指引。
+
+V0.3 候选(本里程碑不做):
+- `userConfig` 工厂 emit(用户 enable plugin 时填表)
+- `dependencies`(team-plugin 间依赖,eg 引用 `code-reviewer` plugin)
+- 多 phase 一次性 init(当前 V0.2 单 phase 起步,多 phase 走 skill 多轮 init)
+
 ---
 
 ## 7. 里程碑路线图


### PR DESCRIPTION
## Summary

Closes **V0.2 M0.22** (`docs/dev-plan-v0-2.md §8`) — `ccteam-team-author` skill for meta-agent + `ccteam team init` / `ccteam team publish` CLI; team factory output is a Claude Code plugin (manifest + standard subdirs) with `team.yaml` as a top-level unknown field.

1. **M0.22.1 `ccteam-team-author` skill** — new skill at `crates/ccteam-core/src/templates/ccteam_team_author_skill.md` (parallel to `ccteam-control`); guides meta-agent through the dialog: phase list / tools / golden_rules / retro_schema / verdict_schema / plugin metadata.
2. **M0.22.2 staging layout** — `~/.config/ccteam/teams/<name>/` with `.claude-plugin/plugin.json` + `team.yaml` + `phases/` + standard `agents/` `commands/` `hooks/hooks.json` `.mcp.json`. Phase markdown templates use M0.18 frontmatter; bodies pure domain (test enforces no `PHASE_DONE` / `ESCALATE` literals).
3. **M0.22.3 `ccteam team publish <name>`** — `--target local` symlinks to `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`; `--target github` uses `gh` (precheck + auth, fail-loud if unavailable).
4. **M0.22.4 doctor `--validate-team` extension** — added plugin manifest schema check on top of M0.18's base validation.

## Maps to

- PRD: `docs/prd-v0-2.md §4`
- Design: `docs/v0-2-claude-code-alignment-review.md §2` (plugin format reuse)
- Dev plan: `docs/dev-plan-v0-2.md §8`

## Plugin manifest schema sourcing

Verified by inspection of `~/.claude/plugins/marketplaces/claude-plugins-official/plugins/*/.claude-plugin/plugin.json` (examples: `code-review`, `mcp-server-dev`, `frontend-design`, `hookify`, `feature-dev`, `commit-commands`, `skill-creator`, `explanatory-output-style`). Field set: `name`, `description`, `author { name, email? }`, occasional `version`. `PluginManifest` struct mirrors exactly that. Reference path documented in `docs/tech-design.md §6.12` + `docs/interfaces.md §5.5.1`.

## Test results

| Item | Before | After |
|---|---|---|
| `cargo test --workspace` | 451 / 0 | **476 / 0** (+25) |
| `cargo clippy --workspace --all-targets` warnings | 10 | **10** (0 new) |

Coverage: 19 unit in `team_factory.rs` (manifest validate, init layout, scaffolds, publish local + github, validation), 4 in `team_factory_cli.rs` (report rendering), 2 in `skill.rs` (team-author install idempotency), 1 integration `team_factory_xdg_test.rs` (`XDG_CONFIG_HOME` end-to-end: init + validate + publish-local).

## Red-line grep

- `\"dev\"|\"product-research\"|\"meta-agent\"` in factory code: **0** matches (fully data-driven).
- `PHASE_DONE: |ESCALATE: ` in `crates/ccteam-core/src/templates/`: 2 hits, both in skill.md as **prohibitions** ("Do not write protocol literals..."). Produced phase scaffold bodies clean (enforced by `init_phase_body_excludes_protocol_literals`).

## Documentation sync

- [x] `docs/tech-design.md` — added §6.12 "Team factory (V0.2 M0.22 — 用户自定义 team 落地为 plugin)"
- [x] `docs/interfaces.md` — added §5.5.1 "Plugin manifest 兼容字段 (V0.2 M0.22 team factory)"
- [x] `docs/team-factory-userguide.md` — new ~150-line user guide

## ⚠ Open questions for review

1. **`team.yaml` as plugin top-level unknown field — actually zod-stripped?** Confirmed via alignment-review §2.7 doc (zod default is `strip`), but **not live-tested**. **Recommend manual smoke**: `claude /plugin enable my-team@ccteam-local` against a published team, verify no error mentions `team.yaml`. Fallback if Claude Code's loader changes: relocate to `.ccteam/team.yaml` — resolver path adapts trivially.
2. **doctor zod schema reuse** — chose simplified Rust `PluginManifest::validate` (4-field check) over embedding a JSON-schema validator. Rationale: plugin loader is the authoritative validator; ccteam's pre-publish check just prevents trivial mistakes. PR reviewer can decide if stronger checker is wanted in V0.3.
3. **Cross-team `dependencies` (cross-plugin reuse)** — V0.2 design only. Manifest struct doesn't emit it; users add by hand. Implementation deferred to V0.3 per task instructions.
4. **`userConfig`** — same as above. Documented in user guide as "add by hand post-init", deferred to V0.3.
5. **`gh` unavailable / unauthenticated** — handled fail-loud per spec. `command_exists("gh")` + `gh auth status` precheck before any side-effect; clear error message points at `gh auth login`.

## Boundary respected with M0.21

- Did not touch `watchdog.rs` / `watchdog.yaml` / daemon health
- Did not touch `crates/ccteam-core/src/templates/meta_agent_role.md`
- `--validate-team` extension is scoped purely to that branch in `run_doctor`

## Test plan

- [ ] `cargo test --workspace` passes (476 / 0)
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] Manual: `ccteam team init my-team` → staging dir created with manifest + team.yaml + phases/
- [ ] Manual: `ccteam team publish my-team --target local` → symlink in ccteam-local marketplace
- [ ] Manual: `claude /plugin enable my-team@ccteam-local` → no error about `team.yaml`
- [ ] Manual: `ccteam doctor --validate-team my-team` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)