### PR TITLE
M0.21: watchdog — translation-only smart layer over progress.jsonl + outbox + heartbeat

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -1543,6 +1543,59 @@ fn truncate(s: &str, n: usize) -> &str {
     }
 }
 
+/// `ccteam watchdog scan` (V0.2 M0.21). Reads `~/.ccteam/watchdog.yaml`
+/// (or defaults), scans every project + the daemon heartbeat, and
+/// renders the resulting alerts. With `push_to_user_handle: Some(<h>)`
+/// each alert that survives filtering is also written to the meta-agent
+/// session's outbox so the meta-agent can surface it in NL.
+///
+/// Translation only: never mutates orchestrator state, never kills
+/// sessions, never re-injects prompts. Pure read-side classifier.
+pub fn run_watchdog_scan(
+    paths: &CcteamPaths,
+    format: OutputFormat,
+    push_to_user_handle: Option<&str>,
+) -> Result<String> {
+    let cfg = ccteam_core::load_watchdog_config(paths)?;
+    let alerts = ccteam_core::watchdog_scan(paths, &cfg)?;
+    if let Some(handle) = push_to_user_handle {
+        for alert in &alerts {
+            ccteam_core::push_watchdog_alert_to_meta_outbox(paths, handle, alert)
+                .with_context(|| {
+                    format!("push watchdog alert to meta outbox for `{handle}`")
+                })?;
+        }
+    }
+    Ok(match format {
+        OutputFormat::Json => {
+            serde_json::to_string_pretty(&serde_json::json!({
+                "alerts": alerts,
+                "config": cfg,
+            }))? + "\n"
+        }
+        OutputFormat::Text => render_watchdog_text(&alerts, push_to_user_handle.is_some()),
+    })
+}
+
+fn render_watchdog_text(alerts: &[ccteam_core::WatchdogAlert], pushed: bool) -> String {
+    if alerts.is_empty() {
+        return "watchdog: no alerts.\n".into();
+    }
+    let mut out = format!("watchdog: {} alert(s)\n", alerts.len());
+    for a in alerts {
+        let scope = a.slug.as_deref().unwrap_or("(global)");
+        out.push_str(&format!(
+            "  [{}] {scope}: {}\n",
+            a.kind.as_str(),
+            a.message,
+        ));
+    }
+    if pushed {
+        out.push_str("(also written to meta-agent outbox)\n");
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Mutex, OnceLock};
@@ -2415,5 +2468,29 @@ mod tests {
 
         let err = run_phase_show(&paths, "meta-agent", "anything").unwrap_err();
         assert!(format!("{err:#}").contains("evergreen"));
+    }
+
+    #[test]
+    fn watchdog_scan_text_format_renders_no_alerts_when_healthy() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        std::fs::create_dir_all(&paths.projects_root).unwrap();
+        ccteam_core::write_heartbeat(&paths).unwrap();
+        let out = run_watchdog_scan(&paths, OutputFormat::Text, None).unwrap();
+        assert!(out.contains("no alerts"), "got: {out}");
+    }
+
+    #[test]
+    fn watchdog_scan_json_format_emits_structured_payload() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        std::fs::create_dir_all(&paths.projects_root).unwrap();
+        // Heartbeat absent ⇒ daemon_down alert.
+        let out = run_watchdog_scan(&paths, OutputFormat::Json, None).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+        let alerts = parsed["alerts"].as_array().unwrap();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0]["kind"], "daemon_down");
+        assert!(parsed["config"].is_object());
     }
 }

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -186,6 +186,36 @@ enum Command {
         #[command(subcommand)]
         cmd: PhaseCommand,
     },
+    /// V0.2 M0.21: translation layer that surfaces project anomalies
+    /// (auto-loop cycle / cost / phase duration / daemon down /
+    /// needs_attention.outbox) to the meta-agent as NL notifications.
+    /// Pure read-only — never mutates orchestrator state, never kills
+    /// sessions, never re-injects prompts.
+    Watchdog {
+        #[command(subcommand)]
+        cmd: WatchdogCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum WatchdogCommand {
+    /// Scan all projects + daemon heartbeat once and print every alert
+    /// that survives `~/.ccteam/watchdog.yaml` filtering. With
+    /// `--push --user <handle>` each alert is also appended to the
+    /// meta-agent session's outbox.
+    Scan {
+        #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+        format: OutputFormat,
+        /// Also write each surviving alert to
+        /// `~/projects/<handle>-meta/.ccteam/outbox/`. Pair with
+        /// `--user <handle>`.
+        #[arg(long, default_value_t = false)]
+        push: bool,
+        /// User handle whose meta-agent outbox receives pushed alerts.
+        /// Required when `--push` is passed.
+        #[arg(long, value_name = "HANDLE")]
+        user: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -298,6 +328,22 @@ fn main() -> Result<()> {
             migrate_recommended_agents,
         }),
         Command::Phase { cmd } => run_phase(cmd),
+        Command::Watchdog { cmd } => run_watchdog(cmd),
+    }
+}
+
+fn run_watchdog(cmd: WatchdogCommand) -> Result<()> {
+    let paths = CcteamPaths::from_env()?;
+    match cmd {
+        WatchdogCommand::Scan { format, push, user } => {
+            if push && user.is_none() {
+                anyhow::bail!("`--push` requires `--user <handle>`");
+            }
+            let handle = if push { user.as_deref() } else { None };
+            let body = commands::run_watchdog_scan(&paths, format, handle)?;
+            print!("{body}");
+            Ok(())
+        }
     }
 }
 

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod team_resolver;
 pub mod templates;
 pub mod tmux;
 pub mod tool_surface;
+pub mod watchdog;
 
 pub use dag::{dev_dag, Dag};
 pub use auto_loop::{AutoLoopDecision, AutoLoopFrontMatter, AutoLoopState};
@@ -108,6 +109,12 @@ pub use tool_surface::{
     disable_tool_surface_bootstrap_for_tests, ensure_skills_placeholders,
     migrate_recommended_agent_symlinks, missing_tools, user_claude_dir, MigrationReport,
     MissingTool, ToolSurfaceSnapshot, ToolsRequired, BUILTIN_SUBAGENTS,
+};
+pub use watchdog::{
+    config_path as watchdog_config_path, load_config as load_watchdog_config,
+    push_alert_to_meta_outbox as push_watchdog_alert_to_meta_outbox, scan as watchdog_scan,
+    AlertKind as WatchdogAlertKind, NotifyMode as WatchdogNotifyMode, WatchdogAlert,
+    WatchdogConfig, DEFAULT_NOTIFY_ON_CYCLE_COUNT, WATCHDOG_CONFIG_FILENAME,
 };
 
 /// Crate version, identical to the workspace package version.

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -164,7 +164,72 @@ content_type: text
 3. 处理完一条 inbox 后,orchestrator 自动删掉对应文件;你也不必负责 ack
 4. **特例**:context reset 后新 session 启动时,可能会有未处理的 inbox 文件累积。这时你可以 `Bash: ls ~/projects/__USER_HANDLE__-meta/.ccteam/inbox/` 看一眼
 
