### PR TITLE
V0.2.1: F26-F33 dust patch — V0.2 e2e retro follow-up

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -220,9 +220,10 @@ fn list_disk_teams(paths: &CcteamPaths) -> Result<Vec<String>> {
 /// JSON shape (a single string, not printed — caller decides).
 pub fn run_ls(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
     let projects = collect_projects(paths)?;
+    let daemon_up = ccteam_core::daemon::heartbeat_alive(paths);
     Ok(match format {
-        OutputFormat::Text => render_ls_text(&projects),
-        OutputFormat::Json => render_ls_json(&projects)?,
+        OutputFormat::Text => render_ls_text(&projects, daemon_up),
+        OutputFormat::Json => render_ls_json(&projects, daemon_up)?,
     })
 }
 
@@ -695,7 +696,17 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         out.push_str(&render_reset_shipped_teams_report(paths, &opts)?);
     }
     if let Some(team) = &opts.validate_team {
-        out.push_str(&render_validate_team_report(paths, team)?);
+        let (report, fails) = render_validate_team_report(paths, team)?;
+        out.push_str(&report);
+        // F30 — `--help` advertises "Fails-loud on schema violations
+        // and IO-contract gaps". Honor that: any [FAIL] (phase-level
+        // or plugin-section) → non-zero exit so CI can gate on it.
+        if fails > 0 {
+            anyhow::bail!(
+                "ccteam doctor --validate-team {team}: {fails} fail(s) — \
+                 see report above\n\n{out}",
+            );
+        }
     }
     if opts.migrate_recommended_agents {
         out.push_str(&render_migrate_recommended_agents_report(&opts)?);
@@ -716,13 +727,20 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
 ///    `ESCALATE:`) inside the body trigger a warn (not error — bodies
 ///    are user territory; `docs/v0-2/phase-prompt-architecture.md` §9 docks
 ///    this as warn-not-fail by design).
-fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String> {
+fn render_validate_team_report(
+    paths: &CcteamPaths,
+    team: &str,
+) -> Result<(String, u32)> {
     use ccteam_core::{
         default_user_staging_dir, resolve_team, staging_dir_for, validate_staged_team,
         TeamResolveContext, TEAM_SOURCES,
     };
 
     let mut out = format!("ccteam doctor --validate-team {team}\n\n");
+    // F30 — accumulate every [FAIL] line into a single counter so the
+    // top-level Summary and the `run_doctor` exit code agree. Phase-
+    // section findings sum into this same counter below.
+    let mut fails = 0u32;
     let user_staging = default_user_staging_dir();
     let ctx = TeamResolveContext::for_orchestrator(&paths.root, &user_staging);
 
@@ -734,6 +752,9 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
     if staged.join(".claude-plugin/plugin.json").exists() {
         out.push_str("# Plugin manifest checks (staged tree)\n");
         for line in validate_staged_team(&staged)? {
+            if line.starts_with("[FAIL]") {
+                fails += 1;
+            }
             out.push_str(&format!("{line}\n"));
         }
         out.push('\n');
@@ -746,7 +767,9 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
         }
         Err(err) => {
             out.push_str(&format!("[FAIL] team.yaml load: {err:#}\n"));
-            return Ok(out);
+            fails += 1;
+            out.push_str(&format!("\nSummary: 0 ok, 0 warn, {fails} fail\n"));
+            return Ok((out, fails));
         }
     };
 
@@ -754,7 +777,8 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
         out.push_str(
             "[OK] team is evergreen — skipping phase IO / markdown checks\n",
         );
-        return Ok(out);
+        out.push_str(&format!("\nSummary: 1 ok, 0 warn, {fails} fail\n"));
+        return Ok((out, fails));
     }
 
     // Locate the phase dir on disk via the same priority order the
@@ -771,7 +795,9 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
                 "[FAIL] could not locate team directory after resolve — \
                  run `ccteam doctor --reset-shipped-teams`\n",
             );
-            return Ok(out);
+            fails += 1;
+            out.push_str(&format!("\nSummary: 0 ok, 0 warn, {fails} fail\n"));
+            return Ok((out, fails));
         }
     };
     let phase_dir = team_dir.join(&spec.phase_dir);
@@ -780,7 +806,9 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
             "[FAIL] phase_dir {} does not exist\n",
             phase_dir.display(),
         ));
-        return Ok(out);
+        fails += 1;
+        out.push_str(&format!("\nSummary: 0 ok, 0 warn, {fails} fail\n"));
+        return Ok((out, fails));
     }
 
     // Sort phase markdowns so IO contract checks run in the
@@ -804,7 +832,8 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
             "[WARN] no phase markdowns under {}\n",
             phase_dir.display(),
         ));
-        return Ok(out);
+        out.push_str(&format!("\nSummary: 0 ok, 1 warn, {fails} fail\n"));
+        return Ok((out, fails));
     }
 
     // Project-bootstrapped artifacts the orchestrator writes before
@@ -819,7 +848,6 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
 
     let mut ok = 0u32;
     let mut warns = 0u32;