-## 7. outbox 输出
+## 7. Watchdog 角色(V0.2 M0.21)
+
+你的另一面身份是 **ccteam watchdog** —— 把 orchestrator / 各项目埋的低层信号
+"翻译"成用户能读懂的 NL 通知。这是 **translation only** 角色,严格红线:
+
+- ❌ **不做技术决策**(不替项目 session 拍板"该不该重启"/"该不该 kill"/"该不该改方案")
+- ❌ **不调 orchestrator API 改状态**(不发 control 信号 / 不写 progress.jsonl 事件)
+- ❌ **不主动 kill / 重启 / 派单**(看到信号 → 在 outbox 写一条 NL 通知,等用户回复)
+- ✅ 只做 surface:把"daemon 心跳停了 60 秒 / project X 的 auto-loop 卡在第 2 次 / project Y 在 implement 烧了 $30 还没出 PHASE_DONE"翻译成"老板,这件事要不要看一眼"
+
+### 7.1 watchdog 数据源(`Bash` 调 ccteam,纯只读)
+
+```bash
+# 一次扫所有信号(daemon health + 全项目)
+ccteam watchdog scan --format json | jq
+
+# 同时把高/普 priority alert 写进自己 outbox
+ccteam watchdog scan --push --user __USER_HANDLE__
+```
+
+四个信号源:
+
+| 信号 | 来源 | 含义 |
+|---|---|---|
+| `needs_attention` | `<project>/.ccteam/needs_attention.outbox.json`(M0.19 Stop hook L3 兜底) | phase 卡到第二次 Stop 都没正常收尾 — 严重 |
+| `auto_loop_cycle` | `<project>/.ccteam/auto-loop.state.md::iteration` | self-loop 已重试 N 次,接近 cap 还没通过 |
+| `cost_overrun` | `state.json::cost_used_usd` 超 `~/.ccteam/watchdog.yaml::notify_on_phase_cost_usd` | 钱烧到设定的报警阈值 |
+| `phase_duration_overrun` | `state.json::last_progress_event_at` 距今超阈值分钟 | phase 静默太久 |
+| `daemon_down` | `~/.ccteam/state/orchestrator.heartbeat` mtime 超 grace | orchestrator 守护进程死了 |
+
+`~/.ccteam/watchdog.yaml`(用户自己可改;字段见 `interfaces.md` watchdog.yaml schema):
+
+```yaml
+notify_on_cycle_count: 2          # auto-loop iteration 达到此值就 alert(默认 cap-1)
+notify_on_phase_cost_usd: 30.0    # state.cost_used_usd 超此值(USD)alert,无值则不报
+notify_on_phase_duration_min: 60  # phase last event 超此分钟数 alert,无值则不报
+notify_mode: normal               # quiet / normal / verbose
+                                  # quiet 仅放行 cost_overrun + daemon_down(其他静默)
+                                  # verbose 不去重,每次扫都重发 needs_attention
+```
+
+### 7.2 周期任务(每条 user 请求间隙 / context reset 后第一件事)
+
+按下面顺序跑(允许跳过若该信号本次为空):
+
+1. 跑 `ccteam watchdog scan --format json` 看是否有 alert
+2. **`daemon_down` 必报**: 立即 NL 告知用户 "orchestrator 守护进程似乎挂了, MCP 命令现在失效, 要 `ccteam start --foreground` 重启吗?"
+3. **其他 alert 按 priority 处理**:
+   - `cost_overrun` (priority=high): "X 项目 cost = $Y 已超你配的 $Z 阈值, 还烧吗?"
+   - `needs_attention` (priority=high): "X 项目 phase 卡死(第二次 Stop 都没正常收尾),pane tail: <30 行>。要不要 attach 看看?"
+   - `auto_loop_cycle` (priority=normal): "X 项目 self-loop 第 N/M 轮还没通过,要不要看一眼?"
+   - `phase_duration_overrun` (priority=normal): "X 项目 phase Y 已静默 ZZ 分钟,要 peek 一下吗?"
+4. **永远不要主动派单 / kill / 改 state** —— 用户没决定前,你只 surface
+
+### 7.3 触发频率
+
+- M0.21 默认:**手动触发** —— 你在收到用户消息 / 启动 / context reset 时主动跑一次
+- 后续(M2+ channel layer)会有 cron-style 自动触发,届时本节会被自动重写
+
+### 7.4 跟克制规则的边界
+
+watchdog 角色是 "克制规则"(§3) 的特例 —— 你**仍然不写代码、不派单、不 kill**;
+不同点是 watchdog 允许你**主动**(而非被动等用户问)发起一条 NL 通知。但 NL
+通知本身只能是"陈述 + 问题",不是"我已经替你做了 X"。
+
+## 8. outbox 输出
 
 你产出的每条对外回应**都要写一份 outbox 文件**,这样未来 channel adapter(M2+)能把它推回外部消息系统(Telegram、飞书等)。M1 阶段终端 attach 模式下,用户能直接在终端看到你的回应,outbox 写了不浪费(adapter 上线后立即生效)。
 

--- a/crates/ccteam-core/src/watchdog.rs
+++ b/crates/ccteam-core/src/watchdog.rs
@@ -1,0 +1,860 @@
+//! Watchdog — translation layer that surfaces project anomalies as
+//! meta-agent notifications. **Never mutates orchestrator state.**
+//!
+//! V0.2 M0.21. The watchdog is a smart-layer translator: it reads
+//! existing telemetry (per-project `progress.jsonl` / `state.json`,
+//! `<project>/.ccteam/needs_attention.outbox.json`, the orchestrator
+//! daemon heartbeat) and emits zero or more `WatchdogAlert`s describing
+//! what a meta-agent should ask the user about. It does not call
+//! orchestrator APIs, never kills sessions, never re-injects prompts —
+//! that's the orchestrator's job (tech-design red line: "smart layer
+//! only translates, never decides").
+//!
+//! Four signal sources, in detection order:
+//! 1. `<project>/.ccteam/needs_attention.outbox.json` (M0.19 Stop hook
+//!    L3 fail-safe — recursion guard)
+//! 2. `auto-loop.state.md::iteration >= notify_on_cycle_count`
+//!    (auto-loop has spent at least `cycle_count` re-feeds without
+//!    completing)
+//! 3. phase cost / duration thresholds — any `state.json` with
+//!    `cost_used_usd > notify_on_phase_cost_usd` or current phase
+//!    older than `notify_on_phase_duration_min`
+//! 4. orchestrator daemon heartbeat stale (M0.23.1)
+//!
+//! User config lives at `~/.ccteam/watchdog.yaml`; missing file ⇒ defaults.
+//! `notify_mode: quiet` suppresses everything except `daemon_down` and
+//! cost-overrun alerts (those are too important to silence).
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::auto_loop;
+use crate::daemon::{self, DaemonHealth};
+use crate::inbox::{
+    outbox_filename, OutboxEventKind, OutboxFrontMatter, OutboxMessage, OutboxPriority,
+    LATEST_SCHEMA_VERSION,
+};
+use crate::meta_agent::meta_slug;
+use crate::paths::CcteamPaths;
+use crate::state::ProjectState;
+
+/// Default value of `notify_on_cycle_count`. Set to one less than the
+/// usual `auto_loop_max_iterations` (3) so the watchdog fires *before*
+/// the loop exhausts its retries.
+pub const DEFAULT_NOTIFY_ON_CYCLE_COUNT: u32 = 2;
+
+/// Filename under `~/.ccteam/` where user config lives.
+pub const WATCHDOG_CONFIG_FILENAME: &str = "watchdog.yaml";
+
+/// User-facing config (`~/.ccteam/watchdog.yaml`). Missing file ⇒
+/// `WatchdogConfig::default()`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WatchdogConfig {
+    /// Fire an alert once `auto-loop.state.md::iteration` reaches this
+    /// number. Default `DEFAULT_NOTIFY_ON_CYCLE_COUNT` (= 2).
+    #[serde(default = "default_cycle_count")]
+    pub notify_on_cycle_count: u32,
+
+    /// Fire an alert when `state.json::cost_used_usd` exceeds this many
+    /// USD. `None` ⇒ rely on the project's existing `cost_policy` only.
+    #[serde(default)]
+    pub notify_on_phase_cost_usd: Option<f64>,
+
+    /// Fire an alert when the current phase has been in flight longer
+    /// than this many minutes (measured from `last_progress_event_at`).
+    /// `None` ⇒ disabled.
+    #[serde(default)]
+    pub notify_on_phase_duration_min: Option<u32>,
+
+    /// Verbosity. `quiet` suppresses cycle/duration alerts but never
+    /// silences `daemon_down` or cost-overrun (those are urgent enough
+    /// to break through). `verbose` is the same as `normal` plus the
+    /// `needs_attention` Stop-hook fallback gets surfaced even if the
+    /// meta-agent has already been notified.
+    #[serde(default)]
+    pub notify_mode: NotifyMode,
+}
+
+fn default_cycle_count() -> u32 {
+    DEFAULT_NOTIFY_ON_CYCLE_COUNT
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotifyMode {
+    /// Suppress non-urgent alerts. `daemon_down` and `cost_overrun`
+    /// still fire — they signal real damage if ignored.
+    Quiet,
+    /// Default. Fires every alert kind once per scan.
+    #[default]
+    Normal,
+    /// Same as `Normal` but does not deduplicate — every scan emits a
+    /// `needs_attention` alert even if the file hasn't changed since
+    /// the previous scan.
+    Verbose,
+}
+
+impl Default for WatchdogConfig {
+    fn default() -> Self {
+        Self {
+            notify_on_cycle_count: DEFAULT_NOTIFY_ON_CYCLE_COUNT,
+            notify_on_phase_cost_usd: None,
+            notify_on_phase_duration_min: None,
+            notify_mode: NotifyMode::default(),
+        }
+    }
+}
+
+/// Resolve `<root>/watchdog.yaml`.
+pub fn config_path(paths: &CcteamPaths) -> PathBuf {
+    paths.root.join(WATCHDOG_CONFIG_FILENAME)
+}
+
+/// Load `watchdog.yaml`. Returns `WatchdogConfig::default()` when the
+/// file is absent. Parse errors fail-loud — a typo in user config
+/// shouldn't silently revert to defaults.
+pub fn load_config(paths: &CcteamPaths) -> Result<WatchdogConfig> {
+    let path = config_path(paths);
+    load_config_at(&path)
+}
+
+/// Testable inner — load from an explicit path.
+pub fn load_config_at(path: &Path) -> Result<WatchdogConfig> {
+    if !path.exists() {
+        return Ok(WatchdogConfig::default());
+    }
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    if body.trim().is_empty() {
+        return Ok(WatchdogConfig::default());
+    }
+    serde_yaml::from_str(&body)
+        .with_context(|| format!("parse {}", path.display()))
+}
+
+/// Discriminator for `WatchdogAlert`. The variant name is the only
+/// piece tests / docs reference, so it's stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertKind {
+    /// Stop hook L3 fail-safe wrote `needs_attention.outbox.json`.
+    NeedsAttention,
+    /// Auto-loop iteration crossed `notify_on_cycle_count`.
+    AutoLoopCycle,
+    /// Project cost exceeded `notify_on_phase_cost_usd`.
+    CostOverrun,
+    /// Current phase duration exceeded `notify_on_phase_duration_min`.
+    PhaseDurationOverrun,
+    /// Orchestrator daemon heartbeat is stale or missing.
+    DaemonDown,
+}
+
+impl AlertKind {
+    /// Whether `quiet` mode should still surface this alert. Cost and
+    /// daemon-down are too consequential to silence.
+    pub fn breaks_through_quiet(self) -> bool {
+        matches!(self, AlertKind::CostOverrun | AlertKind::DaemonDown)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AlertKind::NeedsAttention => "needs_attention",
+            AlertKind::AutoLoopCycle => "auto_loop_cycle",
+            AlertKind::CostOverrun => "cost_overrun",
+            AlertKind::PhaseDurationOverrun => "phase_duration_overrun",
+            AlertKind::DaemonDown => "daemon_down",
+        }
+    }
+}
+
+/// One alert emitted by the watchdog. Carries enough context for the
+/// meta-agent to ask the user a useful question, but does not commit to
+/// any action — the meta-agent decides what to do with it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WatchdogAlert {
+    pub kind: AlertKind,
+    /// Project slug; `None` for cross-project alerts (only `daemon_down`
+    /// today).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    /// Human-readable explanation. Safe to surface verbatim.
+    pub message: String,
+    /// When this alert was generated.
+    pub emitted_at: DateTime<Utc>,
+    /// Free-form details (cycle count, cost, pane tail, etc). Schema
+    /// is alert-kind specific; meta-agent only needs the message text
+    /// to ask the user, the rest is for triage.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub details: serde_json::Value,
+}
+
+/// Top-level scan: walk every project + check daemon health, return
+/// every alert that survives `notify_mode` filtering. Stable order:
+/// daemon alert first, then projects sorted by slug, then alert kinds
+/// in `AlertKind` declaration order.
+pub fn scan(paths: &CcteamPaths, config: &WatchdogConfig) -> Result<Vec<WatchdogAlert>> {
+    scan_at(paths, config, SystemTime::now(), Utc::now())
+}
+
+/// Testable inner — explicit `now` so heartbeat / phase-duration
+/// classification is deterministic.
+pub fn scan_at(
+    paths: &CcteamPaths,
+    config: &WatchdogConfig,
+    now_system: SystemTime,
+    now_utc: DateTime<Utc>,
+) -> Result<Vec<WatchdogAlert>> {
+    let mut alerts = Vec::new();
+
+    // Signal 4: daemon heartbeat. Cross-project, fires once per scan.
+    let heartbeat = daemon::heartbeat_path(paths);
+    let health = daemon::check_health_at(&heartbeat, now_system);
+    if !health.is_healthy() {
+        alerts.push(WatchdogAlert {
+            kind: AlertKind::DaemonDown,
+            slug: None,
+            message: health.describe(),
+            emitted_at: now_utc,
+            details: serde_json::to_value(HealthDetails::from(&health)).unwrap_or_default(),
+        });
+    }
+
+    let projects_root = &paths.projects_root;
+    if !projects_root.exists() {
+        return Ok(filter(alerts, config));
+    }
+
+    let mut entries: Vec<(String, PathBuf)> = Vec::new();
+    for entry in std::fs::read_dir(projects_root)
+        .with_context(|| format!("read_dir {}", projects_root.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(slug) = entry.file_name().to_str().map(String::from) else {
+            continue;
+        };
+        entries.push((slug, entry.path()));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (slug, project_dir) in entries {
+        scan_project(paths, &slug, &project_dir, now_utc, &mut alerts)?;
+    }
+
+    Ok(filter(alerts, config))
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct HealthDetails {
+    status: &'static str,
+    age_secs: Option<u64>,
+}
+
+impl From<&DaemonHealth> for HealthDetails {
+    fn from(h: &DaemonHealth) -> Self {
+        match h {
+            DaemonHealth::Healthy { age_secs } => Self {
+                status: "healthy",
+                age_secs: Some(*age_secs),
+            },
+            DaemonHealth::NoHeartbeat => Self {
+                status: "no_heartbeat",
+                age_secs: None,
+            },
+            DaemonHealth::Stale { age_secs } => Self {
+                status: "stale",
+                age_secs: Some(*age_secs),
+            },
+        }
+    }
+}
+
+fn scan_project(
+    paths: &CcteamPaths,
+    slug: &str,
+    project_dir: &Path,
+    now_utc: DateTime<Utc>,
+    alerts: &mut Vec<WatchdogAlert>,
+) -> Result<()> {
+    // Signal 1: Stop hook L3 fail-safe (M0.19).
+    let needs = project_dir.join(".ccteam").join("needs_attention.outbox.json");
+    if needs.exists() {
+        let body = std::fs::read_to_string(&needs)
+            .with_context(|| format!("read {}", needs.display()))?;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).unwrap_or_else(|_| serde_json::json!({"raw": body}));
+        let reason = parsed
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("phase produced no PHASE_DONE/ESCALATE/outbox");
+        alerts.push(WatchdogAlert {
+            kind: AlertKind::NeedsAttention,
+            slug: Some(slug.to_string()),
+            message: format!("project `{slug}` flagged needs_attention: {reason}"),
+            emitted_at: now_utc,
+            details: parsed,
+        });
+    }
+
+    // Signal 2: auto-loop iteration count (read auto-loop.state.md;
+    // dev-plan §7 calls this `auto_loop_cycle`, the on-disk field is
+    // `iteration`).
+    let auto_loop_path = auto_loop::path_in(project_dir);
+    if let Some(state) = auto_loop::read(&auto_loop_path)? {
+        // Surface the iteration even before we know the user's
+        // threshold — `filter` enforces it. This keeps the cycle count
+        // visible in the details payload.
+        let iteration = state.front.iteration;
+        let max = state.front.max_iterations;
+        if iteration >= 1 {
+            alerts.push(WatchdogAlert {
+                kind: AlertKind::AutoLoopCycle,
+                slug: Some(slug.to_string()),
+                message: format!(
+                    "project `{slug}` auto-loop on iteration {iteration}/{max} (signal: {})",
+                    state.front.completion_signal,
+                ),
+                emitted_at: now_utc,
+                details: serde_json::json!({
+                    "iteration": iteration,
+                    "max_iterations": max,
+                    "completion_signal": state.front.completion_signal,
+                }),
+            });
+        }
+    }
+
+    // Signals 3a + 3b: cost / duration thresholds — read state.json.
+    let state_path = paths.project_state(slug);
+    let Ok(state) = ProjectState::load(&state_path) else {
+        return Ok(());
+    };
+
+    // Cost overrun (signal 3a) — emit unconditionally; `filter`
+    // applies the threshold.
+    alerts.push(WatchdogAlert {
+        kind: AlertKind::CostOverrun,
+        slug: Some(slug.to_string()),
+        message: format!(
+            "project `{slug}` cost_used_usd = {:.2} (phase `{}`)",
+            state.cost_used_usd,
+            display_phase(&state.current_phase),
+        ),
+        emitted_at: now_utc,
+        details: serde_json::json!({
+            "cost_used_usd": state.cost_used_usd,
+            "phase": state.current_phase,
+            "team": state.team,
+        }),
+    });
+
+    // Phase-duration overrun (signal 3b).
+    if let Some(last_event) = state.last_progress_event_at {
+        let elapsed = now_utc
+            .signed_duration_since(last_event)
+            .num_seconds()
+            .max(0) as u64;
+        alerts.push(WatchdogAlert {
+            kind: AlertKind::PhaseDurationOverrun,
+            slug: Some(slug.to_string()),
+            message: format!(
+                "project `{slug}` phase `{}` last event {}s ago",
+                display_phase(&state.current_phase),
+                elapsed,
+            ),
+            emitted_at: now_utc,
+            details: serde_json::json!({
+                "phase": state.current_phase,
+                "elapsed_seconds": elapsed,
+                "last_event_at": last_event.to_rfc3339_opts(SecondsFormat::Secs, true),
+            }),
+        });
+    }
+
+    Ok(())
+}
+
+fn display_phase(phase: &str) -> &str {
+    if phase.is_empty() {
+        "<idle>"
+    } else {
+        phase
+    }
+}
+
+/// Apply `notify_mode` + per-kind thresholds to a candidate list.
+fn filter(alerts: Vec<WatchdogAlert>, config: &WatchdogConfig) -> Vec<WatchdogAlert> {
+    alerts
+        .into_iter()
+        .filter(|a| keep(a, config))
+        .collect()
+}
+
+fn keep(alert: &WatchdogAlert, config: &WatchdogConfig) -> bool {
+    let quiet = matches!(config.notify_mode, NotifyMode::Quiet);
+    match alert.kind {
+        AlertKind::DaemonDown => true,
+        AlertKind::CostOverrun => {
+            // Threshold gate: drop unless cost crosses configured limit.
+            // Quiet mode doesn't suppress (cost is the user's money).
+            let Some(limit) = config.notify_on_phase_cost_usd else {
+                return false;
+            };
+            let cost = alert
+                .details
+                .get("cost_used_usd")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            cost > limit
+        }
+        AlertKind::PhaseDurationOverrun => {
+            if quiet {
+                return false;
+            }
+            let Some(limit_min) = config.notify_on_phase_duration_min else {
+                return false;
+            };
+            let elapsed = alert
+                .details
+                .get("elapsed_seconds")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            elapsed > (limit_min as u64) * 60
+        }
+        AlertKind::AutoLoopCycle => {
+            if quiet {
+                return false;
+            }
+            let iteration = alert
+                .details
+                .get("iteration")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+            iteration >= config.notify_on_cycle_count
+        }
+        AlertKind::NeedsAttention => !quiet,
+    }
+}
+
+/// Render an alert into a meta-agent outbox file under
+/// `~/projects/<user-handle>-meta/.ccteam/outbox/`. Returns the path
+/// written. The meta-agent's own session reads its outbox and surfaces
+/// each entry in NL.
+///
+/// `event_kind` is `Escalation` for `DaemonDown` / `CostOverrun` /
+/// `NeedsAttention` (the user has to see them) and `Progress` for the
+/// softer `AutoLoopCycle` / `PhaseDurationOverrun` (they describe state,
+/// no action mandated).
+pub fn push_alert_to_meta_outbox(
+    paths: &CcteamPaths,
+    user_handle: &str,
+    alert: &WatchdogAlert,
+) -> Result<PathBuf> {
+    let slug = meta_slug(user_handle)?;
+    let outbox_dir = paths
+        .project_ccteam_dir(&slug)
+        .join("outbox");
+    std::fs::create_dir_all(&outbox_dir)
+        .with_context(|| format!("create {}", outbox_dir.display()))?;
+
+    let now = Utc::now();
+    let seq = next_outbox_seq(&outbox_dir, now)?;
+    let filename = outbox_filename(now, seq);
+    let path = outbox_dir.join(filename);
+
+    let event_kind = match alert.kind {
+        AlertKind::DaemonDown | AlertKind::CostOverrun | AlertKind::NeedsAttention => {
+            OutboxEventKind::Escalation
+        }
+        AlertKind::AutoLoopCycle | AlertKind::PhaseDurationOverrun => OutboxEventKind::Progress,
+    };
+    let priority = match alert.kind {
+        AlertKind::DaemonDown | AlertKind::CostOverrun => OutboxPriority::High,
+        _ => OutboxPriority::Normal,
+    };
+
+    let body = render_alert_body(alert);
+    let msg = OutboxMessage {
+        front: OutboxFrontMatter {
+            schema_version: LATEST_SCHEMA_VERSION,
+            in_reply_to: None,
+            in_reply_to_source_msg_id: None,
+            target_channels: Vec::new(),
+            created_at: now,
+            priority,
+            event_kind,
+        },
+        body,
+    };
+    msg.save(&path)?;
+    Ok(path)
+}
+
+/// Compute the next 1-based sequence number that produces a fresh
+/// filename for `now`. Scans the outbox dir for the same compact
+/// timestamp prefix and bumps past the highest existing seq. Falls back
+/// to `001` when none exists. The caller atomic-writes; ignoring this
+/// would race a concurrent meta-agent reply, but watchdog is the only
+/// caller that runs as a Rust process so a single-process bump is fine.
+fn next_outbox_seq(dir: &Path, now: DateTime<Utc>) -> Result<u32> {
+    let prefix_ts = now.to_rfc3339_opts(SecondsFormat::Secs, true).replace(':', "");
+    let prefix = format!("reply-{prefix_ts}-");
+    let mut max = 0u32;
+    if dir.exists() {
+        for entry in std::fs::read_dir(dir)
+            .with_context(|| format!("read_dir {}", dir.display()))?
+        {
+            let Ok(entry) = entry else { continue };
+            let Some(name) = entry.file_name().to_str().map(String::from) else {
+                continue;
+            };
+            let Some(rest) = name.strip_prefix(&prefix) else {
+                continue;
+            };
+            let Some(seq_str) = rest.strip_suffix(".md") else {
+                continue;
+            };
+            if let Ok(n) = seq_str.parse::<u32>() {
+                if n > max {
+                    max = n;
+                }
+            }
+        }
+    }
+    Ok(max + 1)
+}
+
+fn render_alert_body(alert: &WatchdogAlert) -> String {
+    let mut body = format!("# watchdog: {}\n\n{}\n", alert.kind.as_str(), alert.message);
+    if let Some(slug) = &alert.slug {
+        body.push_str(&format!("\n- project: `{slug}`\n"));
+    }
+    body.push_str(&format!(
+        "- emitted_at: {}\n",
+        alert.emitted_at.to_rfc3339_opts(SecondsFormat::Secs, true),
+    ));
+    if !alert.details.is_null() {
+        body.push_str("\n## details\n\n```json\n");
+        body.push_str(
+            &serde_json::to_string_pretty(&alert.details)
+                .unwrap_or_else(|_| alert.details.to_string()),
+        );
+        body.push_str("\n```\n");
+    }
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auto_loop::AutoLoopState;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    fn paths(tmp: &TempDir) -> CcteamPaths {
+        CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        }
+    }
+
+    fn write_state(p: &CcteamPaths, slug: &str, mutate: impl FnOnce(&mut ProjectState)) {
+        let dir = p.project_ccteam_dir(slug);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut s = ProjectState::initial(slug.to_string());
+        mutate(&mut s);
+        s.save(&p.project_state(slug)).unwrap();
+    }
+
+    #[test]
+    fn load_config_returns_defaults_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let cfg = load_config(&p).unwrap();
+        assert_eq!(cfg, WatchdogConfig::default());
+        assert_eq!(cfg.notify_on_cycle_count, 2);
+        assert!(cfg.notify_on_phase_cost_usd.is_none());
+        assert_eq!(cfg.notify_mode, NotifyMode::Normal);
+    }
+
+    #[test]
+    fn load_config_parses_user_overrides() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("home")).unwrap();
+        let path = tmp.path().join("home").join("watchdog.yaml");
+        std::fs::write(
+            &path,
+            "notify_on_cycle_count: 5\nnotify_on_phase_cost_usd: 10.5\nnotify_mode: quiet\n",
+        )
+        .unwrap();
+        let cfg = load_config_at(&path).unwrap();
+        assert_eq!(cfg.notify_on_cycle_count, 5);
+        assert_eq!(cfg.notify_on_phase_cost_usd, Some(10.5));
+        assert_eq!(cfg.notify_mode, NotifyMode::Quiet);
+    }
+
+    #[test]
+    fn load_config_fails_loud_on_garbled_yaml() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("watchdog.yaml");
+        std::fs::write(&path, "notify_on_cycle_count: not-a-number\n").unwrap();
+        assert!(load_config_at(&path).is_err());
+    }
+
+    #[test]
+    fn quiet_mode_silences_auto_loop_alert_but_not_daemon_down() {
+        assert!(AlertKind::DaemonDown.breaks_through_quiet());
+        assert!(AlertKind::CostOverrun.breaks_through_quiet());
+        assert!(!AlertKind::AutoLoopCycle.breaks_through_quiet());
+        assert!(!AlertKind::NeedsAttention.breaks_through_quiet());
+        assert!(!AlertKind::PhaseDurationOverrun.breaks_through_quiet());
+    }
+
+    #[test]
+    fn scan_emits_daemon_down_when_heartbeat_missing() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        std::fs::create_dir_all(&p.projects_root).unwrap();
+        let cfg = WatchdogConfig::default();
+        let alerts = scan(&p, &cfg).unwrap();
+        assert_eq!(alerts.len(), 1);
+        assert_eq!(alerts[0].kind, AlertKind::DaemonDown);
+        assert!(alerts[0].slug.is_none());
+    }
+
+    #[test]
+    fn scan_skips_daemon_down_when_heartbeat_fresh() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        std::fs::create_dir_all(&p.projects_root).unwrap();
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let cfg = WatchdogConfig::default();
+        let alerts = scan(&p, &cfg).unwrap();
+        assert!(
+            alerts.iter().all(|a| a.kind != AlertKind::DaemonDown),
+            "fresh heartbeat must not trip daemon-down: {alerts:?}",
+        );
+    }
+
+    #[test]
+    fn scan_surfaces_needs_attention_outbox() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let slug = "dev-x";
+        write_state(&p, slug, |_| {});
+        let needs = p
+            .project_ccteam_dir(slug)
+            .join("needs_attention.outbox.json");
+        std::fs::write(
+            &needs,
+            r#"{"schema_version":1,"slug":"dev-x","reason":"stalled cold"}"#,
+        )
+        .unwrap();
+        let cfg = WatchdogConfig::default();
+        let alerts = scan(&p, &cfg).unwrap();
+        let needs_alerts: Vec<_> = alerts
+            .iter()
+            .filter(|a| a.kind == AlertKind::NeedsAttention)
+            .collect();
+        assert_eq!(needs_alerts.len(), 1);
+        assert_eq!(needs_alerts[0].slug.as_deref(), Some(slug));
+        assert!(needs_alerts[0].message.contains("stalled cold"));
+    }
+
+    #[test]
+    fn scan_filters_auto_loop_below_cycle_threshold() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let slug = "dev-y";
+        write_state(&p, slug, |_| {});
+        // iteration=1 < default threshold 2 ⇒ no alert.
+        let alp = auto_loop::path_in(&p.project_dir(slug));
+        let mut s = AutoLoopState::new(slug.into(), "fix".into(), 3, "DONE".into());
+        s.front.iteration = 1;
+        auto_loop::write(&alp, &s).unwrap();
+        let cfg = WatchdogConfig::default();
+        let alerts = scan(&p, &cfg).unwrap();
+        assert!(alerts.iter().all(|a| a.kind != AlertKind::AutoLoopCycle));
+    }
+
+    #[test]
+    fn scan_emits_auto_loop_at_threshold() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let slug = "dev-y";
+        write_state(&p, slug, |_| {});
+        let alp = auto_loop::path_in(&p.project_dir(slug));
+        let mut s = AutoLoopState::new(slug.into(), "fix".into(), 3, "DONE".into());
+        s.front.iteration = 2;
+        auto_loop::write(&alp, &s).unwrap();
+        let cfg = WatchdogConfig::default();
+        let alerts = scan(&p, &cfg).unwrap();
+        let cycle: Vec<_> = alerts
+            .iter()
+            .filter(|a| a.kind == AlertKind::AutoLoopCycle)
+            .collect();
+        assert_eq!(cycle.len(), 1);
+        assert_eq!(cycle[0].slug.as_deref(), Some(slug));
+        assert!(cycle[0].message.contains("2/3"));
+    }
+
+    #[test]
+    fn quiet_mode_suppresses_auto_loop_but_not_cost_overrun() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let slug = "dev-z";
+        write_state(&p, slug, |s| {
+            s.cost_used_usd = 50.0;
+            s.current_phase = "implement".into();
+        });
+        let alp = auto_loop::path_in(&p.project_dir(slug));
+        let mut als = AutoLoopState::new(slug.into(), "fix".into(), 3, "DONE".into());
+        als.front.iteration = 3;
+        auto_loop::write(&alp, &als).unwrap();
+        let cfg = WatchdogConfig {
+            notify_mode: NotifyMode::Quiet,
+            notify_on_phase_cost_usd: Some(10.0),
+            ..WatchdogConfig::default()
+        };
+        let alerts = scan(&p, &cfg).unwrap();
+        assert!(alerts.iter().all(|a| a.kind != AlertKind::AutoLoopCycle));
+        assert!(alerts.iter().any(|a| a.kind == AlertKind::CostOverrun));
+    }
+
+    #[test]
+    fn cost_overrun_threshold_gates() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let slug = "dev-cheap";
+        write_state(&p, slug, |s| s.cost_used_usd = 5.0);
+        // No threshold ⇒ no alert.
+        let cfg = WatchdogConfig::default();
+        let alerts = scan(&p, &cfg).unwrap();
+        assert!(alerts.iter().all(|a| a.kind != AlertKind::CostOverrun));
+        // Threshold below cost ⇒ alert.
+        let cfg = WatchdogConfig {
+            notify_on_phase_cost_usd: Some(1.0),
+            ..WatchdogConfig::default()
+        };
+        let alerts = scan(&p, &cfg).unwrap();
+        assert!(alerts.iter().any(|a| a.kind == AlertKind::CostOverrun));
+        // Threshold above cost ⇒ no alert.
+        let cfg = WatchdogConfig {
+            notify_on_phase_cost_usd: Some(10.0),
+            ..WatchdogConfig::default()
+        };
+        let alerts = scan(&p, &cfg).unwrap();
+        assert!(alerts.iter().all(|a| a.kind != AlertKind::CostOverrun));
+    }
+
+    #[test]
+    fn phase_duration_overrun_uses_last_event_age() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let slug = "dev-slow";
+        let then = Utc::now() - chrono::Duration::minutes(45);
+        write_state(&p, slug, |s| {
+            s.last_progress_event_at = Some(then);
+            s.current_phase = "implement".into();
+        });
+        let cfg = WatchdogConfig {
+            notify_on_phase_duration_min: Some(30),
+            ..WatchdogConfig::default()
+        };
+        let alerts = scan(&p, &cfg).unwrap();
+        let dur: Vec<_> = alerts
+            .iter()
+            .filter(|a| a.kind == AlertKind::PhaseDurationOverrun)
+            .collect();
+        assert_eq!(dur.len(), 1);
+        assert_eq!(dur[0].slug.as_deref(), Some(slug));
+    }
+
+    #[test]
+    fn push_alert_to_meta_outbox_writes_canonical_outbox_file() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        // Pre-create the meta-agent outbox dir; push doesn't bootstrap
+        // the meta project, just writes outbox files.
+        let alert = WatchdogAlert {
+            kind: AlertKind::DaemonDown,
+            slug: None,
+            message: "daemon down".into(),
+            emitted_at: Utc::now(),
+            details: serde_json::json!({"status": "no_heartbeat"}),
+        };
+        let path = push_alert_to_meta_outbox(&p, "rob", &alert).unwrap();
+        assert!(path.exists());
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("watchdog: daemon_down"));
+        assert!(body.contains("event_kind: escalation"));
+        assert!(body.contains("priority: high"));
+        // Round-trip parse.
+        let m = OutboxMessage::load(&path).unwrap();
+        assert_eq!(m.front.event_kind, OutboxEventKind::Escalation);
+        assert_eq!(m.front.priority, OutboxPriority::High);
+    }
+
+    #[test]
+    fn push_alert_uses_progress_priority_for_soft_alerts() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let alert = WatchdogAlert {
+            kind: AlertKind::AutoLoopCycle,
+            slug: Some("dev-q".into()),
+            message: "loop on 2/3".into(),
+            emitted_at: Utc::now(),
+            details: serde_json::Value::Null,
+        };
+        let path = push_alert_to_meta_outbox(&p, "rob", &alert).unwrap();
+        let m = OutboxMessage::load(&path).unwrap();
+        assert_eq!(m.front.event_kind, OutboxEventKind::Progress);
+        assert_eq!(m.front.priority, OutboxPriority::Normal);
+    }
+
+    #[test]
+    fn push_alert_to_meta_outbox_increments_seq_within_same_second() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let alert = WatchdogAlert {
+            kind: AlertKind::DaemonDown,
+            slug: None,
+            message: "x".into(),
+            emitted_at: Utc::now(),
+            details: serde_json::Value::Null,
+        };
+        let p1 = push_alert_to_meta_outbox(&p, "rob", &alert).unwrap();
+        let p2 = push_alert_to_meta_outbox(&p, "rob", &alert).unwrap();
+        assert_ne!(p1, p2, "second push must produce a distinct filename");
+    }
+
+    #[test]
+    fn scan_at_uses_provided_now_for_heartbeat_classification() {
+        // Independent confirmation that scan_at honors the deterministic
+        // `now` clock — important because tests above relied on the
+        // implicit assumption.
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        crate::daemon::write_heartbeat(&p).unwrap();
+        let mtime = std::fs::metadata(crate::daemon::heartbeat_path(&p))
+            .unwrap()
+            .modified()
+            .unwrap();
+        // Far past the grace ⇒ stale.
+        let stale_now = mtime + Duration::from_secs(600);
+        let alerts = scan_at(&p, &WatchdogConfig::default(), stale_now, Utc::now()).unwrap();
+        assert!(alerts.iter().any(|a| a.kind == AlertKind::DaemonDown));
+    }
+}