-    let mut fails = 0u32;
 
     for path in &entries {
         let file = path.file_name().and_then(|s| s.to_str()).unwrap_or("?");
@@ -879,7 +907,7 @@ fn render_validate_team_report(paths: &CcteamPaths, team: &str) -> Result<String
     out.push_str(&format!(
         "\nSummary: {ok} ok, {warns} warn, {fails} fail\n",
     ));
-    Ok(out)
+    Ok((out, fails))
 }
 
 fn strip_frontmatter(body: &str) -> &str {
@@ -906,7 +934,17 @@ pub fn run_phase_show(
     };
 
     let user_staging = default_user_staging_dir();
-    let ctx = TeamResolveContext::for_orchestrator(&paths.root, &user_staging);
+    // V0.2.1 F28: when run from inside a project tree, layer 1
+    // (Project) wins so `phase show` reflects what the orchestrator
+    // would actually inject. Falls back to user / repo when there's
+    // no `.ccteam/team/team.yaml` in cwd.
+    let cwd = std::env::current_dir().ok();
+    let mut ctx = TeamResolveContext::for_orchestrator(&paths.root, &user_staging);
+    if let Some(cwd) = cwd.as_deref() {
+        if cwd.join(".ccteam").join("team").join("team.yaml").exists() {
+            ctx = ctx.with_project(cwd);
+        }
+    }
 
     let spec = resolve_team(team, &ctx)
         .with_context(|| format!("resolve team `{team}`"))?;
@@ -1388,11 +1426,21 @@ fn collect_artifacts(paths: &CcteamPaths, slug: &str) -> Map<String, Value> {
     m
 }
 
-fn render_ls_text(projects: &[ProjectSummary]) -> String {
-    if projects.is_empty() {
-        return "(no projects under ~/projects/. start one with `ccteam new \"<request>\"`.)\n".into();
-    }
+fn render_ls_text(projects: &[ProjectSummary], daemon_up: bool) -> String {
     let mut out = String::new();
+    // F27 — daemon health one-liner, always emitted (even on the
+    // empty-projects path) so users can disambiguate "no projects" from
+    // "daemon never came up".
+    out.push_str(&format!(
+        "daemon: {}\n",
+        if daemon_up { "up" } else { "down" }
+    ));
+    if projects.is_empty() {
+        out.push_str(
+            "(no projects under ~/projects/. start one with `ccteam new \"<request>\"`.)\n",
+        );
+        return out;
+    }
     out.push_str("SLUG                                     PHASE          STATE       COST   AGE\n");
     for p in projects {
         let phase = display_phase(&p.state.current_phase);
@@ -1419,7 +1467,7 @@ fn display_phase(phase: &str) -> &str {
     }
 }
 
-fn render_ls_json(projects: &[ProjectSummary]) -> Result<String> {
+fn render_ls_json(projects: &[ProjectSummary], daemon_up: bool) -> Result<String> {
     let active_count = projects
         .iter()
         .filter(|p| p.state.phase_state == PhaseState::InFlight)
@@ -1446,8 +1494,11 @@ fn render_ls_json(projects: &[ProjectSummary]) -> Result<String> {
         .collect();
     let v = json!({
         "projects": arr,
+        // F27 — `running` is now a real bool driven by
+        // `daemon::heartbeat_alive` so meta-agent / MCP consumers can
+        // gate writes on daemon liveness without an extra round trip.
         "orchestrator": {
-            "running": null,
+            "running": daemon_up,
             "active_count": active_count,
             "max_concurrent": 1,
         }
@@ -1808,6 +1859,51 @@ mod tests {
         assert_eq!(v["projects"].as_array().unwrap().len(), 2);
         assert_eq!(v["orchestrator"]["active_count"], 0);
         assert_eq!(v["orchestrator"]["max_concurrent"], 1);
+    }
+
+    #[test]
+    fn f27_run_ls_text_reports_daemon_down_when_no_heartbeat() {
+        // F27 — `ls` text output annotates daemon health on its first
+        // line so users can disambiguate "no projects" from "daemon
+        // never came up".
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let body = run_ls(&paths, OutputFormat::Text).unwrap();
+        let first_line = body.lines().next().unwrap_or("");
+        assert!(
+            first_line == "daemon: down",
+            "expected first line `daemon: down`; got: {first_line}",
+        );
+    }
+
+    #[test]
+    fn f27_run_ls_json_orchestrator_running_is_bool() {
+        // F27 — `orchestrator.running` was hardcoded `null` pre-V0.2.1;
+        // now it's a real bool gated on heartbeat freshness so MCP /
+        // meta-agent consumers can treat it as a status field.
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let body = run_ls(&paths, OutputFormat::Json).unwrap();
+        let v: Value = serde_json::from_str(&body).unwrap();
+        let running = &v["orchestrator"]["running"];
+        assert!(
+            running.is_boolean(),
+            "expected orchestrator.running:bool; got: {running:?}",
+        );
+        // No heartbeat written → must be false.
+        assert_eq!(running.as_bool(), Some(false));
+    }
+
+    #[test]
+    fn f27_run_ls_text_reports_daemon_up_on_fresh_heartbeat() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        ccteam_core::daemon::write_heartbeat(&paths).unwrap();
+        let body = run_ls(&paths, OutputFormat::Text).unwrap();
+        assert!(
+            body.starts_with("daemon: up"),
+            "expected `daemon: up` head line on fresh heartbeat; got:\n{body}",
+        );
     }
 
     #[test]
@@ -2399,9 +2495,13 @@ mod tests {
             validate_team: Some("totally-unknown".into()),
             ..DoctorOptions::default()
         };
-        let report = run_doctor(&paths, opts).unwrap();
-        assert!(report.contains("[FAIL] team.yaml load"), "got: {report}");
+        // F30 — fail-loud: any [FAIL] line bubbles a non-zero exit.
+        let err = run_doctor(&paths, opts).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("[FAIL] team.yaml load"), "got: {msg}");
+        assert!(msg.contains("1 fail"), "expected fails counter; got: {msg}");
     }
+
 
     #[test]
     fn validate_team_warns_when_phase_body_contains_protocol_literal() {

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -57,6 +57,15 @@ enum Command {
         /// `claude /plugin add <id>` first).
         #[arg(long, default_value_t = false)]
         skip_tool_check: bool,
+        /// F29 — override the claude argv used to spawn project tmux
+        /// sessions. Whitespace-split. Wins over `CCTEAM_CLAUDE_ARGV`
+        /// env which wins over the production default
+        /// (`claude --dangerously-skip-permissions --model …`). Used
+        /// by e2e harnesses to inject a stub claude (eg
+        /// `--claude-argv "sh -c 'cat > /dev/null'"`) so phase
+        /// pipeline can be exercised without burning LLM cost.
+        #[arg(long, value_name = "ARGV")]
+        claude_argv: Option<String>,
     },
     /// Create a new project from a one-line request.
     New {
@@ -318,7 +327,8 @@ fn main() -> Result<()> {
             foreground: _,
             tick_seconds,
             skip_tool_check,
-        } => run_start(tick_seconds, skip_tool_check),
+            claude_argv,
+        } => run_start(tick_seconds, skip_tool_check, claude_argv),
         Command::New { request, file, team } => run_new(request, file, team),
         Command::Ls { format } => run_ls(format),
         Command::Show { slug, format } => run_show(&slug, format),
@@ -500,7 +510,11 @@ fn run_hook(cmd: HookCommand) -> Result<()> {
     }
 }
 
-fn run_start(tick_seconds: u64, skip_tool_check: bool) -> Result<()> {
+fn run_start(
+    tick_seconds: u64,
+    skip_tool_check: bool,
+    claude_argv_flag: Option<String>,
+) -> Result<()> {
     init_tracing();
     let paths = CcteamPaths::from_env()?;
 
@@ -537,11 +551,20 @@ fn run_start(tick_seconds: u64, skip_tool_check: bool) -> Result<()> {
         );
     }
 
-    let config = OrchestratorConfig {
+    // F29 — precedence: CLI flag > CCTEAM_CLAUDE_ARGV env > production
+    // default. `OrchestratorConfig::default()` already reads the env;
+    // the flag layers on top.
+    let mut config = OrchestratorConfig {
         tick_interval: Duration::from_secs(tick_seconds.max(1)),
         skip_tool_check,
         ..OrchestratorConfig::default()
     };
+    if let Some(raw) = claude_argv_flag {
+        let parts: Vec<String> = raw.split_whitespace().map(String::from).collect();
+        if !parts.is_empty() {
+            config.claude_argv = parts;
+        }
+    }
     // Write the pidfile *before* constructing the orchestrator so a
     // second `ccteam start` against the same root errors out cleanly
     // before either side has touched tmux.

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -657,10 +657,13 @@ pub fn install_mcp_into(claude_json: &std::path::Path, ccteam_bin: &std::path::P
 
 /// Production path: locate `~/.claude.json` and the running binary,
 /// then call `install_mcp_into`.
+///
+/// V0.2.1 F26: honors `CLAUDE_CONFIG_HOME` via
+/// [`ccteam_core::projects::resolve_claude_json_path`] so e2e harnesses
+/// get the same redirection sibling installers (`--install-skill`,
+/// `--install-memory-bridge`) already honor through `user_claude_dir()`.
 pub fn install_mcp() -> Result<std::path::PathBuf> {
-    let claude_json = dirs::home_dir()
-        .ok_or_else(|| anyhow!("could not resolve home directory"))?
-        .join(".claude.json");
+    let claude_json = ccteam_core::projects::resolve_claude_json_path()?;
     let bin = ccteam_core::current_ccteam_bin()?;
     install_mcp_into(&claude_json, &bin)?;
     Ok(claude_json)

--- a/crates/ccteam-cli/tests/doctor_validate_team_fail_loud_test.rs
+++ b/crates/ccteam-cli/tests/doctor_validate_team_fail_loud_test.rs
@@ -1,0 +1,92 @@
+//! F30 — `ccteam doctor --validate-team <team>` must be fail-loud:
+//! any `[FAIL]` line (phase-section or plugin-manifest section) bubbles
+//! a non-zero process exit. Run as integration tests so the
+//! `XDG_CONFIG_HOME` env mutation runs in its own process and doesn't
+//! race against unit tests in the same binary (CLAUDE.md §六 rule).
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Run `ccteam doctor --validate-team <team>` with `CCTEAM_HOME` and
+/// `XDG_CONFIG_HOME` pointed at the tempdir so the test cannot pollute
+/// the developer's real `~/.ccteam/` or `~/.config/ccteam/`.
+fn run_doctor_validate(
+    home: &std::path::Path,
+    xdg: &std::path::Path,
+    team: &str,
+) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    Command::new(bin)
+        .arg("doctor")
+        .arg("--validate-team")
+        .arg(team)
+        .env("CCTEAM_HOME", home)
+        .env("XDG_CONFIG_HOME", xdg)
+        // Override HOME too so the staging-dir fallback (resolver's
+        // last branch) cannot escape the tempdir.
+        .env("HOME", xdg)
+        .output()
+        .expect("spawn ccteam doctor")
+}
+
+#[test]
+fn validate_team_unknown_team_exits_nonzero() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("ccteam-home");
+    let xdg = tmp.path().join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&xdg).unwrap();
+
+    let out = run_doctor_validate(&home, &xdg, "totally-unknown");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit; stdout={stdout}; stderr={stderr}",
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("[FAIL] team.yaml load"),
+        "expected fail line; got stdout={stdout}; stderr={stderr}",
+    );
+}
+
+#[test]
+fn validate_team_corrupt_plugin_manifest_exits_nonzero() {
+    // Stage a plugin tree with a deliberately-broken plugin.json
+    // (missing required `author` field) at the user staging dir for a
+    // synthetic team. Without resetting shipped teams the team.yaml
+    // resolution will fail, but the plugin-section [FAIL] runs first
+    // and is what we want to count — the assertion confirms the
+    // plugin-section finding is in the report and the exit is non-zero.
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("ccteam-home");
+    let xdg = tmp.path().join("xdg");
+    std::fs::create_dir_all(&home).unwrap();
+
+    // staging_dir_for default = `$XDG_CONFIG_HOME/ccteam/teams/<name>/`
+    let staging = xdg.join("ccteam").join("teams").join("smoketeam");
+    std::fs::create_dir_all(staging.join(".claude-plugin")).unwrap();
+    std::fs::write(
+        staging.join(".claude-plugin/plugin.json"),
+        // Deliberately missing `author` → PluginManifest::validate fails.
+        r#"{"name":"smoketeam","description":"corrupt fixture"}"#,
+    )
+    .unwrap();
+    std::fs::write(staging.join("team.yaml"), "name: smoketeam\n").unwrap();
+    std::fs::create_dir_all(staging.join("phases")).unwrap();
+
+    let out = run_doctor_validate(&home, &xdg, "smoketeam");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit; stdout={stdout}; stderr={stderr}",
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("[FAIL] plugin.json"),
+        "expected plugin-section fail in report; got stdout={stdout}; stderr={stderr}",
+    );
+}

--- a/crates/ccteam-cli/tests/install_mcp_claude_config_home_test.rs
+++ b/crates/ccteam-cli/tests/install_mcp_claude_config_home_test.rs
@@ -1,0 +1,69 @@
+//! F26 — `install_mcp()` honors `CLAUDE_CONFIG_HOME` so e2e harnesses
+//! redirect the `.claude.json` mcpServers write away from the
+//! developer's real `~/.claude.json`.
+//!
+//! Mirrors the redirection sibling installers
+//! (`--install-skill`, `--install-memory-bridge`) get through
+//! `user_claude_dir()`. Pre-V0.2.1 `install_mcp()` went straight
+//! through `dirs::home_dir()` and ignored the env, which forced e2e
+//! suites to override `HOME` instead.
+
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[test]
+fn install_mcp_writes_to_claude_config_home_when_set() {
+    let tmp = TempDir::new().unwrap();
+    // CLAUDE_CONFIG_HOME points at a `.claude/` dir. The `.claude.json`
+    // file is its sibling — same convention as the trust-entry writer
+    // (`projects::resolve_claude_json_path`).
+    let claude_dir = tmp.path().join("isolated").join(".claude");
+    std::fs::create_dir_all(&claude_dir).unwrap();
+    let expected_json = tmp.path().join("isolated").join(".claude.json");
+    assert!(
+        !expected_json.exists(),
+        "fixture: .claude.json should not exist yet",
+    );
+
+    // Sandbox HOME so even if the env-resolution logic regresses we
+    // don't pollute the developer's real home dir.
+    let fake_home = tmp.path().join("fake-home");
+    std::fs::create_dir_all(&fake_home).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let out = Command::new(bin)
+        .args(["doctor", "--install-mcp"])
+        .env("CLAUDE_CONFIG_HOME", &claude_dir)
+        .env("HOME", &fake_home)
+        .env("CCTEAM_HOME", tmp.path().join("ccteam-home"))
+        .output()
+        .expect("spawn ccteam doctor --install-mcp");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "doctor --install-mcp should succeed; stdout={stdout}; stderr={stderr}",
+    );
+
+    assert!(
+        expected_json.exists(),
+        "expected install_mcp to write {} (CLAUDE_CONFIG_HOME redirect); stdout={stdout}",
+        expected_json.display(),
+    );
+    // Sanity: the real fake_home/.claude.json should NOT be touched.
+    assert!(
+        !fake_home.join(".claude.json").exists(),
+        "install_mcp wrote to fallback HOME path despite CLAUDE_CONFIG_HOME being set",
+    );
+
+    // mcpServers.ccteam landed.
+    let body = std::fs::read_to_string(&expected_json).unwrap();
+    let parsed: Value = serde_json::from_str(&body).unwrap();
+    assert!(
+        parsed["mcpServers"]["ccteam"].is_object(),
+        "expected mcpServers.ccteam in {}; got: {body}",
+        expected_json.display(),
+    );
+}

--- a/crates/ccteam-cli/tests/start_claude_argv_flag_test.rs
+++ b/crates/ccteam-cli/tests/start_claude_argv_flag_test.rs
@@ -1,0 +1,23 @@
+//! F29 — `ccteam start --claude-argv "<line>"` parses and the help
+//! text advertises the flag. The flag plumbs through to
+//! `OrchestratorConfig.claude_argv` (verified at the lib level in
+//! `crates/ccteam-core/tests/orchestrator_claude_argv_env_test.rs`);
+//! this test only confirms the CLI surface so a typo doesn't silently
+//! drop the flag.
+
+use std::process::Command;
+
+#[test]
+fn ccteam_start_help_advertises_claude_argv_flag() {
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let out = Command::new(bin)
+        .args(["start", "--help"])
+        .output()
+        .expect("spawn ccteam start --help");
+    assert!(out.status.success(), "ccteam start --help should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--claude-argv"),
+        "help text should mention --claude-argv; got: {stdout}",
+    );
+}

--- a/crates/ccteam-core/src/daemon.rs
+++ b/crates/ccteam-core/src/daemon.rs
@@ -239,6 +239,13 @@ pub fn check_health(paths: &CcteamPaths) -> DaemonHealth {
     check_health_at(&heartbeat_path(paths), SystemTime::now())
 }
 
+/// V0.2.1 F27 — boolean variant of [`check_health`] for callers that
+/// only care "up or down" (text/json `ls` annotation). Returns `true`
+/// iff the heartbeat is fresh; missing or stale heartbeat → `false`.
+pub fn heartbeat_alive(paths: &CcteamPaths) -> bool {
+    check_health(paths).is_healthy()
+}
+
 /// Testable inner: classify based on the file at `path` relative to `now`.
 pub fn check_health_at(path: &Path, now: SystemTime) -> DaemonHealth {
     let metadata = match std::fs::metadata(path) {

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -47,7 +47,7 @@ use crate::tool_surface::{user_claude_dir, ToolSurfaceSnapshot};
 /// `Orchestrator::process_project` looks this up by `state.team` and
 /// uses the right `dag` for state-machine transitions, so dev and
 /// product-research can run concurrently without a global team flag.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TeamRuntime {
     pub spec: TeamSpec,
     pub templates: Vec<PhaseTemplate>,
@@ -233,14 +233,36 @@ pub const DEFAULT_CLAUDE_MODEL: &str = "claude-sonnet-4-6[1m]";
 
 impl Default for OrchestratorConfig {
     fn default() -> Self {
+        // F29 — `CCTEAM_CLAUDE_ARGV` lets CLI / e2e harness inject a
+        // stub claude (eg `sh -c 'echo …'`) without rebuilding the
+        // binary. Whitespace-split for shell-style invocation; empty /
+        // unset = production default below. CLI flag still wins via
+        // an explicit `OrchestratorConfig.claude_argv` assignment in
+        // `ccteam start`.
+        let claude_argv = std::env::var("CCTEAM_CLAUDE_ARGV")
+            .ok()
+            .and_then(|raw| {
+                let parts: Vec<String> = raw
+                    .split_whitespace()
+                    .map(String::from)
+                    .collect();
+                if parts.is_empty() {
+                    None
+                } else {
+                    Some(parts)
+                }
+            })
+            .unwrap_or_else(|| {
+                vec![
+                    "claude".into(),
+                    "--dangerously-skip-permissions".into(),
+                    "--model".into(),
+                    DEFAULT_CLAUDE_MODEL.into(),
+                ]
+            });
         Self {
             tick_interval: Duration::from_secs(30),
-            claude_argv: vec![
-                "claude".into(),
-                "--dangerously-skip-permissions".into(),
-                "--model".into(),
-                DEFAULT_CLAUDE_MODEL.into(),
-            ],
+            claude_argv,
             ready_timeout: Duration::from_secs(60),
             post_ready_warmup: Duration::from_secs(3),
             skip_tool_check: false,
@@ -345,6 +367,50 @@ impl Orchestrator {
         self.teams.get(team)
     }
 
+    /// V0.2.1 F28 — project-scoped resolution. When the project carries
+    /// a `<project_dir>/.ccteam/team/team.yaml`, that override wins over
+    /// the global cache. Otherwise returns a borrowed handle to the
+    /// cached runtime so the common case stays zero-allocation.
+    ///
+    /// `Cow` lets the rare project-override case return an owned
+    /// `TeamRuntime` (rebuilt by re-resolving + reloading phase
+    /// templates from the override's team_dir) while the dominant
+    /// "no override" path keeps the original `&TeamRuntime` semantics.
+    /// Callers that don't need the override can keep using
+    /// [`Self::team_runtime`].
+    pub fn team_runtime_for_state<'a>(
+        &'a self,
+        state: &ProjectState,
+    ) -> Option<std::borrow::Cow<'a, TeamRuntime>> {
+        let project_dir = self.paths.project_dir(&state.slug);
+        let override_yaml = project_dir
+            .join(".ccteam")
+            .join("team")
+            .join("team.yaml");
+        if !override_yaml.exists() {
+            return self
+                .team_runtime(&state.team)
+                .map(std::borrow::Cow::Borrowed);
+        }
+        // Project has an override — re-resolve + rebuild a TeamRuntime
+        // from the override's team_dir. The override is per-project so
+        // we deliberately do NOT cache.
+        match build_project_team_runtime(&self.paths, state, &project_dir) {
+            Ok(rt) => Some(std::borrow::Cow::Owned(rt)),
+            Err(err) => {
+                tracing::warn!(
+                    team = %state.team,
+                    slug = %state.slug,
+                    error = format!("{err:#}"),
+                    "project-layer team override failed to build; \
+                     falling back to global cached runtime",
+                );
+                self.team_runtime(&state.team)
+                    .map(std::borrow::Cow::Borrowed)
+            }
+        }
+    }
+
     /// Iterate every registered team. Used by `ccteam doctor` and tests.
     pub fn teams(&self) -> impl Iterator<Item = &TeamRuntime> {
         self.teams.values()
@@ -409,7 +475,9 @@ impl Orchestrator {
         // shape only when the team or template is missing (e.g. an
         // unknown team `state.team` slipped past validation), keeping
         // the dispatch path resilient.
-        let prompt = match self.team_runtime(&state.team) {
+        // V0.2.1 F28: project-layer override wins via
+        // `team_runtime_for_state`.
+        let prompt = match self.team_runtime_for_state(state) {
             Some(team) => match team.templates.iter().find(|tpl| tpl.name == phase) {
                 Some(template) => {
                     let protocol_dirs: Vec<&str> = team
@@ -470,7 +538,8 @@ impl Orchestrator {
         let Some(prev) = state.phase_history.last() else {
             return Vec::new();
         };
-        let Some(team) = self.team_runtime(&state.team) else {
+        // V0.2.1 F28: project-layer override wins.
+        let Some(team) = self.team_runtime_for_state(state) else {
             return Vec::new();
         };
         let Some(template) = team.templates.iter().find(|t| t.name == prev.phase) else {
@@ -628,7 +697,10 @@ impl Orchestrator {
         // always tries to come up. (§6.4 candidate 5 declarative replacement
         // for the prior `state.team == META_TEAM_NAME` literal.)
         let is_evergreen = self.is_evergreen(&state.team);
-        let team_dag = self.team_runtime(&state.team).map(|t| &t.dag);
+        // V0.2.1 F28: project-layer override wins for the DAG used to
+        // gate the "terminal state" early-exit.
+        let team_for_dag = self.team_runtime_for_state(state);
+        let team_dag = team_for_dag.as_deref().map(|t| &t.dag);
         if !is_evergreen && team_dag.is_some_and(|d| d.is_terminal_state(state)) {
             return Ok(());
         }
@@ -693,7 +765,9 @@ impl Orchestrator {
         // state.json is a misconfiguration — we log + skip rather
         // than panicking so a single broken project doesn't take the
         // whole orchestrator down.
-        let team = match self.team_runtime(&state.team) {
+        // V0.2.1 F28: project-layer override wins for the duration of
+        // this `process_project` call (re-resolved per tick, no cache).
+        let team_cow = match self.team_runtime_for_state(&state) {
             Some(t) => t,
             None => {
                 tracing::error!(
@@ -705,6 +779,7 @@ impl Orchestrator {
                 return Ok(state);
             }
         };
+        let team: &TeamRuntime = team_cow.as_ref();
         const MAX_ITERS: u32 = 4;
         let progress_path = self.paths.progress_jsonl(slug);
         let state_path = self.paths.project_state(slug);
@@ -1414,8 +1489,9 @@ impl Orchestrator {
         if matches!(policy, CostPolicy::None) {
             return Ok(Some(state));
         }
+        // V0.2.1 F28: project-layer override wins for terminal-state check.
         if self
-            .team_runtime(&state.team)
+            .team_runtime_for_state(&state)
             .is_some_and(|t| t.dag.is_terminal_state(&state))
         {
             return Ok(Some(state));
@@ -1493,7 +1569,9 @@ impl Orchestrator {
         if self.is_evergreen(&state.team) {
             return;
         }
-        let team = self.team_runtime(&state.team);
+        // V0.2.1 F28: project-layer override wins.
+        let team_cow = self.team_runtime_for_state(state);
+        let team: Option<&TeamRuntime> = team_cow.as_deref();
         if team.is_some_and(|t| t.dag.is_terminal_state(state)) {
             return;
         }
@@ -1842,6 +1920,101 @@ fn load_team_runtimes(paths: &CcteamPaths) -> Result<HashMap<String, TeamRuntime
         );
     }
     Ok(teams)
+}
+
+/// V0.2.1 F28 — rebuild a single team's runtime from a project-layer
+/// override. Called per-tick (no caching) so a project can edit its
+/// `<project_dir>/.ccteam/team/team.yaml` without restarting the
+/// orchestrator. The override's `phase_dir` is resolved relative to the
+/// project's `team_dir` (`<project_dir>/.ccteam/team/`); when the
+/// override doesn't ship phase markdowns, the resolution falls back
+/// through TEAM_SOURCES so user / repo phase templates still drive the
+/// DAG (the override is mainly for spec-level fields like
+/// `golden_rules` / `description`).
+fn build_project_team_runtime(
+    paths: &CcteamPaths,
+    state: &ProjectState,
+    project_dir: &Path,
+) -> Result<TeamRuntime> {
+    use crate::team_resolver::{
+        default_user_staging_dir, resolve_team, TeamResolveContext, TEAM_SOURCES,
+    };
+
+    let user_staging = default_user_staging_dir();
+    let ctx = TeamResolveContext::for_orchestrator(&paths.root, &user_staging)
+        .with_project(project_dir);
+
+    let spec = resolve_team(&state.team, &ctx)
+        .with_context(|| format!("project-layer resolve team `{}`", state.team))?;
+
+    if spec.evergreen {
+        let dag = Dag::from_templates(&[]).with_context(|| {
+            format!("team `{}` build empty phase DAG (project layer)", spec.name)
+        })?;
+        return Ok(TeamRuntime {
+            spec,
+            templates: Vec::new(),
+            dag,
+        });
+    }
+
+    // Locate phase_dir on disk via the same priority order the
+    // resolver used for the spec. The override's team_dir is
+    // `<project_dir>/.ccteam/team/`; if the override only carries
+    // a `team.yaml` (no phases/ subdir), fall through to user/repo
+    // so phase markdowns still load.
+    let team_dir = TEAM_SOURCES
+        .iter()
+        .filter_map(|s| s.path_for(&state.team, &ctx))
+        .find(|p| p.exists())
+        .and_then(|p| p.parent().map(Path::to_path_buf))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "project-layer team `{}` resolved spec but no team_dir found",
+                state.team,
+            )
+        })?;
+    let phase_dir = team_dir.join(&spec.phase_dir);
+    let templates = if phase_dir.exists() {
+        load_phase_templates(&phase_dir)?
+    } else {
+        // Project override carried just team.yaml; reuse user/repo
+        // phase markdowns by walking sources skipping the project layer.
+        let fallback_ctx =
+            TeamResolveContext::for_orchestrator(&paths.root, &user_staging);
+        let fallback_team_dir = TEAM_SOURCES
+            .iter()
+            .filter_map(|s| s.path_for(&state.team, &fallback_ctx))
+            .find(|p| p.exists())
+            .and_then(|p| p.parent().map(Path::to_path_buf));
+        match fallback_team_dir {
+            Some(d) => {
+                let pd = d.join(&spec.phase_dir);
+                if pd.exists() {
+                    load_phase_templates(&pd)?
+                } else {
+                    Vec::new()
+                }
+            }
+            None => Vec::new(),
+        }
+    };
+    for t in &templates {
+        t.validate_m0().with_context(|| {
+            format!(
+                "project-layer team `{}` template `{}` failed M0 validation",
+                spec.name, t.name,
+            )
+        })?;
+    }
+    let dag = Dag::from_templates(&templates).with_context(|| {
+        format!("project-layer team `{}` build phase DAG", spec.name)
+    })?;
+    Ok(TeamRuntime {
+        spec,
+        templates,
+        dag,
+    })
 }
 
 /// M3.6: static intersection of `open_decisions` (outbox basenames the

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -301,7 +301,12 @@ pub fn pre_trust_project(project_dir: &Path) -> Result<()> {
 /// isolation tests (`tool_surface_e2e_test`-style) get a redirected
 /// trust write too. Production sets neither and falls through to
 /// `dirs::home_dir()`.
-fn resolve_claude_json_path() -> Result<PathBuf> {
+///
+/// Also reused by `ccteam doctor --install-mcp` (V0.2.1 F26) so the
+/// MCP install path honors the same env redirection as the trust-entry
+/// writer and the sibling `--install-skill` / `--install-memory-bridge`
+/// paths.
+pub fn resolve_claude_json_path() -> Result<PathBuf> {
     resolve_claude_json_path_from_env(
         std::env::var("CLAUDE_CONFIG_HOME").ok(),
         dirs::home_dir(),

--- a/crates/ccteam-core/src/team.rs
+++ b/crates/ccteam-core/src/team.rs
@@ -29,6 +29,7 @@ use crate::phases::GoldenRule;
 /// each field as a tagged document so future projects can pull only
 /// the field types relevant to their own team.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct RetroFieldSpec {
     /// snake_case field name. Used as the markdown subsection slug
     /// AND the RAG index tag, so keep it stable per team — renaming
@@ -102,6 +103,7 @@ impl Default for GoldenRuleEnforcement {
 ///   `cmd` / `pattern` are tolerated (ignored) but trigger a warn so
 ///   operators notice the dead field.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ProtocolRule {
     pub rule_id: String,
     #[serde(default)]
@@ -120,6 +122,7 @@ pub struct ProtocolRule {
 /// the inject prompt. Phase markdown bodies may also reference domain
 /// rules implicitly (the user's freedom; doctor doesn't lint bodies).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DomainRule {
     pub rule_id: String,
     pub directive: String,
@@ -175,19 +178,25 @@ impl<'de> Deserialize<'de> for TeamGoldenRules {
         use serde::de::Error as DeError;
 
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Structured {
+            #[serde(default)]
+            protocol: Vec<ProtocolRule>,
+            #[serde(default)]
+            domain: Vec<DomainRule>,
+        }
+
+        #[derive(Deserialize)]
         #[serde(untagged)]
         enum Either {
-            Structured {
-                #[serde(default)]
-                protocol: Vec<ProtocolRule>,
-                #[serde(default)]
-                domain: Vec<DomainRule>,
-            },
+            Structured(Structured),
             Legacy(Vec<GoldenRule>),
         }
 
         match Either::deserialize(d).map_err(D::Error::custom)? {
-            Either::Structured { protocol, domain } => Ok(TeamGoldenRules { protocol, domain }),
+            Either::Structured(Structured { protocol, domain }) => {
+                Ok(TeamGoldenRules { protocol, domain })
+            }
             Either::Legacy(list) => Ok(TeamGoldenRules {
                 protocol: list
                     .into_iter()
@@ -213,6 +222,7 @@ impl<'de> Deserialize<'de> for TeamGoldenRules {
 /// All fields default so an M3 team.yaml can ship without any
 /// `critic_dimensions:` block — M5 will start adding them.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CriticDimensionSpec {
     /// snake_case name. Used as the dimension identifier in M5
     /// scoring output and as the RAG tag for cross-project memory.
@@ -263,6 +273,7 @@ impl Default for CriticStrictness {
 /// mechanism. The `route` field selects which built-in `kind` the
 /// orchestrator uses to handle the escalate event.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EscalateGrammarExtension {
     /// e.g. `MARKET_DUPLICATE` / `HYPOTHESIS_REJECTED`. Free-form
     /// uppercase by convention; the Stop hook matches on this exact
@@ -342,6 +353,7 @@ impl Default for CostPolicy {
 /// orchestrator can route phases / ESCALATE prefixes / golden-rule
 /// enforcement per team without ccteam-core knowing the team name.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TeamSpec {
     /// Team identifier. Must match the `--team` arg / `state.json.team`
     /// field. snake-case lowercase — gets used as a directory name.
@@ -1171,5 +1183,41 @@ mod tests {
         assert_eq!(spec.phase_dir, "phases");
         assert_eq!(spec.verdict_schema, vec!["verdict".to_string()]);
         assert_eq!(spec.escalate_grammar_extensions.len(), 3);
+    }
+
+    // F31 — `deny_unknown_fields` fail-loud on typo'd / unknown keys
+    // (V0.2.1). Two negatives: one at TeamSpec top level, one at a
+    // nested struct (RetroFieldSpec). Other nested structs share the
+    // same serde attribute path so coverage is by symmetry.
+
+    #[test]
+    fn f31_top_level_unknown_field_fails_loud() {
+        // typo: `cost_polciy` instead of `cost_policy` — pre-V0.2.1
+        // this silently fell back to defaults.
+        let src = "name: dev\ncost_polciy: none\n";
+        let err = TeamSpec::parse(src).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown field") && msg.contains("cost_polciy"),
+            "expected unknown-field error mentioning `cost_polciy`, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn f31_nested_unknown_field_fails_loud() {
+        // typo inside a retro_schema entry — `descripton` instead of
+        // `description`.
+        let src = concat!(
+            "name: dev\n",
+            "retro_schema:\n",
+            "  - field: tech_stack\n",
+            "    descripton: Languages used\n",
+        );
+        let err = TeamSpec::parse(src).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unknown field") && msg.contains("descripton"),
+            "expected unknown-field error mentioning `descripton`, got: {msg}",
+        );
     }
 }

--- a/crates/ccteam-core/src/team_factory.rs
+++ b/crates/ccteam-core/src/team_factory.rs
@@ -278,9 +278,15 @@ fn render_phase_scaffold(scaffold: &PhaseScaffold<'_>) -> String {
             yaml.push_str(&format!("- `{output}`\n"));
         }
     }
+    // F33 — V0.2 e2e retro flagged the prior wording for naming the
+    // protocol keywords inline (even backticked, an LLM reading the
+    // body could mistake them for signal). Replace with intent-only
+    // wording — the inject prompt remains the single producer of the
+    // actual control sequences.
     yaml.push_str(
-        "\n> 本文件由 ccteam team factory 生成。正文是任务描述,正文不写协议关键字\n\
-         > (`PHASE_DONE` / `ESCALATE` 由 orchestrator inject prompt 注入)。\n",
+        "\n> 本文件由 ccteam team factory 生成。正文只描述领域任务;\n\
+         > 阶段切换 / 升级信号由 orchestrator 在每次 phase prompt 注入时附带,\n\
+         > 不要在正文里复述。\n",
     );
     yaml
 }
@@ -618,6 +624,8 @@ mod tests {
     fn init_phase_body_excludes_protocol_literals() {
         // V0.2 M0.18: phase markdown bodies must not carry PHASE_DONE /
         // ESCALATE. Those are inject-prompt-only.
+        // V0.2.1 F33: also forbid the bare-token form so an LLM reading
+        // the body can't mistake even a backticked token for signal.
         let tmp = TempDir::new().unwrap();
         let report = run_init(&tmp);
         for path in &report.phase_paths {
@@ -630,6 +638,18 @@ mod tests {
             assert!(
                 !body.contains("ESCALATE:"),
                 "phase {} body has ESCALATE literal",
+                path.display(),
+            );
+            // F33 — bare-token form (no colon, but recognizable). Both
+            // backticked (`PHASE_DONE`) and unbacked tokens count.
+            assert!(
+                !body.contains("PHASE_DONE"),
+                "phase {} body has bare PHASE_DONE token (F33)",
+                path.display(),
+            );
+            assert!(
+                !body.contains("ESCALATE"),
+                "phase {} body has bare ESCALATE token (F33)",
                 path.display(),
             );
         }

--- a/crates/ccteam-core/tests/orchestrator_claude_argv_env_test.rs
+++ b/crates/ccteam-core/tests/orchestrator_claude_argv_env_test.rs
@@ -1,0 +1,54 @@
+//! F29 — `OrchestratorConfig::default()` reads `CCTEAM_CLAUDE_ARGV`
+//! when set so e2e harnesses can inject a stub claude without
+//! rebuilding the binary.
+//!
+//! Env-mutating tests live in their own integration binary per
+//! CLAUDE.md §六 ("env-mutating tests放 `crates/*/tests/*.rs`
+//! integration (各独立进程)") so they don't race against unit-test
+//! readers of the same env var inside the lib binary.
+
+use ccteam_core::OrchestratorConfig;
+
+/// Each test mutates the same env var — serialize them within this
+/// binary using a static mutex so the precedence checks don't race.
+fn env_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[test]
+fn default_reads_ccteam_claude_argv_when_set() {
+    let _g = env_lock().lock().unwrap();
+    std::env::set_var("CCTEAM_CLAUDE_ARGV", "sh -c echo-stub");
+    let cfg = OrchestratorConfig::default();
+    assert_eq!(
+        cfg.claude_argv,
+        vec!["sh".to_string(), "-c".to_string(), "echo-stub".to_string()],
+    );
+    std::env::remove_var("CCTEAM_CLAUDE_ARGV");
+}
+
+#[test]
+fn default_falls_back_to_claude_when_env_missing() {
+    let _g = env_lock().lock().unwrap();
+    std::env::remove_var("CCTEAM_CLAUDE_ARGV");
+    let cfg = OrchestratorConfig::default();
+    assert_eq!(cfg.claude_argv.first().map(String::as_str), Some("claude"));
+    assert!(
+        cfg.claude_argv
+            .iter()
+            .any(|a| a == "--dangerously-skip-permissions"),
+        "default argv should carry --dangerously-skip-permissions; got {:?}",
+        cfg.claude_argv,
+    );
+}
+
+#[test]
+fn default_treats_empty_env_as_unset() {
+    let _g = env_lock().lock().unwrap();
+    std::env::set_var("CCTEAM_CLAUDE_ARGV", "   ");
+    let cfg = OrchestratorConfig::default();
+    // All-whitespace env collapses to no parts → fallback to default.
+    assert_eq!(cfg.claude_argv.first().map(String::as_str), Some("claude"));
+    std::env::remove_var("CCTEAM_CLAUDE_ARGV");
+}

--- a/crates/ccteam-core/tests/team_resolver_project_layer_e2e_test.rs
+++ b/crates/ccteam-core/tests/team_resolver_project_layer_e2e_test.rs
@@ -1,0 +1,126 @@
+//! F28 — project-layer team override (`<project_dir>/.ccteam/team/team.yaml`)
+//! must win over the user / repo cached runtime when the orchestrator
+//! resolves a team for a specific project. Pre-V0.2.1 the production
+//! callers passed `for_orchestrator(...)` everywhere, so the Project
+//! source was dead code (M0.17 ship description claimed first-source-
+//! wins; e2e Suite B5 caught it).
+//!
+//! This test goes through the public `team_runtime_for_state` helper,
+//! which is the single seam the dispatch path uses post-V0.2.1.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ccteam_core::{
+    disable_tool_surface_bootstrap_for_tests, write_all_global_team_templates, CcteamPaths,
+    Orchestrator, OrchestratorConfig, Parallelism, PhaseState, ProjectState,
+};
+use tempfile::TempDir;
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_slug() -> String {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("f28-proj-{pid}-{n}")
+}
+
+fn fresh_paths(tmp: &TempDir) -> CcteamPaths {
+    CcteamPaths {
+        root: tmp.path().join("ccteam-home"),
+        projects_root: tmp.path().join("projects"),
+    }
+}
+
+fn fresh_state(slug: &str, team: &str) -> ProjectState {
+    let mut s = ProjectState::initial_for_team(slug.to_string(), team.to_string());
+    s.tmux_session = format!("ccteam-{slug}");
+    s.current_phase = "plan-eng".into();
+    s.phase_state = PhaseState::Idle;
+    s
+}
+
+#[test]
+fn project_layer_team_override_wins_over_repo_cached_runtime() {
+    disable_tool_surface_bootstrap_for_tests();
+
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    // Seed shipped teams in repo layer (`<root>/teams/dev/...`) so
+    // the orchestrator's startup walk caches a TeamRuntime keyed `dev`.
+    write_all_global_team_templates(&paths.root, false).unwrap();
+
+    // Build the orchestrator with the cache populated.
+    let config = OrchestratorConfig {
+        skip_tool_check: true,
+        ..OrchestratorConfig::default()
+    };
+    let orch = Orchestrator::new(paths.clone(), config).unwrap();
+
+    let slug = unique_slug();
+    let project_dir = paths.project_dir(&slug);
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    // Sanity: with no override the cached repo runtime drives.
+    let state = fresh_state(&slug, "dev");
+    let baseline = orch.team_runtime_for_state(&state).expect("dev runtime");
+    let baseline_desc = baseline.spec.description.clone();
+    drop(baseline);
+
+    // Now drop a project-layer override that mutates a spec field
+    // (description) so we can fingerprint which layer drove the
+    // resolver. The override copies the repo phase_dir convention so
+    // template loading keeps working without per-project markdowns.
+    let override_dir = project_dir.join(".ccteam").join("team");
+    std::fs::create_dir_all(&override_dir).unwrap();
+    std::fs::write(
+        override_dir.join("team.yaml"),
+        "name: dev\n\
+         description: F28-project-override\n",
+    )
+    .unwrap();
+
+    let after = orch.team_runtime_for_state(&state).expect("override runtime");
+    assert_eq!(
+        after.spec.description, "F28-project-override",
+        "project layer override should win; baseline desc was {baseline_desc:?}; \
+         got after.spec.description = {:?}",
+        after.spec.description,
+    );
+    // The DAG must still load (override carried only team.yaml; phase
+    // markdowns came from user/repo fallback).
+    assert!(!after.dag.is_empty(), "phase DAG should load via fallback");
+    assert!(
+        !after.templates.is_empty(),
+        "phase templates should load via fallback",
+    );
+}
+
+#[test]
+fn project_layer_no_override_returns_cached_repo_runtime() {
+    disable_tool_surface_bootstrap_for_tests();
+
+    let tmp = TempDir::new().unwrap();
+    let paths = fresh_paths(&tmp);
+    write_all_global_team_templates(&paths.root, false).unwrap();
+
+    let config = OrchestratorConfig {
+        skip_tool_check: true,
+        ..OrchestratorConfig::default()
+    };
+    let orch = Orchestrator::new(paths.clone(), config).unwrap();
+    let slug = unique_slug();
+    std::fs::create_dir_all(paths.project_dir(&slug)).unwrap();
+
+    let state = fresh_state(&slug, "dev");
+    let runtime = orch.team_runtime_for_state(&state).expect("dev runtime");
+    // No project override → matches Borrowed (the cached one)
+    assert!(matches!(runtime, std::borrow::Cow::Borrowed(_)));
+}
+
+// `Parallelism` is re-exported but not used directly; pull it in as a
+// compile-time check that the test fixture path doesn't drift away
+// from the public surface.
+#[allow(dead_code)]
+fn _parallelism_check() -> Parallelism {
+    Parallelism::Solo
+}

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -27,16 +27,16 @@
 **2026-05-06 post-M3/M4 sweep**:F2/F3/F4/F9/F10/F11/F12/F13/F20 由 M3 团队
 抽象 + M4 跨项目记忆批量关闭;**2026-05-07 fix_loop → auto_loop rename batch**:
 F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭;**2026-05-08 V0.2 M0.23**:加 F24 + F25
-P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候选),
-分布:
+P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候选;
+**2026-05-08 V0.2.1 patch**:F26-F33 全部修复),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
 | **P0 阻塞泛化(剩余)** | 0 | — |
-| **P1 该做但可后置(剩余)** | 6 | F15(M1+ block-push 时做)、F23(conditional;待 spike 重跑)、**F28 / F29 / F30 / F31(2026-05-08 V0.2 e2e 加,V0.2.1 候选)** |
-| **P2 边角(剩余)** | 5 | F17、**F26 / F27 / F32 / F33(2026-05-08 V0.2 e2e 加,V0.2.1 候选)** |
+| **P1 该做但可后置(剩余)** | 2 | F15(M1+ block-push 时做)、F23(conditional;待 spike 重跑) |
+| **P2 边角(剩余)** | 1 | F17 |
 | **N/A 已是领域无关** | 2 | F14, F19(M3 docs sweep 后)|
-| **已修复** | 20 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)、**F24 / F25(2026-05-08 M0.23 PR)** |
+| **已修复** | 28 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)、**F24 / F25(2026-05-08 M0.23 PR)**、**F26 / F27 / F28 / F29 / F30 / F31 / F32 / F33(2026-05-08 V0.2.1 patch)** |
 
 ### V0.2 §6 反模式候选状态(docs/v0-2/prd.md)
 
@@ -521,7 +521,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **后续**:Claude 团队若推出更新 model 别名(eg `claude-sonnet-4-7[1m]`),
   改 `DEFAULT_CLAUDE_MODEL` 一处即可;CLI flag 形式保持稳定。
 
-### F28 — Project-layer team override 是 dead code(2026-05-08 加,待 V0.2.1)
+### F28 — Project-layer team override 是 dead code(2026-05-08 加;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-core/src/team_resolver.rs:48-52`
   (`TEAM_SOURCES = [Project, User, Repo]`)+ `:139`(`with_project()`
@@ -537,8 +537,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   project 层真 first-source-wins。
 - **优先级**:**P1**(用户报"per-project override 不生效"时阻塞)。
 - **来源**:V0.2 e2e Suite B B5 / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:加 `Orchestrator::team_runtime_for_state(state)` (返回 `Cow<TeamRuntime>`);dispatch / process_project / stall / cost 命中 callsite 切到 project-aware lookup;`run_phase_show` 在 cwd 有 `.ccteam/team/team.yaml` 时走 `with_project(cwd)`;e2e test `team_resolver_project_layer_e2e_test.rs` 验证 project layer 真 first-source-wins。`TEAM_SOURCES::Project` enum variant 保留(M0.17 设计未改)。
 
-### F29 — 无 CLI/env stub-claude 注入路径(2026-05-08 加,待 V0.2.1)
+### F29 — 无 CLI/env stub-claude 注入路径(2026-05-08 加;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-core/src/orchestrator.rs:238`
   (`OrchestratorConfig.claude_argv` 仅 Rust struct);
@@ -552,8 +553,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   (shell-split);`ccteam start --claude-argv "<line>"` flag。
 - **优先级**:**P1**(testability;阻塞纯 CLI e2e 验证 phase loop)。
 - **来源**:V0.2 e2e Suite B B1/B2 / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:`OrchestratorConfig::default()` 读 `CCTEAM_CLAUDE_ARGV`(whitespace-split);`ccteam start --claude-argv "<line>"` flag(优先级:flag > env > default);integration tests `orchestrator_claude_argv_env_test.rs` + `start_claude_argv_flag_test.rs`。
 
-### F30 — `doctor --validate-team` `[FAIL]` 不影响 exit code(2026-05-08 加,待 V0.2.1)
+### F30 — `doctor --validate-team` `[FAIL]` 不影响 exit code(2026-05-08 加;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-cli/src/commands.rs::render_validate_team_report`
   (line 719 起);Summary 计数器只 sum 每 phase finding,plugin-section
@@ -567,8 +569,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   `[FAIL]` 进 Summary;exit code 据 `failures > 0` 设非零。
 - **优先级**:**P1**(team factory CI gating 缺位)。
 - **来源**:V0.2 e2e Suite D D7 / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:`render_validate_team_report` 改返回 `(String, u32 fails)`,plugin-section + phase-section `[FAIL]` 全部累计进 fails;`run_doctor` 在 `fails > 0` 时 `bail!` → 非零 exit code;integration test `doctor_validate_team_fail_loud_test.rs` 验证 unknown team / corrupt plugin manifest 都触发非零退出。
 
-### F31 — `TeamSpec` 缺 `#[serde(deny_unknown_fields)]`(2026-05-08 加;落实 M0.22 ⚠1,待 V0.2.1)
+### F31 — `TeamSpec` 缺 `#[serde(deny_unknown_fields)]`(2026-05-08 加;落实 M0.22 ⚠1;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-core/src/team.rs:107`(`TeamSpec` struct
   顶级)+ nested(`TeamGoldenRules` 等)。
@@ -581,6 +584,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   的 `TeamSpec` 严格 schema 互不冲突。**
 - **优先级**:**P1**(team factory ship 前最好修)。
 - **来源**:V0.2 e2e Suite D D8 / M0.22 PR ⚠1 / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:`#[serde(deny_unknown_fields)]` 加到 `TeamSpec` 顶层 + 所有 ccteam 自己定义的子结构(`RetroFieldSpec` / `ProtocolRule` / `DomainRule` / `TeamGoldenRules.Structured` / `CriticDimensionSpec` / `EscalateGrammarExtension`);`team::tests::f31_top_level_unknown_field_fails_loud` + `f31_nested_unknown_field_fails_loud` 验证 typo 触发 fail-loud。
 
 ---
 
@@ -623,7 +627,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **解耦方案**:F5 重命名时一并改,`fix_loop_test.rs` → `auto_loop_test.rs`。
 - **优先级**:**P2**(随 F5 一并改)。
 
-### F26 — `mcp_serve::install_mcp()` 不 honor `CLAUDE_CONFIG_HOME`(2026-05-08 加,待 V0.2.1)
+### F26 — `mcp_serve::install_mcp()` 不 honor `CLAUDE_CONFIG_HOME`(2026-05-08 加;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-cli/src/mcp_serve.rs:660-666`
   (用 `dirs::home_dir()` 写入 `~/.claude.json`,asymmetric with
@@ -634,8 +638,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **解耦方案**:走 `user_claude_dir()`(已 honor `CLAUDE_CONFIG_HOME`)。
 - **优先级**:**P2**(e2e harness 痛点,production 用户透明)。
 - **来源**:V0.2 e2e Suite A / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:`install_mcp()` 走 `ccteam_core::projects::resolve_claude_json_path()`(已 honor `CLAUDE_CONFIG_HOME`,与 trust-entry writer + sibling installers 对称);integration test `install_mcp_claude_config_home_test.rs` 验证 redirect。
 
-### F27 — `ccteam ls` 无 daemon health 注解(2026-05-08 加,待 V0.2.1)
+### F27 — `ccteam ls` 无 daemon health 注解(2026-05-08 加;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-cli/src/commands.rs::render_ls_text`
   (1391-1409 行;无 daemon section);`render_ls_json`(1422-1456;
@@ -651,8 +656,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **优先级**:**P2**(meta-agent 已可通过 MCP `ls` JSON `orchestrator`
   字段读取 — 该字段需先填值)。
 - **来源**:V0.2 e2e Suite A A5 / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:`daemon::heartbeat_alive(&Paths) -> bool` public helper;`render_ls_text` head 一行 `daemon: <up|down>`;`render_ls_json` `orchestrator.running` 改 bool;3 unit tests 覆盖 down / up / json shape。
 
-### F32 — daemon path doc drift(2026-05-08 加,docs-only)
+### F32 — daemon path doc drift(2026-05-08 加,docs-only;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`docs/v0-2/dev-plan.md §9` M0.23.1 写
   `~/.ccteam/daemon.{pid,heartbeat}`;实际代码路径
@@ -664,8 +670,9 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **解耦方案**:`docs/v0-2/dev-plan.md §9` M0.23.1 路径段更新一行。
 - **优先级**:**P2**(cosmetic;不影响代码)。
 - **来源**:V0.2 e2e Suite A / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:`docs/v0-2/dev-plan.md §9` M0.23.1 路径段更新为 `~/.ccteam/state/orchestrator.{pid,heartbeat}`,与 tech-design §6.8 / 实际代码对齐。
 
-### F33 — team factory phase scaffold body 含 bare protocol tokens(2026-05-08 加,待 V0.2.1)
+### F33 — team factory phase scaffold body 含 bare protocol tokens(2026-05-08 加;**已修复:2026-05-08(V0.2.1 PR)**)
 
 - **文件:行号**:`crates/ccteam-core/src/team_factory.rs` phase
   scaffold render(`init_phase_body_excludes_protocol_literals` test
@@ -681,6 +688,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   从 body 删,只在用户指南文档讲。
 - **优先级**:**P2**(cosmetic;validator 行为正确)。
 - **来源**:V0.2 e2e Suite D D5 / `docs/v0-2/e2e-retro.md`。
+- **2026-05-08 已修复(V0.2.1 PR)**:scaffold body 注释改为意图描述("阶段切换 / 升级信号由 orchestrator 在每次 phase prompt 注入时附带,不要在正文里复述"),不再出现协议关键字本身;`init_phase_body_excludes_protocol_literals` 测试加严:bare-token 形式(无 colon)也被检测。
 
 ---
 

--- a/docs/v0-2/dev-plan.md
+++ b/docs/v0-2/dev-plan.md
@@ -371,7 +371,7 @@ M0.16 (foundation)
 ### 任务
 
 - [ ] **M0.23.1** orchestrator daemon health supervision
-  - daemon 写 `~/.ccteam/daemon.pid` + `~/.ccteam/daemon.heartbeat`(每 30s)
+  - daemon 写 `~/.ccteam/state/orchestrator.pid` + `~/.ccteam/state/orchestrator.heartbeat`(每 30s;沿用 M1.5 `state/` 子目录约定 + `orchestrator.*` 命名)
   - MCP 任意命令入口 + meta-agent skill 启动时 health check
   - daemon 死亡时:meta-agent 立即 surface "daemon down",MCP 命令 fail-loud
 - [ ] **M0.23.2** 1M context 默认启用

--- a/docs/v0-2/e2e-retro.md
+++ b/docs/v0-2/e2e-retro.md
@@ -162,17 +162,17 @@ V0.2 **可 ship**。e2e 主路径(init / 迁移 / hook self-loop / watchdog 翻�
 
 ---
 
-## 6. V0.2.1 patch 计划(建议)
+## 6. V0.2.1 patch 计划(**全部完成:2026-05-08 V0.2.1 PR**)
 
 按工作量 + 影响排序:
 
-| Patch | F | 工作量 | 描述 |
-|---|---|---|---|
-| **P1** | F31 | <1h | 加 `#[serde(deny_unknown_fields)]` 到 `TeamSpec` + nested struct;补 1 个测试 |
-| **P2** | F30 | 1-2h | `render_validate_team_report` 累计 plugin-section `[FAIL]` 进 Summary + 非零 exit |
-| **P3** | F28 | 2-4h | `for_orchestrator` callsite 改 `with_project(state.project_dir)`;`run_phase_show` 同;补 e2e 验证 project-layer 真 first-source-wins |
-| **P4** | F29 | 1-2h | `OrchestratorConfig::default()` 读 `CCTEAM_CLAUDE_ARGV`;`ccteam start --claude-argv <shell-line>` flag。让 V0.2.2 e2e 真跑 phase loop |
-| **P5** | F26 / F27 / F32 / F33 | <1h each | env / 注解 / docs 各小修(可合 1 PR) |
+| Patch | F | 工作量 | 描述 | 状态 |
+|---|---|---|---|---|
+| **P1** | F31 | <1h | 加 `#[serde(deny_unknown_fields)]` 到 `TeamSpec` + nested struct;补 1 个测试 | **完成(V0.2.1 PR)** |
+| **P2** | F30 | 1-2h | `render_validate_team_report` 累计 plugin-section `[FAIL]` 进 Summary + 非零 exit | **完成(V0.2.1 PR)** |
+| **P3** | F28 | 2-4h | `for_orchestrator` callsite 改 `with_project(state.project_dir)`;`run_phase_show` 同;补 e2e 验证 project-layer 真 first-source-wins | **完成(V0.2.1 PR)** — `team_runtime_for_state` 返 `Cow<TeamRuntime>`,dispatch / process / stall / cost 切换 |
+| **P4** | F29 | 1-2h | `OrchestratorConfig::default()` 读 `CCTEAM_CLAUDE_ARGV`;`ccteam start --claude-argv <shell-line>` flag。让 V0.2.2 e2e 真跑 phase loop | **完成(V0.2.1 PR)** |
+| **P5** | F26 / F27 / F32 / F33 | <1h each | env / 注解 / docs 各小修(可合 1 PR) | **完成(V0.2.1 PR)** |
 
 **前置 NRS smoke**(用户 1 分钟):
 - NRS-1:`ccteam team init smoke && ccteam team publish smoke --target local && claude /plugin enable smoke@ccteam-local` — 看 stderr 是否含 "unknown key team.yaml"。结果决定 F31 是否升级 P0


### PR DESCRIPTION
## Summary

Closes 8 F-finding from V0.2 e2e retro (`docs/v0-2/e2e-retro.md` §3 + §6) — single PR, no new requirements, scope-locked dust patch.

### P1 medium (4)

- **F28 — Project-layer team override dead code → wired up**. `TEAM_SOURCES = [Project, User, Repo]` enum preserved (no deletion); `load_team_runtimes` / `run_phase_show` / `bootstrap_project` now call `with_project(<project_dir>)` instead of `for_orchestrator(...)`. Per-tick re-resolve when project override exists (no global cache shadowing); non-override path keeps zero-alloc `&TeamRuntime` via `Cow::Borrowed`. New e2e test asserts project-layer wins over repo.
- **F29 — stub-claude injection path**. `OrchestratorConfig::default()` reads `CCTEAM_CLAUDE_ARGV` env (whitespace-split). `ccteam start --claude-argv "<line>"` flag added. Priority: **flag > env > default**. Default unchanged (`claude --dangerously-skip-permissions --model claude-sonnet-4-6[1m]`).
- **F30 — `doctor --validate-team` `[FAIL]` now fail-loud**. `render_validate_team_report` accumulates plugin-section findings into Summary counter; `run_doctor` returns non-zero exit when any finding is `Fail` severity. Corruption test (delete `author` from `plugin.json`) gates non-zero exit.
- **F31 — `TeamSpec` strict schema**. `#[serde(deny_unknown_fields)]` added to `TeamSpec` + 6 nested structs (`RetroFieldSpec`, `EscalateGrammarExtension`, `CriticDimensionSpec`, `TeamGoldenRules`, `ProtocolRule`, `DomainRule` — `VerdictFieldSpec` doesn't exist; `verdict_schema` is `Vec<String>`). Two negative tests: typo at top-level + nested.

### P2 minor (4)

- **F26 — `install_mcp` honors `CLAUDE_CONFIG_HOME`**. Switched from `dirs::home_dir()` to `resolve_claude_json_path` (consistent with sibling install fns).
- **F27 — `ccteam ls` daemon health annotation**. New `daemon::heartbeat_alive(&Paths) -> bool` helper (stat mtime > 60s grace = stale). `render_ls_text` adds `daemon: <up|down>` head line; `render_ls_json` populates `orchestrator.running: bool` (was `null`).
- **F32 — daemon path doc drift**. `docs/v0-2/dev-plan.md §9` M0.23.1 path text corrected: `~/.ccteam/daemon.{pid,heartbeat}` → `~/.ccteam/state/orchestrator.{pid,heartbeat}` (matches actual code path).
- **F33 — team factory phase scaffold bare tokens**. Body comment rewrote; no protocol keywords (even backticked) appear in produced phase markdown bodies.

## Maps to

- Source: `docs/v0-2/e2e-retro.md` §3 (findings) + §6 (patch plan)
- Audit: `docs/dev-coupling-audit.md` F26-F33 each annotated `**已修复:2026-05-08(V0.2.1 PR)**` with implementation summary

## Test results

| Item | Before | After |
|---|---|---|
| `cargo test --workspace` | 497 / 0 | **511 / 0** (+14) |
| `cargo clippy --workspace --all-targets` warnings | 10 | **10** (0 new) |

New tests: 5 integration + 9 unit/inline:
- `tests/doctor_validate_team_fail_loud_test.rs` (F30, 2)
- `tests/install_mcp_claude_config_home_test.rs` (F26, 1)
- `tests/start_claude_argv_flag_test.rs` (F29, 1)
- `tests/orchestrator_claude_argv_env_test.rs` (F29, 3)
- `tests/team_resolver_project_layer_e2e_test.rs` (F28, 2)
- in-source: F31 (2 in `team.rs`), F27 (3 in `commands.rs`), F33 (existing test extended)

## Red-line grep

- `with_project|for_orchestrator` in `crates/ccteam-core/src/orchestrator.rs` + `crates/ccteam-cli/src/`: `with_project` now used in `build_project_team_runtime` and `run_phase_show` (no dead code); `for_orchestrator` retained at startup walk + plugin-validator + fallback paths.
- `deny_unknown_fields` in `crates/ccteam-core/src/team.rs`: **8 hits** (TeamSpec + 7 nested).
- bare `PHASE_DONE` / `ESCALATE` in `crates/ccteam-core/src/team_factory.rs` scaffold render: **0 hits** (only in source rustdoc comments + test assertions).
- `\bdev\b|\bproduct-research\b|\bmeta-agent\b` in `crates/ccteam-core/src/`: **0 new** literal additions.

## Documentation sync

- [x] `docs/dev-coupling-audit.md` — F26-F33 each marked `**已修复:2026-05-08(V0.2.1 PR)**` with implementation summary
- [x] `docs/dev-coupling-audit.md` summary table: P1 6→2, P2 5→1, 已修复 20→28
- [x] `docs/v0-2/e2e-retro.md` §6 — each patch row marked `完成(V0.2.1 PR)` with brief implementation note
- [x] `docs/v0-2/dev-plan.md §9` M0.23.1 path text corrected (F32)

## Notes / minor deviations

- **`VerdictFieldSpec` skipped** — doesn't exist in codebase (`verdict_schema` is `Vec<String>`); other ccteam-defined nested structs all got `deny_unknown_fields`.
- **F28 cache semantics** — re-resolve per tick when project override exists (per task instruction). Non-override path keeps zero-alloc `&TeamRuntime` via `Cow::Borrowed`. `TeamRuntime` gained `Clone` derive for `Cow::Owned` variant.
- **F30 signature change** — `render_validate_team_report`: `Result<String>` → `Result<(String, u32)>` (private fn; only caller is `run_doctor`).

## Test plan

- [ ] `cargo test --workspace` passes (511 / 0)
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] Manual: project-layer override at `<project>/.ccteam/team/team.yaml` wins over repo (F28 e2e covers this)
- [ ] Manual: `CCTEAM_CLAUDE_ARGV="sh -c 'echo test'" ccteam start --foreground` runs stub claude (F29)
- [ ] Manual: corrupt `plugin.json` (drop `author`), `ccteam doctor --validate-team my-team` returns non-zero exit (F30)
- [ ] Manual: `ccteam ls` head line shows `daemon: down` when heartbeat absent (F27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)