--- a/crates/ccteam-core/tests/watchdog_e2e_test.rs
+++ b/crates/ccteam-core/tests/watchdog_e2e_test.rs
@@ -1,0 +1,139 @@
+//! V0.2 M0.21 e2e: watchdog `scan` + `push_alert_to_meta_outbox`
+//! exercise on a fully-laid-out project tree. Lives in `tests/` so it
+//! runs in its own process — keeps any future env-touching tests
+//! isolated from the lib's `#[cfg(test)] mod tests`.
+
+use ccteam_core::{
+    auto_loop::{self, AutoLoopState},
+    push_watchdog_alert_to_meta_outbox, watchdog_scan, write_heartbeat, CcteamPaths,
+    OutboxEventKind, OutboxMessage, OutboxPriority, ProjectState, WatchdogAlertKind,
+    WatchdogConfig, WatchdogNotifyMode,
+};
+use tempfile::TempDir;
+
+fn paths(tmp: &TempDir) -> CcteamPaths {
+    CcteamPaths {
+        root: tmp.path().join("home"),
+        projects_root: tmp.path().join("projects"),
+    }
+}
+
+fn write_state(p: &CcteamPaths, slug: &str, mutate: impl FnOnce(&mut ProjectState)) {
+    let dir = p.project_ccteam_dir(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut s = ProjectState::initial(slug.to_string());
+    mutate(&mut s);
+    s.save(&p.project_state(slug)).unwrap();
+}
+
+#[test]
+fn auto_loop_iteration_2_surfaces_alert_then_pushes_to_meta_outbox() {
+    // Mirrors dev-plan §7 acceptance: "phase auto_loop cycle 第 2 次时,
+    // meta-agent surface 一条用户可读通知".
+    let tmp = TempDir::new().unwrap();
+    let p = paths(&tmp);
+    write_heartbeat(&p).unwrap();
+
+    let slug = "dev-bookmark";
+    write_state(&p, slug, |s| {
+        s.current_phase = "implement".into();
+    });
+    let alp = auto_loop::path_in(&p.project_dir(slug));
+    let mut s = AutoLoopState::new(slug.into(), "fix tests".into(), 3, "PHASE_DONE".into());
+    s.front.iteration = 2;
+    auto_loop::write(&alp, &s).unwrap();
+
+    let cfg = WatchdogConfig::default();
+    let alerts = watchdog_scan(&p, &cfg).unwrap();
+    let cycle: Vec<_> = alerts
+        .iter()
+        .filter(|a| a.kind == WatchdogAlertKind::AutoLoopCycle)
+        .collect();
+    assert_eq!(cycle.len(), 1);
+    let alert = cycle[0];
+    assert_eq!(alert.slug.as_deref(), Some(slug));
+    assert!(alert.message.contains("2/3"));
+
+    let path = push_watchdog_alert_to_meta_outbox(&p, "rob", alert).unwrap();
+    let msg = OutboxMessage::load(&path).unwrap();
+    // Cycle alerts are progress-priority (informational, not action-mandated).
+    assert_eq!(msg.front.event_kind, OutboxEventKind::Progress);
+    assert_eq!(msg.front.priority, OutboxPriority::Normal);
+    assert!(msg.body.contains("auto_loop_cycle"));
+    assert!(msg.body.contains(slug));
+}
+
+#[test]
+fn quiet_mode_drops_cycle_alert_but_pushes_daemon_down_when_heartbeat_missing() {
+    // Mirrors dev-plan §7 acceptance: "用户改 watchdog.yaml notify_mode:
+    // quiet → 通知不再 surface" — *except* the breaks-through-quiet
+    // signals (cost / daemon down).
+    let tmp = TempDir::new().unwrap();
+    let p = paths(&tmp);
+    // Deliberately do NOT write heartbeat ⇒ daemon_down should fire.
+    std::fs::create_dir_all(&p.projects_root).unwrap();
+
+    let slug = "dev-bookmark";
+    write_state(&p, slug, |s| s.current_phase = "implement".into());
+    let alp = auto_loop::path_in(&p.project_dir(slug));
+    let mut s = AutoLoopState::new(slug.into(), "fix".into(), 3, "PHASE_DONE".into());
+    s.front.iteration = 3;
+    auto_loop::write(&alp, &s).unwrap();
+
+    let cfg = WatchdogConfig {
+        notify_mode: WatchdogNotifyMode::Quiet,
+        ..WatchdogConfig::default()
+    };
+    let alerts = watchdog_scan(&p, &cfg).unwrap();
+    assert!(
+        alerts
+            .iter()
+            .all(|a| a.kind != WatchdogAlertKind::AutoLoopCycle),
+        "quiet mode must suppress auto_loop_cycle, got: {alerts:?}",
+    );
+    let daemon: Vec<_> = alerts
+        .iter()
+        .filter(|a| a.kind == WatchdogAlertKind::DaemonDown)
+        .collect();
+    assert_eq!(daemon.len(), 1, "daemon_down breaks through quiet");
+
+    let path = push_watchdog_alert_to_meta_outbox(&p, "rob", daemon[0]).unwrap();
+    let msg = OutboxMessage::load(&path).unwrap();
+    assert_eq!(msg.front.event_kind, OutboxEventKind::Escalation);
+    assert_eq!(msg.front.priority, OutboxPriority::High);
+}
+
+#[test]
+fn watchdog_does_not_mutate_state_or_progress_jsonl() {
+    // Sanity check the "translation only" red line: a full scan must
+    // not touch state.json (mtime unchanged) or progress.jsonl
+    // (file count unchanged).
+    let tmp = TempDir::new().unwrap();
+    let p = paths(&tmp);
+    write_heartbeat(&p).unwrap();
+    std::fs::create_dir_all(p.root.join("progress")).unwrap();
+
+    let slug = "dev-watch";
+    write_state(&p, slug, |s| {
+        s.cost_used_usd = 100.0;
+        s.current_phase = "implement".into();
+    });
+    let state_path = p.project_state(slug);
+    let mtime_before = std::fs::metadata(&state_path).unwrap().modified().unwrap();
+    let progress_dir = p.root.join("progress");
+    let count_before = std::fs::read_dir(&progress_dir).unwrap().count();
+
+    let cfg = WatchdogConfig {
+        notify_on_phase_cost_usd: Some(50.0),
+        ..WatchdogConfig::default()
+    };
+    let _ = watchdog_scan(&p, &cfg).unwrap();
+
+    let mtime_after = std::fs::metadata(&state_path).unwrap().modified().unwrap();
+    assert_eq!(mtime_before, mtime_after, "scan must not touch state.json");
+    let count_after = std::fs::read_dir(&progress_dir).unwrap().count();
+    assert_eq!(
+        count_before, count_after,
+        "scan must not write to progress/",
+    );
+}

--- a/docs/dev-plan-v0-2.md
+++ b/docs/dev-plan-v0-2.md
@@ -281,34 +281,42 @@ M0.16 (foundation)
 
 ### 任务
 
-- [ ] **M0.21.1** meta-agent role prompt 升级
-  - `crates/ccteam-core/src/templates/meta_agent_role.md` 加 watchdog 部分
-  - 描述 watchdog 角色边界(不做技术决策,只做 UX 翻译)
-  - 列周期任务:扫所有项目 progress.jsonl summary,做 UX 判断
-- [ ] **M0.21.2** Watchdog 数据源
-  - 信号 1:`needs_attention.outbox.json`(M0.19 Stop hook 兜底产出)
-  - 信号 2:`progress.jsonl` 里 `auto_loop_cycle` 事件 ≥ 2 次
-  - 信号 3:phase 当前 cost / 时长超阈值(已有)
-  - 信号 4:orchestrator daemon health check 失败(M0.23)
-- [ ] **M0.21.3** 通知阈值配置
+- [x] **M0.21.1** meta-agent role prompt 升级
+  - `crates/ccteam-core/src/templates/meta_agent_role.md` 加 watchdog 部分(§7)
+  - 描述 watchdog 角色边界(translation only,不做技术决策)
+  - 列周期任务:`ccteam watchdog scan` + 优先级处理顺序
+- [x] **M0.21.2** Watchdog 数据源
+  - 信号 1:`needs_attention.outbox.json`(M0.19 Stop hook L3 兜底)
+  - 信号 2:`<project>/.ccteam/auto-loop.state.md::iteration`(直接读 state 文件,
+    dev-plan 原写"`progress.jsonl` 里 `auto_loop_cycle` 事件",代码里没这事件;
+    `iteration` 字段是同语义的更直接来源)
+  - 信号 3:phase 当前 cost / 时长超阈值(state.json 字段)
+  - 信号 4:orchestrator daemon heartbeat stale(M0.23.1 已 ship)
+- [x] **M0.21.3** 通知阈值配置
   - `~/.ccteam/watchdog.yaml`(新)— 用户级配置
-  - 字段:`notify_on_cycle_count: u32`(默认 cap-1=2)/ `notify_on_phase_cost_usd: Option<f64>` / `notify_on_phase_duration_min: Option<u32>` / `notify_mode: quiet|normal|verbose`
-- [ ] **M0.21.4** Watchdog 通知机制
-  - meta-agent 通过 outbox(meta-agent 自己的 outbox)推通知
-  - 现有 channel layer(M2+ 未 ship)不依赖,V0.2 仅在 meta-agent session attach 时显示
+  - 字段:`notify_on_cycle_count` / `notify_on_phase_cost_usd` / `notify_on_phase_duration_min` / `notify_mode`
+- [x] **M0.21.4** Watchdog 通知机制
+  - meta-agent 通过自己的 outbox(`~/projects/<handle>-meta/.ccteam/outbox/`)
+    收 alert(`escalation` priority=high / `progress` priority=normal)
+  - V0.2:**手动**触发(meta-agent 跑 `ccteam watchdog scan --push --user <handle>`);
+    M2+ channel layer 上线后才有 cron-style 自动 timer
 
 ### 验收
 
-- [ ] e2e:phase auto_loop cycle 第 2 次时,meta-agent surface 一条用户可读通知
-- [ ] e2e:用户改 `~/.ccteam/watchdog.yaml` `notify_mode: quiet` → 通知不再 surface
-- [ ] watchdog 不改任何 orchestrator 行为(grep `crates/ccteam-core/src/orchestrator.rs` 不调 watchdog)
-- [ ] 369 baseline + ~10 新测试
+- [x] e2e:auto-loop iteration ≥ 2 时 surface NL 通知 + 写 outbox
+  (`crates/ccteam-core/tests/watchdog_e2e_test.rs::auto_loop_iteration_2_surfaces_alert_then_pushes_to_meta_outbox`)
+- [x] e2e:`notify_mode: quiet` 静默 cycle 但 `daemon_down` / `cost_overrun` 仍 surface
+  (`crates/ccteam-core/tests/watchdog_e2e_test.rs::quiet_mode_drops_cycle_alert_but_pushes_daemon_down_when_heartbeat_missing`)
+- [x] watchdog 不改任何 orchestrator 行为(grep `crates/ccteam-core/src/orchestrator.rs` `watchdog` = 0)
+  (额外:`watchdog_does_not_mutate_state_or_progress_jsonl` 验 state.json mtime / progress 计数不变)
+- [x] 451 baseline + 21 新测试 = 472(原估 ~10,实际拆得更细;含 lib + e2e + cli)
 
 ### 文档同步
 
-- `docs/tech-design.md` 加 §3.X watchdog 章节
-- `docs/interfaces.md` 加 `watchdog.yaml` schema
-- 加新红线到 tech-design:**smart layer 只做 translation 不做 decision**
+- [x] `docs/tech-design.md` §3.9 watchdog 章节
+- [x] `docs/tech-design.md` §1 设计原则表加 "smart layer 只做 translation 不做 decision" 红线
+- [x] `docs/interfaces.md` §12.5 `watchdog.yaml` schema + alert 输出契约
+- [x] `docs/interfaces.md` §10.5 + §13 文件路径表 加 `ccteam watchdog scan` / `~/.ccteam/watchdog.yaml`
 
 ---
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1216,6 +1216,9 @@ ccteam resume <slug>                   # 恢复自动调度(接管 attach 后的
 ccteam answer <slug> "回答内容"          # 响应 clarify
 ccteam decisions                       # M1 收尾增量:跨项目决策队列(扫 outbox event_kind: clarify|escalation)
 ccteam decisions --format json         # JSON 输出(meta-agent 主消费;详见 §5.6.4)
+ccteam watchdog scan                   # V0.2 M0.21 translation-only 健康巡检(详见 §12.5)
+ccteam watchdog scan --format json     # 结构化输出(meta-agent 主消费)
+ccteam watchdog scan --push --user <handle>  # 把 alert 写进 meta-agent outbox
 ccteam fork-reply <slug> A             # L3 fork 决策(M1+;A/B/C)
 ccteam fork-reply <slug> B "去掉云同步"  # tweak
 ccteam kick <slug>                     # 软重启项目 session(claude --resume)
@@ -1380,11 +1383,78 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 
 ---
 
+## 12.5 Watchdog `watchdog.yaml` schema(V0.2 M0.21)
+
+> **架构沿革**:V0.2 把"低层信号 → meta-agent NL 通知"独立成 watchdog
+> 角色(tech-design §3.9)。watchdog 是 **translation only** 层:读 4 个数据源
+> + 用户阈值 → 产出 NL alert 写 meta-agent 自己的 outbox。**不动 orchestrator
+> 状态**(零写入 progress.jsonl / state.json / control / inbox)。
+
+### 12.5.1 文件位置
+
+`~/.ccteam/watchdog.yaml`(用户级,全局生效)。文件不存在 ⇒ 全字段走默认。
+解析失败 ⇒ fail-loud(用户配置坏不静默回 default)。
+
+### 12.5.2 字段
+
+| 字段 | 类型 | 默认 | 含义 |
+|---|---|---|---|
+| `notify_on_cycle_count` | `u32` | `2` | `<project>/.ccteam/auto-loop.state.md::iteration` 达到此值即 alert(默认 = 通常 cap 3 - 1) |
+| `notify_on_phase_cost_usd` | `Option<f64>` | `None` | `state.json::cost_used_usd` 超此 USD 数即 alert;`None` ⇒ 不报 cost |
+| `notify_on_phase_duration_min` | `Option<u32>` | `None` | 当前 phase 距 `last_progress_event_at` 超此分钟即 alert;`None` ⇒ 不报 |
+| `notify_mode` | `quiet \| normal \| verbose` | `normal` | 见 §12.5.3 |
+
+### 12.5.3 `notify_mode` 语义
+
+- `quiet` — 仅放行 `cost_overrun` + `daemon_down`(钱 / 守护死必报);静默
+  `auto_loop_cycle` / `phase_duration_overrun` / `needs_attention`
+- `normal` — 默认;每个 alert kind 每次扫描发一次
+- `verbose` — 同 `normal` + 不去重 `needs_attention`(用于 debug,不推荐生产)
+
+### 12.5.4 Alert 输出契约
+
+`ccteam watchdog scan --format json` 输出 schema:
+
+```json
+{
+  "alerts": [
+    {
+      "kind": "needs_attention | auto_loop_cycle | cost_overrun | phase_duration_overrun | daemon_down",
+      "slug": "<team>-<slug> | null",
+      "message": "human-readable NL",
+      "emitted_at": "RFC3339",
+      "details": { "/* alert-kind specific */": "..." }
+    }
+  ],
+  "config": { /* echoed WatchdogConfig */ }
+}
+```
+
+`--push --user <handle>` 时,每条 alert 还原成 `<project>/<handle>-meta/.ccteam/outbox/reply-<ts>-<NNN>.md`(§3.4.3 outbox schema):
+
+| Alert kind | `event_kind` | `priority` |
+|---|---|---|
+| `daemon_down` / `cost_overrun` / `needs_attention` | `escalation` | `high` |
+| `auto_loop_cycle` / `phase_duration_overrun` | `progress` | `normal` |
+
+### 12.5.5 调用约束(translation only)
+
+- watchdog 读以下文件;**不写**它们任意一个:
+  - `~/.ccteam/state/orchestrator.heartbeat`(只 stat mtime)
+  - `<project>/.ccteam/state.json`
+  - `<project>/.ccteam/auto-loop.state.md`
+  - `<project>/.ccteam/needs_attention.outbox.json`
+- watchdog 唯一**写**目标:`~/projects/<handle>-meta/.ccteam/outbox/reply-*.md`
+- `ccteam-core::orchestrator` 模块 grep `watchdog` 必为 **0 次**(核心红线)
+
+---
+
 ## 13. 关键文件路径速查
 
 | 路径 | 用途 |
 |---|---|
 | `~/.ccteam/config.yml` | 全局配置(并发、阈值、信任档位、模型单价) |
+| `~/.ccteam/watchdog.yaml` | V0.2 M0.21:translation-only watchdog 阈值 + notify_mode(详见 §12.5) |
 | `~/.ccteam/inbox/` | 用户提需求 |
 | `~/.ccteam/queue/<state>/` | 项目状态分桶 |
 | `~/.ccteam/control/` | 用户 → orchestrator 控制信号(详见 §3.3) |

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -24,6 +24,7 @@
 | **纵深防御替代人值守** | 痛点 11：关键节点不把控 | L1 架构约束（hooks + required_outputs）+ L2 多 agent 互检 + cross-cutting watcher（议事）+ L3 用户兜底（仅 deadlock 弹）；详见 §3.6 |
 | **pipeline 编排 sub-skill** | 痛点 12：工作流插件靠人手动调 | 9 主干 phase + 每 phase front matter `sub_skills` 字段；orchestrator 自动 trigger，产物自动接力；复用 gstack / claude-plugins-official 的 plugin，不重写；详见 §6.10 |
 | **并行规模自适应** | 痛点 13：大项目串行慢、并行规模选不对 | plan-eng 按 spec 复杂度选 `parallelism: solo / agent_team / multi_session`；subagent 任何粒度可叠加（ad-hoc，不在协议中声明）；三档叠加层级，不是互斥；详见 §3.3、§6.3、§6.11 |
+| **smart layer 只 translate,不 decide**（V0.2 M0.21） | watchdog / 后续 ux-helper 不能改 orchestrator 状态 | translation 层(meta-agent watchdog 等)只读取既有遥测,产出 NL 通知;**绝不**调 orchestrator API、写 progress.jsonl、kill session、re-inject prompt;**所有状态变更只能由 orchestrator + hooks 走;** 详见 §3.X |
 
 ---
 
@@ -693,6 +694,56 @@ LLM 推理只发生在两处:① **L2 项目级 claude**(tmux 内) ② **L0 用�
 - **不抄核心**:9-phase 编排、Seed Gate、跨项目 lessons(走官方 `~/.claude/rules/` + 可选 claude-mem)、Defense in Depth 是 ccteam 差异化护城河,AoE 没有
 
 详见 development-plan M4.9 任务说明。
+
+### 3.9 Watchdog(translation-only smart layer,V0.2 M0.21)
+
+> **架构沿革**:meta-agent(§3.8)主路径是"用户主动问 → meta-agent 答"。
+> 但 ccteam 的疼点之一是**没人值守时项目静默卡死**——L2 hooks 只能记录,
+> 没法主动捅醒用户。V0.2 把"低层信号 → 用户能读懂的 NL"这一步独立出来叫
+> **watchdog**:不是新组件 / 新进程,而是 meta-agent 的一个角色面 +
+> 一组 ccteam Rust 函数。
+
+**translation only 红线**(本文 §1 表格新增条):
+- ❌ watchdog 不调 orchestrator API、不写 progress.jsonl、不 kill session、不 re-inject prompt
+- ❌ watchdog 不替用户拍板("该不该 attach"、"该不该 kill"、"该不该改方案")
+- ✅ watchdog 只读 4 个数据源,翻译成 NL,推到 meta-agent 自己的 outbox(§3.4.3)
+
+**4 个数据源**(全是只读):
+
+| 信号 | 路径 | 来源 milestone |
+|---|---|---|
+| `needs_attention` | `<project>/.ccteam/needs_attention.outbox.json` | M0.19 Stop hook L3 兜底 |
+| `auto_loop_cycle` | `<project>/.ccteam/auto-loop.state.md::iteration` | M0.12 ralph-loop |
+| `cost_overrun` / `phase_duration_overrun` | `<project>/.ccteam/state.json::cost_used_usd` / `last_progress_event_at` | 一直有 |
+| `daemon_down` | `~/.ccteam/state/orchestrator.heartbeat` mtime | M0.23.1 |
+
+**信号源选择**(详见 `docs/v0-2-claude-code-alignment-review.md` §3.3):
+**不用 SessionEnd**——其 `exit_reason` 6 个枚举全是用户主动事件,stall 不触发。
+靠外部 timer + Stop hook L3 兜底就够了。
+
+**用户配置**:`~/.ccteam/watchdog.yaml`(interfaces.md `watchdog.yaml schema`):
+
+```yaml
+notify_on_cycle_count: 2          # 默认 cap-1=2
+notify_on_phase_cost_usd: 30.0    # USD,可选
+notify_on_phase_duration_min: 60  # 分钟,可选
+notify_mode: normal               # quiet / normal / verbose
+```
+
+`quiet` 模式只放行 `cost_overrun` + `daemon_down`(钱 / 守护死必报);
+`verbose` 不去重,每次扫描都重发 `needs_attention`。
+
+**触发**(M0.21):**手动**——meta-agent 自己跑 `ccteam watchdog scan` 这条命令。
+M2+ channel layer 上线后会有 cron-style 自动触发(60s 默认推荐;
+当前 milestone 不实现自动 timer)。
+
+**实施要点**:
+- 全部代码在 `crates/ccteam-core/src/watchdog.rs`(单文件,~600 行)
+- `crates/ccteam-cli/src/main.rs::Command::Watchdog::Scan` 暴露 CLI:
+  `ccteam watchdog scan [--push --user <handle>]`
+- meta-agent role prompt(§3.8 引用)新增 §7 描述 watchdog 角色边界
+- `crates/ccteam-core/src/orchestrator.rs` **零** watchdog 引用
+  (grep `watchdog` 命中 0 次是核心红线)
 
 ---
 


### PR DESCRIPTION
## Summary

Closes **V0.2 M0.21** (`docs/dev-plan-v0-2.md §7`) — meta-agent gains a watchdog subsystem that scans projects for stall / cost / daemon signals and pushes UX-translated alerts. Strict translation layer — no orchestrator behavior is modified.

1. **M0.21.1 meta-agent role prompt** — `crates/ccteam-core/src/templates/meta_agent_role.md` gains §7 describing the watchdog role (translation only, no technical decisions; periodic `ccteam watchdog scan`).
2. **M0.21.2 four data sources** — read-only:
   - `needs_attention.outbox.json` (M0.19 Stop hook fallback)
   - `<project>/.ccteam/auto-loop.state.md::iteration` ≥ 2 (the on-disk auto-loop counter; dev-plan §7's `auto_loop_cycle` event doesn't exist in the codebase, semantically equivalent)
   - phase cost / duration thresholds
   - `~/.ccteam/state/orchestrator.heartbeat` mtime (M0.23 daemon supervision)
3. **M0.21.3 `~/.ccteam/watchdog.yaml`** — user-level config: `notify_on_cycle_count: u32` (default 2 = cap-1) / `notify_on_phase_cost_usd: Option<f64>` / `notify_on_phase_duration_min: Option<u32>` / `notify_mode: quiet | normal | verbose`.
4. **M0.21.4 alert delivery** — meta-agent's own outbox; V0.2 surfaces only when meta-agent session is attached. M2+ channel layer not depended on.

## Maps to

- PRD: `docs/prd-v0-2.md §3`
- Design: `docs/v0-2-claude-code-alignment-review.md §3.3` (signal source choice; SessionEnd not used)
- Dev plan: `docs/dev-plan-v0-2.md §7`

## Translation-layer red line (new)

Added to `docs/tech-design.md §1` design-principles table: **"smart layer 只 translate,不 decide"**. Watchdog reads only; never mutates orchestrator state.

Verified: `grep "watchdog" crates/ccteam-core/src/orchestrator.rs` = **0 hits**.

## Test results

| Item | Before | After |
|---|---|---|
| `cargo test --workspace` | 451 / 0 | **472 / 0** (+21) |
| `cargo clippy --workspace --all-targets` warnings | 10 | **10** (0 new) |

Coverage: 16 unit in `watchdog::tests` (config defaults, signal extraction, alert pruning, quiet/normal/verbose, breaks-through-quiet for CostOverrun + DaemonDown), 3 integration `tests/watchdog_e2e_test.rs` (XDG_CONFIG_HOME end-to-end with seeded project state), 2 in `commands::tests` (CLI report rendering).

## Red-line grep

- `grep "watchdog" crates/ccteam-core/src/orchestrator.rs` → **0**
- `\bdev\b|\bproduct-research\b|\bmeta-agent\b` in `crates/ccteam-core/src/`: +19 hits, all in `watchdog.rs` docstrings / test slugs (`"dev-x"` etc.). **Zero behavioral branches keyed on team name** — watchdog reads `state.team` field, never compares to literal.

## Documentation sync

- [x] `docs/tech-design.md` §3.9 — new "Watchdog (translation-only smart layer, V0.2 M0.21)" chapter
- [x] `docs/tech-design.md` §1 — design-principles table gains "smart layer 只 translate,不 decide" red line
- [x] `docs/interfaces.md` §12.5 — `~/.ccteam/watchdog.yaml` schema + `notify_mode` semantics + alert-output JSON contract
- [x] `docs/interfaces.md` §10.5 + §13 — `ccteam watchdog scan` command + path
- [x] `docs/dev-plan-v0-2.md` §7 — tasks ticked with test names

## ⚠ Open questions for review

1. **No timer in V0.2** — `ccteam watchdog scan` is **manually invoked** by the meta-agent (per role prompt §7). Recommendation when M2+ channel layer ships: 60s cron-style. Rationale: no daemon currently exists to host a timer without violating the "watchdog never runs alongside orchestrator decisions" red line. Documented in tech-design §3.9.
2. **`auto_loop_cycle` event source** — dev-plan §7 named a `progress.jsonl` event `auto_loop_cycle ≥ 2`; that event doesn't exist in the codebase. Read instead from `<project>/.ccteam/auto-loop.state.md::iteration` (the on-disk loop counter). Same semantic. Documented in module-level comment + dev-plan §7.
3. **Multi-project scan strategy** — implemented as scan-all-projects under `~/projects/*/.ccteam/state.json` (mirrors `discover_projects` + `collect_decisions`). Single scan ≤ tens of ms in practice.
4. **`quiet` mode + cost-overrun emergency** — `AlertKind::breaks_through_quiet()` returns true for `CostOverrun` + `DaemonDown` only; other kinds silenced under quiet. Audited by `quiet_mode_drops_cycle_alert_but_pushes_daemon_down_when_heartbeat_missing`.

## Boundary respected with M0.22

- Did not touch `team_factory.rs` / `ccteam-team-author` skill / `ccteam team` subcommand / `--validate-team` plugin manifest extension
- Watchdog scope confined to its own module + meta-agent role prompt §7

## Test plan

- [ ] `cargo test --workspace` passes (472 / 0)
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] Manual: seed project with auto-loop iteration ≥ 2, run `ccteam watchdog scan` → meta-agent outbox sees alert
- [ ] Manual: kill daemon, run `ccteam watchdog scan` → DaemonDown alert breaks through `quiet` mode
- [ ] Manual: confirm `grep watchdog crates/ccteam-core/src/orchestrator.rs` = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)