### PR TITLE
v0.2.2 PR #1: F39 cct convention sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 | 当前 next | V0.3 候选方向待定,deferred 项见 `docs/v0-2/README.md` 末尾 |
 | 永久 deferred | M2.2 agent_team enablement(spike A,Claude Code 无 first-class CLI surface — 见 `docs/v0-1/m2-agent-team-spike.md`)|
 
-**ccteam 是 Claude Code 之上的元工具,不是独立 AI 系统**:每个项目一个 Claude Code 长 session(tmux 守护,hooks 上报,MCP 接外部);Rust orchestrator 编排;用户通过 meta-agent(常驻 ccteam-managed claude session)+ `ccteam-control` skill / `ccteam-mcp` MCP 用自然语言对话操作。详见 `docs/tech-design.md` §2.1 三层架构。
+**ccteam 是 Claude Code 之上的元工具,不是独立 AI 系统**:每个项目一个 Claude Code 长 session(tmux 守护,hooks 上报,MCP 接外部);Rust orchestrator 编排(binary 名 `cct`,F39 起);用户通过 meta-agent(常驻 ccteam-managed claude session)+ `cct-control` skill / `ccteam` MCP server(`mcp__ccteam__*` 命名空间)用自然语言对话操作。详见 `docs/tech-design.md` §2.1 三层架构。
 
 ---
 
@@ -59,6 +59,7 @@
 - **retro 写 `~/.claude/rules/ccteam-lessons-<team>.md` 必须限 marked section**:`<!-- ccteam-managed:lessons begin/end -->` 包裹,不污染用户其他段;phase prompt 严格约束,doctor `--install-memory-bridge` 只重写自己段(幂等)
 - **新建项目目录走 `~/projects/<team>-<slug>/` 约定**(F22 后):`pick_unused_slug` 强制 team 前缀;meta-agent 仍 `<handle>-meta` 后缀(独立路径)
 - **`ccteam-core` 不出现 team 名字面量**:strategic doc §3 红线;团队特定行为靠 `team.yaml` 数据驱动
+- **`cct` 短前缀约定**(V0.2.2 F39):binary 名 `cct`,自带 skill `cct-control` / `cct-team-author`,顶层 `skills/` 目录是 SoT;**项目名仍叫 ccteam**(`crates/ccteam-{cli,core,hooks}` / `~/.ccteam/` / git repo / MCP 命名空间 `mcp__ccteam__*` 不动 — 详 PRD §8.3)。`cct doctor` 自带 V0.1/V0.2 → V0.2.2 迁移逻辑;新代码 / phase prompt / docs 一律用 `cct`
 
 ---
 
@@ -67,7 +68,7 @@
 | 机制 | 用途 | 文档 |
 |---|---|---|
 | **CLAUDE.md** | 项目级 / 用户级持久指令 | best-practices §4.1 |
-| **Skills** | `ccteam-control` skill(M1.8 ✅)/ `ccgram-messaging`(M3+ 多 orchestrator) | tech-design §6.7 |
+| **Skills** | `cct-control`(M1.8 ✅,V0.2.2 F39 改名)/ `cct-team-author`(M0.22 ✅)/ `ccgram-messaging`(M3+ 多 orchestrator);自带 skill SoT 在 repo 根 `skills/` | tech-design §6.7 |
 | **MCP** | `ccteam-mcp`(M2 ✅,9 tools)/ `claude-mem`(M4 可选) | tech-design §6.4 |
 | **Subagents** | phase 内 `Task(subagent_type=...)` 节流;`code-reviewer` 等 8 个 plugin agent 已 ln -sf | best-practices §6.3 |
 | **Hooks** | `progress.jsonl append` / `parse-phase-end` / `cost-accumulate` 已 ship;`Stop`/`SubagentStop`/`SessionEnd` 都进 idle 列表(F1+F2 修复) | tech-design §6.2 |
@@ -94,11 +95,22 @@
 
 跨 session 见主仓 dirty 状态:先 `git stash push -m "<owner-session> WIP"` 再切;别盲目 `git checkout -- .`。
 
+### Patch 版本(V0.x.y)开发流程
+
+1. **doc-first**:PRD + dev-plan 落 `docs/v0-x-y/`;用户 review 后才动代码
+2. **worktree-per-PR**:每个 finding 单独 `git worktree add -b <branch> /tmp/ccteam-<name> origin/main`
+3. **subagent 派工**:主 session 用 Agent 工具派每个 worktree(briefing 含 PRD section + 验收条目)
+4. **PR review/fix/merge**:主 session 拉 PR diff review → 退回 fix 或本地补 → merge
+5. **cargo bump**:`workspace.package.version` 同步 bump,commit subject 用 `vX.Y.Z:` 前缀
+6. **CLAUDE.md baseline 更新**:`cargo test --workspace` 通过新数后回填 §一表格
+
+(主仓 main 不变 dirty;worktree 工具流详上节"多 session 并行编辑同一仓库")
+
 ---
 
 ## 六、易踩的坑(实战累积)
 
-- **不要给 ccteam 自己加 ccteam 风格的 hook/orchestrator** — 循环引用排错地狱。本仓库用 Claude Code 默认行为开发,只产出物(`~/projects/<team>-<slug>/`)挂 ccteam hook
+- **不要给 ccteam 自己加 ccteam 风格的 hook/orchestrator** — 循环引用排错地狱。本仓库用 Claude Code 默认行为开发,只产出物(`~/projects/<team>-<slug>/`)挂 cct 自己的 hook
 - **`.claude/settings.json` 的 `bypassPermissions` 是开发态便利** — 产品形态是 `--dangerously-skip-permissions` + 容器隔离,语义不同(best-practices §4.2 三选一)
 - **phase prompt 别写太长** — 单条 send-keys 装得下;复杂内容用 `@文件引用`(best-practices §3)
 - **`claude-plugins-official` 是参考实现,不是依赖** — 别 vendor 一份;按 §3.7 三粒度选(@引用 / 拷贝改 / 整 plugin install)
@@ -108,5 +120,6 @@
 - **跨 session 协作时见到主仓 dirty 状态** → `git stash push -m "<owner-session> WIP"` 再切,别盲目 `git checkout -- .`
 - **改了 `ccteam-core` 公共 API**(如 `pick_unused_slug` 签名)→ grep 全 caller(包括 tests / mcp_serve.rs / commands.rs)
 - **F22 后 slug 带 team 前缀**:`run_new` test 期望 `dev-<base>` 而非 `<base>`;改新 slug 路径时验证 rules `paths:` 还匹配
-- **V0.1 → V0.2 升级一次性迁移**:M0.20 后 plugin agent 通过 spawned session `enabledPlugins` 启用,不再 ln -sf 进 `~/.claude/agents/`。V0.1 用户首次升级 V0.2 时跑 `ccteam doctor --migrate-recommended-agents` 清理旧 ln -sf(只删 ccteam 自己创建的 marketplace symlink,用户手写 agent 不动)
+- **V0.1 → V0.2 升级一次性迁移**:M0.20 后 plugin agent 通过 spawned session `enabledPlugins` 启用,不再 ln -sf 进 `~/.claude/agents/`。V0.1 用户首次升级 V0.2 时跑 `cct doctor --migrate-recommended-agents` 清理旧 ln -sf(只删 ccteam 自己创建的 marketplace symlink,用户手写 agent 不动)
+- **V0.2 → V0.2.2 升级一次性迁移**(F39):binary `ccteam` → `cct`,skill `ccteam-{control,team-author}` → `cct-{control,team-author}`。`cct doctor --install-skill` / `--install-meta-agent` 自动检测 + 清旧 skill dir(marker 校验,只清 ccteam-managed 的;用户手改保留 + warn) + rewrite `~/projects/<slug>/.claude/settings.json` 老 hook command 路径(原子写)
 - **本文件不超过 250 行** — CLAUDE.md 越长 cache 越贵,Claude 越忽略(best-practices §4.1 + §8)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You talk to a **meta-agent** — a permanent Claude Code session that understand
 ```
 You:    "Make a Rust CLI for managing bookmarks, SQLite-backed."
 Meta:   "I'll dispatch the dev team. Slug = dev-bookmark-cli-rust-sqlite.
-         Tracking via `ccteam show dev-bookmark-cli-rust-sqlite`."
+         Tracking via `cct show dev-bookmark-cli-rust-sqlite`."
 [~30 minutes later]
 Meta:   "dev-bookmark-cli-rust-sqlite shipped. 22 tests green, $4.80
          cost, retro lessons appended to ~/.claude/rules/ccteam-lessons-dev.md."
@@ -35,7 +35,7 @@ You:    "I want a team for iterating an existing app: new requirement →
          feasibility → architecture → implementation → tests → release."
 Meta:   "Drafting a custom team. Plugin manifest + 6 phase markdowns
          under ~/.config/ccteam/teams/iter-app/. Run
-         `ccteam team publish iter-app --target local` when ready."
+         `cct team publish iter-app --target local` when ready."
 ```
 
 ## Why ccteam
@@ -75,23 +75,23 @@ ccteam --version
 One-time setup (idempotent — re-runs are no-ops):
 
 ```bash
-ccteam init                                       # ~/.ccteam/ skeleton
-ccteam doctor --install-skill                     # ccteam-control skill (any claude session reaches ccteam)
-ccteam doctor --install-mcp                       # 9-tool MCP server in ~/.claude.json
-ccteam doctor --install-memory-bridge             # ~/.claude/rules/ccteam-lessons-<team>.md placeholders
-ccteam doctor --install-meta-agent <your-handle>  # bootstrap your meta-agent project
-ccteam doctor --tool-surface                      # health check (must be green)
+cct init                                       # ~/.ccteam/ skeleton
+cct doctor --install-skill                     # cct-control skill (any claude session reaches ccteam)
+cct doctor --install-mcp                       # 9-tool MCP server in ~/.claude.json
+cct doctor --install-memory-bridge             # ~/.claude/rules/ccteam-lessons-<team>.md placeholders
+cct doctor --install-meta-agent <your-handle>  # bootstrap your meta-agent project
+cct doctor --tool-surface                      # health check (must be green)
 ```
 
 `<your-handle>` is whatever you want to call yourself — snake_case, e.g. `rob` or `alice`.
 
-> **Upgrading from a pre-2026-05 ccteam?** Run `ccteam doctor --migrate-recommended-agents` once after the upgrade. Spawned project sessions now resolve plugin agents through Claude Code's plugin pipeline, so the legacy `~/.claude/agents/<name>.md` symlinks ccteam used to create are obsolete; this command removes them. User-authored agents are preserved.
+> **Upgrading from a pre-2026-05 ccteam?** Run `cct doctor --migrate-recommended-agents` once after the upgrade. Spawned project sessions now resolve plugin agents through Claude Code's plugin pipeline, so the legacy `~/.claude/agents/<name>.md` symlinks ccteam used to create are obsolete; this command removes them. User-authored agents are preserved.
 
 ## Quick start
 
 ```bash
 # Terminal A — start the orchestrator (foreground; keep this open)
-ccteam start --foreground
+cct start --foreground
 
 # Terminal B — talk to the meta-agent
 tmux attach -t ccteam-meta-<your-handle>
@@ -112,7 +112,7 @@ claude
 # Or:   "Dispatch a dev team to make a todo CLI in Python."
 ```
 
-The meta-agent uses the `ccteam-control` skill plus the `ccteam-mcp` 9-tool MCP server you installed, so any Claude Code session understands ccteam.
+The meta-agent uses the `cct-control` skill plus the `ccteam-mcp` 9-tool MCP server you installed, so any Claude Code session understands ccteam.
 
 ## Built-in teams
 
@@ -131,11 +131,11 @@ To author a custom team, ask the meta-agent:
 The meta-agent walks you through phase definition, tools required, golden-rule constraints, and retro-schema fields, then scaffolds the plugin under `~/.config/ccteam/teams/<name>/`. Publish with:
 
 ```bash
-ccteam team publish <name> --target local              # link into ccteam-local marketplace
-ccteam team publish <name> --target github --repo ...  # push to a GitHub repo as a shareable plugin
+cct team publish <name> --target local              # link into ccteam-local marketplace
+cct team publish <name> --target github --repo ...  # push to a GitHub repo as a shareable plugin
 ```
 
-Anyone who installs your team-plugin via Claude Code's plugin commands gets a fully-functional ccteam team.
+Anyone who installs your team-plugin via Claude Code's plugin commands gets a fully-functional cct team.
 
 ## How it works
 

--- a/crates/ccteam-cli/Cargo.toml
+++ b/crates/ccteam-cli/Cargo.toml
@@ -4,10 +4,10 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-description = "ccteam command-line tool: orchestrator daemon, project management, and hook subcommands."
+description = "cct (ccteam) command-line tool: orchestrator daemon, project management, and hook subcommands."
 
 [[bin]]
-name = "ccteam"
+name = "cct"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -10,10 +10,12 @@ use chrono::Utc;
 use serde_json::{json, Map, Value};
 
 use ccteam_core::{
-    bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
-    migrate_recommended_agent_symlinks, pick_unused_slug, user_claude_dir,
-    write_all_global_team_templates, write_global_helper_templates,
-    write_global_phase_templates, CcteamPaths, InstallSkillOptions, MetaBootstrapReport,
+    bootstrap_meta_project, bootstrap_project, current_cct_bin, install_cct_control_skill,
+    install_cct_team_author_skill, migrate_legacy_skill_dirs,
+    migrate_recommended_agent_symlinks, pick_unused_slug, rewrite_legacy_hook_commands,
+    user_claude_dir, write_all_global_team_templates, write_global_helper_templates,
+    write_global_phase_templates, CcteamPaths, HookCmdRewriteAction, HookCmdRewriteReport,
+    InstallSkillOptions, LegacySkillAction, LegacySkillReport, MetaBootstrapReport,
     MigrationReport, OutboxEventKind, OutboxMessage, PhaseHistoryEntry, PhaseState,
     PhaseTemplate, ProjectState, SessionMailbox, SkillInstallAction, TeamSpec,
     ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES, PHASE_TEMPLATES,
@@ -26,7 +28,7 @@ pub enum OutputFormat {
     Json,
 }
 
-/// Options passed from the `ccteam init` argument parser.
+/// Options passed from the `cct init` argument parser.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InitOptions {
     /// Overwrite existing global phase templates instead of skipping
@@ -34,7 +36,7 @@ pub struct InitOptions {
     pub force: bool,
 }
 
-/// `ccteam init`. Creates `~/.ccteam/{phases,progress,inbox,control,
+/// `cct init`. Creates `~/.ccteam/{phases,progress,inbox,control,
 /// queue,memory,state}`, unpacks the embedded phase templates into
 /// `~/.ccteam/phases/`, and runs a quick health check. Returns a
 /// human-readable report.
@@ -77,7 +79,7 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
         )
     })?;
 
-    let bin = current_ccteam_bin().ok();
+    let bin = current_cct_bin().ok();
 
     let claude = Command::new("claude").arg("--version").output();
     let tmux = Command::new("tmux").arg("-V").output();
@@ -115,12 +117,12 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
     }
 
     out.push_str("\nnext:\n");
-    out.push_str("  ccteam new \"<your one-line request>\"\n");
-    out.push_str("  ccteam start --foreground   # in another terminal\n");
+    out.push_str("  cct new \"<your one-line request>\"\n");
+    out.push_str("  cct start --foreground   # in another terminal\n");
     Ok(out)
 }
 
-/// `ccteam new "request" --team <name>`. Bootstraps a project on disk
+/// `cct new "request" --team <name>`. Bootstraps a project on disk
 /// and returns the chosen slug. Side effects: creates
 /// `~/projects/<slug>/...`. `team` is recorded in state.json so the
 /// orchestrator can route this project through the matching phase set.
@@ -128,29 +130,29 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
 /// **M3.3 fail-fast**: non-dev teams require a `team.yaml` to be
 /// loadable from `~/.ccteam/teams/<team>/team.yaml`. The dev team is
 /// grandfathered in (no team.yaml required) so legacy installs
-/// without `ccteam init` still work. Meta-agent is also allowed
+/// without `cct init` still work. Meta-agent is also allowed
 /// without a team.yaml — its bootstrap path is bespoke.
 ///
 /// V0.2 §6.4 candidate 3: shipped seeds (dev / product-research /
 /// meta-agent) are stamped to disk inside `run_new` so a fresh
-/// install no longer needs an explicit `ccteam init` for the
+/// install no longer needs an explicit `cct init` for the
 /// validation to find them.
 pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String> {
     if request.trim().is_empty() {
-        bail!("ccteam new: request must be non-empty");
+        bail!("cct new: request must be non-empty");
     }
     if team.trim().is_empty() {
-        bail!("ccteam new: --team must be non-empty");
+        bail!("cct new: --team must be non-empty");
     }
     // Self-heal shipped seeds before validating — without this, a
-    // first-time `ccteam new --team product-research` against a
+    // first-time `cct new --team product-research` against a
     // freshly-installed binary would fail with "unknown team".
     // force=false preserves operator hand-edits.
     if let Err(err) = ccteam_core::write_all_global_team_templates(&paths.root, false) {
         tracing::warn!(
             error = %err,
             root = %paths.root.display(),
-            "ccteam new: could not seed shipped team templates",
+            "cct new: could not seed shipped team templates",
         );
     }
     ensure_team_resolvable(paths, team)?;
@@ -175,7 +177,7 @@ fn ensure_team_resolvable(paths: &CcteamPaths, team: &str) -> Result<()> {
     let yaml_path = paths.root.join("teams").join(team).join("team.yaml");
     if yaml_path.exists() {
         TeamSpec::load(&yaml_path).with_context(|| {
-            format!("ccteam new: failed to load {}", yaml_path.display())
+            format!("cct new: failed to load {}", yaml_path.display())
         })?;
         return Ok(());
     }
@@ -183,9 +185,9 @@ fn ensure_team_resolvable(paths: &CcteamPaths, team: &str) -> Result<()> {
         .ok()
         .filter(|t| !t.is_empty())
         .map(|t| t.join(", "))
-        .unwrap_or_else(|| "(none yet — run `ccteam doctor --reset-shipped-teams`)".into());
+        .unwrap_or_else(|| "(none yet — run `cct doctor --reset-shipped-teams`)".into());
     bail!(
-        "ccteam new: unknown team `{team}` — \
+        "cct new: unknown team `{team}` — \
          create {} (see docs/interfaces.md §5.5 for schema), \
          then re-run.\n\
          Teams currently on disk: {known}.",
@@ -216,7 +218,7 @@ fn list_disk_teams(paths: &CcteamPaths) -> Result<Vec<String>> {
     Ok(out)
 }
 
-/// `ccteam ls`. Returns either a human table or the interfaces.md §10.3
+/// `cct ls`. Returns either a human table or the interfaces.md §10.3
 /// JSON shape (a single string, not printed — caller decides).
 pub fn run_ls(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
     let projects = collect_projects(paths)?;
@@ -227,7 +229,7 @@ pub fn run_ls(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
     })
 }
 
-/// `ccteam show <slug>`. Renders the full project view per
+/// `cct show <slug>`. Renders the full project view per
 /// interfaces.md §10.3 (json) or a human-readable summary (text).
 pub fn run_show(paths: &CcteamPaths, slug: &str, format: OutputFormat) -> Result<String> {
     let state_path = paths.project_state(slug);
@@ -244,7 +246,7 @@ pub fn run_show(paths: &CcteamPaths, slug: &str, format: OutputFormat) -> Result
     })
 }
 
-/// `ccteam attach <slug>`. Execs `tmux attach -t ccteam-<slug>`. Exits
+/// `cct attach <slug>`. Execs `tmux attach -t ccteam-<slug>`. Exits
 /// successfully when the user detaches; non-zero on error.
 pub fn run_attach(slug: &str) -> Result<()> {
     let session = TmuxSession::for_slug(slug);
@@ -261,7 +263,7 @@ pub fn run_attach(slug: &str) -> Result<()> {
     Ok(())
 }
 
-/// `ccteam peek <slug>`. Returns the contents of the session's first
+/// `cct peek <slug>`. Returns the contents of the session's first
 /// pane via `tmux capture-pane -p`.
 pub fn run_peek(slug: &str) -> Result<String> {
     let session = TmuxSession::for_slug(slug);
@@ -279,7 +281,7 @@ pub fn run_peek(slug: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-/// `ccteam progress <slug>`. With `tail = false`, returns the entire
+/// `cct progress <slug>`. With `tail = false`, returns the entire
 /// progress.jsonl as text. With `tail = true`, reads + writes to
 /// stdout in a polling loop until Ctrl-C.
 pub fn run_progress(paths: &CcteamPaths, slug: &str, tail: bool) -> Result<()> {
@@ -316,7 +318,7 @@ pub fn run_progress(paths: &CcteamPaths, slug: &str, tail: bool) -> Result<()> {
     }
 }
 
-/// `ccteam resume <slug>`. M0 minimum: clears any user_pause flag, drops
+/// `cct resume <slug>`. M0 minimum: clears any user_pause flag, drops
 /// the escalation marker if present, and sets phase_state back to idle so
 /// the daemon's next tick re-dispatches the current phase. Real
 /// `--resume` (claude session continuation) is M1+.
@@ -360,7 +362,7 @@ pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
     Ok(())
 }
 
-/// One row in the cross-project decisions queue (`ccteam decisions`).
+/// One row in the cross-project decisions queue (`cct decisions`).
 ///
 /// A "decision" = an outbox file in any project's `.ccteam/outbox/` whose
 /// front matter has `event_kind: clarify` or `event_kind: escalation`.
@@ -379,7 +381,7 @@ pub struct DecisionRow {
     pub summary: String,
 }
 
-/// `ccteam decisions`. Aggregate the cross-project decisions queue and
+/// `cct decisions`. Aggregate the cross-project decisions queue and
 /// render it. interfaces.md §5.6.4 — meta-agent uses this as the
 /// surface for "你有 N 条待决策" UX. M1 follow-up increment.
 pub fn run_decisions(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
@@ -596,7 +598,7 @@ fn ellipsize(s: &str, max: usize) -> String {
     }
 }
 
-/// `ccteam doctor` flags. Each mode is a separate boolean / option so
+/// `cct doctor` flags. Each mode is a separate boolean / option so
 /// they can be combined (e.g. `--install-meta-agent rob` implies
 /// `--install-skill` automatically).
 #[derive(Debug, Clone, Default)]
@@ -604,7 +606,10 @@ pub struct DoctorOptions {
     pub dry_run: bool,
     pub force: bool,
     pub tool_surface: bool,
-    /// M1.8: install ~/.claude/skills/ccteam-control/SKILL.md.
+    /// M1.8 (V0.2.2 F39): install `~/.claude/skills/cct-control/SKILL.md`
+    /// and `~/.claude/skills/cct-team-author/SKILL.md`, plus run the
+    /// V0.1/V0.2 → V0.2.2 cleanup migration (legacy skill dirs and
+    /// stale settings.json hook command paths).
     pub install_skill: bool,
     /// M1.0: bootstrap a meta-agent project for the given user handle.
     /// `Some("rob")` ⇒ creates `~/projects/rob-meta/` and triggers
@@ -638,7 +643,7 @@ pub struct DoctorOptions {
     pub migrate_recommended_agents: bool,
 }
 
-/// `ccteam doctor` dispatch. Returns a human-readable report so unit
+/// `cct doctor` dispatch. Returns a human-readable report so unit
 /// tests don't need to capture stdout.
 pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     let any_mode = opts.tool_surface
@@ -651,14 +656,16 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         || opts.migrate_recommended_agents;
     if !any_mode {
         return Ok(String::from(
-            "ccteam doctor: pass at least one mode flag.\n\
+            "cct doctor: pass at least one mode flag.\n\
              \n\
              modes:\n  \
              --tool-surface\n      \
              cross-check phase templates' tools_required against current reachability — \
              plugin-pipeline-aware (V0.2 M0.20).\n  \
              --install-skill [--force]\n      \
-             write ~/.claude/skills/ccteam-control/SKILL.md (M1.8).\n  \
+             write ~/.claude/skills/cct-{control,team-author}/SKILL.md (M1.8 + V0.2.2 F39); \
+             also runs the V0.1/V0.2 → V0.2.2 cleanup (legacy `ccteam-*` skill dirs + \
+             stale settings.json hook command paths).\n  \
              --install-meta-agent <user-handle>\n      \
              bootstrap a meta-agent project for the given user (M1.0). Implies --install-skill.\n  \
              --install-mcp\n      \
@@ -681,7 +688,7 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     // session has the dispatcher tool list immediately.
     let install_skill_now = opts.install_skill || opts.install_meta_agent.is_some();
     if install_skill_now {
-        out.push_str(&render_install_skill_report(&opts)?);
+        out.push_str(&render_install_skill_report(paths, &opts)?);
     }
     if let Some(handle) = &opts.install_meta_agent {
         out.push_str(&render_install_meta_agent_report(paths, handle)?);
@@ -703,7 +710,7 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         // or plugin-section) → non-zero exit so CI can gate on it.
         if fails > 0 {
             anyhow::bail!(
-                "ccteam doctor --validate-team {team}: {fails} fail(s) — \
+                "cct doctor --validate-team {team}: {fails} fail(s) — \
                  see report above\n\n{out}",
             );
         }
@@ -736,7 +743,7 @@ fn render_validate_team_report(
         TeamResolveContext, TEAM_SOURCES,
     };
 
-    let mut out = format!("ccteam doctor --validate-team {team}\n\n");
+    let mut out = format!("cct doctor --validate-team {team}\n\n");
     // F30 — accumulate every [FAIL] line into a single counter so the
     // top-level Summary and the `run_doctor` exit code agree. Phase-
     // section findings sum into this same counter below.
@@ -793,7 +800,7 @@ fn render_validate_team_report(
         None => {
             out.push_str(
                 "[FAIL] could not locate team directory after resolve — \
-                 run `ccteam doctor --reset-shipped-teams`\n",
+                 run `cct doctor --reset-shipped-teams`\n",
             );
             fails += 1;
             out.push_str(&format!("\nSummary: 0 ok, 0 warn, {fails} fail\n"));
@@ -985,7 +992,7 @@ pub fn run_phase_show(
     let template = found_template.ok_or_else(|| {
         anyhow::anyhow!(
             "team `{team}` has no phase `{phase}` under {} — \
-             check `ccteam doctor --validate-team {team}` for the phase list",
+             check `cct doctor --validate-team {team}` for the phase list",
             phase_dir.display(),
         )
     })?;
@@ -1031,7 +1038,7 @@ fn render_reset_shipped_teams_report(
     opts: &DoctorOptions,
 ) -> Result<String> {
     ccteam_core::write_all_global_team_templates(&paths.root, opts.force)?;
-    let mut out = String::from("ccteam doctor --reset-shipped-teams\n\n");
+    let mut out = String::from("cct doctor --reset-shipped-teams\n\n");
     if opts.force {
         out.push_str(
             "  Re-wrote every shipped team's team.yaml + phase markdowns under \
@@ -1050,7 +1057,7 @@ fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions
     // V0.2 §6.4 candidate 3: bridge teams are now discovered by
     // scanning `~/.ccteam/teams/<name>/team.yaml`. Make sure shipped
     // seeds are present before the scan so a fresh install (no
-    // `ccteam init` yet) still lays down dev / product-research
+    // `cct init` yet) still lays down dev / product-research
     // bridges. force=false preserves operator hand-edits.
     if !opts.dry_run {
         ccteam_core::write_all_global_team_templates(&paths.root, false)?;
@@ -1060,9 +1067,9 @@ fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions
     };
     let reports = ccteam_core::install_memory_bridge(&paths.root, install_opts)?;
     let mut out = if opts.dry_run {
-        String::from("ccteam doctor --install-memory-bridge (dry-run)\n\n")
+        String::from("cct doctor --install-memory-bridge (dry-run)\n\n")
     } else {
-        String::from("ccteam doctor --install-memory-bridge\n\n")
+        String::from("cct doctor --install-memory-bridge\n\n")
     };
     for r in &reports {
         let label = match &r.action {
@@ -1091,7 +1098,7 @@ fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions
 
 fn render_install_mcp_report() -> Result<String> {
     let path = crate::mcp_serve::install_mcp()?;
-    let mut out = String::from("ccteam doctor --install-mcp\n\n");
+    let mut out = String::from("cct doctor --install-mcp\n\n");
     out.push_str(&format!("  registered ccteam MCP server in {}\n", path.display()));
     out.push_str("  tools surface : 9 (interfaces §12.2)\n");
     out.push_str("  consumers     : daily-driver claude + meta-agent\n");
@@ -1102,13 +1109,8 @@ fn render_install_mcp_report() -> Result<String> {
     Ok(out)
 }
 
-fn render_install_skill_report(opts: &DoctorOptions) -> Result<String> {
-    let report = install_ccteam_control_skill(InstallSkillOptions {
-        force: opts.force,
-        dry_run: opts.dry_run,
-    })?;
-    let mut out = String::from("ccteam doctor --install-skill\n\n");
-    let label: String = match &report.action {
+fn skill_install_label(action: &SkillInstallAction) -> String {
+    match action {
         SkillInstallAction::Wrote => "wrote".into(),
         SkillInstallAction::AlreadyPresent => "already-present (use --force to overwrite)".into(),
         SkillInstallAction::Replaced => "replaced".into(),
@@ -1119,15 +1121,179 @@ fn render_install_skill_report(opts: &DoctorOptions) -> Result<String> {
                 "no-op (already present)".into()
             }
         }
+    }
+}
+
+fn render_install_skill_report(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<String> {
+    let install_opts = InstallSkillOptions {
+        force: opts.force,
+        dry_run: opts.dry_run,
     };
-    out.push_str(&format!("  ccteam-control  {label}  {}\n", report.target.display()));
+    let mut out = String::from("cct doctor --install-skill\n\n");
+
+    // V0.2.2 F39: install both shipped skills under their cct-* names.
+    let control = install_cct_control_skill(install_opts)?;
+    out.push_str(&format!(
+        "  cct-control      {label}  {}\n",
+        control.target.display(),
+        label = skill_install_label(&control.action),
+    ));
+    let team_author = install_cct_team_author_skill(install_opts)?;
+    out.push_str(&format!(
+        "  cct-team-author  {label}  {}\n",
+        team_author.target.display(),
+        label = skill_install_label(&team_author.action),
+    ));
     out.push('\n');
+
+    // V0.2.2 F39 migration: clean up legacy V0.1/V0.2 skill dirs and
+    // rewrite stale settings.json hook command paths so users upgrading
+    // from V0.2.1 don't end up with duplicate `ccteam-*` + `cct-*` skill
+    // directories or hook commands pointing at a renamed binary.
+    out.push_str(&render_f39_migration(paths, opts)?);
+
+    Ok(out)
+}
+
+/// V0.2.2 F39: detect-and-clean V0.1/V0.2 install artifacts so users
+/// who upgrade `ccteam → cct` don't end up with both naming
+/// conventions live at once. Runs as a side effect of `--install-skill`
+/// and `--install-meta-agent` (PRD §8.2.5 — "no new doctor flag,
+/// migration runs alongside install").
+fn render_f39_migration(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<String> {
+    let mut out = String::new();
+    let claude = match user_claude_dir() {
+        Ok(c) => c,
+        Err(_) => {
+            // No claude dir — no V0.1/V0.2 install to clean up.
+            return Ok(out);
+        }
+    };
+
+    out.push_str("F39 migration (V0.1/V0.2 → V0.2.2 cleanup)\n\n");
+
+    // 1. Legacy skill dirs.
+    let skill_reports = migrate_legacy_skill_dirs(&claude, opts.dry_run)?;
+    let any_skill_action = skill_reports
+        .iter()
+        .any(|r| r.action != LegacySkillAction::NotFound);
+    if any_skill_action {
+        for r in &skill_reports {
+            out.push_str(&render_legacy_skill_line(r, opts.dry_run));
+        }
+    } else {
+        out.push_str("  legacy skills    no `~/.claude/skills/ccteam-*` dirs found — nothing to do.\n");
+    }
+
+    // 2. Stale settings.json hook command paths. Use the orchestrator's
+    // resolved projects root so test fixtures get the tempdir; tests
+    // don't otherwise mutate `~/projects/`.
+    let new_bin = current_cct_bin().ok();
+    if let Some(bin) = new_bin.as_ref() {
+        let hook_reports =
+            scan_project_settings_for_hook_rewrite(&paths.projects_root, bin, opts.dry_run)?;
+        if hook_reports.is_empty() {
+            out.push_str("  legacy hooks     no project `settings.json` files found.\n");
+        } else {
+            let mut any_rewritten = false;
+            for r in &hook_reports {
+                let line = render_hook_rewrite_line(r, opts.dry_run);
+                out.push_str(&line);
+                if matches!(
+                    r.action,
+                    HookCmdRewriteAction::Rewrote { .. } | HookCmdRewriteAction::WouldRewrite { .. }
+                ) {
+                    any_rewritten = true;
+                }
+            }
+            if !any_rewritten {
+                // All NoChangeNeeded — collapse the table to a single
+                // friendly summary instead of dumping every project.
+                out.clear();
+                out.push_str("F39 migration (V0.1/V0.2 → V0.2.2 cleanup)\n\n");
+                for r in &skill_reports {
+                    out.push_str(&render_legacy_skill_line(r, opts.dry_run));
+                }
+                out.push_str(&format!(
+                    "  legacy hooks     scanned {} project settings.json — no rewrites needed.\n",
+                    hook_reports.len(),
+                ));
+            }
+        }
+    } else {
+        out.push_str("  legacy hooks     could not resolve `cct` binary — skipped.\n");
+    }
+    out.push('\n');
+    Ok(out)
+}
+
+fn render_legacy_skill_line(r: &LegacySkillReport, dry_run: bool) -> String {
+    let label = match (&r.action, dry_run) {
+        (LegacySkillAction::NotFound, _) => "not present",
+        (LegacySkillAction::Removed, _) => "removed",
+        (LegacySkillAction::WouldRemove, _) => "would remove",
+        (LegacySkillAction::PreservedHandEdit, _) => "preserved (hand-edited)",
+    };
+    format!(
+        "  {:<28} {:<22} {}\n",
+        format!("{}/", r.legacy_name),
+        label,
+        r.target.display(),
+    )
+}
+
+fn render_hook_rewrite_line(r: &HookCmdRewriteReport, _dry_run: bool) -> String {
+    let label: String = match &r.action {
+        HookCmdRewriteAction::NotFound => "missing".into(),
+        HookCmdRewriteAction::NoChangeNeeded => "ok".into(),
+        HookCmdRewriteAction::WouldRewrite { entries } => {
+            format!("would rewrite {entries}")
+        }
+        HookCmdRewriteAction::Rewrote { entries } => format!("rewrote {entries}"),
+    };
+    format!(
+        "  {:<28} {:<22} {}\n",
+        "settings.json",
+        label,
+        r.target.display(),
+    )
+}
+
+/// Walk every immediate child of `projects_root` and rewrite legacy
+/// hook commands in `<child>/.claude/settings.json`. Returns a per-
+/// project report so the doctor output can summarize.
+fn scan_project_settings_for_hook_rewrite(
+    projects_root: &std::path::Path,
+    new_bin: &std::path::Path,
+    dry_run: bool,
+) -> Result<Vec<HookCmdRewriteReport>> {
+    let mut out: Vec<HookCmdRewriteReport> = Vec::new();
+    let entries = match std::fs::read_dir(projects_root) {
+        Ok(e) => e,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("read_dir {}", projects_root.display()));
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let settings = path.join(".claude").join("settings.json");
+        if !settings.exists() {
+            continue;
+        }
+        let report = rewrite_legacy_hook_commands(&settings, new_bin, dry_run)?;
+        out.push(report);
+    }
     Ok(out)
 }
 
 fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> Result<String> {
     let report: MetaBootstrapReport = bootstrap_meta_project(paths, user_handle)?;
-    let mut out = String::from("ccteam doctor --install-meta-agent\n\n");
+    let mut out = String::from("cct doctor --install-meta-agent\n\n");
     out.push_str(&format!("  user handle      {user_handle}\n"));
     out.push_str(&format!("  project slug     {}\n", report.slug));
     out.push_str(&format!("  project dir      {}\n", report.project_dir.display()));
@@ -1145,7 +1311,7 @@ fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> R
         "attach with      tmux attach -t ccteam-meta-{}\n",
         ccteam_core::meta_slug(user_handle)?.trim_end_matches("-meta"),
     ));
-    out.push_str("\nrun `ccteam start --foreground` (in another terminal) to wake the meta session.\n");
+    out.push_str("\nrun `cct start --foreground` (in another terminal) to wake the meta session.\n");
     Ok(out)
 }
 
@@ -1154,9 +1320,9 @@ fn render_migrate_recommended_agents_report(opts: &DoctorOptions) -> Result<Stri
     let reports = migrate_recommended_agent_symlinks(&claude, opts.dry_run)?;
     let mut out = String::new();
     out.push_str(if opts.dry_run {
-        "ccteam doctor --migrate-recommended-agents (dry-run)\n"
+        "cct doctor --migrate-recommended-agents (dry-run)\n"
     } else {
-        "ccteam doctor --migrate-recommended-agents\n"
+        "cct doctor --migrate-recommended-agents\n"
     });
     out.push('\n');
     if reports.is_empty() {
@@ -1202,7 +1368,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
     let templates = load_local_phase_templates(paths)?;
 
     let mut out = String::new();
-    out.push_str("ccteam doctor --tool-surface\n");
+    out.push_str("cct doctor --tool-surface\n");
     out.push_str(&format!(
         "\nclaude dir       : {}\n",
         claude.display()
@@ -1223,7 +1389,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
 
     if templates.is_empty() {
         out.push_str(
-            "no phase templates under ~/.ccteam/phases/ — run `ccteam init` first.\n",
+            "no phase templates under ~/.ccteam/phases/ — run `cct init` first.\n",
         );
         return Ok(out);
     }
@@ -1274,7 +1440,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
     if any_missing {
         out.push_str(
             "**Verdict:** at least one phase has a missing tool. \
-             `ccteam start` will refuse until they're installed (or pass --skip-tool-check).\n",
+             `cct start` will refuse until they're installed (or pass --skip-tool-check).\n",
         );
     } else {
         out.push_str("**Verdict:** all phase tool dependencies reachable.\n");
@@ -1387,12 +1553,12 @@ pub fn collect_recent_events(
 /// Collect every `.md` artifact under `<project>/.ccteam/` so non-dev
 /// teams (e.g. product-research with `verdict.md` / `rationale.md` /
 /// `next-steps.md` / `brief.md` / `market-survey.md`) get listed in
-/// `ccteam show <slug> --format json` without ccteam-cli holding a
+/// `cct show <slug> --format json` without ccteam-cli holding a
 /// per-team artifact whitelist (F8 fix, 2026-05-07).
 ///
 /// Key = file stem with `-` → `_` (e.g. `plan-eng.md` → `plan_eng`)
 /// so existing JSON consumers (the meta-agent dispatch tree, the
-/// ccteam-control skill) keep working without a schema migration.
+/// cct-control skill) keep working without a schema migration.
 /// Sub-directories under `.ccteam/` (e.g. `outbox/`, `inbox/`) are
 /// not enumerated — those have dedicated views.
 ///
@@ -1437,7 +1603,7 @@ fn render_ls_text(projects: &[ProjectSummary], daemon_up: bool) -> String {
     ));
     if projects.is_empty() {
         out.push_str(
-            "(no projects under ~/projects/. start one with `ccteam new \"<request>\"`.)\n",
+            "(no projects under ~/projects/. start one with `cct new \"<request>\"`.)\n",
         );
         return out;
     }
@@ -1456,7 +1622,7 @@ fn render_ls_text(projects: &[ProjectSummary], daemon_up: bool) -> String {
     out
 }
 
-/// `current_phase` is empty between `ccteam new` and the first
+/// `current_phase` is empty between `cct new` and the first
 /// dispatch; surface that as `pending` instead of a blank column so
 /// `ls` and `show` are readable on fresh projects.
 fn display_phase(phase: &str) -> &str {
@@ -1608,7 +1774,7 @@ fn truncate(s: &str, n: usize) -> &str {
     }
 }
 
-/// `ccteam watchdog scan` (V0.2 M0.21). Reads `~/.ccteam/watchdog.yaml`
+/// `cct watchdog scan` (V0.2 M0.21). Reads `~/.ccteam/watchdog.yaml`
 /// (or defaults), scans every project + the daemon heartbeat, and
 /// renders the resulting alerts. With `push_to_user_handle: Some(<h>)`
 /// each alert that survives filtering is also written to the meta-agent
@@ -1739,7 +1905,7 @@ mod tests {
         // `run_new` self-heals shipped seeds first, so
         // `product-research`'s yaml lands at
         // ~/.ccteam/teams/product-research/team.yaml during this
-        // call — no manual `ccteam init` needed.
+        // call — no manual `cct init` needed.
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
@@ -1951,7 +2117,7 @@ mod tests {
     #[test]
     fn run_resume_appends_resumed_history_after_escalated_entry() {
         // E2E 2026-05-06 F8: an escalated `phase_history` entry leaves
-        // `Dag::is_terminal_state` permanently true. `ccteam resume`
+        // `Dag::is_terminal_state` permanently true. `cct resume`
         // must append a paired `"resumed"` entry so future ticks
         // dispatch again. Append-only — the original escalated entry
         // stays intact for audit.
@@ -2132,9 +2298,16 @@ mod tests {
         assert_eq!(state.team, "meta-agent");
         assert_eq!(state.tmux_session, "ccteam-meta-rob");
 
-        // Skill landed under the redirected ~/.claude/.
-        let skill_path = tmp.path().join("skills/ccteam-control/SKILL.md");
-        assert!(skill_path.is_file(), "skill SKILL.md not written: {}", skill_path.display());
+        // Skill landed under the redirected ~/.claude/. V0.2.2 F39 →
+        // both shipped skills should be written under cct-* names.
+        let control = tmp.path().join("skills/cct-control/SKILL.md");
+        assert!(control.is_file(), "cct-control SKILL.md not written: {}", control.display());
+        let team_author = tmp.path().join("skills/cct-team-author/SKILL.md");
+        assert!(
+            team_author.is_file(),
+            "cct-team-author SKILL.md not written: {}",
+            team_author.display(),
+        );
 
         std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
@@ -2155,8 +2328,69 @@ mod tests {
         assert!(report.contains("install-skill"));
         assert!(!report.contains("install-meta-agent"));
 
-        let skill_path = tmp.path().join("skills/ccteam-control/SKILL.md");
-        assert!(skill_path.is_file());
+        // V0.2.2 F39: both shipped skills land under cct-* names.
+        assert!(tmp.path().join("skills/cct-control/SKILL.md").is_file());
+        assert!(tmp.path().join("skills/cct-team-author/SKILL.md").is_file());
+        std::env::remove_var("CLAUDE_CONFIG_HOME");
+    }
+
+    #[test]
+    fn run_doctor_install_skill_runs_f39_legacy_skill_cleanup() {
+        // V0.2.2 F39: --install-skill detects + removes any
+        // ~/.claude/skills/ccteam-{control,team-author}/ left over from
+        // V0.1/V0.2 installs whose body still carries the
+        // ccteam-managed marker (or canonical frontmatter).
+        ensure_isolation();
+        let _guard = env_lock().lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
+        // Stage a V0.2.x install.
+        let legacy = tmp.path().join("skills/ccteam-control");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("SKILL.md"),
+            "---\nname: ccteam-control\n---\n# legacy body\n",
+        )
+        .unwrap();
+
+        let opts = DoctorOptions {
+            install_skill: true,
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(report.contains("F39 migration"), "F39 report header missing: {report}");
+        assert!(report.contains("ccteam-control/"), "legacy entry missing: {report}");
+        assert!(!legacy.exists(), "legacy ccteam-control dir survived");
+        // New name still landed.
+        assert!(tmp.path().join("skills/cct-control/SKILL.md").is_file());
+        std::env::remove_var("CLAUDE_CONFIG_HOME");
+    }
+
+    #[test]
+    fn run_doctor_install_skill_preserves_user_hand_edited_legacy_skill() {
+        // F39: a legacy directory whose SKILL.md was hand-edited
+        // (no marker, no canonical frontmatter) is preserved.
+        ensure_isolation();
+        let _guard = env_lock().lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
+        let legacy = tmp.path().join("skills/ccteam-team-author");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(
+            legacy.join("SKILL.md"),
+            "---\nname: my-fork\n---\n# user wrote this\n",
+        )
+        .unwrap();
+
+        let opts = DoctorOptions {
+            install_skill: true,
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(report.contains("preserved"), "F39 should report preserve: {report}");
+        assert!(legacy.exists(), "hand-edited legacy dir was unexpectedly removed");
         std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
 
@@ -2223,8 +2457,8 @@ mod tests {
 
     #[test]
     fn run_new_self_heals_shipped_seeds_for_first_time_install() {
-        // V0.2 §6.4 candidate 3: a fresh install (no `ccteam init`) where
-        // ~/.ccteam/teams/ is empty must still let `ccteam new --team
+        // V0.2 §6.4 candidate 3: a fresh install (no `cct init`) where
+        // ~/.ccteam/teams/ is empty must still let `cct new --team
         // product-research` succeed because run_new self-heals.
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
@@ -2238,7 +2472,7 @@ mod tests {
         assert!(paths.root.join("teams/product-research/team.yaml").is_file());
     }
 
-    // -------- ccteam decisions (M1 follow-up) --------
+    // -------- cct decisions (M1 follow-up) --------
 
     /// Helper: write an outbox file with caller-controlled front matter
     /// to `<projects_root>/<slug>/.ccteam/outbox/<filename>`. Uses

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -1,4 +1,4 @@
-//! `ccteam` binary entry point.
+//! `cct` binary entry point (V0.2.2 F39 renamed from `ccteam`).
 
 mod commands;
 mod mcp_serve;
@@ -15,7 +15,7 @@ use commands::{InitOptions, OutputFormat};
 
 #[derive(Parser)]
 #[command(
-    name = "ccteam",
+    name = "cct",
     version,
     about = "Autonomous AI development orchestrator built on Claude Code",
 )]
@@ -113,13 +113,13 @@ enum Command {
         format: OutputFormat,
     },
     /// M2.5: run the ccteam MCP server (stdio JSON-RPC). Wired into
-    /// `~/.claude.json` `mcpServers.ccteam` by `ccteam doctor
+    /// `~/.claude.json` `mcpServers.ccteam` by `cct doctor
     /// --install-mcp` so daily-driver claude sessions and the meta
     /// agent both see the 9-tool surface (interfaces §12).
     McpServe,
     /// Stop the running orchestrator daemon. Sends SIGTERM via the
     /// pidfile so the loop drains gracefully. Does **not** kill any
-    /// tmux sessions — `ccteam start` reattaches to them on next launch
+    /// tmux sessions — `cct start` reattaches to them on next launch
     /// (M1.5).
     Stop,
     /// Health checks + tool-surface maintenance.
@@ -137,14 +137,14 @@ enum Command {
         /// agents/skills + MCP servers) and print a markdown report.
         #[arg(long, default_value_t = false)]
         tool_surface: bool,
-        /// Install the `ccteam-control` skill at
-        /// `~/.claude/skills/ccteam-control/SKILL.md` (M1.8). Idempotent.
+        /// Install the `cct-control` skill at
+        /// `~/.claude/skills/cct-control/SKILL.md` (M1.8). Idempotent.
         #[arg(long, default_value_t = false)]
         install_skill: bool,
         /// Bootstrap a meta-agent project (M1.0) for the given user
         /// handle. Creates `~/projects/<handle>-meta/` with the
         /// dispatcher role prompt + inbox/outbox dirs and (always)
-        /// installs the `ccteam-control` skill. Pass the user handle as
+        /// installs the `cct-control` skill. Pass the user handle as
         /// the value (e.g. `--install-meta-agent rob`).
         #[arg(long, value_name = "HANDLE")]
         install_meta_agent: Option<String>,
@@ -205,7 +205,7 @@ enum Command {
         #[command(subcommand)]
         cmd: WatchdogCommand,
     },
-    /// V0.2 M0.22: author + publish a ccteam team as a Claude Code
+    /// V0.2 M0.22: author + publish a cct team as a Claude Code
     /// plugin. `init` scaffolds the staging tree under
     /// `~/.config/ccteam/teams/<name>/`; `publish` links it into the
     /// `ccteam-local` marketplace or pushes it to a GitHub repo.
@@ -448,14 +448,14 @@ fn run_stop() -> Result<()> {
     let paths = CcteamPaths::from_env()?;
     match ccteam_core::send_sigterm_to_pidfile(&paths)? {
         Some(pid) => {
-            println!("ccteam stop: SIGTERM sent to orchestrator pid {pid}");
+            println!("cct stop: SIGTERM sent to orchestrator pid {pid}");
             println!(
-                "tmux sessions are NOT killed — `ccteam start` will reattach to them.",
+                "tmux sessions are NOT killed — `cct start` will reattach to them.",
             );
             Ok(())
         }
         None => {
-            println!("ccteam stop: no running orchestrator (pidfile absent or stale).");
+            println!("cct stop: no running orchestrator (pidfile absent or stale).");
             Ok(())
         }
     }
@@ -522,21 +522,21 @@ fn run_start(
     // start. force=false skips existing files so operator hand-edits
     // are preserved; the call still ensures `~/.ccteam/teams/<name>/team.yaml`
     // exists for every shipped team (dev / product-research /
-    // meta-agent) — without this, a fresh install missing `ccteam init`
+    // meta-agent) — without this, a fresh install missing `cct init`
     // would leave `is_evergreen("meta-agent") == false` and the
     // dispatcher would fall into the phase-DAG path.
     if let Err(err) = ccteam_core::write_all_global_team_templates(&paths.root, false) {
         tracing::warn!(
             error = %err,
             root = %paths.root.display(),
-            "ccteam start: could not seed shipped team templates; \
-             run `ccteam doctor --reset-shipped-teams` if teams are missing",
+            "cct start: could not seed shipped team templates; \
+             run `cct doctor --reset-shipped-teams` if teams are missing",
         );
     }
 
     if !paths.phases_dir().exists() {
         eprintln!(
-            "ccteam: phases dir {} not found.\n  run `ccteam init` once to unpack templates, then come back.",
+            "ccteam: phases dir {} not found.\n  run `cct init` once to unpack templates, then come back.",
             paths.phases_dir().display()
         );
     }
@@ -546,7 +546,7 @@ fn run_start(
             .unwrap_or(true)
     {
         eprintln!(
-            "ccteam: no projects under {} yet.\n  start one in another terminal: ccteam new \"<your idea>\"",
+            "ccteam: no projects under {} yet.\n  start one in another terminal: cct new \"<your idea>\"",
             paths.projects_root.display()
         );
     }
@@ -566,7 +566,7 @@ fn run_start(
         }
     }
     // Write the pidfile *before* constructing the orchestrator so a
-    // second `ccteam start` against the same root errors out cleanly
+    // second `cct start` against the same root errors out cleanly
     // before either side has touched tmux.
     let pidfile = ccteam_core::write_pidfile(&paths)?;
     tracing::info!(pidfile = %pidfile.display(), "orchestrator pidfile written");
@@ -596,7 +596,7 @@ fn run_start(
                     };
                     tokio::select! {
                         _ = tokio::signal::ctrl_c() => tracing::info!("ctrl+c received"),
-                        _ = sigterm.recv() => tracing::info!("SIGTERM received (ccteam stop)"),
+                        _ = sigterm.recv() => tracing::info!("SIGTERM received (cct stop)"),
                     }
                 }
                 #[cfg(not(unix))]
@@ -619,7 +619,7 @@ fn run_new(request: Option<String>, file: Option<PathBuf>, team: String) -> Resu
             .with_context(|| format!("read {}", path.display()))?,
         (None, Some(text)) => text,
         (None, None) => {
-            anyhow::bail!("ccteam new: provide a request as a positional arg or --file PATH")
+            anyhow::bail!("cct new: provide a request as a positional arg or --file PATH")
         }
     };
     let slug = commands::run_new(&paths, body.trim(), &team)?;
@@ -627,7 +627,7 @@ fn run_new(request: Option<String>, file: Option<PathBuf>, team: String) -> Resu
     println!("  spec   : {}", paths.project_ccteam_dir(&slug).join("spec.md").display());
     println!("  state  : {}", paths.project_state(&slug).display());
     println!("  config : {}", paths.project_dir(&slug).join(".claude/settings.json").display());
-    println!("\nrun `ccteam start --foreground` (in another terminal) to dispatch the first phase.");
+    println!("\nrun `cct start --foreground` (in another terminal) to dispatch the first phase.");
     Ok(())
 }
 

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -47,7 +47,7 @@ const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
 const SERVER_NAME: &str = "ccteam";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Run `ccteam mcp-serve`. Reads JSON-RPC requests one per line from
+/// Run `cct mcp-serve`. Reads JSON-RPC requests one per line from
 /// stdin; writes responses one per line to stdout. Returns when stdin
 /// closes (clean shutdown when the parent disconnects).
 pub async fn run_mcp_serve(paths: CcteamPaths) -> Result<()> {
@@ -643,7 +643,7 @@ pub fn install_mcp_into(claude_json: &std::path::Path, ccteam_bin: &std::path::P
             .with_context(|| format!("create {}", parent.display()))?;
     }
     let mut tmp_os = claude_json.as_os_str().to_owned();
-    tmp_os.push(".ccteam-mcp.tmp");
+    tmp_os.push(".cct-mcp.tmp");
     let tmp = std::path::PathBuf::from(tmp_os);
     {
         let mut f = std::fs::File::create(&tmp)
@@ -664,7 +664,7 @@ pub fn install_mcp_into(claude_json: &std::path::Path, ccteam_bin: &std::path::P
 /// `--install-memory-bridge`) already honor through `user_claude_dir()`.
 pub fn install_mcp() -> Result<std::path::PathBuf> {
     let claude_json = ccteam_core::projects::resolve_claude_json_path()?;
-    let bin = ccteam_core::current_ccteam_bin()?;
+    let bin = ccteam_core::current_cct_bin()?;
     install_mcp_into(&claude_json, &bin)?;
     Ok(claude_json)
 }
@@ -697,13 +697,16 @@ mod tests {
 
     #[test]
     fn install_mcp_into_writes_command_args_env_for_ccteam_server() {
+        // V0.2.2 F39: binary is `cct` but the MCP server name stays
+        // `ccteam` (PRD §8.3 — server-name rename deferred to V0.3 to
+        // avoid touching every user's `~/.claude.json`).
         let tmp = tempfile::TempDir::new().unwrap();
         let claude_json = tmp.path().join(".claude.json");
-        let ccteam_bin = std::path::PathBuf::from("/usr/local/bin/ccteam");
-        install_mcp_into(&claude_json, &ccteam_bin).unwrap();
+        let cct_bin = std::path::PathBuf::from("/usr/local/bin/cct");
+        install_mcp_into(&claude_json, &cct_bin).unwrap();
         let body = std::fs::read_to_string(&claude_json).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/ccteam");
+        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/cct");
         assert_eq!(v["mcpServers"]["ccteam"]["args"][0], "mcp-serve");
     }
 
@@ -716,11 +719,11 @@ mod tests {
             r#"{"userID": "rob", "mcpServers": {"playwright": {"command": "npx"}}}"#,
         )
         .unwrap();
-        install_mcp_into(&claude_json, &std::path::PathBuf::from("/x/ccteam")).unwrap();
+        install_mcp_into(&claude_json, &std::path::PathBuf::from("/x/cct")).unwrap();
         let v: Value = serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
         assert_eq!(v["userID"], "rob");
         assert_eq!(v["mcpServers"]["playwright"]["command"], "npx");
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/x/ccteam");
+        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/x/cct");
     }
 
     #[test]

--- a/crates/ccteam-cli/src/team_factory_cli.rs
+++ b/crates/ccteam-cli/src/team_factory_cli.rs
@@ -1,10 +1,10 @@
-//! V0.2 M0.22 — `ccteam team {init,publish}` CLI handlers.
+//! V0.2 M0.22 — `cct team {init,publish}` CLI handlers.
 //!
 //! `init` is intentionally lightweight: it stamps a single-phase
 //! starter staging tree (`<staging>/.claude-plugin/plugin.json` +
 //! `team.yaml` + `phases/01-intake.md` + `README.md`). The team author
 //! then either edits the staging files directly or runs the meta-agent
-//! `ccteam-team-author` skill, which interview-mode produces the same
+//! `cct-team-author` skill, which interview-mode produces the same
 //! tree with N phases instead of one.
 //!
 //! `publish` calls `ccteam_core::publish_team` for the local target.

--- a/crates/ccteam-cli/tests/doctor_validate_team_fail_loud_test.rs
+++ b/crates/ccteam-cli/tests/doctor_validate_team_fail_loud_test.rs
@@ -16,7 +16,7 @@ fn run_doctor_validate(
     xdg: &std::path::Path,
     team: &str,
 ) -> std::process::Output {
-    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let bin = env!("CARGO_BIN_EXE_cct");
     Command::new(bin)
         .arg("doctor")
         .arg("--validate-team")

--- a/crates/ccteam-cli/tests/install_mcp_claude_config_home_test.rs
+++ b/crates/ccteam-cli/tests/install_mcp_claude_config_home_test.rs
@@ -32,7 +32,7 @@ fn install_mcp_writes_to_claude_config_home_when_set() {
     let fake_home = tmp.path().join("fake-home");
     std::fs::create_dir_all(&fake_home).unwrap();
 
-    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let bin = env!("CARGO_BIN_EXE_cct");
     let out = Command::new(bin)
         .args(["doctor", "--install-mcp"])
         .env("CLAUDE_CONFIG_HOME", &claude_dir)

--- a/crates/ccteam-cli/tests/m3_product_research_e2e_test.rs
+++ b/crates/ccteam-cli/tests/m3_product_research_e2e_test.rs
@@ -447,7 +447,7 @@ fn decisions_queue_lists_clarify_outbox_from_product_research_project() {
 /// CCTEAM_HOME / CCTEAM_PROJECTS_ROOT redirected to the test sandbox.
 /// Returns the captured stdout on success.
 fn run_ccteam_subcommand(paths: &CcteamPaths, args: &[&str]) -> anyhow::Result<String> {
-    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let bin = env!("CARGO_BIN_EXE_cct");
     let out = Command::new(bin)
         .args(args)
         .env("CCTEAM_HOME", paths.root.as_os_str())

--- a/crates/ccteam-cli/tests/mcp_e2e_test.rs
+++ b/crates/ccteam-cli/tests/mcp_e2e_test.rs
@@ -25,7 +25,7 @@ struct McpServer {
 
 impl McpServer {
     fn spawn(home: &std::path::Path, projects: &std::path::Path) -> Self {
-        let bin = env!("CARGO_BIN_EXE_ccteam");
+        let bin = env!("CARGO_BIN_EXE_cct");
         let mut child = Command::new(bin)
             .arg("mcp-serve")
             .env("CCTEAM_HOME", home)

--- a/crates/ccteam-cli/tests/start_claude_argv_flag_test.rs
+++ b/crates/ccteam-cli/tests/start_claude_argv_flag_test.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 #[test]
 fn ccteam_start_help_advertises_claude_argv_flag() {
-    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let bin = env!("CARGO_BIN_EXE_cct");
     let out = Command::new(bin)
         .args(["start", "--help"])
         .output()

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -48,10 +48,10 @@ pub use memory_bridge::{
     InstallMemoryBridgeOptions, MemoryBridgeAction, MemoryBridgeReport,
 };
 pub use skill::{
-    install_ccteam_control_skill, install_ccteam_team_author_skill,
+    install_cct_control_skill, install_cct_team_author_skill,
     install_into as install_skill_into, install_skill_body_into,
     InstallSkillOptions, InstallSkillReport, SkillInstallAction,
-    CCTEAM_CONTROL_SKILL_NAME, CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+    CCT_CONTROL_SKILL_NAME, CCT_TEAM_AUTHOR_SKILL_NAME, LEGACY_SKILL_NAMES,
 };
 pub use orchestrator::MAX_CONCURRENT_PROJECTS;
 pub use orchestrator::{
@@ -96,7 +96,7 @@ pub use team_resolver::{
     TeamSource, TEAM_SOURCES,
 };
 pub use templates::{
-    current_ccteam_bin, project_phase_filename, render_project_settings,
+    current_cct_bin, project_phase_filename, render_project_settings,
     write_all_global_team_templates, write_global_helper_templates,
     write_global_phase_templates, write_project_phase_templates,
     write_project_phase_templates_for_team, write_project_settings,
@@ -114,7 +114,9 @@ pub use plugin_resolution::{
 };
 pub use tool_surface::{
     disable_tool_surface_bootstrap_for_tests, ensure_skills_placeholders,
-    migrate_recommended_agent_symlinks, missing_tools, user_claude_dir, MigrationReport,
+    migrate_legacy_skill_dirs, migrate_recommended_agent_symlinks, missing_tools,
+    rewrite_legacy_hook_commands, user_claude_dir, HookCmdRewriteAction,
+    HookCmdRewriteReport, LegacySkillAction, LegacySkillReport, MigrationReport,
     MissingTool, ToolSurfaceSnapshot, ToolsRequired, BUILTIN_SUBAGENTS,
 };
 pub use watchdog::{

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -901,8 +901,12 @@ mod tests {
         // Reject the placeholder having survived the render — that's the
         // PATH-dependent failure mode we're guarding against.
         assert!(
-            !cmd.contains("__CCTEAM_BIN__"),
+            !cmd.contains("{{CCT_BIN}}"),
             "settings.json placeholder should be substituted, got: {cmd}",
+        );
+        assert!(
+            !cmd.contains("__CCTEAM_BIN__"),
+            "legacy F39 placeholder should not return, got: {cmd}",
         );
     }
 }

--- a/crates/ccteam-core/src/skill.rs
+++ b/crates/ccteam-core/src/skill.rs
@@ -1,10 +1,17 @@
-//! `ccteam-control` skill installation (M1.8).
+//! `cct-control` + `cct-team-author` skill installation (M1.8 + M0.22.1).
 //!
 //! Skills live at `~/.claude/skills/<name>/SKILL.md` (or under a plugin
-//! tree). The `ccteam-control` skill body is shipped inside the binary
-//! and written to disk by `ccteam doctor --install-skill`. The
-//! `--install-meta-agent` path also calls this so a freshly-bootstrapped
-//! meta-agent has the skill on first launch.
+//! tree). The `cct-control` and `cct-team-author` skill bodies are
+//! shipped inside the binary and written to disk by
+//! `cct doctor --install-skill`. The `--install-meta-agent` path also
+//! calls this so a freshly-bootstrapped meta-agent has both skills on
+//! first launch.
+//!
+//! V0.2.2 F39: skill names migrated from `ccteam-{control,team-author}`
+//! to `cct-{control,team-author}`; the markdown bodies live under the
+//! repo-root `skills/` directory (cross-dir `include_str!` into the
+//! ccteam-core binary). Migration of V0.1/V0.2 user installs is handled
+//! by `cct doctor` (see `migrate_legacy_skill_dirs` in tool_surface).
 
 use std::path::{Path, PathBuf};
 
@@ -13,21 +20,37 @@ use anyhow::{Context, Result};
 use crate::tool_surface::user_claude_dir;
 
 /// Skill directory name. Embedded SKILL.md ships under this folder
-/// inside `~/.claude/skills/`.
-pub const CCTEAM_CONTROL_SKILL_NAME: &str = "ccteam-control";
+/// inside `~/.claude/skills/`. V0.2.2 F39: `ccteam-control` → `cct-control`.
+pub const CCT_CONTROL_SKILL_NAME: &str = "cct-control";
 
-/// V0.2 M0.22.1 — `ccteam-team-author` skill name. Walks the
+/// V0.2 M0.22.1 — `cct-team-author` skill name. Walks the
 /// meta-agent through the team-factory dialogue (phase list, tools,
 /// golden rules, retro / verdict schema, plugin metadata) before
-/// invoking `ccteam team init`.
-pub const CCTEAM_TEAM_AUTHOR_SKILL_NAME: &str = "ccteam-team-author";
+/// invoking `cct team init`.
+///
+/// V0.2.2 F39: renamed from `ccteam-team-author`.
+pub const CCT_TEAM_AUTHOR_SKILL_NAME: &str = "cct-team-author";
+
+/// V0.2.2 F39: legacy V0.1/V0.2 skill directory names that
+/// `cct doctor` migrates. Exposed so the migration helper can scan
+/// for stale installs without re-declaring the names.
+pub const LEGACY_SKILL_NAMES: &[&str] = &["ccteam-control", "ccteam-team-author"];
 
 /// Embedded `SKILL.md` body. Written verbatim during install.
-const CCTEAM_CONTROL_SKILL_MD: &str = include_str!("templates/ccteam_control_skill.md");
+///
+/// V0.2.2 F39: skill bodies live at `<repo>/skills/cct-<name>/SKILL.md`
+/// (top-level `skills/` directory) so they're authoritative outside
+/// the Rust source tree.
+pub const CCT_CONTROL_SKILL_MD: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../skills/cct-control/SKILL.md"
+));
 
 /// Embedded `SKILL.md` body for the team-author skill (V0.2 M0.22.1).
-const CCTEAM_TEAM_AUTHOR_SKILL_MD: &str =
-    include_str!("templates/ccteam_team_author_skill.md");
+pub const CCT_TEAM_AUTHOR_SKILL_MD: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../skills/cct-team-author/SKILL.md"
+));
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InstallSkillOptions {
@@ -52,23 +75,23 @@ pub enum SkillInstallAction {
     DryRun { would_write: bool },
 }
 
-/// Install the `ccteam-control` skill into `~/.claude/skills/ccteam-control/SKILL.md`.
-pub fn install_ccteam_control_skill(opts: InstallSkillOptions) -> Result<InstallSkillReport> {
+/// Install the `cct-control` skill into `~/.claude/skills/cct-control/SKILL.md`.
+pub fn install_cct_control_skill(opts: InstallSkillOptions) -> Result<InstallSkillReport> {
     let claude = user_claude_dir().context("resolve ~/.claude/")?;
     install_into(&claude, opts)
 }
 
-/// V0.2 M0.22.1: install the `ccteam-team-author` skill into
-/// `~/.claude/skills/ccteam-team-author/SKILL.md`. Same idempotent
-/// semantics as `install_ccteam_control_skill`.
-pub fn install_ccteam_team_author_skill(
+/// V0.2 M0.22.1: install the `cct-team-author` skill into
+/// `~/.claude/skills/cct-team-author/SKILL.md`. Same idempotent
+/// semantics as `install_cct_control_skill`.
+pub fn install_cct_team_author_skill(
     opts: InstallSkillOptions,
 ) -> Result<InstallSkillReport> {
     let claude = user_claude_dir().context("resolve ~/.claude/")?;
     install_skill_body_into(
         &claude,
-        CCTEAM_TEAM_AUTHOR_SKILL_NAME,
-        CCTEAM_TEAM_AUTHOR_SKILL_MD,
+        CCT_TEAM_AUTHOR_SKILL_NAME,
+        CCT_TEAM_AUTHOR_SKILL_MD,
         opts,
     )
 }
@@ -78,8 +101,8 @@ pub fn install_ccteam_team_author_skill(
 pub fn install_into(claude_dir: &Path, opts: InstallSkillOptions) -> Result<InstallSkillReport> {
     install_skill_body_into(
         claude_dir,
-        CCTEAM_CONTROL_SKILL_NAME,
-        CCTEAM_CONTROL_SKILL_MD,
+        CCT_CONTROL_SKILL_NAME,
+        CCT_CONTROL_SKILL_MD,
         opts,
     )
 }
@@ -138,8 +161,17 @@ mod tests {
         assert_eq!(report.action, SkillInstallAction::Wrote);
         assert!(report.target.exists());
         let body = std::fs::read_to_string(&report.target).unwrap();
-        assert!(body.starts_with("---\n"), "must start with YAML front matter");
-        assert!(body.contains("name: ccteam-control"));
+        // V0.2.2 F39: bodies are wrapped in `<!-- ccteam-managed:skill begin/end -->`
+        // markers; the YAML front matter follows the open marker.
+        assert!(
+            body.contains("<!-- ccteam-managed:skill begin -->"),
+            "must contain ccteam-managed begin marker (F39 migration prerequisite)",
+        );
+        assert!(
+            body.contains("<!-- ccteam-managed:skill end -->"),
+            "must contain ccteam-managed end marker",
+        );
+        assert!(body.contains("---\nname: cct-control"));
         assert!(body.contains("allowed-tools: [Bash]"));
         // Required body chapters per interfaces §11.3.
         for required in ["Capability index", "Typical workflows", "Decision principles", "What this skill cannot do"] {
@@ -159,12 +191,12 @@ mod tests {
     fn force_overwrites_existing_file() {
         let tmp = tempfile::TempDir::new().unwrap();
         install_into(tmp.path(), InstallSkillOptions::default()).unwrap();
-        let target = tmp.path().join("skills/ccteam-control/SKILL.md");
+        let target = tmp.path().join("skills/cct-control/SKILL.md");
         std::fs::write(&target, "tampered\n").unwrap();
         let r = install_into(tmp.path(), InstallSkillOptions { force: true, dry_run: false }).unwrap();
         assert_eq!(r.action, SkillInstallAction::Replaced);
         let body = std::fs::read_to_string(&target).unwrap();
-        assert!(body.contains("name: ccteam-control"));
+        assert!(body.contains("name: cct-control"));
     }
 
     #[test]
@@ -185,19 +217,19 @@ mod tests {
     // ---------------- V0.2 M0.22.1 team-author skill ----------------
 
     #[test]
-    fn team_author_skill_installs_under_ccteam_team_author_dir() {
+    fn team_author_skill_installs_under_cct_team_author_dir() {
         let tmp = tempfile::TempDir::new().unwrap();
         let report = install_skill_body_into(
             tmp.path(),
-            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
-            CCTEAM_TEAM_AUTHOR_SKILL_MD,
+            CCT_TEAM_AUTHOR_SKILL_NAME,
+            CCT_TEAM_AUTHOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
         assert_eq!(report.action, SkillInstallAction::Wrote);
         let body = std::fs::read_to_string(&report.target).unwrap();
-        assert!(body.starts_with("---\n"));
-        assert!(body.contains("name: ccteam-team-author"));
+        assert!(body.contains("<!-- ccteam-managed:skill begin -->"));
+        assert!(body.contains("name: cct-team-author"));
         assert!(body.contains("Capability index"));
     }
 
@@ -206,15 +238,15 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         install_skill_body_into(
             tmp.path(),
-            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
-            CCTEAM_TEAM_AUTHOR_SKILL_MD,
+            CCT_TEAM_AUTHOR_SKILL_NAME,
+            CCT_TEAM_AUTHOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
         let r2 = install_skill_body_into(
             tmp.path(),
-            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
-            CCTEAM_TEAM_AUTHOR_SKILL_MD,
+            CCT_TEAM_AUTHOR_SKILL_NAME,
+            CCT_TEAM_AUTHOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();

--- a/crates/ccteam-core/src/templates.rs
+++ b/crates/ccteam-core/src/templates.rs
@@ -1,9 +1,12 @@
 //! Embedded ccteam templates rendered into produced-project trees by
-//! `ccteam new` and the global `~/.ccteam/` skeleton produced by
-//! `ccteam init`. The settings.json source uses the placeholder
-//! `__CCTEAM_BIN__` for the binary path so we can rewrite hook commands
+//! `cct new` and the global `~/.ccteam/` skeleton produced by
+//! `cct init`. The settings.json source uses the placeholder
+//! `{{CCT_BIN}}` for the binary path so we can rewrite hook commands
 //! to absolute paths at install time (otherwise hook subprocesses
-//! inherit Claude Code's PATH and silently fail to find `ccteam`).
+//! inherit Claude Code's PATH and silently fail to find `cct`).
+//!
+//! V0.2.2 F39: placeholder renamed from `__CCTEAM_BIN__` (binary now
+//! `cct`); the substitution semantics are unchanged.
 
 use std::path::Path;
 
@@ -11,10 +14,10 @@ use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 
 /// Per-project `.claude/settings.json` template. The template uses
-/// `__CCTEAM_BIN__` everywhere a real install would name `ccteam`; we
-/// substitute the running binary's absolute path at write time so hook
-/// subprocesses don't depend on the user's PATH (which Claude Code
-/// inherits and may not include the ccteam install dir).
+/// `{{CCT_BIN}}` everywhere a real install would name the absolute
+/// `cct` binary path; we substitute the running binary's absolute path
+/// at write time so hook subprocesses don't depend on the user's PATH
+/// (which Claude Code inherits and may not include the cct install dir).
 pub const PROJECT_SETTINGS_JSON: &str = include_str!("templates/settings.json");
 
 /// Phase template payloads — `(global_filename_with_index_prefix, body)`.
@@ -71,7 +74,7 @@ const PRODUCT_RESEARCH_PHASE_TEMPLATES: &[(&str, &str)] = &[
 ];
 
 /// Embedded `team.yaml` files keyed by team name. M3.4 ships dev +
-/// product-research; V0.2 M0.16 adds meta-agent (evergreen). `ccteam
+/// product-research; V0.2 M0.16 adds meta-agent (evergreen). `cct
 /// init` writes these to `~/.ccteam/teams/<name>/team.yaml`. The
 /// orchestrator reads them at startup to resolve `phase_dir`,
 /// registered ESCALATE prefixes, the V0.2 `evergreen` / `cost_policy`
@@ -89,7 +92,7 @@ const META_AGENT_PHASE_TEMPLATES: &[(&str, &str)] = &[];
 
 /// One team's compile-time bundle: a `team.yaml` body + the phase
 /// markdowns to stamp into the project's `<project>/.ccteam/phases/`
-/// dir on `ccteam new`. Looking up by team name keeps every
+/// dir on `cct new`. Looking up by team name keeps every
 /// per-team artifact in one place — adding a team is a config change.
 ///
 /// V0.2 §6.4 candidate 3: `pub(crate)` — runtime code paths now read
@@ -144,7 +147,7 @@ pub(crate) fn team_bundle(team: &str) -> Option<TeamTemplateBundle> {
 }
 
 /// M2.4: helper templates that phase markdown can `@`-reference. Shipped
-/// inside the binary so a fresh install (or `ccteam doctor`) can stamp
+/// inside the binary so a fresh install (or `cct doctor`) can stamp
 /// them into `~/.ccteam/templates/` without an external git checkout.
 ///
 /// `(on_disk_filename, body)` — phase markdown references them as
@@ -182,10 +185,13 @@ pub fn project_phase_filename(global: &str) -> &str {
     }
 }
 
-/// Resolve the path to the running ccteam binary. Falls back from
+/// Resolve the path to the running cct binary. Falls back from
 /// canonicalized to raw `current_exe()` because `canonicalize` rejects
 /// some `/proc/self/exe`-style paths in container test environments.
-pub fn current_ccteam_bin() -> Result<std::path::PathBuf> {
+///
+/// V0.2.2 F39: function renamed from `current_ccteam_bin` (binary
+/// renamed to `cct`); behavior is unchanged.
+pub fn current_cct_bin() -> Result<std::path::PathBuf> {
     let raw = std::env::current_exe().context("std::env::current_exe")?;
     Ok(raw.canonicalize().unwrap_or(raw))
 }
@@ -213,25 +219,25 @@ pub struct EnabledPluginsSetting {
     pub plugin_ids: std::collections::BTreeSet<String>,
 }
 
-/// Render `PROJECT_SETTINGS_JSON` with `__CCTEAM_BIN__` replaced by the
+/// Render `PROJECT_SETTINGS_JSON` with `{{CCT_BIN}}` replaced by the
 /// given absolute binary path, `extra_env` merged into the top-level
 /// `env` block, and `enabled` written under `enabledPlugins`. Validates
 /// that the rewritten body is still valid JSON so a path with
 /// shell-hostile characters can't silently corrupt the settings file.
 pub fn render_project_settings(
-    ccteam_bin: &Path,
+    cct_bin: &Path,
     extra_env: &SettingsEnv,
     enabled: &EnabledPluginsSetting,
 ) -> Result<String> {
-    let bin = ccteam_bin
+    let bin = cct_bin
         .to_str()
-        .ok_or_else(|| anyhow!("ccteam binary path not valid UTF-8: {}", ccteam_bin.display()))?;
+        .ok_or_else(|| anyhow!("cct binary path not valid UTF-8: {}", cct_bin.display()))?;
     if bin.contains('"') || bin.contains('\\') {
         return Err(anyhow!(
-            "ccteam binary path contains characters that can't be embedded in settings.json: {bin}"
+            "cct binary path contains characters that can't be embedded in settings.json: {bin}"
         ));
     }
-    let body = PROJECT_SETTINGS_JSON.replace("__CCTEAM_BIN__", bin);
+    let body = PROJECT_SETTINGS_JSON.replace("{{CCT_BIN}}", bin);
     let mut v: Value = serde_json::from_str(&body)
         .with_context(|| format!("rendered settings.json is not valid JSON (bin={bin})"))?;
     if let Some(env) = v.get_mut("env").and_then(|e| e.as_object_mut()) {
@@ -258,11 +264,11 @@ pub fn render_project_settings(
 }
 
 /// Write `<project_dir>/.claude/settings.json` with hook commands
-/// pointing at the running ccteam binary by absolute path, the
+/// pointing at the running cct binary by absolute path, the
 /// effective `CCTEAM_HOME` / `CCTEAM_PROJECTS_ROOT` baked into `env`,
 /// and the spawned-session `enabledPlugins` set. Creates the parent
 /// dir if missing. Idempotent — overwrites any prior render so
-/// re-running after a ccteam upgrade refreshes paths and the
+/// re-running after a cct upgrade refreshes paths and the
 /// plugin set.
 pub fn write_project_settings(
     project_dir: &Path,
@@ -272,7 +278,7 @@ pub fn write_project_settings(
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create {}", dir.display()))?;
     let path = dir.join("settings.json");
-    let bin = current_ccteam_bin()?;
+    let bin = current_cct_bin()?;
     let extra = SettingsEnv {
         ccteam_home: std::env::var("CCTEAM_HOME").ok(),
         ccteam_projects_root: std::env::var("CCTEAM_PROJECTS_ROOT").ok(),
@@ -332,7 +338,7 @@ pub fn write_project_phase_templates_for_team(
 }
 
 /// Write each `PHASE_TEMPLATES` entry into `<global_dir>/phases/` under
-/// its full prefixed name (e.g. `02-plan-eng.md`). Used by `ccteam init`
+/// its full prefixed name (e.g. `02-plan-eng.md`). Used by `cct init`
 /// so the orchestrator can load + validate templates from `~/.ccteam/`.
 /// `force == false` skips files already on disk so an operator can hand-
 /// edit a global template and not lose it on re-init.
@@ -408,9 +414,9 @@ pub fn write_all_global_team_templates(global_dir: &Path, force: bool) -> Result
 /// `@~/.ccteam/templates/<filename>` reference resolves. Idempotent;
 /// `force == false` preserves operator hand-edits.
 ///
-/// Called by `ccteam init` (global skeleton) and `bootstrap_project`
-/// (defensive — covers the user who jumps straight to `ccteam new`
-/// without `ccteam init`). The two callers don't conflict because
+/// Called by `cct init` (global skeleton) and `bootstrap_project`
+/// (defensive — covers the user who jumps straight to `cct new`
+/// without `cct init`). The two callers don't conflict because
 /// the writer is a no-op when files are already in place.
 pub fn write_global_helper_templates(global_dir: &Path, force: bool) -> Result<()> {
     let dir = global_dir.join("templates");
@@ -465,7 +471,7 @@ mod tests {
         // entry for `AskUserQuestion` so the hook can deny the call
         // before the assistant blocks waiting on an offline user.
         let body = render_project_settings(
-            Path::new("/usr/local/bin/ccteam"),
+            Path::new("/usr/local/bin/cct"),
             &SettingsEnv::default(),
             &EnabledPluginsSetting::default(),
         )
@@ -477,13 +483,13 @@ mod tests {
             .find(|e| e.get("matcher").and_then(|m| m.as_str()) == Some("AskUserQuestion"))
             .expect("PreToolUse must have an AskUserQuestion matcher entry");
         let cmd = intercept["hooks"][0]["command"].as_str().unwrap();
-        assert_eq!(cmd, "/usr/local/bin/ccteam hook intercept-ask");
+        assert_eq!(cmd, "/usr/local/bin/cct hook intercept-ask");
     }
 
     #[test]
-    fn template_session_start_uses_absolute_ccteam_path() {
+    fn template_session_start_uses_absolute_cct_path() {
         let body = render_project_settings(
-            Path::new("/usr/local/bin/ccteam"),
+            Path::new("/usr/local/bin/cct"),
             &SettingsEnv::default(),
             &EnabledPluginsSetting::default(),
         )
@@ -497,25 +503,30 @@ mod tests {
         assert_eq!(
             cmds,
             vec![
-                "/usr/local/bin/ccteam hook load-context",
-                "/usr/local/bin/ccteam hook progress-append session_start"
+                "/usr/local/bin/cct hook load-context",
+                "/usr/local/bin/cct hook progress-append session_start"
             ],
         );
     }
 
     #[test]
-    fn raw_template_uses_placeholder_not_bare_ccteam() {
-        // Guard against accidentally re-introducing `"command": "ccteam …"`
+    fn raw_template_uses_placeholder_not_bare_cct() {
+        // Guard against accidentally re-introducing `"command": "cct …"`
         // — the un-substituted form makes hook subprocesses depend on PATH,
         // which Claude Code inherits from its parent and which often does
-        // not include the ccteam install dir.
+        // not include the cct install dir.
         assert!(
-            PROJECT_SETTINGS_JSON.contains("__CCTEAM_BIN__"),
-            "template should reference __CCTEAM_BIN__ placeholder",
+            PROJECT_SETTINGS_JSON.contains("{{CCT_BIN}}"),
+            "template should reference {{CCT_BIN}} placeholder",
         );
         assert!(
-            !PROJECT_SETTINGS_JSON.contains("\"ccteam hook"),
-            "template should not embed bare `ccteam hook` — see render_project_settings",
+            !PROJECT_SETTINGS_JSON.contains("\"cct hook"),
+            "template should not embed bare `cct hook` — see render_project_settings",
+        );
+        // F39 sweep guard: legacy placeholder must not return.
+        assert!(
+            !PROJECT_SETTINGS_JSON.contains("__CCTEAM_BIN__"),
+            "template should not embed legacy __CCTEAM_BIN__ placeholder (F39)",
         );
     }
 

--- a/crates/ccteam-core/src/templates/memory_bridge_dev.md
+++ b/crates/ccteam-core/src/templates/memory_bridge_dev.md
@@ -9,7 +9,7 @@ paths:
 
 Auto-populated by the ccteam `ship` phase retro segment. The retro segment
 overwrites only the marked block below — anything you write outside of it is
-preserved across `ccteam doctor --install-memory-bridge` re-runs.
+preserved across `cct doctor --install-memory-bridge` re-runs.
 
 Field layout matches `teams/dev.yaml.retro_schema`:
 

--- a/crates/ccteam-core/src/templates/memory_bridge_product_research.md
+++ b/crates/ccteam-core/src/templates/memory_bridge_product_research.md
@@ -9,7 +9,7 @@ paths:
 
 Auto-populated by the ccteam `verdict` phase retro segment (REJECT branch).
 The retro segment overwrites only the marked block below — anything you write
-outside of it is preserved across `ccteam doctor --install-memory-bridge`
+outside of it is preserved across `cct doctor --install-memory-bridge`
 re-runs.
 
 Field layout matches `teams/product-research.yaml.retro_schema`:

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — ccteam meta-agent (__USER_HANDLE__)
 
 > 本文件是 ccteam 自动生成的 meta-agent role prompt(__GENERATED_AT__)。
-> 不要手改 — 下次 `ccteam doctor --install-meta-agent __USER_HANDLE__` 会覆盖。
+> 不要手改 — 下次 `cct doctor --install-meta-agent __USER_HANDLE__` 会覆盖。
 
 ## 1. 你是谁
 
@@ -11,7 +11,7 @@
 
 身份要点:
 - 你看到的工具列表里有 `Task` / `Bash` / `Read` / `Edit` / `Write` 等通用工具,但你**默认不调用 Edit/Write 改用户代码**——那是项目 session(L2)的活
-- ccteam-control skill 已经为你装好(`~/.claude/skills/ccteam-control/`),里面是 ccteam CLI 命令清单与典型工作流
+- cct-control skill 已经为你装好(`~/.claude/skills/cct-control/`),里面是 ccteam CLI 命令清单与典型工作流
 - 你的对话历史会在 context 接近 60% 时被压缩到本文件的"当前进度"节,新 session 启动后自动加载
 
 ## 2. 决策树(每次收到用户请求都跑一遍)
@@ -21,7 +21,7 @@
 ### 第 1 步:这是问答还是项目请求?
 
 - **问答** —— 例:"ccteam 的 Seed Gate 是什么意思?"/"我的 todo-cli 项目跑到哪了?"
-  - 直接回答。可以用 `Bash` 调 `ccteam ls --format json` / `ccteam show <slug> --format json` 拿数据
+  - 直接回答。可以用 `Bash` 调 `cct ls --format json` / `cct show <slug> --format json` 拿数据
   - 不要派单
 - **项目请求** —— 例:"做一个 todo cli"/"帮我写个书签管理器"
   - 进入第 2 步
@@ -57,20 +57,20 @@ M3 起 ccteam 支持 **dev** 与 **product-research** 两支团队。先判断�
 
 ### 第 4 步:派单
 
-通过 `Bash` 调 ccteam-control skill 文档里的命令——按第 2 步选定的团队:
+通过 `Bash` 调 cct-control skill 文档里的命令——按第 2 步选定的团队:
 
 ```bash
 # dev 路径
-ccteam new --team=dev "用户最终确认的 brief"
+cct new --team=dev "用户最终确认的 brief"
 
 # product-research 路径(产研判断 idea 值不值得做)
-ccteam new --team=product-research "用户最终确认的 brief"
+cct new --team=product-research "用户最终确认的 brief"
 ```
 
 派完之后,在 outbox 写一条 `event_kind: reply` 告诉用户:
 - 项目 slug + 派的团队
 - 预计第一个里程碑:dev 是 plan-eng(~30 分钟);product-research 是 kickoff 反向面试(可能立即问问题)
-- 后续怎么跟踪(`ccteam show <slug>` / `ccteam attach <slug>`)
+- 后续怎么跟踪(`cct show <slug>` / `cct attach <slug>`)
 - product-research 路径:**告知用户预期产物**——verdict.md 给出 PASS/CONCERN/REJECT/CLARIFY 判断,以及 next-steps.md 提示是否派 dev 团队
 
 ## 3. 克制规则(dispatcher not worker)
@@ -80,41 +80,41 @@ ccteam new --team=product-research "用户最终确认的 brief"
 - ❌ **不要**自己 `Edit` / `Write` 用户的项目代码
 - ❌ **不要**自己 `Bash` 跑 `git clone` / `npm init` / `cargo new` 起项目骨架
 - ❌ **不要**自己写完一份代码再"派给 ccteam"——那等于绕开整套 phase pipeline
-- ✅ 识别项目级请求时,**默认走 `ccteam new` 派单**,让对应团队 session 干活
+- ✅ 识别项目级请求时,**默认走 `cct new` 派单**,让对应团队 session 干活
 - ✅ 只有用户**明确说"你直接帮我写 X"**(例:"先别建项目,你直接写一段 yaml 给我看")时才走 worker 路径——这种情况下你做完直接回答即可,不进 ccteam pipeline
 
 为什么?ccteam 的全套机制(progress.jsonl / phase 边界 / cost 累计 / context reset / Seed Gate / Critic)只在项目 session 里生效。你绕开它 = 失去这一切保障 = 退回到普通 claude 的体验。
 
 ## 4. 派单工具(M1 用 Bash;M2.8+ 切 ccteam-mcp MCP)
 
-M1 阶段用 `Bash` 工具调 ccteam CLI(经 ccteam-control skill 启发):
+M1 阶段用 `Bash` 工具调 ccteam CLI(经 cct-control skill 启发):
 
 ```bash
 # 立项 —— dev 路径
-ccteam new --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
+cct new --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
 
 # 立项 —— product-research 路径(产研判断 idea 值不值得做)
-ccteam new --team=product-research "AI 菜谱生成器,拍冰箱照片自动写菜谱"
+cct new --team=product-research "AI 菜谱生成器,拍冰箱照片自动写菜谱"
 
 # 看一项目
-ccteam show <slug> --format json | jq
+cct show <slug> --format json | jq
 
 # 全局态
-ccteam ls --format json | jq
+cct ls --format json | jq
 
 # 看一项目实时输出
-ccteam progress <slug> --tail   # 流式;通常你不需要,因为关键事件会经 inbox 推到你这
+cct progress <slug> --tail   # 流式;通常你不需要,因为关键事件会经 inbox 推到你这
 ```
 
 M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具——比 shell parse 更鲁棒。届时本文件会被自动重写,你不必担心兼容。
 
 ## 5. 监控规则
 
-你**不展示 progress 细节**——那是 `ccteam show` / `ccteam progress` 的活。你向用户汇报的只有**关键事件**:
+你**不展示 progress 细节**——那是 `cct show` / `cct progress` 的活。你向用户汇报的只有**关键事件**:
 
 | 事件 | 你怎么说 |
 |---|---|
-| 派单成功 | "已派 dev 团队,slug = `<slug>`,跟踪用 `ccteam show <slug>`" |
+| 派单成功 | "已派 dev 团队,slug = `<slug>`,跟踪用 `cct show <slug>`" |
 | escalation(项目卡住) | 用 NL 描述卡点 + 列 ccteam 推荐的 2-3 条出路;让用户回 NL 选一条 |
 | shipped(项目完成) | 一句话总结 + 项目目录路径 |
 | stall 软告警 | "项目 X 静默 5/15/30 分钟,看起来卡了,要不要 attach 看看?" |
@@ -126,16 +126,16 @@ M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具�
 ccteam 跨项目聚合所有 `event_kind: clarify | escalation` 的 outbox 文件成一个**决策队列**。命令:
 
 ```bash
-ccteam decisions                 # 表格视图
-ccteam decisions --format json   # 结构化,适合你 jq 筛选
+cct decisions                 # 表格视图
+cct decisions --format json   # 结构化,适合你 jq 筛选
 ```
 
 **你必须主动用这个**——这是 mode 2(用户离线时)异步决策机制的入口(interfaces.md §5.6.4)。具体规则:
 
-- **session 启动 / context reset 后**:第一件事跑一次 `ccteam decisions --format json`,看有没有用户离开期间堆积的决策。**有则主动汇报**,例:"刚回来发现 3 个项目在等你拍板:bookmark-mgr 问 SQLite 还是 Postgres?todo-cli 报 max_clarify_rounds 撞顶。先处理哪个?"
-- **用户 NL 说"批一下今天的决策" / "看看 pending"**:跑 `ccteam decisions`,逐条 NL 化展示,等用户每条 NL 答复
-- **每次用户答复某条决策后**:用 `ccteam-control` 把答案写到对应 project session 的 inbox(`Bash` 调 `ccteam new`-style 路径,M2.8 后改 `ccteam__send_to_session` MCP 工具)
-- **绝不**主动 tail 单个项目的 outbox —— 用全局 `ccteam decisions` 一站式聚合
+- **session 启动 / context reset 后**:第一件事跑一次 `cct decisions --format json`,看有没有用户离开期间堆积的决策。**有则主动汇报**,例:"刚回来发现 3 个项目在等你拍板:bookmark-mgr 问 SQLite 还是 Postgres?todo-cli 报 max_clarify_rounds 撞顶。先处理哪个?"
+- **用户 NL 说"批一下今天的决策" / "看看 pending"**:跑 `cct decisions`,逐条 NL 化展示,等用户每条 NL 答复
+- **每次用户答复某条决策后**:用 `cct-control` 把答案写到对应 project session 的 inbox(`Bash` 调 `cct new`-style 路径,M2.8 后改 `ccteam__send_to_session` MCP 工具)
+- **绝不**主动 tail 单个项目的 outbox —— 用全局 `cct decisions` 一站式聚合
 
 **与 mode 1 的关系**:用户已经 `tmux attach` 到具体 project session 时,phase 内 claude 用 AskUserQuestion 直接问,**不**走 outbox 也**不**进决策队列。决策队列只装 mode 2(异步)写出来的 clarify / escalation。
 
@@ -166,7 +166,7 @@ content_type: text
 
 ## 7. Watchdog 角色(V0.2 M0.21)
 
-你的另一面身份是 **ccteam watchdog** —— 把 orchestrator / 各项目埋的低层信号
+你的另一面身份是 **cct watchdog** —— 把 orchestrator / 各项目埋的低层信号
 "翻译"成用户能读懂的 NL 通知。这是 **translation only** 角色,严格红线:
 
 - ❌ **不做技术决策**(不替项目 session 拍板"该不该重启"/"该不该 kill"/"该不该改方案")
@@ -178,10 +178,10 @@ content_type: text
 
 ```bash
 # 一次扫所有信号(daemon health + 全项目)
-ccteam watchdog scan --format json | jq
+cct watchdog scan --format json | jq
 
 # 同时把高/普 priority alert 写进自己 outbox
-ccteam watchdog scan --push --user __USER_HANDLE__
+cct watchdog scan --push --user __USER_HANDLE__
 ```
 
 四个信号源:
@@ -209,8 +209,8 @@ notify_mode: normal               # quiet / normal / verbose
 
 按下面顺序跑(允许跳过若该信号本次为空):
 
-1. 跑 `ccteam watchdog scan --format json` 看是否有 alert
-2. **`daemon_down` 必报**: 立即 NL 告知用户 "orchestrator 守护进程似乎挂了, MCP 命令现在失效, 要 `ccteam start --foreground` 重启吗?"
+1. 跑 `cct watchdog scan --format json` 看是否有 alert
+2. **`daemon_down` 必报**: 立即 NL 告知用户 "orchestrator 守护进程似乎挂了, MCP 命令现在失效, 要 `cct start --foreground` 重启吗?"
 3. **其他 alert 按 priority 处理**:
    - `cost_overrun` (priority=high): "X 项目 cost = $Y 已超你配的 $Z 阈值, 还烧吗?"
    - `needs_attention` (priority=high): "X 项目 phase 卡死(第二次 Stop 都没正常收尾),pane tail: <30 行>。要不要 attach 看看?"

--- a/crates/ccteam-core/src/templates/settings.json
+++ b/crates/ccteam-core/src/templates/settings.json
@@ -10,16 +10,16 @@
     "SessionStart": [
       {
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook load-context", "timeout": 5},
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append session_start", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook load-context", "timeout": 5},
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append session_start", "async": true}
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook parse-phase-end", "timeout": 10},
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append Stop", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook parse-phase-end", "timeout": 10},
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append Stop", "async": true}
         ]
       }
     ],
@@ -27,42 +27,42 @@
       {
         "matcher": "idle_prompt|permission_prompt",
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append notification", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append notification", "async": true}
         ]
       }
     ],
     "PreToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append PreToolUse", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append PreToolUse", "async": true}
         ]
       },
       {
         "matcher": "AskUserQuestion",
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook intercept-ask", "timeout": 5}
+          {"type": "command", "command": "{{CCT_BIN}} hook intercept-ask", "timeout": 5}
         ]
       }
     ],
     "PostToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append PostToolUse", "async": true},
-          {"type": "command", "command": "__CCTEAM_BIN__ hook cost-accumulate", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append PostToolUse", "async": true},
+          {"type": "command", "command": "{{CCT_BIN}} hook cost-accumulate", "async": true}
         ]
       }
     ],
     "SubagentStop": [
       {
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append SubagentStop", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append SubagentStop", "async": true}
         ]
       }
     ],
     "SessionEnd": [
       {
         "hooks": [
-          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append SessionEnd", "async": true}
+          {"type": "command", "command": "{{CCT_BIN}} hook progress-append SessionEnd", "async": true}
         ]
       }
     ]

--- a/crates/ccteam-core/src/tool_surface.rs
+++ b/crates/ccteam-core/src/tool_surface.rs
@@ -400,6 +400,247 @@ pub struct MigrationReport {
     pub removed: bool,
 }
 
+/// V0.2.2 F39: outcome of a single legacy skill directory check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LegacySkillAction {
+    /// Directory absent — V0.1/V0.2 user never installed this skill, or
+    /// already cleaned up. Reported as "no-op".
+    NotFound,
+    /// Body carried the `<!-- ccteam-managed:skill … -->` marker (or the
+    /// matching frontmatter `name:`); we wrote the stale dir away.
+    Removed,
+    /// `dry_run=true` — would have removed; filesystem untouched.
+    WouldRemove,
+    /// Body had no marker — operator hand-edited the legacy skill.
+    /// Preserved (with a warning logged via the report); user must
+    /// remove manually.
+    PreservedHandEdit,
+}
+
+/// V0.2.2 F39: report for one `~/.claude/skills/<legacy>/` directory.
+#[derive(Debug, Clone)]
+pub struct LegacySkillReport {
+    /// `<claude_dir>/skills/<legacy_name>/`.
+    pub target: PathBuf,
+    /// One of the V0.1/V0.2 `LEGACY_SKILL_NAMES` entries.
+    pub legacy_name: String,
+    pub action: LegacySkillAction,
+}
+
+/// V0.2.2 F39: detect and (when safe) remove `~/.claude/skills/ccteam-{control,team-author}/`
+/// dirs left over from V0.1/V0.2 installs. The cct doctor migration
+/// path calls this after the new `cct-{control,team-author}` skills
+/// have been installed so users can collapse to a single skill set.
+///
+/// **Safety contract (PRD §8.2.5)**: only removes a legacy directory
+/// whose `SKILL.md` body still carries the `<!-- ccteam-managed:skill ... -->`
+/// marker or the matching `name: ccteam-{control,team-author}` YAML
+/// frontmatter. Operator hand-edits (no marker, no canonical frontmatter)
+/// are preserved as-is — the user must remove them manually if they
+/// want a clean tree.
+///
+/// `dry_run=true` reports without touching the filesystem.
+pub fn migrate_legacy_skill_dirs(
+    claude_dir: &Path,
+    dry_run: bool,
+) -> Result<Vec<LegacySkillReport>> {
+    use crate::skill::LEGACY_SKILL_NAMES;
+
+    let skills_dir = claude_dir.join("skills");
+    let mut out: Vec<LegacySkillReport> = Vec::new();
+
+    for legacy in LEGACY_SKILL_NAMES {
+        let dir = skills_dir.join(legacy);
+        let skill_md = dir.join("SKILL.md");
+        if !dir.exists() {
+            out.push(LegacySkillReport {
+                target: dir,
+                legacy_name: (*legacy).to_string(),
+                action: LegacySkillAction::NotFound,
+            });
+            continue;
+        }
+
+        // Body must carry the ccteam-managed marker (the body we shipped
+        // through V0.1/V0.2 plus the V0.2.2 wrapper) **or** the
+        // canonical frontmatter `name: ccteam-…` so we can be sure it's
+        // the unedited shipped skill. Either signal alone is enough.
+        let body = std::fs::read_to_string(&skill_md).unwrap_or_default();
+        let canonical_frontmatter = format!("name: {legacy}");
+        let is_managed = body.contains("<!-- ccteam-managed:skill begin -->")
+            || body.contains(&canonical_frontmatter);
+        if !is_managed {
+            out.push(LegacySkillReport {
+                target: dir,
+                legacy_name: (*legacy).to_string(),
+                action: LegacySkillAction::PreservedHandEdit,
+            });
+            continue;
+        }
+
+        if dry_run {
+            out.push(LegacySkillReport {
+                target: dir,
+                legacy_name: (*legacy).to_string(),
+                action: LegacySkillAction::WouldRemove,
+            });
+            continue;
+        }
+
+        std::fs::remove_dir_all(&dir)
+            .with_context(|| format!("remove_dir_all {}", dir.display()))?;
+        out.push(LegacySkillReport {
+            target: dir,
+            legacy_name: (*legacy).to_string(),
+            action: LegacySkillAction::Removed,
+        });
+    }
+    Ok(out)
+}
+
+/// V0.2.2 F39: outcome of a single project's settings.json hook
+/// command rewrite (legacy `… ccteam hook …` → `<current_exe> hook …`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookCmdRewriteAction {
+    /// File absent — nothing to do.
+    NotFound,
+    /// File present, no hook command referenced a legacy `ccteam`
+    /// binary path. Idempotent re-run after a successful migration
+    /// hits this branch.
+    NoChangeNeeded,
+    /// `dry_run=true` — would have rewritten N entries.
+    WouldRewrite { entries: usize },
+    /// Rewrote N hook commands and atomically wrote the file.
+    Rewrote { entries: usize },
+}
+
+/// V0.2.2 F39: report for one `~/projects/<slug>/.claude/settings.json`.
+#[derive(Debug, Clone)]
+pub struct HookCmdRewriteReport {
+    pub target: PathBuf,
+    pub action: HookCmdRewriteAction,
+}
+
+/// V0.2.2 F39: rewrite legacy `… /ccteam hook …` (or `ccteam hook …`
+/// without an absolute prefix) entries in a project's settings.json
+/// so they invoke the new `cct` binary at the running ccteam
+/// process's `current_exe()` path. Idempotent — re-runs after success
+/// hit `NoChangeNeeded`.
+///
+/// Detection rule: any `command` string that ends with the legacy
+/// segment `/ccteam hook ` or starts with `ccteam hook ` (no slash).
+/// The replacement substitutes everything up through the binary path
+/// with the new binary path. Hook subcommands (e.g. `progress-append
+/// session_start`) are preserved verbatim so this works for every hook
+/// in `templates/settings.json`.
+pub fn rewrite_legacy_hook_commands(
+    settings_path: &Path,
+    new_bin: &Path,
+    dry_run: bool,
+) -> Result<HookCmdRewriteReport> {
+    if !settings_path.exists() {
+        return Ok(HookCmdRewriteReport {
+            target: settings_path.to_path_buf(),
+            action: HookCmdRewriteAction::NotFound,
+        });
+    }
+
+    let new_bin_str = new_bin
+        .to_str()
+        .ok_or_else(|| anyhow!("cct binary path not valid UTF-8: {}", new_bin.display()))?;
+    if new_bin_str.contains('"') || new_bin_str.contains('\\') {
+        return Err(anyhow!(
+            "cct binary path contains characters that can't be embedded in settings.json: {new_bin_str}"
+        ));
+    }
+
+    let body = std::fs::read_to_string(settings_path)
+        .with_context(|| format!("read {}", settings_path.display()))?;
+    let mut v: serde_json::Value = serde_json::from_str(&body)
+        .with_context(|| format!("parse {}", settings_path.display()))?;
+
+    let mut rewritten = 0usize;
+    let Some(hooks) = v.get_mut("hooks").and_then(|h| h.as_object_mut()) else {
+        return Ok(HookCmdRewriteReport {
+            target: settings_path.to_path_buf(),
+            action: HookCmdRewriteAction::NoChangeNeeded,
+        });
+    };
+    for (_event, list) in hooks.iter_mut() {
+        let Some(arr) = list.as_array_mut() else {
+            continue;
+        };
+        for entry in arr.iter_mut() {
+            let Some(inner_hooks) =
+                entry.get_mut("hooks").and_then(|h| h.as_array_mut())
+            else {
+                continue;
+            };
+            for hook in inner_hooks.iter_mut() {
+                let Some(cmd_val) = hook.get_mut("command") else {
+                    continue;
+                };
+                let Some(cmd) = cmd_val.as_str() else {
+                    continue;
+                };
+                if let Some(new_cmd) = rewrite_one_hook_command(cmd, new_bin_str) {
+                    *cmd_val = serde_json::Value::String(new_cmd);
+                    rewritten += 1;
+                }
+            }
+        }
+    }
+
+    if rewritten == 0 {
+        return Ok(HookCmdRewriteReport {
+            target: settings_path.to_path_buf(),
+            action: HookCmdRewriteAction::NoChangeNeeded,
+        });
+    }
+    if dry_run {
+        return Ok(HookCmdRewriteReport {
+            target: settings_path.to_path_buf(),
+            action: HookCmdRewriteAction::WouldRewrite { entries: rewritten },
+        });
+    }
+
+    let body = serde_json::to_string_pretty(&v).context("serialize updated settings.json")?;
+    // Atomic write: write to `<path>.tmp` then rename so a crash mid-
+    // write can't leave a half-rewritten settings.json on disk.
+    let tmp = settings_path.with_extension("json.cct-migrate.tmp");
+    std::fs::write(&tmp, &body)
+        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, settings_path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), settings_path.display()))?;
+    Ok(HookCmdRewriteReport {
+        target: settings_path.to_path_buf(),
+        action: HookCmdRewriteAction::Rewrote { entries: rewritten },
+    })
+}
+
+/// V0.2.2 F39: rewrite one hook `command` string. Returns `None` when
+/// the command does not look like a legacy `ccteam hook …` invocation
+/// (so the caller can leave it alone — preserves operator-authored
+/// hooks). Otherwise returns the rewritten string with the binary path
+/// swapped to `new_bin`.
+fn rewrite_one_hook_command(cmd: &str, new_bin: &str) -> Option<String> {
+    // Already pointing at the new `cct` binary? Idempotency.
+    if cmd.contains("/cct hook ") || cmd.starts_with("cct hook ") {
+        return None;
+    }
+    // Absolute path ending with `/ccteam hook …`.
+    if let Some(idx) = cmd.find("/ccteam hook ") {
+        let tail = &cmd[idx + "/ccteam".len()..];
+        return Some(format!("{new_bin}{tail}"));
+    }
+    // Bare `ccteam hook …` with no path prefix (uncommon but legal in
+    // V0.1 templates).
+    if let Some(rest) = cmd.strip_prefix("ccteam hook ") {
+        return Some(format!("{new_bin} hook {rest}"));
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -609,5 +850,181 @@ mod tests {
         assert!(!reports[0].removed);
         // Dry-run preserves the symlink.
         assert!(stale.symlink_metadata().unwrap().file_type().is_symlink());
+    }
+
+    // -------------------- V0.2.2 F39 migration helpers --------------------
+
+    fn write_legacy_skill(claude: &Path, name: &str, body: &str) -> PathBuf {
+        let dir = claude.join("skills").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("SKILL.md");
+        std::fs::write(&path, body).unwrap();
+        dir
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_reports_not_found_when_clean() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
+        assert_eq!(reports.len(), 2);
+        for r in &reports {
+            assert_eq!(r.action, LegacySkillAction::NotFound);
+        }
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_removes_managed_install() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let dir = write_legacy_skill(
+            &claude,
+            "ccteam-control",
+            "<!-- ccteam-managed:skill begin -->\n---\nname: ccteam-control\n---\n# body\n<!-- ccteam-managed:skill end -->\n",
+        );
+        let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
+        let ctrl = reports
+            .iter()
+            .find(|r| r.legacy_name == "ccteam-control")
+            .unwrap();
+        assert_eq!(ctrl.action, LegacySkillAction::Removed);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_removes_v0_2_install_via_frontmatter() {
+        // V0.2.0 / V0.2.1 shipped the skill body without the
+        // ccteam-managed marker (the marker is V0.2.2 F39 prep). Detect
+        // it by frontmatter `name:` instead.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let dir = write_legacy_skill(
+            &claude,
+            "ccteam-team-author",
+            "---\nname: ccteam-team-author\n---\n# body\n",
+        );
+        let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
+        let ta = reports
+            .iter()
+            .find(|r| r.legacy_name == "ccteam-team-author")
+            .unwrap();
+        assert_eq!(ta.action, LegacySkillAction::Removed);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_preserves_hand_edits() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let dir = write_legacy_skill(
+            &claude,
+            "ccteam-control",
+            "---\nname: my-custom-fork\n---\n# user wrote this\n",
+        );
+        let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
+        let ctrl = reports
+            .iter()
+            .find(|r| r.legacy_name == "ccteam-control")
+            .unwrap();
+        assert_eq!(ctrl.action, LegacySkillAction::PreservedHandEdit);
+        assert!(dir.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_dry_run_does_not_remove() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let dir = write_legacy_skill(
+            &claude,
+            "ccteam-control",
+            "<!-- ccteam-managed:skill begin -->\n---\nname: ccteam-control\n---\n",
+        );
+        let reports = migrate_legacy_skill_dirs(&claude, true).unwrap();
+        let ctrl = reports
+            .iter()
+            .find(|r| r.legacy_name == "ccteam-control")
+            .unwrap();
+        assert_eq!(ctrl.action, LegacySkillAction::WouldRemove);
+        assert!(dir.exists());
+    }
+
+    fn legacy_settings_json(legacy_bin: &str) -> String {
+        format!(
+            r#"{{
+  "hooks": {{
+    "SessionStart": [
+      {{"hooks": [
+        {{"type": "command", "command": "{legacy_bin} hook load-context", "timeout": 5}},
+        {{"type": "command", "command": "{legacy_bin} hook progress-append session_start", "async": true}}
+      ]}}
+    ],
+    "Stop": [
+      {{"hooks": [{{"type": "command", "command": "{legacy_bin} hook parse-phase-end"}}]}}
+    ]
+  }}
+}}"#
+        )
+    }
+
+    #[test]
+    fn rewrite_legacy_hook_commands_swaps_absolute_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, legacy_settings_json("/home/u/.cargo/bin/ccteam")).unwrap();
+        let new_bin = PathBuf::from("/home/u/.cargo/bin/cct");
+        let rep = rewrite_legacy_hook_commands(&path, &new_bin, false).unwrap();
+        assert_eq!(rep.action, HookCmdRewriteAction::Rewrote { entries: 3 });
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("/home/u/.cargo/bin/cct hook load-context"), "got: {body}");
+        assert!(!body.contains("/ccteam hook"), "legacy path survived: {body}");
+    }
+
+    #[test]
+    fn rewrite_legacy_hook_commands_dry_run_does_not_write() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("settings.json");
+        let original = legacy_settings_json("/home/u/.cargo/bin/ccteam");
+        std::fs::write(&path, &original).unwrap();
+        let new_bin = PathBuf::from("/home/u/.cargo/bin/cct");
+        let rep = rewrite_legacy_hook_commands(&path, &new_bin, true).unwrap();
+        assert_eq!(rep.action, HookCmdRewriteAction::WouldRewrite { entries: 3 });
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, original);
+    }
+
+    #[test]
+    fn rewrite_legacy_hook_commands_idempotent_when_already_cct() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("settings.json");
+        std::fs::write(&path, legacy_settings_json("/home/u/.cargo/bin/cct")).unwrap();
+        let new_bin = PathBuf::from("/home/u/.cargo/bin/cct");
+        let rep = rewrite_legacy_hook_commands(&path, &new_bin, false).unwrap();
+        assert_eq!(rep.action, HookCmdRewriteAction::NoChangeNeeded);
+    }
+
+    #[test]
+    fn rewrite_legacy_hook_commands_handles_missing_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("settings.json");
+        let new_bin = PathBuf::from("/usr/local/bin/cct");
+        let rep = rewrite_legacy_hook_commands(&path, &new_bin, false).unwrap();
+        assert_eq!(rep.action, HookCmdRewriteAction::NotFound);
+    }
+
+    #[test]
+    fn rewrite_one_hook_command_handles_bare_ccteam_prefix() {
+        let got = rewrite_one_hook_command("ccteam hook progress-append PreToolUse", "/x/cct");
+        assert_eq!(
+            got.as_deref(),
+            Some("/x/cct hook progress-append PreToolUse"),
+        );
+    }
+
+    #[test]
+    fn rewrite_one_hook_command_returns_none_for_unrelated_commands() {
+        assert!(
+            rewrite_one_hook_command("/usr/bin/jq .progress[]", "/x/cct").is_none(),
+            "should not touch operator-authored hooks",
+        );
     }
 }

--- a/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
+++ b/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
@@ -1,15 +1,15 @@
 //! M1.3 acceptance test (end-to-end meta-agent dispatch).
 //!
 //! Production flow we're modeling:
-//!   1. `ccteam doctor --install-meta-agent <user>` lays down the
-//!      meta-agent project + role prompt + ccteam-control skill.
+//!   1. `cct doctor --install-meta-agent <user>` lays down the
+//!      meta-agent project + role prompt + cct-control skill.
 //!   2. orchestrator brings up `ccteam-meta-<user>` tmux session.
 //!   3. user / channel adapter writes an inbox file with a project
 //!      request.
 //!   4. orchestrator's inbox watcher injects the body into the meta
 //!      session via send-keys (idle path, since the session is fresh).
 //!   5. inside the session, claude reads the body, decides to
-//!      `ccteam new --team=dev` (we mock this — see below).
+//!      `cct new --team=dev` (we mock this — see below).
 //!   6. meta writes an outbox `event_kind: reply` confirming the
 //!      dispatch.
 //!
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use ccteam_core::tmux::{tmux_available, TmuxSession};
 use ccteam_core::{
-    bootstrap_meta_project, current_ccteam_bin, disable_tool_surface_bootstrap_for_tests,
+    bootstrap_meta_project, current_cct_bin, disable_tool_surface_bootstrap_for_tests,
     inbox_filename, install_skill_into, write_global_phase_templates, CcteamPaths, InboxFrontMatter,
     InboxMessage, InstallSkillOptions, Orchestrator, OrchestratorConfig, OutboxEventKind,
     OutboxFrontMatter, OutboxMessage, OutboxPriority, ProjectState, SessionMailbox,
@@ -50,34 +50,35 @@ fn meta_dispatch_e2e_inbox_to_outbox() {
         eprintln!("[skip] tmux not on PATH");
         return;
     }
-    // Note: in the test binary `current_ccteam_bin()` returns the test
-    // binary itself (which doesn't speak `ccteam new`). Cross-crate
-    // CARGO_BIN_EXE_ccteam isn't exported either, so we model the
+    // Note: in the test binary `current_cct_bin()` returns the test
+    // binary itself (which doesn't speak `cct new`). Cross-crate
+    // CARGO_BIN_EXE_cct isn't exported either, so we model the
     // dispatch by laying down a project directory + state.json
     // directly inside the shell stand-in. The real meta-agent binds
-    // its `Bash("ccteam new ...")` call in production; that subshell
+    // its `Bash("cct new ...")` call in production; that subshell
     // execution path is covered by the dedicated `commands::run_new`
     // unit tests.
-    let _ = current_ccteam_bin().ok();
+    let _ = current_cct_bin().ok();
     isolation();
 
     let tmp = TempDir::new().unwrap();
     let paths = fresh_paths(&tmp);
     write_global_phase_templates(&paths.root, true).unwrap();
 
-    // Step 1: install meta-agent + ccteam-control skill (M1.0 + M1.8).
+    // Step 1: install meta-agent + cct-control skill (M1.0 + M1.8 +
+    // V0.2.2 F39 rename).
     let user = format!("e2e-{}", std::process::id());
     let report = bootstrap_meta_project(&paths, &user).unwrap();
     let claude_root = tmp.path().join("claude-home");
     install_skill_into(&claude_root, InstallSkillOptions::default()).unwrap();
-    assert!(claude_root.join("skills/ccteam-control/SKILL.md").is_file());
+    assert!(claude_root.join("skills/cct-control/SKILL.md").is_file());
 
     // Step 2/3: prepare a stand-in for claude that, on first run,
     // (a) touches the ready marker so ensure_session unblocks,
     // (b) waits for the inbox-injected message body to arrive on
     //     stdin (we approximate this by polling for the orchestrator's
     //     `inbox_consumed` progress event),
-    // (c) executes `ccteam new --team=dev "<brief>"` to dispatch,
+    // (c) executes `cct new --team=dev "<brief>"` to dispatch,
     // (d) writes the meta outbox reply file.
     //
     // The orchestrator's send-keys will land "做一个 todo cli\n" in
@@ -93,11 +94,11 @@ fn meta_dispatch_e2e_inbox_to_outbox() {
     let dispatched_slug_dir = paths.projects_root.join("todo-cli");
     let dispatched_str = dispatched_slug_dir.to_string_lossy().to_string();
 
-    // Shell stand-in for `claude` running ccteam-control via Bash:
+    // Shell stand-in for `claude` running cct-control via Bash:
     //   1. touch ready marker
     //   2. read first line from the pane (orchestrator's send-keys
     //      delivers the inbox body)
-    //   3. simulate `ccteam new --team=dev "<brief>"` by laying down
+    //   3. simulate `cct new --team=dev "<brief>"` by laying down
     //      `<projects>/todo-cli/.ccteam/state.json`
     //   4. write meta outbox `event_kind: reply` confirming dispatch
     //   5. stay alive so the test can attach.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -305,7 +305,7 @@ event_kind: reply                             # reply | progress | escalation | 
 
 # NL reply body
 
-收到了。我已经用 `ccteam new` 派单给 dev 团队,slug = bookmark-mgr-a3f9。
+收到了。我已经用 `cct new` 派单给 dev 团队,slug = bookmark-mgr-a3f9。
 预计 30 分钟内 plan-eng 完成,有 escalation 我会同步。
 ```
 
@@ -399,7 +399,7 @@ interfaces §3.4.3"。具体写哪些事件:
 | `ESCALATE: NEED_USER_INPUT — <questions>` | `need_user_input` | `null` | 写 escalation.md,inbox 等用户 |
 | `ESCALATE: ABORT — <reason>` | `abort` | `null` | 项目永久标 escalated,M0 等同 NEED_USER_INPUT |
 | `ESCALATE: INSUFFICIENT_CLARIFICATION — <last_question>` | `insufficient_clarification` | `null` | M2.3+:phase 已撞 `max_clarify_rounds` 上限,best-effort artifact 已产出;orchestrator 写 escalation.md,outbox `event_kind: escalation`,等用户决定继续 / 接受 / abort(详见 §5.6.2) |
-| `ESCALATE: PHASE_DONE_PENDING — <reason>` | (special — emits standalone `phase_done_pending` event, not `escalate`) | `null` | M3.6 ✅:phase 产出 required_outputs 但部分子任务 defer。Stop hook 从 reason 解析 outbox 文件名(`reply-*.md` / `clarify-*.md` / `escalation-*.md`),写 `event: "phase_done_pending"` 含 `phase` / `open_decisions[]` / `reason` 三字段;orchestrator 走 `TickAction::AdvancePhasePending`,看下 phase `required_inputs` 与 `open_decisions` 静态交集决定 advance / 切 `PhaseState::DonePending` 阻塞(`ccteam resume` 清除) |
+| `ESCALATE: PHASE_DONE_PENDING — <reason>` | (special — emits standalone `phase_done_pending` event, not `escalate`) | `null` | M3.6 ✅:phase 产出 required_outputs 但部分子任务 defer。Stop hook 从 reason 解析 outbox 文件名(`reply-*.md` / `clarify-*.md` / `escalation-*.md`),写 `event: "phase_done_pending"` 含 `phase` / `open_decisions[]` / `reason` 三字段;orchestrator 走 `TickAction::AdvancePhasePending`,看下 phase `required_inputs` 与 `open_decisions` 静态交集决定 advance / 切 `PhaseState::DonePending` 阻塞(`cct resume` 清除) |
 | `ESCALATE: <free text>`(无前缀) | `need_user_input` | `null` | 等同显式 NEED_USER_INPUT,reason 是整段文本 |
 
 分隔符:em dash `—`(U+2014)、`--`、` - `(单 dash 必须前后有空格——这是为了不切碎 `plan-eng` 这类 phase 名)。
@@ -595,7 +595,7 @@ confidence: 0.0-1.0
 
 ### 5.4 `tools_required` 字段语义(M0.5+)
 
-声明 phase 模板里会用到的工具,orchestrator 启动时枚举本机可达项 + 交叉比对,缺谁报谁 + 给修复命令(`ccteam start` 直接 fail-fast,除非加 `--skip-tool-check`)。
+声明 phase 模板里会用到的工具,orchestrator 启动时枚举本机可达项 + 交叉比对,缺谁报谁 + 给修复命令(`cct start` 直接 fail-fast,除非加 `--skip-tool-check`)。
 
 | 子字段 | 名字来源 | "可达"判定 |
 |---|---|---|
@@ -607,7 +607,7 @@ confidence: 0.0-1.0
 
 `bootstrap_project` 已在 §1.2 项目创建路径里自动写 `enabledPlugins` + 占位 skills 目录,所以 happy path 上模板要的工具默认都有;只有用户手工编辑模板加了非推荐工具时才会触发本节的校验失败。
 
-V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `ccteam doctor --migrate-recommended-agents` 一次性清理。
+V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `cct doctor --migrate-recommended-agents` 一次性清理。
 
 ---
 
@@ -630,7 +630,7 @@ V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `cct
 ```yaml
 # ~/.ccteam/teams/product-research/team.yaml — 完整字段示例
 name: product-research                  # 必填。snake-case [a-z0-9_-]+,与 --team / state.json.team 对齐
-description: Product research team       # 可选。`ccteam ls --teams`(M3.4)显示
+description: Product research team       # 可选。`cct ls --teams`(M3.4)显示
 phase_dir: phases-product-research       # 默认 `phases`。phase 模板 markdown 所在目录(相对 ~/.ccteam/)
 
 # M3.4 verdict-emitting phase 名 list。对应 §5.3 通用 verdict schema。
@@ -734,7 +734,7 @@ claude_md_template: |
 <staging>/
   .claude-plugin/
     plugin.json                       # Claude Code plugin manifest(严格 schema)
-  team.yaml                           # ccteam team 配置(plugin loader unknown,zod strip)
+  team.yaml                           # cct team 配置(plugin loader unknown,zod strip)
   phases/
     01-<phase>.md                     # 同 §5.1 frontmatter
     ...
@@ -780,7 +780,7 @@ V0.3 candidate)。
 §2.7)。`team.yaml` 不会污染 plugin 加载,ccteam 通过
 `team_resolver::resolve_team` 直接读。
 
-**校验**(`ccteam doctor --validate-team <name>`,M0.22.4 在 M0.18.5
+**校验**(`cct doctor --validate-team <name>`,M0.22.4 在 M0.18.5
 基础上扩展):
 1. `.claude-plugin/plugin.json` 解析 + `PluginManifest::validate`
    (name / description / author.name 非空,name 字符集合法)
@@ -791,7 +791,7 @@ V0.3 candidate)。
 **实现位置**:`crates/ccteam-core/src/team_factory.rs`(`PluginManifest` /
 `PluginAuthor` / `init_team_staging` / `validate_staged_team` /
 `publish_team`)。CLI 入口在 `crates/ccteam-cli/src/team_factory_cli.rs`
-`ccteam team {init,publish}`。
+`cct team {init,publish}`。
 
 ---
 
@@ -833,9 +833,9 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 - `sync` mode → 不写任何 outbox(用 AskUserQuestion 直接对话)
 - `async` / `hybrid` mode → 写 `clarify`(还想问)或 `escalation`(过 max_clarify_rounds 或 verdict=REJECT)
 
-#### 5.6.4 与 `ccteam decisions` CLI 的关系(M1 收尾增量)
+#### 5.6.4 与 `cct decisions` CLI 的关系(M1 收尾增量)
 
-`ccteam decisions` 扫所有 `~/projects/*/.ccteam/outbox/*.md` 过滤 `event_kind: clarify | escalation`,聚合成跨项目决策队列。**用户在 meta session attach 时,meta-agent 主动汇报队列**(role prompt 启发,M1.0 已落)。
+`cct decisions` 扫所有 `~/projects/*/.ccteam/outbox/*.md` 过滤 `event_kind: clarify | escalation`,聚合成跨项目决策队列。**用户在 meta session attach 时,meta-agent 主动汇报队列**(role prompt 启发,M1.0 已落)。
 
 ---
 
@@ -843,7 +843,7 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 
 ### 6.1 项目 `.claude/settings.json` 完整模板
 
-> **D1 备注**:所有 hook 都是 `ccteam` 单 binary 的子命令(`ccteam hook <name>`),不再是独立 bash/python 脚本——零运行时依赖,与 orchestrator 共享 serde schema。debug 时可手动跑 `ccteam hook <subcmd>` 喂 stdin JSON(详见 §10.6)。
+> **D1 备注**:所有 hook 都是 `ccteam` 单 binary 的子命令(`cct hook <name>`),不再是独立 bash/python 脚本——零运行时依赖,与 orchestrator 共享 serde schema。debug 时可手动跑 `cct hook <subcmd>` 喂 stdin JSON(详见 §10.6)。
 >
 > **M0 备注**:M0.4 渲染的模板是下面 JSON 的一个真子集——**不含** `PostToolUse(Bash:git push.*)` 拦截分支(M1+ 才补上 `block-push` 子命令实现)。M0 渲染源在 `crates/ccteam-core/src/templates/settings.json`。
 
@@ -860,16 +860,16 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
     "SessionStart": [
       {
         "hooks": [
-          {"type": "command", "command": "ccteam hook load-context", "timeout": 5},
-          {"type": "command", "command": "ccteam hook progress-append session_start", "async": true}
+          {"type": "command", "command": "cct hook load-context", "timeout": 5},
+          {"type": "command", "command": "cct hook progress-append session_start", "async": true}
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          {"type": "command", "command": "ccteam hook parse-phase-end", "timeout": 10},
-          {"type": "command", "command": "ccteam hook progress-append Stop", "async": true}
+          {"type": "command", "command": "cct hook parse-phase-end", "timeout": 10},
+          {"type": "command", "command": "cct hook progress-append Stop", "async": true}
         ]
       }
     ],
@@ -877,48 +877,48 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
       {
         "matcher": "idle_prompt|permission_prompt",
         "hooks": [
-          {"type": "command", "command": "ccteam hook progress-append notification", "async": true}
+          {"type": "command", "command": "cct hook progress-append notification", "async": true}
         ]
       }
     ],
     "PreToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "ccteam hook progress-append PreToolUse", "async": true}
+          {"type": "command", "command": "cct hook progress-append PreToolUse", "async": true}
         ]
       },
       {
         "matcher": "AskUserQuestion",
         "hooks": [
-          {"type": "command", "command": "ccteam hook intercept-ask", "timeout": 5}
+          {"type": "command", "command": "cct hook intercept-ask", "timeout": 5}
         ]
       }
     ],
     "PostToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "ccteam hook progress-append PostToolUse", "async": true},
-          {"type": "command", "command": "ccteam hook cost-accumulate", "async": true}
+          {"type": "command", "command": "cct hook progress-append PostToolUse", "async": true},
+          {"type": "command", "command": "cct hook cost-accumulate", "async": true}
         ]
       },
       {
         "matcher": "Bash:git push.*",
         "hooks": [
-          {"type": "command", "command": "ccteam hook block-push"}
+          {"type": "command", "command": "cct hook block-push"}
         ]
       }
     ],
     "SubagentStop": [
       {
         "hooks": [
-          {"type": "command", "command": "ccteam hook progress-append SubagentStop", "async": true}
+          {"type": "command", "command": "cct hook progress-append SubagentStop", "async": true}
         ]
       }
     ],
     "SessionEnd": [
       {
         "hooks": [
-          {"type": "command", "command": "ccteam hook progress-append SessionEnd", "async": true}
+          {"type": "command", "command": "cct hook progress-append SessionEnd", "async": true}
         ]
       }
     ]
@@ -935,7 +935,7 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 | `Notification:idle_prompt` | claude 显式等待用户输入 → idle 信号 |
 | `Notification:permission_prompt` | 不应出现(`--dangerously-skip-permissions` 兜底);出现说明配置失效 |
 | `PreToolUse`(通用) | append 工具调用事件;活跃信号(stall 检测反向判断) |
-| `PreToolUse(matcher: AskUserQuestion)` | **V0.2 M0.19.3**:`ccteam hook intercept-ask` 返回 `permissionDecision: deny`,assistant 改写 outbox。机制详见 `docs/v0-2/alignment-review.md` §3.2 |
+| `PreToolUse(matcher: AskUserQuestion)` | **V0.2 M0.19.3**:`cct hook intercept-ask` 返回 `permissionDecision: deny`,assistant 改写 outbox。机制详见 `docs/v0-2/alignment-review.md` §3.2 |
 | `PostToolUse`(通用) | append 事件;`cost-accumulate.sh` 累加 token / cost 到 `state.json` |
 | `PostToolUse(Bash matcher)` | 拦截危险命令(`git push` / `rm -rf /` / deploy 脚本) |
 | `SubagentStop` | 子 agent 退出(仅 Agent Teams phase 内相关) |
@@ -981,7 +981,7 @@ stop_hook_active == true?
 }
 ```
 
-`ccteam hook intercept-ask` 返回的 PreToolUse 决策(`hooks.ts:608-625`):
+`cct hook intercept-ask` 返回的 PreToolUse 决策(`hooks.ts:608-625`):
 
 ```json
 {
@@ -1189,35 +1189,35 @@ fork_timeout_hours: 24            # L3 默认通过超时(careful 模式忽略)
 ### 10.1 启动 / 停止
 
 ```bash
-ccteam start                           # 启动 orchestrator(前台)
-ccteam start --daemon                  # 启动并 daemonize
-ccteam stop                            # 优雅停机(保留 tmux session)
-ccteam stop --kill-sessions            # 同时关闭所有 tmux session(慎用)
-ccteam mcp-serve                       # M2+:作为 ccteam-mcp 跑 stdio MCP 协议(详见 §12)
+cct start                           # 启动 orchestrator(前台)
+cct start --daemon                  # 启动并 daemonize
+cct stop                            # 优雅停机(保留 tmux session)
+cct stop --kill-sessions            # 同时关闭所有 tmux session(慎用)
+cct mcp-serve                       # M2+:作为 ccteam-mcp 跑 stdio MCP 协议(详见 §12)
 ```
 
 ### 10.2 提交需求
 
 ```bash
-ccteam new "需求文本"
-ccteam new -f spec.md                  # 从文件提
-ccteam new --mode yolo "需求"          # 覆盖默认 trust_mode
+cct new "需求文本"
+cct new -f spec.md                  # 从文件提
+cct new --mode yolo "需求"          # 覆盖默认 trust_mode
 ```
 
 ### 10.3 查询状态
 
 ```bash
-ccteam ls                              # 所有项目状态(human 表格)
-ccteam ls --format json                # JSON 输出(给 LLM / 脚本用)
-ccteam show <slug>                     # 单项目详情(含 session 状态、cost、最近 progress)
-ccteam show <slug> --format json       # JSON 输出
-ccteam progress <slug> --tail          # 实时 tail progress.jsonl
-ccteam progress <slug> --phase implement  # 看特定 phase 事件
+cct ls                              # 所有项目状态(human 表格)
+cct ls --format json                # JSON 输出(给 LLM / 脚本用)
+cct show <slug>                     # 单项目详情(含 session 状态、cost、最近 progress)
+cct show <slug> --format json       # JSON 输出
+cct progress <slug> --tail          # 实时 tail progress.jsonl
+cct progress <slug> --phase implement  # 看特定 phase 事件
 ```
 
 **`--format json` 是 M0 强制项**——所有查询命令必须支持,以让"用户自带 claude"路径(详见 [tech-design.md §3.8](./tech-design.md#38-用户接口层))通过 Bash 工具调时无需解析表格。
 
-#### `ccteam ls --format json` schema
+#### `cct ls --format json` schema
 
 ```json
 {
@@ -1243,7 +1243,7 @@ ccteam progress <slug> --phase implement  # 看特定 phase 事件
 }
 ```
 
-#### `ccteam show <slug> --format json` schema
+#### `cct show <slug> --format json` schema
 
 是 §2.1 项目级 state.json 的全量 + 派生字段:
 
@@ -1270,23 +1270,23 @@ ccteam progress <slug> --phase implement  # 看特定 phase 事件
 ### 10.4 进入项目
 
 ```bash
-ccteam attach <slug>                   # tmux attach 到项目 master session
-ccteam attach <slug> --sub backend-api # multi-session 项目 attach 到子模块 session(M3+)
-ccteam peek <slug>                     # tmux capture-pane 一次性看当前屏,不 attach
+cct attach <slug>                   # tmux attach 到项目 master session
+cct attach <slug> --sub backend-api # multi-session 项目 attach 到子模块 session(M3+)
+cct peek <slug>                     # tmux capture-pane 一次性看当前屏,不 attach
 ```
 
 ### 10.5 控制
 
 ```bash
 ccteam reject <slug>                   # 否决
-ccteam pause <slug>                    # 暂停(不杀 session)
-ccteam resume <slug>                   # 恢复自动调度(接管 attach 后的暂停)
+cct pause <slug>                    # 暂停(不杀 session)
+cct resume <slug>                   # 恢复自动调度(接管 attach 后的暂停)
 ccteam answer <slug> "回答内容"          # 响应 clarify
-ccteam decisions                       # M1 收尾增量:跨项目决策队列(扫 outbox event_kind: clarify|escalation)
-ccteam decisions --format json         # JSON 输出(meta-agent 主消费;详见 §5.6.4)
-ccteam watchdog scan                   # V0.2 M0.21 translation-only 健康巡检(详见 §12.5)
-ccteam watchdog scan --format json     # 结构化输出(meta-agent 主消费)
-ccteam watchdog scan --push --user <handle>  # 把 alert 写进 meta-agent outbox
+cct decisions                       # M1 收尾增量:跨项目决策队列(扫 outbox event_kind: clarify|escalation)
+cct decisions --format json         # JSON 输出(meta-agent 主消费;详见 §5.6.4)
+cct watchdog scan                   # V0.2 M0.21 translation-only 健康巡检(详见 §12.5)
+cct watchdog scan --format json     # 结构化输出(meta-agent 主消费)
+cct watchdog scan --push --user <handle>  # 把 alert 写进 meta-agent outbox
 ccteam fork-reply <slug> A             # L3 fork 决策(M1+;A/B/C)
 ccteam fork-reply <slug> B "去掉云同步"  # tweak
 ccteam kick <slug>                     # 软重启项目 session(claude --resume)
@@ -1299,46 +1299,46 @@ ccteam kick <slug>                     # 软重启项目 session(claude --resume
 # 直接编辑 ~/.claude/rules/ccteam-lessons-<team>.md 看 / 改跨项目 lessons。
 # ccteam 不提供 memory 子命令(无自建索引,无东西可 rebuild)。
 ccteam config edit                                # 改全局配置
-ccteam doctor                                     # 体检:列出可用 mode flags
-ccteam doctor --tool-surface                      # phase tools_required 交叉表(plugin pipeline 感知,V0.2 M0.20)
-ccteam doctor --install-skill                     # M1.8 写 ccteam-control skill
-ccteam doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
-ccteam doctor --install-mcp                       # M2.5 在 ~/.claude.json 注册 mcpServers.ccteam(详见 §12)
-ccteam doctor --install-memory-bridge             # M4.2 写 ~/.claude/rules/ccteam-lessons-{dev,product-research}.md 占位 + paths frontmatter scope
-ccteam doctor --migrate-recommended-agents        # V0.2 M0.20 一次性清理 V0.1 ln -sf 残留 (~/.claude/agents/ 下指向 marketplace 的 symlink)
-ccteam hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
+cct doctor                                     # 体检:列出可用 mode flags
+cct doctor --tool-surface                      # phase tools_required 交叉表(plugin pipeline 感知,V0.2 M0.20)
+cct doctor --install-skill                     # M1.8 写 cct-control skill
+cct doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
+cct doctor --install-mcp                       # M2.5 在 ~/.claude.json 注册 mcpServers.ccteam(详见 §12)
+cct doctor --install-memory-bridge             # M4.2 写 ~/.claude/rules/ccteam-lessons-{dev,product-research}.md 占位 + paths frontmatter scope
+cct doctor --migrate-recommended-agents        # V0.2 M0.20 一次性清理 V0.1 ln -sf 残留 (~/.claude/agents/ 下指向 marketplace 的 symlink)
+cct hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
                                                   # subcmd ∈ {progress-append, parse-phase-end,
                                                   # cost-accumulate, load-context, block-push}
 ```
 
-#### `ccteam stop` 行为契约(M1.5)
+#### `cct stop` 行为契约(M1.5)
 
-`ccteam stop` 通过 `~/.ccteam/state/orchestrator.pid` 找到正在跑的
-orchestrator,发 SIGTERM。**不杀任何 tmux session**——`ccteam start`
+`cct stop` 通过 `~/.ccteam/state/orchestrator.pid` 找到正在跑的
+orchestrator,发 SIGTERM。**不杀任何 tmux session**——`cct start`
 下次启动时通过 `discover_projects` + `ensure_session` 自动 reattach
-所有活跃 session(meta + 项目)。pidfile 由 `ccteam start` 写入,
-退出时清理;若 pidfile 指向的 PID 已死,`ccteam start` 自动重新认领。
+所有活跃 session(meta + 项目)。pidfile 由 `cct start` 写入,
+退出时清理;若 pidfile 指向的 PID 已死,`cct start` 自动重新认领。
 
 ---
 
-## 11. `ccteam-control` skill(M1+)
+## 11. `cct-control` skill(M1+)
 
 让用户在自己的 Claude Code session 里调度 ccteam。架构论证见 [tech-design.md §3.8 / §6.7](./tech-design.md#38-用户接口层)。
 
 ### 11.1 安装位置
 
 ```
-~/.claude/skills/ccteam-control/
+~/.claude/skills/cct-control/
 └── SKILL.md
 ```
 
-由 ccteam M1 release 通过 `ccteam doctor --install-skill` 写入,或手动 `cp` from binary unpack。装一次,所有 claude session 自动可见。
+由 ccteam M1 release 通过 `cct doctor --install-skill` 写入,或手动 `cp` from binary unpack。装一次,所有 claude session 自动可见。
 
 ### 11.2 SKILL.md 字段约定
 
 ```yaml
 ---
-name: ccteam-control
+name: cct-control
 description: |
   Manage ccteam projects from any Claude Code session.
   Use when the user asks about ccteam status, wants to start a new ccteam project,
@@ -1371,7 +1371,7 @@ M1 时 skill 让 claude 用 Bash 工具 + `--format json` 调 CLI。M2 ccteam-mc
 
 ### 11.5 Meta-agent role prompt(M1.0)
 
-`ccteam doctor --install-meta-agent <user>` 落地两件事:
+`cct doctor --install-meta-agent <user>` 落地两件事:
 
 1. **项目骨架** `~/projects/<user>-meta/` —— 通过 `bootstrap_project(team=meta-agent)`
    生成,然后把 `state.json.tmux_session` 改成 `ccteam-meta-<user>`(注:与项目
@@ -1411,19 +1411,19 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 }
 ```
 
-由 `ccteam doctor --install-mcp` 写入(M2 release)。`ccteam mcp-serve` 是 binary 子命令,stdio 协议。
+由 `cct doctor --install-mcp` 写入(M2 release)。`cct mcp-serve` 是 binary 子命令,stdio 协议。
 
 ### 12.2 暴露的 tool 清单(M2.5 起,9 tool)
 
 | Tool 名 | 对应 CLI / 行为 | 入参 | 返回 |
 |---|---|---|---|
-| `ccteam__ls` | `ccteam ls --format json` | `{}` | §10.3 ls JSON schema(扩 `team`) |
-| `ccteam__show` | `ccteam show <slug> --format json` | `{slug: string}` | §10.3 show JSON schema |
-| `ccteam__new` | `ccteam new "..."` | `{prompt: string, team?: string}` | `{slug: string, workspace: string}` |
-| `ccteam__peek` | `ccteam peek <slug>` | `{slug: string}` | tmux capture-pane stdout 字符串 |
-| `ccteam__progress` | `ccteam progress <slug>` | `{slug: string, last_n?: number}` | `{events: [...]}` |
+| `ccteam__ls` | `cct ls --format json` | `{}` | §10.3 ls JSON schema(扩 `team`) |
+| `ccteam__show` | `cct show <slug> --format json` | `{slug: string}` | §10.3 show JSON schema |
+| `ccteam__new` | `cct new "..."` | `{prompt: string, team?: string}` | `{slug: string, workspace: string}` |
+| `ccteam__peek` | `cct peek <slug>` | `{slug: string}` | tmux capture-pane stdout 字符串 |
+| `ccteam__progress` | `cct progress <slug>` | `{slug: string, last_n?: number}` | `{events: [...]}` |
 | `ccteam__pause` | 设 `state.user_pause_pending=true` | `{slug: string}` | `{ok: bool, slug: string, user_pause_pending: bool}` |
-| `ccteam__resume` | `ccteam resume <slug>` | `{slug: string}` | `{ok: bool, slug: string}` |
+| `ccteam__resume` | `cct resume <slug>` | `{slug: string}` | `{ok: bool, slug: string}` |
 | `ccteam__send_to_session`(M2.5 新)| 原子写 `<session>/.ccteam/inbox/msg-<ts>-NNN.md`(§3.4.2)| `{session: string, body: string, content_type?: "text"\|"markdown"}` | `{ok: bool, session: string, inbox_file: string}` |
 | `ccteam__inject_decision`(M2.5 新)| 构造 ESCALATE-shape payload(§4.1.1),走 `send_to_session` 落 inbox | `{slug: string, escalate_kind: "revert_to_phase"\|"need_user_input"\|"abort"\|"insufficient_clarification"\|"phase_done_pending", args?: {target_phase?: string, reason?: string}}` | `{ok: bool, slug: string, inbox_file: string}` |
 
@@ -1437,10 +1437,10 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 
 ### 12.3 不暴露的(M2 显式排除)
 
-- `ccteam attach` — tty 交互,MCP 协议不适合
-- `ccteam start / stop` — orchestrator 生命周期管理是 ops 决策,不让 LLM 误调
+- `cct attach` — tty 交互,MCP 协议不适合
+- `cct start / stop` — orchestrator 生命周期管理是 ops 决策,不让 LLM 误调
 - ~~`ccteam memory rebuild`~~ — M4 简化后无自建索引,该命令不存在
-- `ccteam doctor --install-*` — 单机配置变更,走 CLI(避免 MCP server 给 LLM 改 ~/.claude.json 的能力)
+- `cct doctor --install-*` — 单机配置变更,走 CLI(避免 MCP server 给 LLM 改 ~/.claude.json 的能力)
 
 ### 12.4 双消费者
 
@@ -1481,7 +1481,7 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 
 ### 12.5.4 Alert 输出契约
 
-`ccteam watchdog scan --format json` 输出 schema:
+`cct watchdog scan --format json` 输出 schema:
 
 ```json
 {
@@ -1552,27 +1552,27 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 ```rust
 // crates/ccteam-core/src/lib.rs(示意签名,实际可调整)
 
-/// 读单项目状态(对应 §2.1 state.json 的全量结构 + 派生字段;§10.3 `ccteam show --format json` 的内核)。
+/// 读单项目状态(对应 §2.1 state.json 的全量结构 + 派生字段;§10.3 `cct show --format json` 的内核)。
 pub fn get_state(slug: &str) -> Result<ProjectState, CoreError>;
 
-/// 列所有项目摘要(§10.3 `ccteam ls --format json` 的内核)。
+/// 列所有项目摘要(§10.3 `cct ls --format json` 的内核)。
 pub fn list_projects() -> Result<Vec<ProjectSummary>, CoreError>;
 
 /// 提交控制信号——写 §3.3 `~/.ccteam/control/` 文件,orchestrator 下一轮扫到生效。
 /// `ControlSignal` 枚举覆盖 reject / pause / resume / answer / boost / fork-reply。
 pub fn submit_control(slug: &str, signal: ControlSignal) -> Result<(), CoreError>;
 
-/// 一次性读取 progress.jsonl 末尾 N 条事件(§10.3 `ccteam progress --tail` 的非流式入口)。
+/// 一次性读取 progress.jsonl 末尾 N 条事件(§10.3 `cct progress --tail` 的非流式入口)。
 pub fn tail_progress(slug: &str, last_n: usize) -> Result<Vec<Event>, CoreError>;
 
 /// 流式订阅 progress.jsonl(`tokio` Stream;inotify 监听末尾)。
 /// TUI / web dashboard 实时事件推送的主接口。
 pub fn attach_progress(slug: &str) -> Result<impl Stream<Item = Result<Event, CoreError>>, CoreError>;
 
-/// 提交新需求(对应 §10.2 `ccteam new`),返回分配的 slug 与项目目录。
+/// 提交新需求(对应 §10.2 `cct new`),返回分配的 slug 与项目目录。
 pub fn submit_inbox(spec: InboxSpec) -> Result<NewProjectHandle, CoreError>;
 
-/// 一次性 capture 项目 tmux pane 当前屏(§10.4 `ccteam peek` 的内核;不 attach)。
+/// 一次性 capture 项目 tmux pane 当前屏(§10.4 `cct peek` 的内核;不 attach)。
 pub fn peek_pane(slug: &str, lines: Option<usize>) -> Result<PaneCapture, CoreError>;
 ```
 
@@ -1580,8 +1580,8 @@ pub fn peek_pane(slug: &str, lines: Option<usize>) -> Result<PaneCapture, CoreEr
 
 | `ccteam-core` 类型 | wire 格式(CLI `--format json` / MCP tool 返回) | 来源章节 |
 |---|---|---|
-| `ProjectState` | `ccteam show --format json` 全量 | §2.1 + §10.3 |
-| `ProjectSummary` | `ccteam ls --format json` `projects[]` 元素 | §10.3 |
+| `ProjectState` | `cct show --format json` 全量 | §2.1 + §10.3 |
+| `ProjectSummary` | `cct ls --format json` `projects[]` 元素 | §10.3 |
 | `Event` | progress.jsonl 单行 | §4.1 |
 | `ControlSignal` | `~/.ccteam/control/` 文件命名约定 | §3.3 |
 | `InboxSpec` | `~/.ccteam/inbox/*.md` front matter + body | §3.1 |

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -137,7 +137,7 @@ session + 每个项目 session)是独立 OS 进程;Rust orchestrator 是另一�
 **为什么用 tmux 长 session 而非每 phase 一个 `claude -p` 子进程？**
 
 - **prompt cache 复用**：Anthropic prompt cache TTL 5 分钟，命中后费用降到约 10%。每 phase 起新子进程意味着重读 CLAUDE.md / spec / 上游产物，反复触发冷启动；同 session 跨 phase 共享缓存，长跑项目（数小时-数天）累计省下大量成本。
-- **可观测性天然解决**：tmux 是终端 UI，用户 `ccteam attach <slug>` 立刻看到 Claude 在做什么；headless 子进程必须靠解析 stream-json 才能知情。
+- **可观测性天然解决**：tmux 是终端 UI，用户 `cct attach <slug>` 立刻看到 Claude 在做什么；headless 子进程必须靠解析 stream-json 才能知情。
 - **可中断 / 可注入**：用户 attach 后直接键入指令纠偏（"等等，先别用 SQLite"），Ctrl+C 中断推理；headless 模式没有这个能力。
 - **detach 即守护**：tmux session 在用户断开后继续运行——这是 tmux 的本质优势，刚好契合"关掉电脑团队继续跑"。
 - **不限制 max_turns / max_budget**：长 session 模式下不再硬封顶（理由见 §6.8）；只保留 stall 检测作为软告警。
@@ -154,7 +154,7 @@ session + 每个项目 session)是独立 OS 进程;Rust orchestrator 是另一�
 
 **写入端**（多种异步入口）：
 - **Telegram bot**：用户发消息 → bot 写文件
-- **`ccteam new "做一个书签管理器"`**：CLI 直接写文件
+- **`cct new "做一个书签管理器"`**：CLI 直接写文件
 - **手动 `echo` / 编辑器**：完全降级路径
 
 **文件格式**：
@@ -254,7 +254,7 @@ TeamSpec.evergreen,**不许**回到 `state.team == META_TEAM_NAME` 字面量
 V0.3 真要 cost 追踪不杀时再定义具体行为)。
 
 `teams/meta-agent.yaml` 是首个 evergreen 范例,V0.2 起作为 shipped seed
-随 binary 发布;`Orchestrator::new` / `ccteam start` / `ccteam doctor
+随 binary 发布;`Orchestrator::new` / `cct start` / `cct doctor
 --reset-shipped-teams` 都会把它写到 `~/.ccteam/teams/meta-agent/team.yaml`。
 
 #### 3.2.2 Team layout + TEAM_SOURCES(V0.2 §5.1 / §5.2)
@@ -415,7 +415,7 @@ test-run phase
 
 #### V0.2 M0.19.3 — PreToolUse 拦截 AskUserQuestion
 
-`AskUserQuestion` 是 LLM 内部同步阻塞,Stop hook 不会触发。bootstrap 写 `<project>/.claude/settings.json` 时配 `PreToolUse` matcher `AskUserQuestion`,跑 `ccteam hook intercept-ask` 返回 `permissionDecision: deny`(reason 指引去 outbox)。LLM 收到 deny 立即改写 outbox。pair 的 prompt-layer 软约束在 team.yaml `golden_rules.protocol.forbid_ask_user_question` —— inject prompt 把 directive 文字写进协议红线段(progress.rs `build_phase_prompt_for_template_with_team`)。
+`AskUserQuestion` 是 LLM 内部同步阻塞,Stop hook 不会触发。bootstrap 写 `<project>/.claude/settings.json` 时配 `PreToolUse` matcher `AskUserQuestion`,跑 `cct hook intercept-ask` 返回 `permissionDecision: deny`(reason 指引去 outbox)。LLM 收到 deny 立即改写 outbox。pair 的 prompt-layer 软约束在 team.yaml `golden_rules.protocol.forbid_ask_user_question` —— inject prompt 把 directive 文字写进协议红线段(progress.rs `build_phase_prompt_for_template_with_team`)。
 
 ### 3.6 三层防御协议（Defense in Depth）
 
@@ -527,7 +527,7 @@ L1 → L2 → L3，不并联。L2 启动前 L1 已通过；L3 启动前 L2 已�
 
 **ccteam 实际改动量**(已 ship,M4.1–M4.4):
 - M4.1 retro phase prompt(纯 markdown)
-- M4.2 `ccteam doctor --install-memory-bridge`(创建 rules 占位文件 + marked section + path frontmatter,**唯一一段 ccteam 代码**)
+- M4.2 `cct doctor --install-memory-bridge`(创建 rules 占位文件 + marked section + path frontmatter,**唯一一段 ccteam 代码**)
 - M4.3 Seed/verdict phase prompt(纯 markdown,含 conversation continuity——M4.6 已折叠进 M4.3)
 - M4.4 容器 bind-mount `~/.claude/` spike(已验证 rules + claude-mem hook 在 `--dangerously-skip-permissions` 容器内可见)
 
@@ -547,8 +547,8 @@ ccteam 全系统 6 类 claude 会出现的位置:
 |---|---|---|---|
 | **L0 Channel Layer** | **不是**(各 channel 适配器进程,无内嵌 LLM,Symphony 反模式禁止) | 适配器进程随用户配置启动 | M2+ stub,大概率复用开源方案 |
 | **L0.5 meta-agent session** | **是**(ccteam-managed 常驻 tmux + claude) | 常驻、永不 terminal | 已 ship(M1) |
-| **L1 编排层**(orchestrator daemon) | 不是(Rust) | 常驻 | ccteam start 后 |
-| **L2 项目级 claude**(每项目一个 tmux session) | 是 | 常驻(长 session,直到 ship/abort) | ccteam new 后 |
+| **L1 编排层**(orchestrator daemon) | 不是(Rust) | 常驻 | cct start 后 |
+| **L2 项目级 claude**(每项目一个 tmux session) | 是 | 常驻(长 session,直到 ship/abort) | cct new 后 |
 | **L3 phase 内 agent team / subagent** | 是(Task 工具启动) | 短命(phase 内,跑完返回总结即销毁) | subagent 已 ship(M2);agent_team 永久 deferred(spike A,docs/v0-1/m2-agent-team-spike.md) |
 | **L4 multi_session 子模块 claude** | 是(每子模块一个完整 session) | 常驻 | 未 ship(M4.8) |
 | **L5 横切短命 claude**(cost-watcher / scope-watcher / drift-detector) | 是 | 短命(Stop hook 触发,跑完即退) | 已 ship(M1) |
@@ -564,33 +564,33 @@ dumb router。这条贯彻到底,避免 Symphony 多层 agent 反模式
 |---|---|---|
 | 生命周期 | 永不 terminal,跟用户 ccteam 实例同寿 | ship / abort 即终态 |
 | 行为模式 | 事件循环(等输入→处理→等输入)| phase DAG(plan-eng → ... → ship) |
-| 主要工具 | `ccteam-control` skill(已 ship,M1.8)/ `ccteam-mcp`(已 ship,M2.8)/ 跨项目 lessons(已 ship,M4 走 `~/.claude/rules/` + auto-memory)| 项目级文件操作 / 内嵌 plugin agents(已 ship,V0.2 M0.20 改走 `enabledPlugins` 写到 `<project>/.claude/settings.json`,Claude Code in-memory plugin pipeline 自动 namespace `<plugin>:<name>`,不再 ln -sf 进 `~/.claude/agents/`) |
+| 主要工具 | `cct-control` skill(已 ship,M1.8)/ `ccteam-mcp`(已 ship,M2.8)/ 跨项目 lessons(已 ship,M4 走 `~/.claude/rules/` + auto-memory)| 项目级文件操作 / 内嵌 plugin agents(已 ship,V0.2 M0.20 改走 `enabledPlugins` 写到 `<project>/.claude/settings.json`,Claude Code in-memory plugin pipeline 自动 namespace `<plugin>:<name>`,不再 ln -sf 进 `~/.claude/agents/`) |
 | context reset | 60% 阈值时桥接 CLAUDE.md(M0.10 已 ship);跨项目记忆通过 `~/.claude/rules/ccteam-lessons-<user>-meta.md` 滚动累积(M4 路径,无独立 conversation-log) | 60% 阈值时把当前 phase 进度写 CLAUDE.md(已 ship,M0.10) |
 | 用户 attach | `tmux attach -t ccteam-meta-<user>`,直接 NL 对话 | `tmux attach -t ccteam-<team>-<slug>`,可介入项目执行 |
 
 #### CLI(已 ship,M0)
 
 ```bash
-ccteam new "做一个本地书签管理器"     # 写 inbox(无 LLM,纯薄壳)
-ccteam ls                              # 查所有项目状态
-ccteam show <slug>                     # 详情
-ccteam progress <slug> --tail          # 实时 tail progress.jsonl
+cct new "做一个本地书签管理器"     # 写 inbox(无 LLM,纯薄壳)
+cct ls                              # 查所有项目状态
+cct show <slug>                     # 详情
+cct progress <slug> --tail          # 实时 tail progress.jsonl
 ccteam answer <slug> "用 PWA"          # 回应 clarify 问题
-ccteam attach <slug> / peek <slug>     # 介入 / 瞄一眼
-ccteam start / stop                    # orchestrator 生命周期
+cct attach <slug> / peek <slug>     # 介入 / 瞄一眼
+cct start / stop                    # orchestrator 生命周期
 ```
 
 **关键约束**:CLI 必须输出 LLM 友好的结构化数据——所有查询命令支持 `--format json`(详见 [interfaces.md §10](./interfaces.md#10-cli-命令签名))。理由:让用户自带 claude 通过 Bash 工具调时不用解析表格。
 
-#### meta-agent session + inbox/outbox 协议 + ccteam-control skill(已 ship,M1)
+#### meta-agent session + inbox/outbox 协议 + cct-control skill(已 ship,M1)
 
 > **架构沿革**:原 M1 把"Telegram bot 实现"列为核心任务。现在
 > Telegram bot **下沉到 Channel Layer(M2+ stub)**;M1 只交付能跑 NL 对话
-> 的最小集合:meta-agent 长会话 + inbox/outbox 文件协议 + ccteam-control
+> 的最小集合:meta-agent 长会话 + inbox/outbox 文件协议 + cct-control
 > skill。
 
 - **meta-agent session**(已 ship,M1.0):ccteam-managed 常驻 tmux session,
-  跑 `claude --dangerously-skip-permissions`,装 `ccteam-control` skill。
+  跑 `claude --dangerously-skip-permissions`,装 `cct-control` skill。
   用户用 `tmux attach -t ccteam-meta-<user>` 在终端 NL 对话,meta-agent
   调 ccteam CLI 派单 / 查项目 / 跨项目召回(详见 development-plan §3 M1)
 - **inbox/outbox 文件协议**(已 ship,M1.1):`<session>/.ccteam/inbox/msg-<n>.md`
@@ -598,9 +598,9 @@ ccteam start / stop                    # orchestrator 生命周期
   inbox,触发 send-keys 注入到对应 session;session 写 outbox,
   Channel Layer(M2+ stub)读 outbox 推到对应 channel。**M1 不实现具体
   channel,只把协议钉死**
-- **ccteam-control skill**(已 ship,M1.8):描述 ccteam CLI 命令清单 +
+- **cct-control skill**(已 ship,M1.8):描述 ccteam CLI 命令清单 +
   典型工作流。**首要 consumer 是 meta-agent session,次要 consumer
-  是用户自己的 daily-driver claude**(详见 [interfaces.md §11](./interfaces.md#11-ccteam-control-skillm1))
+  是用户自己的 daily-driver claude**(详见 [interfaces.md §11](./interfaces.md#11-cct-control-skillm1))
 - **CLARIFY 多轮**(推至 channel 层):channel 层落地后再设计;当前用
   "tmux attach 直接对话"覆盖
 
@@ -630,13 +630,13 @@ ccteam start / stop                    # orchestrator 生命周期
    session,channel 是 dumb router
 
 **用户自带 daily-driver claude 仍然有用**:用户在自己电脑前已经开了一
-个 claude 处理别的事,装 `ccteam-control` skill 后随时可调度 ccteam,
+个 claude 处理别的事,装 `cct-control` skill 后随时可调度 ccteam,
 这条**作为辅助路径保留**,但不是 ccteam 的核心入口。核心入口是
 meta-agent session + Channel Layer。
 
 #### Web 仪表盘——不在主线
 
-曾考虑过 M2 Web 仪表盘。**剥离主线**——`ccteam ls --format json` + 用户自带 claude 的对话能力已覆盖"用人话汇报"需求。Web 仪表盘永远在 backlog,不进里程碑(参见 §11 / development-plan §2.2)。
+曾考虑过 M2 Web 仪表盘。**剥离主线**——`cct ls --format json` + 用户自带 claude 的对话能力已覆盖"用人话汇报"需求。Web 仪表盘永远在 backlog,不进里程碑(参见 §11 / development-plan §2.2)。
 
 #### 前端层(可插拔)
 
@@ -665,7 +665,7 @@ ccteam 核心(orchestrator + tmux + hooks)是 **headless 状态引擎**——所
 +----------------------------------------------------------+
 ```
 
-**Warp / iTerm2 / Alacritty 等本地终端 = 用户终端选择,不是 ccteam 集成对象**。`ccteam attach <slug>` 在任何 tmux 兼容终端里行为完全一致——ccteam 透明兼容,无需特殊适配。用户偏好哪个终端就用哪个,与 ccteam 无关。
+**Warp / iTerm2 / Alacritty 等本地终端 = 用户终端选择,不是 ccteam 集成对象**。`cct attach <slug>` 在任何 tmux 兼容终端里行为完全一致——ccteam 透明兼容,无需特殊适配。用户偏好哪个终端就用哪个,与 ccteam 无关。
 
 **前端档位**:
 
@@ -679,7 +679,7 @@ ccteam 核心(orchestrator + tmux + hooks)是 **headless 状态引擎**——所
 
 任何前端(CLI / TUI / web dashboard)**不得**在 ccteam 内引入新 LLM 层。
 
-- ✅ web dashboard 通过 xterm.js + WebSocket 桥**直通到 tmux 内的项目级 claude**——等价于"远程版 `ccteam attach`"。用户在浏览器键入 = 通过 send-keys 注入 tmux,不经任何 ccteam 中介 LLM
+- ✅ web dashboard 通过 xterm.js + WebSocket 桥**直通到 tmux 内的项目级 claude**——等价于"远程版 `cct attach`"。用户在浏览器键入 = 通过 send-keys 注入 tmux,不经任何 ccteam 中介 LLM
 - ✅ web 介入触发 `PreToolUse` hook 检测 user_attach,自动暂停 phase(与本地 attach 语义一致)
 - ❌ 不在 ccteam 层起 meta-claude / 自实现聊天 UI / 翻译用户 prompt(已被否决的 `ccteam chat` 路径复活)
 
@@ -733,14 +733,14 @@ notify_mode: normal               # quiet / normal / verbose
 `quiet` 模式只放行 `cost_overrun` + `daemon_down`(钱 / 守护死必报);
 `verbose` 不去重,每次扫描都重发 `needs_attention`。
 
-**触发**(M0.21):**手动**——meta-agent 自己跑 `ccteam watchdog scan` 这条命令。
+**触发**(M0.21):**手动**——meta-agent 自己跑 `cct watchdog scan` 这条命令。
 M2+ channel layer 上线后会有 cron-style 自动触发(60s 默认推荐;
 当前 milestone 不实现自动 timer)。
 
 **实施要点**:
 - 全部代码在 `crates/ccteam-core/src/watchdog.rs`(单文件,~600 行)
 - `crates/ccteam-cli/src/main.rs::Command::Watchdog::Scan` 暴露 CLI:
-  `ccteam watchdog scan [--push --user <handle>]`
+  `cct watchdog scan [--push --user <handle>]`
 - meta-agent role prompt(§3.8 引用)新增 §7 描述 watchdog 角色边界
 - `crates/ccteam-core/src/orchestrator.rs` **零** watchdog 引用
   (grep `watchdog` 命中 0 次是核心红线)
@@ -835,7 +835,7 @@ if running_count < config.max_concurrent_projects:
 | fix-cycle 撞 3 次顶 | escalate，附三次诊断 + capture-pane 快照 |
 | Seed REJECT | 终态，归档 + 通知 |
 | explicit `ESCALATE: ...` 输出 / escalation.md | 终态，转发给用户 |
-| 用户 attach 中手动介入 | 自动暂停 phase 推进，等 detach 或 `ccteam resume <slug>` |
+| 用户 attach 中手动介入 | 自动暂停 phase 推进，等 detach 或 `cct resume <slug>` |
 
 ---
 
@@ -922,12 +922,12 @@ fi
 #### 用户介入
 
 ```bash
-ccteam attach <slug>     # = tmux attach -t ccteam-<team>-<slug>
+cct attach <slug>     # = tmux attach -t ccteam-<team>-<slug>
 # 用户键入文本 → claude 当作 prompt 接收
 # Ctrl+B D 离开（claude 继续跑）
 ```
 
-orchestrator 通过 `PreToolUse` hook 检测最近一次输入源：若来自人（vs. 来自 send-keys 时盖的 marker），自动暂停 phase 推进，等 `ccteam resume <slug>` 或用户 detach 超过 N 分钟（视为放权）。
+orchestrator 通过 `PreToolUse` hook 检测最近一次输入源：若来自人（vs. 来自 send-keys 时盖的 marker），自动暂停 phase 推进，等 `cct resume <slug>` 或用户 detach 超过 N 分钟（视为放权）。
 
 #### 关键约束
 
@@ -945,7 +945,7 @@ orchestrator 通过 `PreToolUse` hook 检测最近一次输入源：若来自人
 
 **为什么 hooks 是 ccteam 可观测性命脉**:Claude Code hooks 是 deterministic 的(详见 claude-code-best-practices §4.5)——同一事件触发同一脚本,这是把"AI 的随机推理"转成"系统可处理的事件流"的桥。ccteam 把所有 phase 边界 / 工具调用 / 退出信号都通过 hooks 落到 progress.jsonl,orchestrator 据此做状态转移,完全不解析 tmux 终端文本。
 
-**实现形态**:hook 实现是 `ccteam hook <name>` 子命令(如 `ccteam hook progress-append` / `ccteam hook parse-phase-end` / `ccteam hook cost-accumulate`)——单 binary 分发,与 orchestrator 共享同一份 serde schema(progress.jsonl 事件定义、state.json 字段),不再依赖独立 bash / python 脚本运行时。official plugin 自带的 hook(如 `security_reminder_hook.py`)通过 shell shim 包装挂上,不直接依赖。
+**实现形态**:hook 实现是 `cct hook <name>` 子命令(如 `cct hook progress-append` / `cct hook parse-phase-end` / `cct hook cost-accumulate`)——单 binary 分发,与 orchestrator 共享同一份 serde schema(progress.jsonl 事件定义、state.json 字段),不再依赖独立 bash / python 脚本运行时。official plugin 自带的 hook(如 `security_reminder_hook.py`)通过 shell shim 包装挂上,不直接依赖。
 
 **Hook 写作纪律**(实现 PR 必须遵守):
 - append 类必须 `async: true`——别拖慢主流程
@@ -1042,7 +1042,7 @@ agent（本节）= 在 phase 内或后台**并行**跑的 multi-agent；sub-skil
 
 完整 tool schema 与协议见 [interfaces.md §12](./interfaces.md#12-ccteam-mcp-mcp-server-m2)。**M0 / M1 走 CLI `--format json` 兜底路径**——用户的 claude 用 Bash 工具调即可;M2 后 MCP 路径作为首选,CLI 仍然保留作为脚本化入口。
 
-**实现形态**:`ccteam-mcp` 与 `ccteam-core` 同 crate(workspace 内 lib + 多 binary),通过 `ccteam mcp-serve` 子命令暴露——读写同一份 state.json / progress.jsonl,**为将来 `ccteam tui`(未 ship,M4.9) / `ccteam serve` web 前端(backlog)预留同一状态读写 API**。三种前端共用 `ccteam-core` lib API(详见 §3.8 前端层小节),MCP 只是把这套 API 套上 MCP wire protocol 给外部 LLM 消费。
+**实现形态**:`ccteam-mcp` 与 `ccteam-core` 同 crate(workspace 内 lib + 多 binary),通过 `cct mcp-serve` 子命令暴露——读写同一份 state.json / progress.jsonl,**为将来 `ccteam tui`(未 ship,M4.9) / `ccteam serve` web 前端(backlog)预留同一状态读写 API**。三种前端共用 `ccteam-core` lib API(详见 §3.8 前端层小节),MCP 只是把这套 API 套上 MCP wire protocol 给外部 LLM 消费。
 
 #### Plugin pipeline(V0.2 M0.20,候选 7)
 
@@ -1119,22 +1119,22 @@ ccteam 出两个 skill:
 
 用户在自己的 Claude Code 里手动喊 `/ccteam-implement` 等,跑单 phase——作为不起 daemon 的 fallback。product-research team 的 phase 序列(`01-kickoff` / `02-market-survey` / `03-differentiation-analysis` / `04-value-proposition` / `05-feasibility` / `06-verdict`)走 `phases-product-research/` 子目录。
 
-#### `ccteam-control`(已 ship,M1+,用户自带 claude 调度 ccteam 的入口)
+#### `cct-control`(已 ship,M1+,用户自带 claude 调度 ccteam 的入口)
 
 ```
-~/.claude/skills/ccteam-control/
+~/.claude/skills/cct-control/
 └── SKILL.md           # CLI 命令清单 + 典型工作流 + 何时 attach vs peek
 ```
 
 **用途**:用户在任意目录开 `claude` → skill 自动激活 → claude 知道:
-- 怎么调 `ccteam ls --format json` 看跨项目状态
-- 怎么调 `ccteam new "..."` 立项(并先多轮澄清)
-- 卡住时综合 `ccteam peek <slug>` + `ccteam progress <slug> --tail` 给用户一句可贴的纠偏 prompt
-- 何时该建议用户 `ccteam attach`(自己介入)vs `ccteam pause`(暂停后再决定)
+- 怎么调 `cct ls --format json` 看跨项目状态
+- 怎么调 `cct new "..."` 立项(并先多轮澄清)
+- 卡住时综合 `cct peek <slug>` + `cct progress <slug> --tail` 给用户一句可贴的纠偏 prompt
+- 何时该建议用户 `cct attach`(自己介入)vs `cct pause`(暂停后再决定)
 
 这是 §3.8"用户自带 claude 当入口"路径的实现。M2 已上 ccteam-mcp MCP server(§6.4),skill 仍保留作为发现 / 引导层。
 
-完整 SKILL.md 内容契约见 [interfaces.md §11](./interfaces.md#11-ccteam-control-skillm1)。
+完整 SKILL.md 内容契约见 [interfaces.md §11](./interfaces.md#11-cct-control-skillm1)。
 
 ### 6.8 透明度与可观测性
 
@@ -1142,7 +1142,7 @@ ccteam 长跑场景下"看不到 AI 在干什么"是首要担忧。三层透明�
 
 #### 第一层：tmux session（给人看，零延迟）
 
-`ccteam attach <slug>` 立即看到完整 claude 交互界面：
+`cct attach <slug>` 立即看到完整 claude 交互界面：
 - 当前 thinking
 - 上一次 tool call 的输入与结果
 - 文件 diff
@@ -1170,7 +1170,7 @@ orchestrator 监听 progress.jsonl 最新事件时间戳：
 | 静默时长 | 动作 |
 |---|---|
 | < 5 min | 正常（推理 / 长 Bash / 网络等待） |
-| 5–15 min | 第一次软告警："项目 X 看起来卡了，要不要 `ccteam attach`？" |
+| 5–15 min | 第一次软告警："项目 X 看起来卡了，要不要 `cct attach`？" |
 | 15–30 min | 标记 `suspicious`，但**仍不 kill**；告警升级 |
 | > 30 min | 升级为 escalation，由用户决定 |
 
@@ -1187,7 +1187,7 @@ orchestrator 监听 progress.jsonl 最新事件时间戳：
 | 项目累计 $50 | 再次软告警 + 触发 retro 评估 |
 | 项目累计 $200 | 物理上限，kill + escalate |
 
-阈值都在 `~/.ccteam/config.yml` 里可调；CLI `ccteam show <slug>` 可实时查询。
+阈值都在 `~/.ccteam/config.yml` 里可调；CLI `cct show <slug>` 可实时查询。
 
 #### Daemon 健康监督（M0.23.1)
 
@@ -1195,7 +1195,7 @@ orchestrator 是**所有 phase 派发 + inbox 派送**的单点 — daemon 死�
 
 | 文件 | 谁写 | 谁读 | 语义 |
 |---|---|---|---|
-| `~/.ccteam/state/orchestrator.pid` | daemon 启动时写 | `ccteam stop` | PID(已有,M1.5) |
+| `~/.ccteam/state/orchestrator.pid` | daemon 启动时写 | `cct stop` | PID(已有,M1.5) |
 | `~/.ccteam/state/orchestrator.heartbeat` | daemon 每 30s 写 | MCP 入口 / meta-agent skill | mtime 是 liveness 唯一来源 |
 
 **判定**:`now - mtime ≤ 60s` → healthy;否则 stale(grace 是 2× heartbeat 间隔,容忍单次 GC pause / 阻塞 IO)。文件不存在 → no_heartbeat(daemon 未启动)。
@@ -1345,13 +1345,13 @@ meta-agent ───────────►  CLI/factory ──────�
   (skill)                              ~/.config/ccteam/teams/<name>/
 ```
 
-1. **Interview** — 元 agent 跑 `ccteam-team-author` skill,跟用户对话收集 metadata(name / description / author)+ phase 列表 + tools + golden_rules + retro_schema + verdict_schema。一次一题,默认值能用就用。
-2. **Init** — `ccteam team init <name>` 落 staging 树到 `~/.config/ccteam/teams/<name>/`,内含:
+1. **Interview** — 元 agent 跑 `cct-team-author` skill,跟用户对话收集 metadata(name / description / author)+ phase 列表 + tools + golden_rules + retro_schema + verdict_schema。一次一题,默认值能用就用。
+2. **Init** — `cct team init <name>` 落 staging 树到 `~/.config/ccteam/teams/<name>/`,内含:
    - `.claude-plugin/plugin.json`(Claude Code plugin manifest 严格 schema:`name` / `description` / `author`)
-   - `team.yaml`(ccteam team 配置,作为 plugin 顶级 unknown 字段;zod 默认 strip,plugin pipeline 加载时忽略)
+   - `team.yaml`(cct team 配置,作为 plugin 顶级 unknown 字段;zod 默认 strip,plugin pipeline 加载时忽略)
    - `phases/<NN>-<phase>.md`(frontmatter + 正文领域模板;**正文不写 `PHASE_DONE:` / `ESCALATE:`**——M0.18 D 方案,协议关键字仅由 orchestrator inject prompt 注入)
    - `README.md`
-3. **Publish** — `ccteam team publish <name> --target {local|github}`:
+3. **Publish** — `cct team publish <name> --target {local|github}`:
    - `local`:软链 staging 到 `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`,产出 directory-source 标识 `<name>@ccteam-local`(用户 `claude /plugin enable` 启用)
    - `github`:`gh repo create` + push,产出 GitHub URL(用户 `claude /plugin add <owner>/<repo>` 拉取)
 
@@ -1376,7 +1376,7 @@ meta-agent ───────────►  CLI/factory ──────�
 
 - `crates/ccteam-core/src/team_factory.rs` — `init_team_staging` / `publish_team` / `validate_staged_team` 主路径;`PluginManifest` / `PhaseScaffold` / `PublishTarget` 数据类型。
 - `crates/ccteam-core/src/templates/ccteam_team_author_skill.md` — meta-agent 用的 dialogue skill。
-- `crates/ccteam-cli/src/team_factory_cli.rs` — `ccteam team init` / `ccteam team publish` CLI 包装。
+- `crates/ccteam-cli/src/team_factory_cli.rs` — `cct team init` / `cct team publish` CLI 包装。
 - `crates/ccteam-cli/src/commands.rs` — `--validate-team` 加 plugin manifest 段。
 - `docs/v0-2/team-factory-userguide.md` — 用户实操指引。
 

--- a/docs/v0-2-2/README.md
+++ b/docs/v0-2-2/README.md
@@ -1,0 +1,39 @@
+# V0.2.2 文档索引
+
+V0.2.2 是首个**单独目录的 patch 版本**(V0.2.1 折在 `v0-2/e2e-retro.md`)。
+本轮 7 finding(F34-F40)+ 3 配套,7 PR sequencing,实现量超 V0.2.1 dust patch
+量级,docs 单独维护。
+
+base = `origin/main` `170f5a8`(V0.2.1 ship);测试 baseline 511/0。
+
+## 文档清单
+
+| 文件 | 内容 | 何时读 |
+|---|---|---|
+| [`prd.md`](prd.md) | V0.2.2 PRD — 13 节,7 finding 设计 + PR sequencing + 验收 | V0.2.2 设计意图源头 |
+| [`dev-plan.md`](dev-plan.md) | 7 PR milestone 拆解 + worktree 分支 + subagent briefing 模板 | V0.2.2 实施 |
+| [`feedback.md`](feedback.md) | 2026-05-08 用户原始反馈 6 条原文(F34-F37 来源) | F34-F37 设计依据回看 |
+
+## Findings 速查
+
+| F | 性质 | 优先级 | PR # |
+|---|---|---|---|
+| F34 slug 命名控制 | UX 关键 | P1 | 2(依赖 #1)|
+| F35 silence classifier | ship-blocker(auto-loop bug)| P0 | 3(独立)|
+| F36 send-keys subagent guard | ship-blocker(/btw 路由 bug)| P0 | 4(软依赖 #3)|
+| F37 meta-agent 决策树加固 | UX 关键 | P1 | 2(同 F34) |
+| F38 终端截图 PNG | UX 增强 | P2 | 5(软依赖 #3)|
+| F39 `cct` 短前缀约定 sweep | cleanup | P3 | **1**(先 merge,机械 rename)|
+| F40 team 名缩短 + alias | cleanup | P3 | 6(独立)|
+
+## 配套
+
+- **Cargo workspace.version**:`0.0.1` → `0.2.2`(retroactive 修正)
+- **CLAUDE.md §五**:加 patch 开发流程小节(已落档,2026-05-09)
+- **`docs/README.md`**:加 patch 目录约定(已落档,2026-05-09)
+
+## 跟其他文档关系
+
+- 主仓 `CLAUDE.md` §三 红线 + §四 Skills 行 已加 cct 约定(F39 驱动)
+- 完整 PR sequencing + 冲突点矩阵 见 `prd.md §10`
+- 跨版本 SoT(`tech-design` / `interfaces`)在 V0.2.2 ship 各 PR merge 时同步更新

--- a/docs/v0-2-2/dev-plan.md
+++ b/docs/v0-2-2/dev-plan.md
@@ -1,0 +1,1101 @@
+# V0.2.2 开发计划
+
+> Patch 版本实施计划。按依赖顺序拆 7 个 PR(每 PR 对一 finding 或一组同源 finding +
+> 一个 chore PR 收尾)。配套 worktree 分支 + subagent briefing 模板;每 PR 一份
+> briefing 让 worktree subagent 拿到模板 + 进 worktree 即可开干。
+>
+> 配套文档:
+> - 需求决策:`docs/v0-2-2/prd.md`(13 节,1300 行)
+> - 用户反馈源:`docs/v0-2-2/feedback.md`
+> - 文档索引:`docs/v0-2-2/README.md`
+>
+> base = `origin/main` `170f5a8`(V0.2.1 ship);测试 baseline = **511/0**。
+>
+> 跟 V0.2 dev-plan 不同点:V0.2.2 是 patch,**PR-based 而非 milestone-based**(7 PR
+> 各对一 finding,milestone 即 PR)。CLAUDE.md §五 已加 patch 开发流程小节(doc-first
+> → worktree-per-fix → PR → main review → fix → merge → cargo bump)。
+
+---
+
+## 1. PR 总览
+
+| # | finding | branch | 工程量估 | 主要前置依赖 |
+|---|---|---|---|---|
+| **PR #1** | F39 cct convention sweep | `v0-2-2-cct-rename` | ~250 LoC + ~50 测试,~2 天 | 无(机械 rename,先 merge 立约定) |
+| **PR #2** | F34 slug 四层 + F37 meta-agent 决策树 | `v0-2-2-meta-agent-and-slug` | ~400 LoC + ~30 测试 + 1 新 skill,~3-4 天 | **PR #1**(消费 `skills/` 顶层目录 + cct 命名)|
+| **PR #3** | F35 silence classifier + capture-pane 入 outbox | `v0-2-2-silence-classifier` | ~350 LoC + ~25 测试,~3 天 | 无(`tmux.rs` helper 抽离独立)|
+| **PR #4** | F36 subagent guard(defer until SubagentStop)| `v0-2-2-subagent-guard` | ~200 LoC + ~15 测试,~2 天 | 软依赖 PR #3(共享 enriched outbox classification 字段)|
+| **PR #5** | F38 终端截图 PNG(vt100 + imageproc DIY) | `v0-2-2-screenshot` | ~250 LoC + ~150 KB vendored TTF + ~20 测试,~3 天 | 软依赖 PR #3(outbox 加 `screenshot_path` 字段)|
+| **PR #6** | F40 team alias(`product-research` → `research`) | `v0-2-2-team-alias` | ~150 LoC + ~10 测试,~1.5 天 | 无 |
+| **PR #7** | chore:workspace.version + dev-flow + e2e + retro | `v0-2-2-chore` | ~50 LoC + 文档,~1 天 | 全部 PR merge 后,V0.2.2 ship gate |
+
+**总计**:~1.65 kLOC + ~150 测试,~15 天(单人 5 天/周即 3 周)。
+
+### 依赖图
+
+```
+PR #1 (F39 cct rename) — 必先 merge,立约定
+   ↓
+PR #2 (F34 + F37) — 在新 skills/ 目录 + cct 命名上 follow-up
+
+PR #3 (F35 silence classifier) ─┐
+   ↓ (outbox schema 共享)        │
+PR #4 (F36 subagent guard) ──────┤  (#3 / #4 / #5 跟 #1 / #2 解耦,可平行)
+PR #5 (F38 screenshot) ──────────┘   (#5 rebase 到 #3 后加 screenshot_path 字段)
+
+PR #6 (F40 team alias) — 独立面,跟谁都不撞
+
+PR #7 (chore ship gate) — 最后,workspace.version bump + retro
+```
+
+并行机会:**PR #3 / #4 / #5 / #6 同时起 4 个 worktree**(独立编辑面);#1 / #2
+是串行 critical path。
+
+---
+
+## 2. PR #1 — F39 cct convention sweep
+
+> **目标**:三对象同步重命名(binary `ccteam` → `cct`、自带 skill `ccteam-*` →
+> `cct-*`、skill 迁顶层 `skills/` 目录)+ V0.1/V0.2 用户升级迁移。机械 rename,
+> 先 merge 立约定,后续 PR follow-up。
+
+**关联 PRD**:§8(F39 全文)+ §13(CLAUDE.md dev-flow 段)
+
+### 任务
+
+- [ ] **#1.1** binary rename
+  - `crates/ccteam-cli/Cargo.toml::[[bin]] name` `"ccteam"` → `"cct"`
+  - Rust 内 `current_ccteam_bin()` 改 `current_cct_bin()`(全 callsite,grep `git grep -nE 'current_ccteam_bin'`)
+  - `cargo install --path crates/ccteam-cli --force` 后产出 `~/.cargo/bin/cct` 在 PATH 可调
+- [ ] **#1.2** 顶层 `skills/` 目录建立 + 两 skill 迁移
+  - `mkdir skills/`(repo 根)
+  - `git mv crates/ccteam-core/src/templates/ccteam_control_skill.md skills/cct-control/SKILL.md`
+  - `git mv crates/ccteam-core/src/templates/ccteam_team_author_skill.md skills/cct-team-author/SKILL.md`
+  - skill body 内 frontmatter `name:` 字段同步改 cct-* 命名
+  - **PR #2 留位**:`skills/cct-project-creator/` 不在本 PR 创建(F34 PR 加)
+- [ ] **#1.3** Rust 常量 / 函数名同步 rename
+  - `crates/ccteam-core/src/skill.rs::CCTEAM_CONTROL_SKILL_MD` → `CCT_CONTROL_SKILL_MD`
+  - `CCTEAM_TEAM_AUTHOR_SKILL_MD` → `CCT_TEAM_AUTHOR_SKILL_MD`
+  - 跨目录 `include_str!`:`include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../skills/cct-control/SKILL.md"))`
+  - `install_ccteam_control_skill` → `install_cct_control_skill`(+ team-author 同)
+- [ ] **#1.4** settings.json hook 模板用占位符 `{{CCT_BIN}}`
+  - `crates/ccteam-core/src/templates/settings.json` 全 hook command 用占位符
+  - doctor 安装时 `current_exe()` 替换为绝对路径(已支持,只是名字变 cct)
+- [ ] **#1.5** shell-out callsite + 文档 sweep
+  - `git grep -nE '"ccteam"' crates/`(rust 字面 → 改 `"cct"`)
+  - `git grep -nE '\bccteam (new|ls|show|attach|hook|doctor|watchdog|team)\b' README.md docs/tech-design.md docs/interfaces.md docs/requirements.md CLAUDE.md`
+  - 全 forward-looking 文档 `ccteam <cmd>` → `cct <cmd>`;**`docs/v0-1/` `docs/v0-2/` 不动**(历史归档)
+- [ ] **#1.6** V0.1/V0.2 用户升级迁移(`cct doctor` 自动跑)
+  - 检测 `~/.cargo/bin/ccteam` 存在 → warn "old binary detected; safe to rm"(不主动删)
+  - `~/projects/<slug>/.claude/settings.json` hook command 含 `/ccteam ` → rewrite 为 `/cct ` 真实路径(原子写)
+  - `~/.claude/skills/ccteam-{control,team-author}/` marker 校验(`<!-- ccteam-managed -->` 或 frontmatter `name:`)→ 匹配则 `rm -rf`,不匹配(用户手改)→ 保留 + warn
+  - 跟 V0.2.0 `--migrate-recommended-agents` 同模式(install 时清旧 + 新装)
+- [ ] **#1.7** CLAUDE.md §三 / §四 / §五 已加(本 PR 把 §13 PRD 草案的 "patch 开发流程"段也落)
+- [ ] **#1.8** 测试
+  - 黄金 e2e:`cct doctor --install-skill` 后 `~/.claude/skills/cct-{control,team-author,project-creator}/` 三个都存在(注意 PR #2 才加 project-creator,本 PR 只校 2 个)
+  - migration 测试:fixture 模拟 V0.2.1 用户(`~/.claude/skills/ccteam-control/` + 老 settings.json)→ `cct doctor` 跑后清旧 + 新装
+
+### 验收(摘 PRD §10 验收 F39 段)
+
+- [ ] `crates/ccteam-cli/Cargo.toml::[[bin]] name = "cct"`;`cargo build --release` 产物 = `cct`
+- [ ] `skills/cct-{control,team-author}/SKILL.md` ship,旧 `crates/ccteam-core/src/templates/ccteam_*_skill.md` 删
+- [ ] `skill.rs` 三常量 + 三函数 rename(三 = control + team-author + project-creator,但 project-creator 在 PR #2 加,本 PR 只两个)
+- [ ] `settings.json` 模板用 `{{CCT_BIN}}`,doctor 替换为 `current_exe()` 真路径
+- [ ] `cct doctor` 跑迁移路径无回归;markered ccteam-* skill 自动清,unmarkered 保留 + warn
+- [ ] forward-looking 文档全 `ccteam <cmd>` → `cct <cmd>`;`docs/v0-1/` `docs/v0-2/` 不动
+- [ ] `git grep -nE 'ccteam-(control|team-author)'` 在 `crates/` `skills/` `README.md` `CLAUDE.md` 命中 0 次(historical archive 除外)
+- [ ] `cargo test --workspace` 全绿,baseline 511 → ≥ 511
+
+### 文档同步
+
+- `CLAUDE.md` §三红线 / §四 Skills 行 / §五 patch 开发流程小节(本 PR 落)
+- `docs/README.md` patch 目录约定(本 PR 落,与 PRD §13 配套)
+- `docs/interfaces.md` §10 命令清单 `ccteam` → `cct`
+- `docs/dev-coupling-audit.md` F39 close 标记
+
+---
+
+## 3. PR #2 — F34 slug 四层 + F37 meta-agent 决策树
+
+> **目标**:slug 四层调用栈(显式 / meta-agent NL / `claude -p` 智能 / deterministic
+> 兜底)+ 新 `cct-project-creator` skill body + meta-agent role prompt §1 自检反例
+> 加固。F34 + F37 两 finding 同 PR(都改 `meta_agent_role.md`,且 F34 派单流程
+> §3.2.2 重写为指 cct-project-creator skill,与 F37 §6.3 协同)。
+
+**关联 PRD**:§3(F34 全文)+ §6(F37 全文)
+
+**前置**:**PR #1 必须先 merge**(消费 `skills/` 目录 + cct-* 命名 + skill.rs install fn 模板)。
+
+### 任务
+
+- [ ] **#2.1** Tier 1 — `--slug` CLI flag
+  - `crates/ccteam-cli/src/main.rs:71` `Commands::New` 加字段 `slug: Option<String>` / `auto_slug_model: Option<String>` / `no_auto_slug: bool`
+  - `crates/ccteam-cli/src/commands.rs::run_new` 接 `slug: Option<&str>`
+  - B2 前缀语义:`if slug.starts_with(&format!("{team}-"))` verbatim;否则 prepend `<team>-`(详 PRD §3.2.1)
+  - 撞名仍 `pick_unused_slug` 的 `-{4hex}` retry
+- [ ] **#2.2** Tier 4 — `slugify_brief()` deterministic 兜底
+  - `crates/ccteam-core/src/projects.rs` 新函数 `slugify_brief(input: &str) -> String`(~30 LoC,详 PRD §3.2.4)
+  - **不动 `slugify()`**(meta-agent path `<handle>-meta` 用)
+  - `pick_unused_slug` 内部从 `slugify(base)` 切到 `slugify_brief(base)`
+  - 单元测试覆盖 PRD §3.2.4 表的 7 输入预期
+- [ ] **#2.3** Tier 3 — `claude -p` 智能 fallback
+  - `commands.rs::run_new`:无 `--slug` + `which claude` 在 PATH + stdin 是 tty + 非 `--no-auto-slug` → shell out
+  - prompt template 详 PRD §3.2.3(haiku-4-5,15s 超时硬截,sanitize stdout `[a-z0-9-]+` ≤ 60 char)
+  - 失败 fallback 全表(PRD §3.2.3 fallback 链)→ 降级 Tier 4 + log warn 含 reason
+  - flag:`--no-auto-slug` / `--auto-slug-model haiku/sonnet`(默认 haiku)/ env `CCTEAM_AUTO_SLUG=off`
+  - **非 tty(脚本 / e2e)→ auto-accept** 建议(15s 超时硬截兜)
+- [ ] **#2.4** 新 skill `cct-project-creator`
+  - `skills/cct-project-creator/SKILL.md` 新建(skill body 详 PRD §3.2.2;Phase A/B/C/D 流程,AskUserQuestion 结构化选项)
+  - frontmatter `name: cct-project-creator` + 触发词("新项目" / "建一个 X" / "调研 X")
+  - **AskUserQuestion 显式说明**:本 skill 仅在 meta-agent context 调用,project session 的 PreToolUse hook 拦不到 meta-agent(V0.2 §2.4 已 spec)
+- [ ] **#2.5** Rust 端新 install fn
+  - `crates/ccteam-core/src/skill.rs` 加 `CCT_PROJECT_CREATOR_SKILL_MD` 常量 + `install_cct_project_creator_skill` fn
+  - `cct doctor --install-skill` extend 装 3 skills(cct-control / cct-team-author / cct-project-creator)
+- [ ] **#2.6** F37 — `meta_agent_role.md` 决策树加固
+  - §1 自检段加显式反例 + 项目请求边界(详 PRD §6.2.1):「调研 X / 看 X 值不值得做」= 项目请求,**绝不**自起 `Agent(subagent_type=...)` 调研
+  - §2 派单段简化为:走 `cct-project-creator` skill(已自动装好);流程细节走 skill body
+  - §3 克制规则加显式反例(详 PRD §6.2.2):❌ `Agent(subagent_type=general-purpose)` / web 搜索 — 这是 product-research(PR #6 后改 `research`)团队的活
+  - 边界不清场景:问一句 "事实询问还是产研请求?" 不默选(详 PRD §6.2.1)
+- [ ] **#2.7** 测试
+  - `slugify_brief` unit:PRD §3.2.4 表 7 输入断言
+  - `--slug` flag e2e:`cct new --slug ccteam-ui --team dev` → `~/projects/dev-ccteam-ui/`;`--slug dev-x` verbatim;非法字符 fail-loud
+  - Tier 3 fallback e2e:mock claude 返回非法 stdout → 降级 Tier 4
+  - `cct doctor --install-skill` e2e:三 skill 都装 + frontmatter `name:` 校验
+  - meta-agent role prompt e2e:doctor `--install-meta-agent <h>` 后 CLAUDE.md 含新 §1 反例段
+
+### 验收(摘 PRD §10 F34 + F37)
+
+- [ ] `cct new --slug <name> --team <team>` 创建用 `<team>-<name>` 或 verbatim
+- [ ] 撞名 retry 仍工作;非法 slug fail-loud
+- [ ] `skills/cct-project-creator/SKILL.md` ship + `install_cct_project_creator_skill` 落 `~/.claude/skills/`
+- [ ] skill body 用 `AskUserQuestion` 做 slug / team / 关键澄清结构化选择
+- [ ] Tier 3:`cct new` 无 `--slug` + tty,shell out `claude -p --model claude-haiku-4-5-20251001` + Y/n;15s 超时;失败降级 Tier 4
+- [ ] Tier 4:`slugify_brief()` token-aware + stop-word + dedupe + 取前 3 token;`slugify()` 不动
+- [ ] `pick_unused_slug` 切到 `slugify_brief(base)`
+- [ ] `meta_agent_role.md` §1 反例段 + §2 派单段指 skill + §3 克制规则反例
+- [ ] `cct doctor --install-meta-agent <handle>` 重写 CLAUDE.md 含新 §
+
+### 文档同步
+
+- `docs/interfaces.md` §10 `cct new` 加 `--slug` / `--no-auto-slug` / `--auto-slug-model` flag schema
+- `docs/tech-design.md` §3.8 用户接口层 / §6 加 cct-project-creator skill 说明
+- `docs/dev-coupling-audit.md` F34 / F37 close 标记
+
+---
+
+## 4. PR #3 — F35 silence classifier + enriched outbox
+
+> **目标**:orchestrator daemon 主循环加事件感知 silence classifier(读 progress.jsonl
+> 末事件 + 静默时长 → 4 类响应),deterministic re-inject + enriched escalate 写
+> outbox(含 `pane_tail` + classification + last_event 字段);capture-pane helper
+> 提到 ccteam-core。meta-agent role prompt 加 propose-confirm UX 模板。
+
+**关联 PRD**:§4(F35 全文)
+
+### 任务
+
+- [ ] **#3.1** capture-pane helper 提到 ccteam-core
+  - `crates/ccteam-core/src/tmux.rs` 加 `pub fn capture_pane_tail(slug: &str, lines: usize) -> Result<Option<String>>`
+  - `crates/ccteam-hooks/src/parse_phase_end.rs:313`(L3 fail-safe)改引用 ccteam-core helper(回归测试 Stop hook L3 行为不变)
+  - 红线 reminder:**只入 outbox 给 meta-agent / 用户读,不进 orchestrator 状态机**(§3.7 红线"永不解析终端输出")
+- [ ] **#3.2** silence_classifier 模块 + 4 类 enum
+  - `crates/ccteam-core/src/silence_classifier.rs`(新)或 `stall.rs` 升级;权衡:新模块独立单测面更干净,推荐新模块
+  - `enum SilenceClass { Healthy, Terminal, SubagentBusy, SubagentRunaway, MidToolHung, PostStopLimbo, InjectLimbo }`(7 类细分,详 PRD §4.2.1)
+  - `pub fn classify(events: &[ProgressEvent], silent_seconds: u64, thresholds: &StallThresholds) -> SilenceClass`
+  - 复用 `stall.rs::StallThresholds::from_phase`(warn / suspicious / escalate 三阈值不另定义)
+  - 单元测试 7 类全覆盖(eg `PreToolUse(tool=Task)` 后 < escalate 阈值 = `SubagentBusy` / ≥ 阈值 = `SubagentRunaway`)
+- [ ] **#3.3** enriched outbox schema 字段
+  - `<project>/.ccteam/needs_attention.outbox.json` 加新字段(详 PRD §4.2.2):
+    - `ccteam_classification: string`(SilenceClass discriminant)
+    - `ccteam_silent_seconds: u64`
+    - `ccteam_last_event: { ts, event, tool? }`
+    - `ccteam_pane_tail: string`(已有协议,新 case 复用)
+  - `interfaces.md` §6.x 同步 schema
+  - 跟 Stop hook L3 fail-safe 同 schema 共存(L3 不写新字段,只 fail-safe 兜底)
+- [ ] **#3.4** orchestrator daemon tick 集成
+  - `crates/ccteam-core/src/orchestrator.rs::process_project` per-project tick 末加 classifier 调用
+  - 决策表(详 PRD §4.2.1):
+    - `SubagentBusy` / `Healthy` / `Terminal` → 不动
+    - `SubagentRunaway` / `MidToolHung` → enriched escalate(写 outbox + log)
+    - `PostStopLimbo` / `InjectLimbo` → deterministic re-inject 1 次,再失败 → enriched escalate
+  - re-inject 限流:1 次 retry cap(state 字段 `auto_loop.last_reinject_at` 记录)
+  - **红线 reminder**(详 PRD §4.2.3):classifier 是 deterministic;**meta-agent 只 surface 选项**,不发 Ctrl+C / 改 phase / kill;只有 `PostStopLimbo` / `InjectLimbo` deterministic re-inject 由 orchestrator 直接做(已是 deterministic 路径,不经 LLM)
+- [ ] **#3.5** meta-agent role prompt — propose-confirm UX 模板
+  - `meta_agent_role.md` §7 watchdog 段补充 enriched escalate NL 翻译模板(详 PRD §4.2.3)
+  - 模板示例:「项目 X 在 implement 第 12 分钟卡在 Read(file.md) 后无 PostToolUse,看起来 tool hang 而非 subagent 慢工。要不要 (a) `cct attach dev-x` 自看 (b) 让我等再 5 min 重看 (c) 这条不管了?」
+  - **不 autonomous decide** — 用户回弹纠错
+- [ ] **#3.6** 单元 + e2e 测试
+  - `silence_classifier` 7 类 unit
+  - `MidToolHung` / `SubagentRunaway` 触发 enriched outbox 字段完整性断言
+  - `PostStopLimbo` / `InjectLimbo` deterministic re-inject 1 次 + 再失败 → escalate(测试)
+  - capture-pane helper 共用 + Stop hook L3 行为不变 regression
+  - `tick` 频率:每 project 每 5-10s,无新 event 时跑 classify(廉价 — 读 progress.jsonl 末几行 + match)
+
+### 验收(摘 PRD §10 F35)
+
+- [ ] silence_classifier 4+ 类分类 unit 测试覆盖
+- [ ] `MidToolHung` / `SubagentRunaway` 触发 enriched outbox,字段完整(classification / silent_seconds / last_event / pane_tail)
+- [ ] `PostStopLimbo` / `InjectLimbo` deterministic re-inject 1 次,再触发 → enriched escalate
+- [ ] capture-pane helper 提到 ccteam-core,parse_phase_end.rs 改引用,Stop hook L3 行为不变
+- [ ] meta-agent role prompt 加 enriched outbox NL 翻译模板
+
+### 文档同步
+
+- `docs/tech-design.md` §3.5 fix-loop / §6.9 idle injection 加 silence_classifier 说明
+- `docs/interfaces.md` §6.x outbox schema 加新字段(`ccteam_classification` / `ccteam_silent_seconds` / `ccteam_last_event` / `ccteam_pane_tail` 已有)
+- `docs/dev-coupling-audit.md` F35 close
+
+---
+
+## 5. PR #4 — F36 send-keys subagent guard
+
+> **目标**:`dispatch_phase_with_state` 注入路径前加 active-subagent 检测,defer
+> until SubagentStop;pending-inject.json 单文件协议;max-defer-minutes 兜底。
+> 与 F35 协同:F36 主路径主动 defer,F35 `InjectLimbo` 类兜底。
+
+**关联 PRD**:§5(F36 全文)
+
+**前置**:软依赖 PR #3(共享 enriched outbox schema 字段 — `ccteam_classification`
+新增 `InjectDeferTimeout` 一类)。
+
+### 任务
+
+- [ ] **#4.1** `subagent_active(events)` helper
+  - `crates/ccteam-core/src/progress.rs` 加 `pub fn subagent_active(events: &[Value]) -> bool`
+  - 扫末事件序列,counting `PreToolUse(tool=Task)` 和 `SubagentStop`,开多于关 → true
+  - 单测:开 / 关 / 嵌套(PreToolUse(Task) 嵌 PreToolUse(Task) → SubagentStop → 仍有 1 个 active)
+- [ ] **#4.2** `dispatch_phase_with_state` 注入前 guard
+  - `orchestrator.rs::dispatch_phase_with_state` 等所有注入路径前加(详 PRD §5.2):
+    ```rust
+    if subagent_active(&recent_events) {
+        self.queue_pending_inject(slug, phase, attachment_refs);
+        return Ok(());  // 或返 PendingInject 状态
+    }
+    ```
+  - **不发 send-keys**;落 `<project>/.ccteam/pending-inject.json`(单文件,最新覆盖旧的)
+- [ ] **#4.3** pending-inject.json schema
+  - 字段:`{ phase, attachment_refs, enqueued_at, max_defer_minutes }`
+  - `interfaces.md` §6.x 同步加(跟 outbox 同段)
+- [ ] **#4.4** daemon tick 真发 + 兜底
+  - `orchestrator.rs` daemon 主循环 per-project tick:`pending-inject.json` 存在 + subagent 不再 active + 距 `enqueued_at` < `max_defer_minutes`(默认 10) → 真发 send-keys + 删文件
+  - 超时 → fail-loud escalate:`<project>/.ccteam/needs_attention.outbox.json` 加 `ccteam_classification: "InjectDeferTimeout"`(F35 schema 复用)
+- [ ] **#4.5** 测试
+  - `subagent_active` unit:开 / 关 / 嵌套场景
+  - dispatch e2e:active subagent 时 dispatch → 不发 send-keys,pending-inject.json 存在
+  - daemon tick e2e:SubagentStop event 后,pending-inject 真发 + 删文件
+  - 超时 e2e:max-defer-minutes 超 → enriched escalate(InjectDeferTimeout)
+
+### 验收(摘 PRD §10 F36)
+
+- [ ] `subagent_active(events)` unit 测试(开 / 关 / 嵌套)
+- [ ] `dispatch_phase_with_state` 检测 active subagent → pending-inject.json 落盘 + 不发 send-keys
+- [ ] daemon tick 在 SubagentStop event 后真发 pending-inject + 删文件
+- [ ] max-defer-minutes 兜底:超时 → enriched escalate,不无限 defer
+
+### 文档同步
+
+- `docs/tech-design.md` §6.9 idle injection 加 subagent guard 说明
+- `docs/interfaces.md` §6.x pending-inject.json schema
+- `docs/dev-coupling-audit.md` F36 close
+
+---
+
+## 6. PR #5 — F38 终端截图 PNG(vt100 + imageproc DIY)
+
+> **目标**:tmux capture-pane → vt100 状态机 → imageproc 渲染 → PNG,纯 Rust 全栈,
+> vendored JetBrains Mono(OFL),无 system C deps。`mcp__<ns>__screenshot` MCP 工具 +
+> outbox `screenshot_path` 字段(F35 schema rebase 加)。
+
+**关联 PRD**:§7(F38 全文,5 轮迭代敲定 vt100 + imageproc DIY)
+
+**前置**:软依赖 PR #3(F35 outbox 加 `screenshot_path` 字段时 rebase)。
+
+### 任务
+
+- [ ] **#5.1** Cargo deps + vendored TTF
+  - `crates/ccteam-core/Cargo.toml` 加:`vt100 = "0.15"` + `image = "0.25"` + `imageproc = "0.25"` + `ab_glyph = "0.2"`
+  - `crates/ccteam-core/assets/fonts/JetBrainsMono-Regular.ttf` vendor(OFL,~150 KB)
+  - `LICENSES.md` 加 third-party-fonts 注(OFL 文本 + 来源 URL)
+  - `include_bytes!("../assets/fonts/JetBrainsMono-Regular.ttf")` 编译时打包
+- [ ] **#5.2** ANSI_256 调色板常量
+  - `crates/ccteam-core/src/screenshot/ansi_palette.rs`(子模块)
+  - `pub const ANSI_256: [Rgb<u8>; 256]`(16 标准 + 216 立方 6×6×6 + 24 灰阶,标准映射)
+  - 黄金值测试:每段抽 3 个 idx 断言 RGB 正确
+- [ ] **#5.3** screenshot.rs 主模块(~250 LoC)
+  - `crates/ccteam-core/src/screenshot.rs::render_screenshot(paths, slug, lines) -> Result<Option<PathBuf>>`
+  - 流程(详 PRD §7.2.3):
+    1. `capture_pane_with_ansi(slug, lines)` — `tmux capture-pane -e -p -t ccteam-<slug> -S -<lines>`
+    2. `query_pane_dims(slug)` — `tmux display-message -p '#{pane_height} #{pane_width}'`
+    3. `vt100::Parser::new(rows, cols, 0).process(&bytes)`
+    4. 字体加载:env `CCTEAM_SCREENSHOT_FONT_TTF` 优先,缺则 vendored
+    5. cell 度量 `text_size(scale, &font, "M")` → 单 cell w/h
+    6. 遍历 grid:`draw_filled_rect_mut(bg)` + `draw_text_mut(fg + cell.contents())`
+    7. `img.save("<project>/.ccteam/screenshots/<utc>.png")`
+  - `vt100_color_to_rgb(c, default)`:match Default / Idx(i) → ANSI_256[i] / Rgb(r,g,b)
+- [ ] **#5.4** graceful degrade — `std::panic::catch_unwind` 兜底
+  - 失败场景全表(详 PRD §7.2.5):tmux 失败 / vt100 panic / ttf 解析失败 / imageproc panic / IO 失败
+  - 全部 → `Ok(None)` + log warn 含 reason + outbox 不写 `screenshot_path`(主路径不挂)
+  - 红线:**screenshot 永不阻塞 enriched escalate / outbox 写入**;F35 文本 `pane_tail` 是 ASCII 维度兜底
+- [ ] **#5.5** MCP 工具 `mcp__<ns>__screenshot`
+  - `crates/ccteam-cli/src/mcp_serve.rs` 加 tool(跟现 9 工具并列)
+  - input: `{ slug: string, lines?: number }`(default 50)
+  - output: `{ ok: bool, path?: string, reason?: string }`
+  - **MCP namespace 决议**:V0.2.2 默认 `mcp__ccteam__screenshot` 不动 namespace(F39 §8.3 明示 MCP namespace 改名 V0.3 评估)
+- [ ] **#5.6** doctor `--screenshot-smoke <slug>` flag
+  - `crates/ccteam-cli/src/commands.rs` 加 `cct doctor --screenshot-smoke <slug>` 跑端到端渲染
+  - print 命中的 ttf path / 失败 reason(字体 / tmux / IO 哪一层)
+- [ ] **#5.7** F35 outbox schema rebase
+  - 加 `ccteam_screenshot_path: Option<String>` 字段(best-effort,失败 silent)
+  - meta-agent NL 翻译时:有路径就附 "(屏幕截图:file:///<path>)",没有就跳过
+- [ ] **#5.8** 测试
+  - `ANSI_256` 黄金值 unit
+  - `vt100_color_to_rgb` unit(Default / Idx / Rgb 三 case)
+  - `render_screenshot` smoke e2e:固定 ANSI byte 输入 → PNG 生成,断言尺寸 / 非空
+  - graceful degrade e2e:tmux 不存在 → `Ok(None)`(主路径 outbox 仍写)
+  - `cct doctor --screenshot-smoke <slug>` e2e:fixture project + smoke run
+
+### 验收(摘 PRD §10 F38)
+
+- [ ] `Cargo.toml` 加 4 deps(vt100 / image / imageproc / ab_glyph)
+- [ ] vendored JetBrains Mono OFL ttf;`LICENSES.md` 加注
+- [ ] `screenshot.rs::render_screenshot(slug, lines)` API 上线
+- [ ] `ANSI_256: [Rgb<u8>; 256]` 调色板常量
+- [ ] `mcp__<ns>__screenshot(slug, lines?)` MCP 工具(namespace 默认 ccteam)
+- [ ] `CCTEAM_SCREENSHOT_FONT_TTF` env 覆盖字体
+- [ ] graceful degrade 全覆盖(`catch_unwind` 兜潜在 panic)
+- [ ] F35 enriched outbox rebase 加 `screenshot_path` 字段
+- [ ] `cct doctor --screenshot-smoke <slug>` 端到端 verify
+- [ ] `interfaces.md` §12 加 MCP 工具 schema
+- [ ] 颜色映射黄金值测试:输入预设 ANSI escape,断言 cell 颜色映射 ANSI_256 表
+
+### 文档同步
+
+- `docs/interfaces.md` §12 加 `mcp__ccteam__screenshot` MCP 工具 schema
+- `docs/tech-design.md` §3.8 / §6.x screenshot 段
+- `docs/dev-coupling-audit.md` F38 close
+- `LICENSES.md` 加 OFL 字体注(若文件不存在则建)
+
+---
+
+## 7. PR #6 — F40 team 名缩短 + alias 软迁移
+
+> **目标**:`teams/product-research/` → `teams/research/`(`git mv` 保 history),
+> `team.yaml::name = research` + `aliases: [product-research]` + `description` 字段
+> 载全称;`team_resolver` 按 alias 匹配老项目;新项目目录 `~/projects/research-<slug>/`,
+> 老项目仍 `~/projects/product-research-<slug>/` 不动。**不动用户数据**。
+
+**关联 PRD**:§9(F40 全文)
+
+### 任务
+
+- [ ] **#6.1** 仓内 team 重命名(git mv 保 history)
+  - `git mv teams/product-research/ teams/research/`
+  - `teams/research/team.yaml`:
+    - `name: research`(改)
+    - `aliases: [product-research]`(新字段)
+    - `description: "Product research team — kickoff → research → verdict → next-steps;用于'判断 idea 值不值得做'场景"`(新字段载全称)
+  - phase markdown 内容不动(不引用自己 team 名)
+- [ ] **#6.2** `TeamSpec::aliases` 字段 + resolver
+  - `crates/ccteam-core/src/team.rs::TeamSpec` 加 `#[serde(default)] pub aliases: Vec<String>`
+  - `team_resolver::resolve_team(query)` 按 name + aliases 匹配(详 PRD §9.2.2)
+  - 老项目 `state.json::team: "product-research"` → resolver 命中 alias → 加载 `teams/research/team.yaml`(canonical = "research")
+- [ ] **#6.3** `cct new --team` UI
+  - 接受 `research` 或 `product-research`;后者 stderr warn `"deprecated alias, use 'research'"`(不 fail-loud,过渡期友好)
+  - 实际派发 canonical name `research`(新项目 `state.json::team = "research"`)
+  - `cct-project-creator` skill body Phase C team 选择 option label `"research"` + description 用 `team.yaml::description` 全文
+- [ ] **#6.4** 老项目 rules 文件并存
+  - `~/.claude/rules/ccteam-lessons-product-research.md` 不删(已积累跨项目记忆有价值,paths frontmatter 仍匹配 `~/projects/product-research-*`)
+  - 新项目 `~/.claude/rules/ccteam-lessons-research.md`(新生成,paths 匹配 `~/projects/research-*`)
+  - doctor 写一份新的(从 `teams/research/team.yaml::retro_schema` 渲染);老的留着不动
+- [ ] **#6.5** 测试
+  - `crates/ccteam-cli/tests/m3_product_research_e2e_test.rs` 改用 `research` 名
+  - 增 alias resolution 测试:`team: product-research` 也通(state.json 里写 product-research → 加载 research team)
+  - 增 deprecation warn 测试:`cct new --team product-research` stderr 含 "deprecated alias"
+
+### 验收(摘 PRD §10 配套 + §9.2.5)
+
+- [ ] `teams/research/team.yaml::name = research` + `aliases: [product-research]` + `description` 字段
+- [ ] `git log --follow teams/research/team.yaml` 能追到 product-research 历史
+- [ ] `team_resolver` 按 alias 匹配老项目 e2e 通过
+- [ ] `cct new --team product-research` stderr warn + 实际派发 canonical `research`
+- [ ] 老 rules 文件 `ccteam-lessons-product-research.md` 不动;新文件生成
+- [ ] `interfaces.md` §5.5 加 `aliases` 字段
+- [ ] `tech-design.md` §3 团队抽象表更新("领域命名"目标从 V0.3 deferred 改 V0.2.2 ship)
+- [ ] `dev-coupling-audit.md` F40 close
+
+### 文档同步
+
+- `docs/interfaces.md` §5.5 team.yaml schema 加 `aliases` / `description` 字段
+- `docs/tech-design.md` §3 团队抽象表
+- `docs/dev-coupling-audit.md` F40 close
+
+---
+
+## 8. PR #7 — chore:workspace.version + dev-flow + e2e + retro
+
+> **目标**:V0.2.2 ship gate。Cargo workspace.version `"0.0.1"` → `"0.2.2"`(retroactive
+> 修正);CLAUDE.md §一表格 baseline 回填新数;e2e 联跑 + retro。
+
+**关联 PRD**:§12(version bump)+ §13(CLAUDE.md dev-flow,PR #1 已落,本 PR 校验)
+
+**前置**:PR #1-#6 全部 merge。
+
+### 任务
+
+- [ ] **#7.1** Cargo workspace.version bump
+  - `Cargo.toml::workspace.package.version` `"0.0.1"` → `"0.2.2"`
+  - commit subject `v0.2.2: ...` 前缀
+  - 新政策注:每个 minor / patch release **必须 bump** + commit subject 一致(已写 PRD §12)
+- [ ] **#7.2** CLAUDE.md baseline 回填
+  - §一表格 测试 baseline 数从 511 更新到 V0.2.2 实际(预估 511 + 各 PR 新增 ≈ 600+)
+  - "已 ship 里程碑"行加 V0.2.2 patch 段 — 详 docs/v0-2-2/README.md
+- [ ] **#7.3** docs/README.md patch 目录约定
+  - 已 PR #1 落档(2026-05-09);本 PR 校验存在
+- [ ] **#7.4** docs/v0-2-2/e2e-retro.md
+  - 落档 V0.2.2 e2e 联跑结果(7 PR merge 后跑一遍 dev / research 两 team smoke + 看是否新 finding)
+  - 新发现 finding 入 V0.3 候选(不本轮做)
+- [ ] **#7.5** dev-coupling-audit.md
+  - F34-F40 全部 close 标记(各 PR merge 时已加,本 PR 校验)
+- [ ] **#7.6** 红线 grep 矩阵跑一遍(详 §10)
+- [ ] **#7.7** 测试
+  - `cargo test --workspace` 全绿
+  - `cargo clippy --workspace --all-targets` 不新增 warning(4 pre-existing 不算)
+  - dev / research 两 team smoke e2e 各跑一遍
+
+### 验收
+
+- [ ] `Cargo.toml::workspace.package.version = "0.2.2"`
+- [ ] CLAUDE.md §一表格 baseline 数更新
+- [ ] `docs/v0-2-2/e2e-retro.md` 落档
+- [ ] `dev-coupling-audit.md` F34-F40 全 close
+- [ ] `git grep -nE "ccteam-(control|team-author)"` 在 `crates/` `skills/` `README.md` `CLAUDE.md` 0 命中
+- [ ] `git grep -nE 'product-research'` 在 `crates/` `teams/` 命中只在 alias 字段 / 老 rules path / 注释(grep 矩阵详 §10)
+- [ ] cargo test 全绿,clippy 不新增 warning
+
+### 文档同步
+
+- `CLAUDE.md` §一表格(baseline + 已 ship 段)
+- `docs/v0-2-2/e2e-retro.md`(新落)
+- `docs/dev-coupling-audit.md` F34-F40 全 close
+
+---
+
+## 9. Worktree subagent briefing 模板
+
+每个 PR 一份 briefing。subagent 是 **新 session,无对话历史**,模板必须
+self-contained — 含目标 / 必读文件 / 实施步骤 / 红线 grep / 验收 / PR 命令。
+模板设计原则:**briefing 让 subagent 拿到模板 + 进 worktree 即可开干**。
+
+### 9.1 通用前置(每个 PR 都跑一遍)
+
+```bash
+# 1. 进 worktree
+cd /tmp/ccteam-<branch>
+
+# 2. baseline 验证
+cargo test --workspace 2>&1 | grep -E "^test result" | awk '{p+=$4;f+=$6}END{print "baseline:", p, "passed,", f, "failed"}'
+# 期望:511 passed, 0 failed(V0.2.2 base = 170f5a8)
+
+# 3. 读必读文档
+# - PRD 对应章节(每 briefing 列出)
+# - CLAUDE.md §三红线 + §五 PR 纪律
+# - 关联代码文件(每 briefing 列出)
+```
+
+### 9.2 PR #1 briefing(F39 cct rename)
+
+```markdown
+## 任务
+
+V0.2.2 PR #1 — `cct` 短前缀约定 sweep:binary `ccteam` → `cct`、自带 skill
+`ccteam-{control,team-author}` → `cct-{control,team-author}`、迁顶层 `skills/`
+目录、V0.1/V0.2 用户升级迁移。机械 rename,先 merge 立约定。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §8(F39 全文,~150 行)
+2. `docs/v0-2-2/dev-plan.md` §2(本 PR 步骤)
+3. `CLAUDE.md` §三红线("cct 短前缀约定" / "skill 顶层 skills/ 目录")+ §五 PR 纪律
+4. 触点代码:
+   - `crates/ccteam-cli/Cargo.toml`
+   - `crates/ccteam-core/src/skill.rs`
+   - `crates/ccteam-core/src/templates/{ccteam_control,ccteam_team_author}_skill.md`
+   - `crates/ccteam-core/src/templates/settings.json`
+   - `README.md` / `docs/tech-design.md` / `docs/interfaces.md` / `docs/requirements.md`
+
+## 实施步骤(详 dev-plan §2)
+
+1. binary rename(#1.1)
+2. `skills/` 目录建立 + 两 skill 迁移(#1.2)
+3. Rust 常量 / 函数 rename(#1.3)
+4. settings.json 占位符(#1.4)
+5. 文档 sweep(#1.5)
+6. doctor 升级迁移(#1.6)
+7. CLAUDE.md §五 dev-flow 段(#1.7)
+8. 测试(#1.8)
+
+## 红线 grep(commit 前必跑)
+
+```bash
+git grep -nE 'ccteam-(control|team-author)' crates/ skills/ README.md CLAUDE.md
+# 期望:0 命中(historical archive `docs/v0-1/` `docs/v0-2/` 不算)
+
+git grep -nE '"ccteam"' crates/ccteam-cli/src/ crates/ccteam-core/src/
+# 期望:全部是注释 / 测试 fixture / 历史归档,无 forward shell-out
+
+git grep -nE '\bccteam (new|ls|show|attach|hook|doctor|watchdog|team)\b' README.md docs/tech-design.md docs/interfaces.md docs/requirements.md CLAUDE.md
+# 期望:0 命中
+```
+
+## 验收 checklist
+
+详 dev-plan §2 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-cct-rename --title "v0.2.2 PR #1: F39 cct convention sweep" --body "$(cat <<'EOF'
+## Closes
+- F39(`docs/v0-2-2/prd.md` §8)
+- `docs/dev-coupling-audit.md` F39 close
+
+## 改动
+- binary rename `ccteam` → `cct`(`crates/ccteam-cli/Cargo.toml`)
+- 顶层 `skills/` 目录建立,`cct-{control,team-author}` 迁入
+- Rust 常量 / 函数 / settings.json 占位符 sync
+- forward-looking 文档 sweep,V0.1/V0.2 历史不动
+- `cct doctor` 自动迁移老用户(skill 目录 + settings.json hook 路径)
+- `CLAUDE.md` §五 patch 开发流程小节(详 prd.md §13)
+
+## 测试
+- baseline 511 → ?(预期不退步)
+- 新增迁移 e2e 测试
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 9.3 PR #2 briefing(F34 + F37)
+
+```markdown
+## 任务
+
+V0.2.2 PR #2 — slug 四层调用栈(显式 / meta-agent NL / claude -p 智能 / deterministic
+兜底)+ 新 `cct-project-creator` skill body + meta-agent role prompt §1 决策树
+加固。F34 + F37 同 PR(都改 `meta_agent_role.md`,F34 派单流程指 cct-project-creator
+skill 与 F37 协同)。
+
+## 前置
+
+**PR #1 必须先 merge** — 消费 `skills/` 顶层目录 + `cct-*` 命名 + skill.rs install fn
+模板。worktree base 已是 PR #1 merge 后的 main。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §3(F34 全文,~280 行)+ §6(F37 全文,~60 行)
+2. `docs/v0-2-2/dev-plan.md` §3(本 PR 步骤)
+3. `CLAUDE.md` §三红线("控制平面无 LLM" 不破:slug 生成是数据转换 utility,不是控制)+ §五 PR 纪律
+4. 触点代码:
+   - `crates/ccteam-cli/src/main.rs:71`(Commands::New 加字段)
+   - `crates/ccteam-cli/src/commands.rs::run_new`
+   - `crates/ccteam-core/src/projects.rs`(新 `slugify_brief`)
+   - `crates/ccteam-core/src/skill.rs`(新 install_cct_project_creator_skill)
+   - `crates/ccteam-core/src/templates/meta_agent_role.md`(§1 / §2 / §3 改)
+   - `skills/cct-project-creator/SKILL.md`(新建)
+
+## 实施步骤(详 dev-plan §3)
+
+1. Tier 1 `--slug` flag(#2.1)
+2. Tier 4 `slugify_brief()`(#2.2)
+3. Tier 3 `claude -p` 智能 fallback(#2.3)
+4. 新 skill `cct-project-creator`(#2.4)
+5. Rust 端 install fn(#2.5)
+6. F37 meta_agent_role.md §1/§2/§3 改(#2.6)
+7. 测试(#2.7)
+
+## 红线 grep
+
+```bash
+# claude -p 是 < 5s utility,不是控制路径,但仍 grep 验证不污染 orchestrator daemon
+git grep -nE 'Command::new\("claude"\)' crates/ccteam-core/src/orchestrator.rs crates/ccteam-core/src/auto_loop.rs
+# 期望:0 命中(slug 生成不在这两文件)
+
+# meta_agent_role.md 决策树反例段必含
+git grep -nE '调研.*X|Agent\(subagent_type' crates/ccteam-core/src/templates/meta_agent_role.md
+# 期望:命中 ≥ 2(§1 反例 + §3 克制反例)
+
+# AskUserQuestion 拦截只 scope project session
+git grep -nE 'AskUserQuestion' crates/ccteam-core/src/templates/
+# 期望:project settings.json template 命中(拦截);meta-agent 路径不命中(允许)
+```
+
+## 验收 checklist
+
+详 dev-plan §3 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-meta-agent-and-slug --title "v0.2.2 PR #2: F34 slug 四层 + F37 meta-agent 决策树" --body "$(cat <<'EOF'
+## Closes
+- F34(`docs/v0-2-2/prd.md` §3)
+- F37(`docs/v0-2-2/prd.md` §6)
+- `docs/dev-coupling-audit.md` F34 / F37 close
+
+## 改动
+- `cct new --slug` flag + B2 前缀语义(自动加 team 前缀)
+- 四层调用栈:Tier 1 显式 / Tier 2 meta-agent NL / Tier 3 claude -p haiku / Tier 4 slugify_brief deterministic
+- 新 skill `cct-project-creator`(meta-agent 派单工作流,AskUserQuestion 结构化选择)
+- meta_agent_role.md §1 决策树反例(调研 X = 项目请求)+ §3 克制规则(❌ 自起 Agent 调研)
+
+## 测试
+- 新增 ~30 测试(slugify_brief / Tier 3 fallback / skill install / role prompt)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 9.4 PR #3 briefing(F35 silence classifier)
+
+```markdown
+## 任务
+
+V0.2.2 PR #3 — orchestrator 事件感知 silence classifier(读 progress.jsonl 末事件
++ 静默时长 → 7 类响应),enriched outbox + capture-pane helper 提到 ccteam-core,
+meta-agent role prompt 加 propose-confirm UX 模板。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §4(F35 全文,~90 行)
+2. `docs/v0-2-2/dev-plan.md` §4(本 PR 步骤)
+3. `CLAUDE.md` §三红线:**永不解析终端输出**(pane_tail 只入 outbox 给人读,不进状态机) / **永不主动 kill** / **控制平面无 LLM**(classifier 是 deterministic;meta-agent 只 propose,不 decide)
+4. `docs/tech-design.md` §3.5(fix-loop)+ §6.9(idle injection)
+5. 触点代码:
+   - `crates/ccteam-core/src/tmux.rs`(加 `capture_pane_tail` helper)
+   - `crates/ccteam-core/src/silence_classifier.rs`(新模块)
+   - `crates/ccteam-core/src/orchestrator.rs::process_project`(tick 末加 classifier)
+   - `crates/ccteam-core/src/stall.rs`(StallThresholds 复用)
+   - `crates/ccteam-hooks/src/parse_phase_end.rs:313`(改引用 ccteam-core helper)
+   - `crates/ccteam-core/src/templates/meta_agent_role.md` §7
+
+## 实施步骤(详 dev-plan §4)
+
+1. capture-pane helper 提到 ccteam-core(#3.1)
+2. silence_classifier 模块 + enum(#3.2)
+3. enriched outbox schema 字段(#3.3)
+4. orchestrator daemon tick 集成(#3.4)
+5. meta-agent role prompt propose-confirm 模板(#3.5)
+6. 单元 + e2e 测试(#3.6)
+
+## 红线 grep
+
+```bash
+# pane_tail 只入 outbox,不解析进状态机
+git grep -nE 'capture_pane_tail|capture-pane' crates/ccteam-core/src/orchestrator.rs
+# 期望:命中只在 escalate / outbox 写入路径,不在 phase_done / state mutation 路径
+
+# classifier 不发 Ctrl+C / kill
+git grep -nE 'kill|Ctrl-C|C-c' crates/ccteam-core/src/silence_classifier.rs crates/ccteam-core/src/orchestrator.rs
+# 期望:silence_classifier 0 命中;orchestrator 命中只在 daemon shutdown / cost > $200 已有路径
+
+# meta-agent autonomous decide 不破红线 — role prompt 必须是 propose,不是 act
+git grep -nE 'Bash.*tmux send-keys|Bash.*Ctrl-C' crates/ccteam-core/src/templates/meta_agent_role.md
+# 期望:0 命中(meta-agent 只 surface,不发命令)
+```
+
+## 验收 checklist
+
+详 dev-plan §4 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-silence-classifier --title "v0.2.2 PR #3: F35 silence classifier + enriched outbox" --body "$(cat <<'EOF'
+## Closes
+- F35(`docs/v0-2-2/prd.md` §4)
+- `docs/dev-coupling-audit.md` F35 close
+
+## 改动
+- 新 `silence_classifier` 模块,7 类 enum(Healthy / Terminal / SubagentBusy / SubagentRunaway / MidToolHung / PostStopLimbo / InjectLimbo)
+- enriched outbox schema 加 `ccteam_classification` / `ccteam_silent_seconds` / `ccteam_last_event` / `ccteam_pane_tail` 字段
+- capture-pane helper 提到 `ccteam-core::tmux`,Stop hook L3 复用
+- orchestrator daemon tick 集成 classifier;Limbo 类 deterministic re-inject 1 次,失败 → enriched escalate
+- meta-agent role prompt §7 加 propose-confirm UX 模板
+
+## 测试
+- 新增 ~25 测试(classifier 7 类 / outbox 字段完整性 / re-inject 限流 / capture-pane 提取后 L3 行为不变 regression)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 9.5 PR #4 briefing(F36 subagent guard)
+
+```markdown
+## 任务
+
+V0.2.2 PR #4 — `dispatch_phase_with_state` 注入路径前加 active-subagent 检测,
+defer until SubagentStop;pending-inject.json 单文件协议;max-defer-minutes 兜底。
+
+## 前置
+
+**软依赖 PR #3** — 复用 enriched outbox classification 字段(`InjectDeferTimeout`
+新增一类)。worktree base 推荐 PR #3 merge 后的 main;如先于 #3 起,rebase 时
+追加 `InjectDeferTimeout` 字段。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §5(F36 全文,~50 行)
+2. `docs/v0-2-2/dev-plan.md` §5(本 PR 步骤)
+3. `CLAUDE.md` §三红线 — **idle-aware 注入**(已 spec,F36 强化 subagent 维度)
+4. 触点代码:
+   - `crates/ccteam-core/src/progress.rs`(加 `subagent_active` helper)
+   - `crates/ccteam-core/src/orchestrator.rs::dispatch_phase_with_state` + daemon tick
+   - `crates/ccteam-cli/src/main.rs`(若加 `cct dev pending-inject` 调试 CLI 可选)
+
+## 实施步骤(详 dev-plan §5)
+
+1. `subagent_active(events)` helper(#4.1)
+2. dispatch 路径前 guard(#4.2)
+3. pending-inject.json schema(#4.3)
+4. daemon tick 真发 + 兜底(#4.4)
+5. 测试(#4.5)
+
+## 红线 grep
+
+```bash
+# guard 不发 send-keys
+git grep -nE 'send_keys|tmux send-keys' crates/ccteam-core/src/orchestrator.rs
+# 期望:命中只在 daemon tick 真发路径,不在 dispatch 直接路径(active subagent 时)
+
+# pending-inject 只单文件,不积累队列
+git grep -nE 'pending-inject' crates/ccteam-core/src/
+# 期望:文件名 `pending-inject.json` 单数,不带 timestamp 后缀
+```
+
+## 验收 checklist
+
+详 dev-plan §5 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-subagent-guard --title "v0.2.2 PR #4: F36 send-keys subagent guard" --body "$(cat <<'EOF'
+## Closes
+- F36(`docs/v0-2-2/prd.md` §5)
+- `docs/dev-coupling-audit.md` F36 close
+
+## 改动
+- 新 `progress::subagent_active(events)` helper(扫 PreToolUse(Task) / SubagentStop 计数)
+- `dispatch_phase_with_state` active subagent 时 → pending-inject.json 落盘,不发 send-keys
+- daemon tick 在 SubagentStop event 后真发 pending-inject + 删文件
+- max-defer-minutes 兜底(默认 10):超时 → enriched escalate(InjectDeferTimeout class,F35 schema 复用)
+
+## 测试
+- 新增 ~15 测试(subagent_active unit / dispatch e2e / tick 真发 / 超时兜底)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 9.6 PR #5 briefing(F38 screenshot)
+
+```markdown
+## 任务
+
+V0.2.2 PR #5 — tmux capture-pane → vt100 状态机 → imageproc 渲染 → PNG,纯 Rust
+全栈,vendored JetBrains Mono(OFL),无 system C deps;`mcp__<ns>__screenshot`
+MCP 工具 + outbox `screenshot_path` 字段(F35 schema rebase)。
+
+## 前置
+
+**软依赖 PR #3** — F35 outbox 加 `screenshot_path` 字段时 rebase。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §7(F38 全文,~250 行,含 5 轮迭代敲定 vt100 + imageproc DIY)
+2. `docs/v0-2-2/dev-plan.md` §6(本 PR 步骤)
+3. `CLAUDE.md` §三红线:**graceful degrade**(screenshot 永不阻塞 outbox 主路径)
+4. 触点代码:
+   - `crates/ccteam-core/Cargo.toml`(加 4 deps)
+   - `crates/ccteam-core/assets/fonts/JetBrainsMono-Regular.ttf`(vendor)
+   - `crates/ccteam-core/src/screenshot.rs`(新模块)
+   - `crates/ccteam-core/src/screenshot/ansi_palette.rs`(子模块)
+   - `crates/ccteam-cli/src/mcp_serve.rs`(加 screenshot tool)
+   - `crates/ccteam-cli/src/commands.rs`(加 `--screenshot-smoke` flag)
+   - `crates/ccteam-core/src/tmux.rs`(共享 `capture_pane_with_ansi`)
+   - `LICENSES.md`(若不存在则建,加 OFL 注)
+
+## 实施步骤(详 dev-plan §6)
+
+1. Cargo deps + vendored TTF(#5.1)
+2. ANSI_256 调色板(#5.2)
+3. screenshot.rs 主模块(#5.3)
+4. graceful degrade(#5.4)
+5. MCP 工具(#5.5)
+6. doctor `--screenshot-smoke <slug>`(#5.6)
+7. F35 outbox rebase(#5.7)
+8. 测试(#5.8)
+
+## 红线 grep
+
+```bash
+# 无 system C deps
+git grep -nE 'font-kit|fontconfig|freetype' crates/ccteam-core/
+# 期望:0 命中(纯 ab_glyph + vendored ttf)
+
+# graceful degrade 全 catch_unwind
+git grep -nE 'panic::catch_unwind' crates/ccteam-core/src/screenshot
+# 期望:vt100 process / imageproc draw 关键路径 ≥ 2 命中
+
+# screenshot 永不阻塞主路径
+git grep -nE 'render_screenshot' crates/ccteam-core/src/orchestrator.rs crates/ccteam-core/src/silence_classifier.rs
+# 期望:命中只在 best-effort 写 outbox 字段,不在主 escalate 路径(失败 silent,不 propagate)
+```
+
+## 验收 checklist
+
+详 dev-plan §6 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-screenshot --title "v0.2.2 PR #5: F38 终端截图 PNG(vt100 + imageproc DIY)" --body "$(cat <<'EOF'
+## Closes
+- F38(`docs/v0-2-2/prd.md` §7)
+- `docs/dev-coupling-audit.md` F38 close
+
+## 改动
+- 新 `crates/ccteam-core/src/screenshot.rs`(~250 LoC):tmux capture-pane → vt100 → imageproc → PNG
+- 4 cargo deps:vt100 / image / imageproc / ab_glyph(全纯 Rust,无 system C deps)
+- vendored JetBrains Mono(OFL,~150 KB),`include_bytes!` 编译期打包
+- ANSI_256 调色板常量(16 + 216 cube + 24 grayscale)
+- `mcp__ccteam__screenshot(slug, lines?)` MCP 工具
+- F35 enriched outbox 加 `screenshot_path` 字段(best-effort,失败 silent)
+- `cct doctor --screenshot-smoke <slug>` 端到端 verify
+- graceful degrade `catch_unwind` 兜潜在 panic;`CCTEAM_SCREENSHOT_FONT_TTF` env 覆盖字体
+
+## 测试
+- 新增 ~20 测试(ANSI_256 黄金值 / vt100_color_to_rgb / render smoke / graceful degrade / doctor smoke)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 9.7 PR #6 briefing(F40 team alias)
+
+```markdown
+## 任务
+
+V0.2.2 PR #6 — `teams/product-research/` → `teams/research/`(`git mv` 保 history),
+`team.yaml::name = research` + `aliases: [product-research]` + `description` 全称;
+`team_resolver` 按 alias 匹配老项目;**不动用户数据**。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §9(F40 全文,~110 行)
+2. `docs/v0-2-2/dev-plan.md` §7(本 PR 步骤)
+3. `CLAUDE.md` §三红线 — **`ccteam-core` 不出现 team 名字面量**(已 spec;本 PR alias 字段是 yaml 数据驱动,不破)
+4. 触点代码:
+   - `teams/research/team.yaml`(git mv 后改 name + aliases + description)
+   - `crates/ccteam-core/src/team.rs::TeamSpec`(加 aliases 字段)
+   - `crates/ccteam-core/src/team_resolver.rs::resolve_team`
+   - `crates/ccteam-cli/src/commands.rs::run_new`(deprecation warn)
+   - `crates/ccteam-cli/tests/m3_product_research_e2e_test.rs`(改名 + alias resolution 测试)
+   - `crates/ccteam-core/src/templates/cct_project_creator_skill.md`(若 PR #2 已落,Phase C team 选择 option label `research`)
+
+## 实施步骤(详 dev-plan §7)
+
+1. git mv + team.yaml 改(#6.1)
+2. TeamSpec aliases + resolver(#6.2)
+3. cct new --team UI deprecation warn(#6.3)
+4. 老项目 rules 文件并存(#6.4)
+5. 测试(#6.5)
+
+## 红线 grep
+
+```bash
+# ccteam-core 不出现 team 名字面量
+git grep -nE '"product-research"|"research"' crates/ccteam-core/src/
+# 期望:命中只在 注释 / 测试 / yaml 字符串字面量;不在 if team == ... 分叉
+
+# 老 rules 文件并存,不删
+git grep -nE 'ccteam-lessons-product-research' crates/ccteam-core/src/
+# 期望:命中只在 doctor 兜底引用 / 注释,不在 unlink / remove 路径
+```
+
+## 验收 checklist
+
+详 dev-plan §7 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-team-alias --title "v0.2.2 PR #6: F40 team alias(product-research → research)" --body "$(cat <<'EOF'
+## Closes
+- F40(`docs/v0-2-2/prd.md` §9)
+- `docs/dev-coupling-audit.md` F40 close
+
+## 改动
+- `git mv teams/product-research/ teams/research/`(保 history)
+- `team.yaml`:`name: research` + `aliases: [product-research]` + `description` 全称
+- `TeamSpec::aliases` 字段 + resolver alias 匹配
+- `cct new --team product-research` stderr deprecation warn,实际派发 canonical `research`
+- 老项目 `~/projects/product-research-*/` + 老 rules 文件不动(用户数据零迁移)
+
+## 测试
+- alias resolution e2e:state.json team=product-research 仍能加载 research team
+- deprecation warn e2e:stderr 含 "deprecated alias"
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 9.8 PR #7 briefing(chore ship gate)
+
+```markdown
+## 任务
+
+V0.2.2 PR #7 — ship gate。Cargo workspace.version `"0.0.1"` → `"0.2.2"`(retroactive
+修正);CLAUDE.md baseline 回填;e2e retro;dev-coupling-audit 全部 close。
+
+## 前置
+
+PR #1-#6 全部 merge。
+
+## 必读
+
+1. `docs/v0-2-2/prd.md` §12(version bump)+ §13(CLAUDE.md dev-flow)
+2. `docs/v0-2-2/dev-plan.md` §8(本 PR 步骤)+ §10(红线 grep 矩阵)+ §11(文档同步矩阵)
+3. `CLAUDE.md` §一(baseline 回填)+ §五(patch 流程,PR #1 已落)
+
+## 实施步骤(详 dev-plan §8)
+
+1. workspace.version bump(#7.1)
+2. CLAUDE.md baseline(#7.2)
+3. docs/README.md(#7.3,PR #1 已落,本 PR 校验)
+4. e2e-retro.md 落档(#7.4)
+5. dev-coupling-audit F34-F40 close(#7.5)
+6. 红线 grep 矩阵(#7.6)
+7. 测试 + clippy(#7.7)
+
+## 红线 grep 矩阵(详 §10)
+
+详 dev-plan §10 全 PR 跨维度 grep 矩阵。本 PR 是最后 gate,**全部跑一遍**。
+
+## 验收 checklist
+
+详 dev-plan §8 验收段。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-2-2-chore --title "v0.2.2: workspace.version bump + ship gate" --body "$(cat <<'EOF'
+## Closes
+- V0.2.2 ship gate
+- `docs/dev-coupling-audit.md` F34-F40 全 close
+
+## 改动
+- `Cargo.toml::workspace.package.version` `"0.0.1"` → `"0.2.2"`
+- `CLAUDE.md` §一 baseline 回填到 V0.2.2 实际(预期 ~600+)
+- `docs/v0-2-2/e2e-retro.md` 落档(7 PR merge 后 dev / research smoke 联跑结果)
+- 红线 grep 矩阵全跑过(详 dev-plan §10)
+
+## 测试
+- baseline ≥ 511 + V0.2.2 各 PR 新增,全绿
+- clippy 不新增 warning(4 pre-existing 不算)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+---
+
+## 10. 红线 grep 矩阵
+
+每 PR commit 前必查;PR #7 ship gate 全跑一遍。
+
+| 红线维度 | grep | 期望 | 跨 PR |
+|---|---|---|---|
+| **tmux 长 session 不用 `claude -p`** 针对 session lifecycle | `git grep -nE 'Command::new\("claude"\)' crates/ccteam-core/src/orchestrator.rs crates/ccteam-core/src/auto_loop.rs` | 0 命中 | PR #2(slug 用 `claude -p` 但是 utility,不在 orchestrator/auto_loop)|
+| **控制平面无 LLM** 针对控制决策 | `git grep -nE 'Bash.*tmux send-keys\|Ctrl-C\|kill' crates/ccteam-core/src/templates/meta_agent_role.md` | 0 命中(meta-agent 只 propose) | PR #3(F35 propose-confirm)/ PR #2(F37 决策树)|
+| **永不主动 kill** | `git grep -nE 'kill\b' crates/ccteam-core/src/silence_classifier.rs` | 0 命中(Limbo 类只 re-inject 不 kill) | PR #3 |
+| **永不解析终端输出** | `git grep -nE 'capture_pane_tail\|capture-pane' crates/ccteam-core/src/orchestrator.rs` | 命中只在 outbox 写入路径,不在 phase_done / state mutation | PR #3 |
+| **PHASE_DONE / ESCALATE 字面量** 单 source | `git grep -nE 'PHASE_DONE\|ESCALATE:' crates/ccteam-core/src/` | ≤ 5 命中(全在 inject prompt 拼装位置,V0.2 M0.18 已收敛) | F39 sweep 后仍守住基线 |
+| **cct 命名约定** | `git grep -nE 'ccteam-(control\|team-author)' crates/ skills/ README.md CLAUDE.md` | 0 命中(historical archive `docs/v0-1/` `docs/v0-2/` 不算) | PR #1 / 全 PR ship gate |
+| **`ccteam-core` 无 team 字面量** | `git grep -nE '"dev"\|"product-research"\|"research"\|"meta-agent"' crates/ccteam-core/src/` | 命中只在 注释 / 测试 fixture / yaml 字符串字面量(非分叉) | PR #6(F40 alias 是 yaml 数据,不破)|
+| **graceful degrade** | `git grep -nE 'panic::catch_unwind' crates/ccteam-core/src/screenshot` | ≥ 2 命中(vt100 process / imageproc draw) | PR #5 |
+| **screenshot 永不阻塞主路径** | `git grep -nE 'render_screenshot' crates/ccteam-core/src/orchestrator.rs crates/ccteam-core/src/silence_classifier.rs` | 命中只在 best-effort 写 outbox,不 propagate 错误 | PR #5 |
+| **font-kit / system C deps** 不引入 | `git grep -nE 'font-kit\|fontconfig\|freetype' crates/ccteam-core/` | 0 命中 | PR #5 |
+| **AskUserQuestion 拦截 scope project session** | `git grep -nE 'AskUserQuestion' crates/ccteam-core/src/templates/` | project settings.json 命中(拦截);meta-agent 路径不拦(允许) | PR #2 |
+
+---
+
+## 11. 文档同步矩阵
+
+每 PR merge 时同步;PR #7 ship gate 校验完成。
+
+| PR | docs/tech-design.md | docs/interfaces.md | docs/dev-coupling-audit.md | CLAUDE.md / 其他 |
+|---|---|---|---|---|
+| **#1 F39** | — | §10 命令清单 | F39 close | CLAUDE.md §三/§四/§五;docs/README.md patch 约定 |
+| **#2 F34+F37** | §3.8 用户接口层 / §6 skill | §10 `cct new` flag schema | F34 / F37 close | — |
+| **#3 F35** | §3.5 fix-loop / §6.9 idle | §6.x outbox schema(`ccteam_classification` 等)| F35 close | — |
+| **#4 F36** | §6.9 idle | §6.x pending-inject.json | F36 close | — |
+| **#5 F38** | §3.8 / §6.x screenshot | §12 MCP screenshot 工具 | F38 close | LICENSES.md(OFL 注)|
+| **#6 F40** | §3 团队抽象表 | §5.5 team.yaml(aliases / description)| F40 close | — |
+| **#7 chore** | — | — | F34-F40 全 close 校验 | CLAUDE.md §一 baseline 回填;docs/v0-2-2/e2e-retro.md 落档 |
+
+跨版本 SoT 不动:`docs/v0-1/` `docs/v0-2/` 历史归档,反映当时 ship 实情(PR #1 sweep 显式排除)。
+
+---
+
+## 12. 测试 baseline
+
+| PR | base | 增量 | 累计 |
+|---|---|---|---|
+| #1 F39 | 511 | +~50(skill rename + migration e2e) | ~561 |
+| #2 F34+F37 | 561 | +~30(slugify_brief / Tier 3 / skill install / role prompt) | ~591 |
+| #3 F35 | 591 | +~25(classifier 7 类 / outbox 字段 / re-inject 限流)| ~616 |
+| #4 F36 | 616 | +~15(subagent_active / dispatch / tick 真发 / 超时)| ~631 |
+| #5 F38 | 631 | +~20(ANSI_256 / vt100_color / render smoke / degrade)| ~651 |
+| #6 F40 | 651 | +~10(alias resolution / deprecation warn)| ~661 |
+| #7 chore | 661 | 0(配套不加测试,跑全集)| **~661** |
+
+**V0.2.2 ship 测试 baseline 预估:~660+**(对照 V0.2.1 = 511,+ ~150)。clippy
+不新增 warning(4 pre-existing 不算)。
+
+---
+
+## Changelog
+
+- 2026-05-09:初稿。基于 `docs/v0-2-2/prd.md` + V0.2 dev-plan 风格参考拆 7 PR
+  (F39 / F34+F37 / F35 / F36 / F38 / F40 / chore),~1.65 kLOC / ~3 周。每 PR
+  worktree subagent briefing 模板就位,subagent 拿到模板 + 进 worktree 即可开干。

--- a/docs/v0-2-2/feedback.md
+++ b/docs/v0-2-2/feedback.md
@@ -1,0 +1,76 @@
+# V0.2.2 用户反馈原始记录
+
+> 本文件保存 2026-05-08 用户首批 ccteam 实战反馈原文,作为 PRD §1 的引用源。
+> PRD 把这些 issue 归类到 4 个 finding(F34-F37);本文件不做归类,只留原始视角。
+
+---
+
+## 1. 2026-05-08 — slug 命名草率
+
+- **项目**: `dev-dex-ai`(本应为 `hermestrade-home`)
+- **问题**:slug 由 `ccteam new` 自动生成,未参考用户确认的品牌名 HermesTrade
+- **原因**:meta-agent 在收到品牌名之前就已派单,生成 slug 时仅有 brief 摘要 "预测市场+DEX" → `dev-dex-ai`
+- **改进方向**:
+  1. 派单前先确认项目名称 / slug
+  2. 支持 slug 重命名(ccteam 目前不支持)
+  3. 或在收到补充信息后重建项目
+
+## 2. 2026-05-08 — slug 问题 #2
+
+- **项目**: `dev-ccteam-ui-ccteam-1-2-session-subagent-3`(本应为 `ccteam-ui`)
+- 用户明确说了项目名 "ccteam-ui",但 `ccteam new` 仍从 brief 全文生成了冗长 slug
+- **结论**:需要支持 `--slug` 参数,或派单前让用户确认 slug
+
+## 3. 2026-05-08 — API tool call hang 导致 auto-loop 无法恢复
+
+- **项目**: `dev-dex-ai`
+- **现象**:进入 `test-author` 后,`Read(code-review.md)` 的 PreToolUse 发出了但 PostToolUse 再也没回来
+- **影响**:turn 没收尾 → 无 Stop 事件 → auto-loop 停在 iteration 1,永远不会重试
+- **根因**:DeepSeek API 调用未返回,Claude 进程卡在 mid-tool-call
+- **改进方向**:
+  1. orchestrator 加 tool-call 超时检测(N 秒无 PostToolUse → capture-pane 检查 → escalate)
+  2. auto-loop 不应只依赖 Stop 事件,应加时间维度的兜底(N 分钟无任何 progress 事件 → 强制重注入)
+  3. 考虑给 Claude 进程加 `--timeout` 或 API 调用超时
+
+## 4. 2026-05-08 — `/btw` send-keys 路由到 subagent
+
+- **项目**: `dev-ccteam-ui`
+- **现象**:`/btw` 注入 `test-author` prompt 时,`code-reviewer` subagent 仍在活跃,tmux send-keys 把 prompt 敲进了 subagent 的上下文
+- **影响**:subagent 无工具权限,无法执行 test-author;主 agent 从未收到 prompt;同样无 Stop → auto-loop 卡死
+- **根因**:send-keys 注入前没有检查当前是否有活跃 subagent,也没有确保 prompt 送到主 agent
+- **改进方向**:
+  1. 注入前检查是否有活跃 subagent,有则等待或先发 Ctrl+C
+  2. 或改用 inbox 消息机制(让主 agent 主动读取)代替 tmux send-keys
+  3. 注入后做送达确认(短时间内检查是否有相关 progress 事件)
+
+## 5. 2026-05-08 — auto-loop 过度依赖 Stop 事件
+
+- **关联**:以上两个 bug 的共同放大因素
+- **现象**:auto-loop 仅监听 Stop 事件触发重注入,但在 mid-tool-call hang 和 prompt 路由错误场景下,永远不会产生 Stop
+- **根因**:`auto_loop.rs::decide()` 的输入是 `last_assistant_text`,这个数据仅来自 Stop 事件的产出
+- **改进方向**:
+  1. auto-loop 加兜底定时器:N 分钟无 progress 事件 → 强制 capture-pane → 判断是否需要 re-inject
+  2. 或把 progress 事件以外的信号(tool call 超时、subagent 异常退出)也纳入 auto-loop 的触发条件
+
+## 6. 2026-05-08 — meta-agent 绕开 pipeline 自行调研
+
+- **触发**:用户要求调研 Multica 项目
+- **问题**:meta-agent 没有按 CLAUDE.md §2 走 product-research 团队,而是自己起了 `Agent` subagent 做 Web 搜索,直接出结论
+- **违反**:§3 克制规则——"项目级请求默认走 ccteam new 派单,让对应团队 session 干活"
+- **损失**:product-research 的 6-phase pipeline(kickoff → research → verdict → next-steps)没跑,缺少 verdict 结构化判断和可审计的调研记录
+- **改进方向**:
+  1. meta-agent 决策树加 self-check:收到"调研 X"类请求时,先问自己"这是问答还是项目请求?"
+  2. 项目请求 → 走 product-research;纯问答(如"Multica 的 GitHub 地址是什么")→ 直接回答
+  3. 边界不清时,问用户一句:是要我快速查一下,还是走正式产研流程?
+
+---
+
+## 用户给的开发流程要求
+
+> 整理成一个 V0.2.2 的小需求进行开发,注意实现方案不一定参考以上的建议,实现方案从全系统来考虑设计,但是问题是真实的。
+>
+> 开发流程要求,先输出文档到 v0-2-2 文件下,然后启动开发,开始是用当前 session 派 subagent 去做,用 worktree 新分支,最后提 pr,主 agent review → fix → merge。
+>
+> 最终 cargo workplace 中版本也要改。把这些开发流程用简洁的语言记录在 CLAUDE.md。
+
+(以上原话照录;PRD §7 / §10 / §11 把这套流程吸收到正式规约。)

--- a/docs/v0-2-2/prd.md
+++ b/docs/v0-2-2/prd.md
@@ -1,0 +1,1291 @@
+# PRD V0.2.2 — 用户反馈 patch round
+
+> 范围:V0.2.2 增量 patch。基于 2026-05-08 用户首批 ccteam 实战反馈
+> (6 个 issue 跨 slug 命名 / auto-loop 触发模型 / send-keys 路由 / meta-agent
+> 决策树),做最小侵入的根因修复。
+>
+> base = `origin/main` `170f5a8`(V0.2.1 ship);测试 baseline 511/0。
+>
+> 这是首个独立目录的 patch 版本(V0.2.1 折在 `docs/v0-2/`);因为本轮 4 条
+> finding 实现量比 V0.2.1 dust patch 大,单独建 `docs/v0-2-2/` 留档,日后
+> 同样体量的 patch 走同样规约。`docs/README.md` 维护规约配套加一行注。
+
+---
+
+## 1. 背景 — 用户反馈源
+
+2026-05-08 用户在 `dev-dex-ai` / `dev-ccteam-ui` 两个真实项目里跑 ccteam,
+撞出 6 类问题。原始反馈见本目录 `feedback.md`(本 PR 一并落档)。归类到
+4 个反馈 finding(F34-F37);2026-05-09 用户追加 1 个 UX 增强 finding(F38),
+对 F35 enriched outbox 是天然补:
+
+| F | 性质 | 涵盖反馈 issue / 来源 |
+|---|---|---|
+| **F34** slug 命名失控 | 用户体验 — 缺 `--slug` 入口 | issue #1(`dev-dex-ai` ≠ `hermestrade-home`)+ #2(`dev-ccteam-ui-...-3` 太长) |
+| **F35** auto-loop 过度依赖 Stop event | 控制平面盲区 — 静默不分类 | issue #3(API tool-call hang)+ #5(synthesis) |
+| **F36** send-keys 注入到活跃 subagent | 控制平面盲区 — 不感知 subagent 状态 | issue #4(/btw 落到 code-reviewer subagent) |
+| **F37** meta-agent 绕开 pipeline 自调研 | 决策树软约束被漂移 | issue #6(Multica 调研用 Agent subagent 直出) |
+| **F38** 终端截图 PNG | UX 增强 — 给 watchdog/outbox 通知附直观屏幕 | 用户 2026-05-09 追加;补 F35 文本 pane_tail 的视觉维度 |
+| **F39** `cct` 短前缀约定 sweep | 命名约定 — binary `ccteam` → `cct`,自带 skill `ccteam-*` → `cct-*`,CLAUDE.md 加约定 | 用户 2026-05-09 追加;F34 skill 重构同源,统一抽出独立 PR(机械重命名,跟逻辑变更解耦)|
+| **F40** team 名缩短 + alias 支持 | 命名约定 — `product-research` → `research`(team.yaml `name`),`team.yaml::aliases` 字段载老名兼容老项目 | 用户 2026-05-09 追加;V0.2 PRD §5.4 当时设计 alias 但 deferred V0.3,本次拉回 V0.2.2 做 |
+
+7 finding 不耦合主架构,不破红线;V0.2.2 是渐进 patch,不开新版本主线。
+
+---
+
+## 2. 范围
+
+实现 5 finding + 配套:
+
+- **F34**:`ccteam new --slug <name>` CLI flag + meta-agent role prompt 强制
+  派单前确认 slug + B2 自动加 team 前缀语义
+- **F35**:orchestrator 事件感知 silence classifier(progress.jsonl 末事件
+  语义 × 静默时长 → 4 类响应);capture-pane tail 入 enriched outbox;meta-agent
+  propose-confirm UX
+- **F36**:send-keys 前检测 active subagent(PreToolUse(Task) 未配 SubagentStop
+  → defer);max-defer-minutes 兜底
+- **F37**:`meta_agent_role.md` §2 决策树加固(项目请求 vs 问答边界明确
+  化 / "调研 X" 默认派 product-research / 反例显式列)
+- **F38**:`tmux capture-pane -e` 输出 in-process 灌给 `vt100` Parser(终端状态机,
+  纯 Rust,MIT);取 `Screen` 的 cell grid → `imageproc::drawing::draw_filled_rect_mut`
+  + `draw_text_mut`(`ab_glyph` 字体)→ `image` 存 PNG。无 font-kit / 无 system
+  deps(`ab_glyph::FontRef::try_from_slice` 直接读 TTF 字节)。`mcp__cct__screenshot`
+  MCP 工具对外暴露;F35 enriched outbox 加 `screenshot_path` 字段(best-effort,
+  vt100 解析 / imageproc 渲染 / 字体加载 / tmux 任一失败时 graceful degrade 到无 PNG,
+  主路径不挂)
+- **F40**:**team 名缩短 + alias 软迁移**:`teams/product-research/team.yaml::name` 改
+  `research`,`aliases: ["product-research"]` 字段保兼容;ccteam-core `team_resolver`
+  按 alias 匹配老项目;新项目目录 `~/projects/research-<slug>/`,老项目仍走
+  `~/projects/product-research-<slug>/` 不动;`team.yaml::description` 字段载全称
+  ("Product research team — kickoff → research → verdict → next-steps")用于工厂 /
+  doctor / cct-project-creator skill 展示场景;不动用户数据,无破坏性迁移
+- **F39**:**`cct` 短前缀约定 sweep**:`crates/ccteam-cli/Cargo.toml::[[bin]] name`
+  从 `ccteam` 改 `cct`;自带 skill 三个全部 `cct-*` 命名(`cct-control` / `cct-team-author` /
+  `cct-project-creator`);移到顶层 `skills/` 目录;CLAUDE.md / README.md /
+  tech-design.md / interfaces.md 全文 sweep `ccteam <cmd>` → `cct <cmd>`;`ccteam
+  doctor` 自动迁移 V0.1/V0.2 用户的老 settings.json 中绝对路径 + 老 skill 目录;
+  历史 `docs/v0-1/` `docs/v0-2/` 不改
+
+配套:
+
+- **Cargo workspace version bump**:`workspace.package.version` `"0.0.1"` → `"0.2.2"`
+  (V0.1 / V0.2 ship 时未同步,V0.2.2 起正式跟进 — 每个 minor 与 patch 都 bump)
+- **CLAUDE.md §五 PR 纪律**追加 "patch 开发流程"小节(≤ 8 行),记 doc-first
+  → worktree-per-fix subagent → PR → main review → fix → merge → cargo bump
+- **`docs/README.md` 维护规约**追加 patch 版本目录约定(本轮起每个 patch 单独
+  目录)
+
+---
+
+## 3. F34 — slug 命名控制
+
+### 3.1 两个根本问题
+
+| # | 问题 | 表现 |
+|---|---|---|
+| **1** | **生成算法本身质量差** — `pick_unused_slug` 用 `slugify(brief)` 做字符级 normalize(只截 40-char、按 `-` 边界回滚),无 token / 语义层裁剪 | brief "ccteam ui — V1.2 session subagent 3" → 38 char,过 40 cap → `dev-ccteam-ui-v1-2-session-subagent-3` 全文塞进去 |
+| **2** | **缺用户/meta-agent 指定接口** — `ccteam new` 没 `--slug` flag,只能任由算法生成 | 用户原话"ccteam-ui",meta-agent 没法把它直接派给 ccteam,只能等结果再后悔 |
+
+两条**正交**:即便算法升级到 token-aware,用户仍需要一个 override 入口
+(eg 品牌名 `hermestrade-home` 算法永远猜不到);即便有 `--slug`,用户/meta-agent
+不传时的 default 仍要够用。两条都修。
+
+### 3.2 设计 — 四层调用,智能优先
+
+slug 决定按以下优先级,**首层智能 fallback 优先**,deterministic 算法降为最终兜底:
+
+```
+Tier 1: --slug <name> 显式            (用户 / meta-agent 直传)         零延迟,确定
+       ↓ 缺
+Tier 2: meta-agent NL 推荐 + 用户确认  (派单工作流内,LLM 已在场)        零额外 LLM call
+       ↓ 不在 meta-agent 工作流(用户直接 CLI 跑)
+Tier 3: ccteam new 内 shell out claude -p 智能生成 + Y/n 确认           ~2-5s,~$0.0001
+       ↓ claude 不可用 / network 失败 / 用户 --no-auto-slug
+Tier 4: 字符级 deterministic slugify_brief()                             零延迟,最低质量
+```
+
+红线检查(在 §3.2.6 末段):**"tmux 长 session 不用 claude -p"** 针对项目 session
+lifecycle,slug 生成是 < 5s 一次性 utility,不在该红线范围;**"控制平面无 LLM"**
+针对控制决策(re-inject / kill / 改 phase),slug 命名是数据转换(brief → name),
+不在该红线范围。两条都 OK。
+
+#### 3.2.1 Tier 1 — `--slug` CLI flag(显式)
+
+`ccteam new` 加 `--slug <name>` 可选 flag(`crates/ccteam-cli/src/main.rs:71`
+`Commands::New` 加字段;`commands.rs:138` `run_new` 多接 `slug: Option<&str>`)。
+
+**前缀语义 — B2 自动加**(decided):
+
+| 用户输入 | team | 实际 slug | 说明 |
+|---|---|---|---|
+| `--slug ccteam-ui` | `dev` | `dev-ccteam-ui` | 自动加 team 前缀 |
+| `--slug dev-ccteam-ui` | `dev` | `dev-ccteam-ui` | 已带前缀 verbatim |
+| `--slug hermestrade-home` | `dev` | `dev-hermestrade-home` | 无 team 前缀就加 |
+| `--slug product-research-foo` | `dev` | `dev-product-research-foo` | `dev` ≠ `product-research`,加 |
+
+规则:若 `slug.starts_with(&format!("{team}-"))` 则 verbatim;否则 prepend
+`<team>-`。slug 必须满足 `[a-z0-9-]+`;非法字符 fail-loud。撞名 append `-{4hex}`
+retry(沿用 `pick_unused_slug` 现逻辑)。
+
+#### 3.2.2 Tier 2 — `cct-project-creator` skill(meta-agent 派单工作流)
+
+派单工作流封装到一个**新 skill**:`cct-project-creator`,跟已 ship 的
+`ccteam-control`(M1.8)+ `ccteam-team-author`(M0.22)同模式。skill 把
+项目创建的全流程(需求澄清 → slug 推荐 → team 选择 → 派单)从 `meta_agent_role.md`
+里抽出来,role prompt 只保留"什么时候该走 skill"的入口规则,流程细节走 skill
+body。
+
+**关系**:F37 改 `meta_agent_role.md` §1 自检(项目请求 vs 问答),F34 加
+project-creator skill 接管 §2-§4 派单子流程;两个 finding 互补,**同 PR 落地**
+(F34 + F37 PR #1)。
+
+**skill 命名 / 顶层目录 / 迁移逻辑** — 全部归 **F39**(`cct` 约定 sweep,见 §8)
+处理。F34 PR 只**消费** F39 已经建好的 `skills/` 目录 + `cct-*` 命名,**新加**
+一个 `skills/cct-project-creator/SKILL.md` 文件(skill body 内容是 F34 设计核心)。
+F39 PR 必须先 merge,F34 PR 才在新 directory + 新命名上做 follow-up。
+
+**前置约定 — `AskUserQuestion` 在 meta-agent 允许**:
+
+V0.2 §2.4 用 PreToolUse hook 在 **project session** 拦截 `AskUserQuestion`(替换为
+outbox 协议),但**不拦 meta-agent**(`~/projects/<handle>-meta/.claude/settings.json`
+不写该 matcher)。所以 project-creator skill 跑在 meta-agent 里时,**鼓励用
+`AskUserQuestion` 做 slug / team / 关键澄清的结构化选择**,UX 显著优于纯 NL Q&A
+(用户点选 < 反复打字)。
+
+> 红线 reminder:本 skill 显式只在 meta-agent 调用,不被 phase 模板 reference,
+> 不被 project session 触发。AskUserQuestion 在 project session 触发会被 hook deny
+> (V0.2 已 ship)。
+
+**skill body 结构**(草稿,实施时写到模板文件):
+
+```markdown
+---
+name: ccteam-project-creator
+description: 当用户要创建新 ccteam 项目时调用 — 走需求澄清 → slug 推荐 → team 选择 → 派单四步对话流。本 skill 仅在 meta-agent context 内使用,自带使用 AskUserQuestion 做结构化选择。
+trigger:
+  - 用户说"新项目" / "建一个 X" / "做个 X" / "我想做 X"
+  - 用户说"调研 X" / "评估 X" / "看看 X 值不值"(走 product-research team)
+---
+
+## 角色边界
+
+你是项目创建对话向导,**不是 worker**。本 skill 跑完后调 `ccteam new --slug <X> --team <Y> "<refined brief>"` 派给项目 session 干活,你不写代码。
+
+## Phase A — 需求澄清
+
+读用户原始 brief。若信息密度足够(≥ 2 句明确技术形态 / 目标 / 约束)→ 跳 Phase B。
+
+若 brief 单词级(eg "做个 todo"),用 `AskUserQuestion` 问 **1 个**最关键澄清,
+options 给典型选择 + "Other" 让用户自定:
+
+```
+AskUserQuestion({
+  question: "项目什么形态?",
+  options: [
+    { label: "Web 应用", description: "浏览器跑,带前端" },
+    { label: "CLI 工具", description: "命令行,纯文本" },
+    { label: "移动端", description: "iOS / Android" },
+  ]
+})
+```
+
+只问 1 次,不连珠炮。
+
+## Phase B — slug 推荐 + 用户确认(用 AskUserQuestion)
+
+基于 brief + Phase A 答复,算推荐 slug:
+
+规则:
+- **优先用户提到的品牌名 / 专有名词**(eg "HermesTrade DEX" → `hermestrade-home`)
+- **不 verb-leading**:用 `todo-cli` 不用 `build-todo-cli`
+- **2-4 token,kebab-case**
+- **不带 team 前缀**(`ccteam new` 自动加 dev- / product-research- 等)
+
+用 `AskUserQuestion` 给用户三选一:
+
+```
+AskUserQuestion({
+  question: "项目 slug 用什么?",
+  options: [
+    { label: "<推荐 slug>", description: "基于 brief 的 <X>;推荐用这个" },
+    { label: "我来定", description: "选这个我下面会问你想用什么" },
+    { label: "再来一个", description: "换思路重算一次" },
+  ]
+})
+```
+
+用户选"我来定" → 紧接一句 NL "你想用什么 slug?(eg `hermestrade-home`)";
+校 `[a-z0-9-]+` + 长度 ≤ 60。
+用户选"再来一个" → 换 角度重算 + 再 AskUserQuestion。
+
+## Phase C — team 选择(用 AskUserQuestion)
+
+按 `meta_agent_role.md` §2 团队决策树(F37 加固后)默认推断;不确定时:
+
+```
+AskUserQuestion({
+  question: "派给哪支团队?",
+  options: [
+    { label: "dev", description: "立即开发(plan-eng → implement → ship)" },
+    { label: "product-research", description: "先调研判断 idea 值不值得做" },
+  ]
+})
+```
+
+## Phase D — 派单 + 通知
+
+```bash
+Bash: ccteam new --slug <slug> --team <team> "<refined brief>"
+```
+
+派完写 outbox `event_kind: reply`:
+- 项目 slug + 派的团队
+- 第一个里程碑预期(dev: plan-eng ~30 min;research: kickoff 反向面试)
+- 跟踪命令(`ccteam show <slug>` / `ccteam attach <slug>`)
+```
+
+**meta-agent role prompt 改动**(`meta_agent_role.md` §2):
+
+> §2 决策树第 4 步派单段简化为:
+> "走 `ccteam-project-creator` skill(已自动装好,在 `~/.claude/skills/`)。skill 会
+> 引导你跑需求澄清 → slug 推荐 → team 选择 → 派单 全流程。"
+
+派单后**不支持改名**(state.json / `~/.claude/rules/` paths / tmux session
+全要重命名,V0.3 评估)。
+
+#### 3.2.3 Tier 3 — `ccteam new` shell out `claude -p` 智能 fallback
+
+用户**不在 meta-agent 工作流**直接跑 `ccteam new "<brief>"`(无 `--slug`)时,
+ccteam 自己 shell-out 一次短命 `claude -p` 生成推荐 slug。
+
+**机制**:
+
+```rust
+// crates/ccteam-cli/src/commands.rs::run_new
+//
+// 1. 若用户传 --slug → 跳过本节
+// 2. 检测 stdin 是否 tty + claude 是否在 PATH + --no-auto-slug 是否传
+//    任一缺 → 跳到 Tier 4(slugify_brief)
+// 3. shell out claude -p:
+let prompt = format!(
+    "Generate a 2-4 token kebab-case slug for a project with this brief:\n\
+     '{brief}'\n\n\
+     Rules:\n\
+     - Capture the core noun/concept (brand name if present), not action verbs\n\
+     - Drop stop words (a, the, of, etc) and pure-digit tokens\n\
+     - Output ONLY the slug, no explanation, no quotes, no markdown\n\
+     Examples:\n\
+     - 'AI recipe generator from fridge photo' -> recipe-generator\n\
+     - 'Build a todo cli with ratatui' -> todo-cli\n\
+     - 'HermesTrade DEX prediction market' -> hermestrade-dex\n\
+     Slug:"
+);
+let suggestion = Command::new("claude")
+    .args(["-p", "--model", "claude-haiku-4-5-20251001"])  // 用 haiku 降本+提速
+    .stdin(piped(prompt))
+    .timeout(Duration::from_secs(15))  // 超时硬截
+    .output()?;
+let suggestion = sanitize(suggestion.stdout);  // [a-z0-9-]+ 校验 + trim
+```
+
+**用户 UX**:
+
+```
+$ ccteam new "Build HermesTrade DEX home"
+[ccteam] querying claude for slug recommendation...
+[ccteam] suggested: dev-hermestrade-home
+[ccteam] accept? [Y/n] (or rerun with --slug to override):
+```
+
+- 用户回车 / `y` / `Y` → 用建议
+- 用户 `n` → 退出 + print "rerun with --slug <name>"
+- 非 tty 上下文(脚本 / e2e harness)→ **auto-accept** 建议(15s 超时硬截兜)
+
+**flag 语义**:
+
+| flag | 行为 |
+|---|---|
+| `--slug X` | 跳过 Tier 2/3,用 X(B2 前缀语义) |
+| `--no-auto-slug` | 跳过 Tier 3,直接 Tier 4 deterministic |
+| `--auto-slug-model haiku/sonnet` | 选 claude -p 模型,默认 haiku(成本最低) |
+| 默认无 flag | Tier 3 智能 + Y/n 确认(交互);非 tty 时 auto-accept |
+| env `CCTEAM_AUTO_SLUG=off` | 全局禁用 Tier 3 |
+
+**成本与延迟**:
+
+- haiku-4.5 一次 ~60 token in / ~10 token out → ~$0.0001 / 次
+- 网络延迟 + 模型推理 ~2-5s,15s 硬超时
+- 一次 `ccteam new` 投入,项目 lifecycle 长(小时-天级),边际成本可忽略
+
+**失败 fallback 链**:
+
+| 失败模式 | 行为 |
+|---|---|
+| `which claude` 不在 PATH | log warn,降级 Tier 4 |
+| `claude -p` exit code 非 0 | 同上 + reason "claude returned error" |
+| 15s 超时 | kill child + 降级 Tier 4 + reason "claude timeout" |
+| stdout 空 / 含非法字符 / 长度异常(> 60 char) | sanitize 失败 → 降级 Tier 4 |
+| 用户拒绝建议(交互模式)| exit 1,提示 "rerun with --slug <name>" |
+
+#### 3.2.4 Tier 4 — `slugify_brief()` deterministic 兜底
+
+LLM 不可用时仍要给个能跑的 slug。新函数 `slugify_brief()`(**不动 `slugify()`**,
+后者被 meta-agent path `<handle>-meta` 用,handle 已短不能裁):
+
+```rust
+/// 把自由文本 brief 压成 ≤ 3 个有意义 token 的 slug base。
+/// 流程:
+///   1. 字符 normalize(复用 slugify 的 [a-z0-9] / `-` 折叠)
+///   2. 按 `-` 切 token,过滤:
+///      - 英文 stop word(a / an / the / of / to / for / with / that / and / or / in / on / at / is / are)
+///      - 纯数字 token(保留 `v2` / `2k` 这类含字母的)
+///      - 长度 < 2 的 token
+///   3. 去重连续重复(`ccteam ccteam ui` → `ccteam ui`)
+///   4. 取前 3 个剩余 token,join `-`
+///   5. 兜底兜底:过滤后 0 token → fall back 到旧 `slugify()` 输出
+pub fn slugify_brief(input: &str) -> String { /* ~30 LoC */ }
+```
+
+预期产出对照(Tier 4 路径):
+
+| brief | 旧 `slugify()`(40-char cap) | 新 `slugify_brief()` |
+|---|---|---|
+| `ccteam ui — V1.2 session subagent 3` | `ccteam-ui-v1-2-session-subagent-3` | `ccteam-ui-v1` |
+| `Build a tiny Python CLI that converts CSV to JSON` | `build-a-tiny-python-cli-that-converts` | `build-tiny-python` |
+| `AI recipe generator from fridge photo` | `ai-recipe-generator-from-fridge-photo` | `ai-recipe-generator` |
+| `Predict market + DEX` | `predict-market-dex` | `predict-market-dex` |
+| `HermesTrade DEX home` | `hermestrade-dex-home` | `hermestrade-dex-home` |
+| `do the thing` | `do-the-thing` | `do-thing` |
+| `to of and` | `to-of-and` | fall-back `to-of-and`(全 stopword) |
+
+Tier 4 是 deterministic 字符 / token 规则,**不引入 NLP 库**;质量明显低于
+Tier 2/3 但保证可用。
+
+#### 3.2.5 红线 / cost / latency 总结
+
+| 关注点 | Tier 1 显式 | Tier 2 meta-agent | Tier 3 claude -p | Tier 4 deterministic |
+|---|---|---|---|---|
+| 红线 | OK | OK(meta-agent 已是 LLM session,内嵌推荐) | OK(utility 性,非控制路径) | OK |
+| LLM cost | 0 | 0(已在 meta-agent turn 内) | ~$0.0001 / 次(haiku) | 0 |
+| 延迟 | 0 | 0(派单流程内) | 2-5s | 0 |
+| 智能度 | 用户决定 | 高(meta-agent 看完 brief) | 高(独立 LLM judgment) | 低 |
+| 触发条件 | `--slug` flag | 走 meta-agent 派单 | 直接 CLI + 无 `--slug` + 默认 | LLM 不可用 / `--no-auto-slug` |
+
+### 3.3 不做
+
+- **slug 重命名**:涉及 state.json 迁移 / `~/.claude/rules/` paths regex / tmux
+  session 名 / `.ccteam/auto-loop.state.md::slug` 字段 / outbox / progress.jsonl
+  全条线。V0.3 单独评估
+- **强制 `--slug`**:Tier 2/3 智能默认已大幅改善质量,不强制
+- **`claude -p` 异步并行 scaffold**:slug 决定后才能建项目目录,顺序强相关,
+  不可并行;15s 超时是上限
+- **缓存 `claude -p` 结果**:每次 brief 唯一,缓存意义不大
+- **NLP / POS 标注库**(spacy / nltk):Tier 4 deterministic 是兜底,故意保持
+  字符级简单;真要 NLP 走 Tier 3 LLM 路径
+- **多语言 brief**(中文 / 日文):Tier 4 char-set 是 [a-z0-9],中文 brief 走 Tier 4
+  会全部丢字 → fallback "project";Tier 3 LLM 自然支持多语言,推荐用户走默认
+
+---
+
+## 4. F35 — 事件感知 silence classifier
+
+### 4.1 问题
+
+`auto_loop.rs::decide()` 只在 Stop hook 触发时跑(input = `last_assistant_text`)。
+两个失效场景:
+
+- **API tool-call hang**:`PreToolUse` 发了但 `PostToolUse` / `Stop` 永不来 → auto-loop
+  根本不触发 → 项目永远卡在 iteration 1
+- **send-keys 路由错误后**(F36 case):`phase_inject` event 发了但主 agent 没
+  收到(prompt 落到 subagent 上下文)→ 没 Stop → auto-loop 不触发
+
+`stall.rs` 已有 5/15/30 min 软告警,但只是 watchdog 翻译信号,不**驱动**任何
+recovery 动作。
+
+### 4.2 设计 — 事件感知分级
+
+#### 4.2.1 分类规则(deterministic)
+
+orchestrator daemon 主循环新增 silence classifier 步骤,读 `progress.jsonl`
+末事件 + 静默时长,按下表分 4 类:
+
+| 末事件 | 静默时长 | 分类 | 响应 |
+|---|---|---|---|
+| `PreToolUse(tool=Task)` 后无 `SubagentStop` | < phase escalate 阈值(默认 30min) | `SubagentBusy` | 耐心,不动 |
+| `PreToolUse(tool=Task)` + 静默 ≥ escalate 阈值 | — | `SubagentRunaway` | enriched escalate(subagent 跑超时) |
+| `PreToolUse(tool ≠ Task)` 后无 `PostToolUse` 且 ≥ warn 阈值 | — | `MidToolHung` | enriched escalate(tool 看起来 hang) |
+| `Stop` / `SubagentStop` 后 `auto-loop.state.md` 未更新 + 无新事件 ≥ warn 阈值 | — | `PostStopLimbo` | deterministic re-inject 1 次,再失败 → enriched escalate |
+| `phase_inject` 后无任何 event ≥ warn 阈值(F36 case) | — | `InjectLimbo` | deterministic re-inject 1 次(配合 F36 subagent guard:若仍有 active subagent,等 SubagentStop 后真发) |
+| 其他(`PostToolUse` / `phase_done` / `escalate` / 空) | — | `Healthy` 或 `Terminal` | 不动 |
+
+`<phase>.stall_warn_minutes` 仍是阈值基底(`stall.rs::StallThresholds::from_phase`
+驱动 warn / suspicious / escalate);classifier 复用,不另定义。
+
+#### 4.2.2 enriched escalate outbox payload
+
+写到 `<project>/.ccteam/needs_attention.outbox.json`(已有路径,Stop hook L3
+fail-safe 也写这里 — 共享 schema)。新字段:
+
+```json
+{
+  "schema_version": 1,
+  "event_kind": "escalation",
+  "priority": "high",
+  "ccteam_classification": "MidToolHung",  // 新字段
+  "ccteam_silent_seconds": 900,            // 新字段
+  "ccteam_last_event": {                    // 新字段:末 progress event 摘要
+    "ts": "...",
+    "event": "PreToolUse",
+    "tool": "Read"
+  },
+  "ccteam_pane_tail": "...30 行 capture-pane...",  // 已有协议,新 case 复用
+  "body": "项目 X 在 implement 第 12 分钟卡在 Read(...) 后无 PostToolUse..."
+}
+```
+
+`capture_pane_tail` 从 `parse_phase_end.rs:313` 提到 `ccteam-core/src/tmux.rs`
+做共享 helper(F35 + 现有 Stop hook L3 共用),保留"永不解析终端输出"红线
+(只入 outbox 给 meta-agent / 用户读,不进 orchestrator 状态机)。
+
+#### 4.2.3 meta-agent surface(propose-confirm,不 autonomous)
+
+`meta_agent_role.md` §7 watchdog 段补充:见到 enriched escalate 时,**生成
+informed proposal** 给用户:
+
+> "项目 X 在 implement 第 12 分钟卡在 Read(file.md) 后无 PostToolUse,看起来
+> tool hang 而非 subagent 慢工。要不要 (a) `ccteam attach dev-x` 自看 (b)
+> 让我等再 5 min 重看 (c) 这条不管了?"
+
+**红线**:meta-agent 只 surface 选项,**不自己执行 Ctrl+C / 重发 / kill**;
+`PostStopLimbo` / `InjectLimbo` 的 deterministic re-inject 由 orchestrator 直接
+做(已是 deterministic 路径,不经 LLM)。
+
+#### 4.2.4 触发节奏
+
+orchestrator daemon 主循环已有 `process_project` per-project tick;classifier
+塞进 tick(每个 project 每 5-10s 检查一次,无新 event 时跑 classify)。计算
+廉价(读 progress.jsonl 末几行 + 简单 match),不增加 IO 压力。
+
+### 4.3 不做
+
+- meta-agent autonomous decide(直接发 Ctrl+C / 重发):破"控制平面无 LLM"红线
+- LLM-aware classification("用 LLM 看屏幕判断卡没卡"):同上
+- 增加新 phase YAML 字段(`idempotent_inject` 之类):phase prompt 本质是
+  叙事性指令,re-inject 已知安全(LLM 自看 `.ccteam/` 状态决定下一步,不重复
+  执行已做动作);限流靠 1 次 retry cap 和 `auto_loop` 现有 cycle cap
+
+---
+
+## 5. F36 — Send-keys subagent guard
+
+### 5.1 问题
+
+`dispatch_phase_with_state` 在 `progress.jsonl` 末事件是 `PreToolUse(tool=Task)`
+(subagent 活跃)时,仍发 `/btw <prompt>` 到 tmux pane。tmux send-keys 实际
+打到主 agent 的 input buffer,但主 agent 此刻在 wait subagent 完成,**Claude
+Code 把这段文本交给 subagent 处理**(行为已被用户 #4 实测)。
+
+`is_idle()` 当前把 `PreToolUse` 归 busy → 走 `/btw` 包裹路径,但 `/btw` 在
+subagent 活跃场景行为退化。
+
+### 5.2 设计 — Defer until SubagentStop(C1)
+
+`progress.rs` 新增 `subagent_active(events: &[Value]) -> bool`:扫 progress.jsonl
+末事件序列,counting `PreToolUse(tool=Task)` 和 `SubagentStop`,若开多于关 → true。
+
+`Orchestrator` 注入路径(`dispatch_phase_with_state` 等)前加 guard:
+
+```rust
+if subagent_active(&recent_events) {
+    self.queue_pending_inject(slug, phase, attachment_refs);
+    return Ok(());  // 或返 PendingInject 状态,daemon 主循环按 SubagentStop event 触发真发
+}
+```
+
+**Pending inject 落盘**:`<project>/.ccteam/pending-inject.json`(单文件,最新覆盖
+旧的;不积累队列 — 用户 ccteam new / dispatch 不会高频触发,排队不必)。orchestrator
+daemon 主循环在每次 progress event tick 时 check:若文件存在 + subagent 已不活跃
++ 距 enqueue 时间未超 `max_defer_minutes`(默认 10) → 真发,删文件;若超时 → fail-loud
+escalate(`<project>/.ccteam/needs_attention.outbox.json` 加新 classification
+`InjectDeferTimeout`,走 F35 同 channel surface)。
+
+### 5.3 跟 F35 的协同
+
+F35 的 `InjectLimbo` 类(phase_inject 后无后续事件)+ F36 的 pending-inject
+是同一信号的两个面:
+
+- **F36 主路径**:发的当下检测到 active subagent,主动 defer
+- **F35 兜底**:即使 F36 没接住(eg subagent 过几秒才 emit `PreToolUse(Task)`,
+  F36 检测时 race window 没 catch),phase_inject 后无 follow-up 事件超 warn 阈值
+  → F35 的 `InjectLimbo` 兜底重发
+
+两个 finding 同 PR / 不同 PR 都行(见 §7 PR sequencing 推荐 F35 先 / F36 后,
+F36 复用 F35 的 enriched outbox 入口)。
+
+### 5.4 不做
+
+- C2 项目侧多文件队列(`<project>/.ccteam/pending-inject/<ts>.json` 累积):没场景
+  支撑队列(每个项目每次只关心最新待发的 phase prompt)
+- C3 改 inbox 文件机制 dispatch:V0.3 architecture-scale 改造,V0.2.2 不开
+
+---
+
+## 6. F37 — meta-agent 决策树加固
+
+### 6.1 问题
+
+`meta_agent_role.md` §2 决策树写明"问答 vs 项目请求"分流,但**软约束被漂移**:
+2026-05-08 用户问"调研 Multica 项目",meta-agent 没派 product-research,而是
+直接用 Agent subagent 做 web 搜索 + 直出结论。
+
+根因:决策树 §1 步把"X 是什么?"判为问答(对),但"调研 X / X 值不值得做 / X
+有人做过吗"这种语义在 §2 团队选择段才区分,§1 步的反例也没写"调研 X = 项目
+请求"。LLM 看到 §1 "问答" 路径就直答,跳过 §2。
+
+### 6.2 设计 — 决策树加固
+
+`crates/ccteam-core/src/templates/meta_agent_role.md` §2 改:
+
+#### 6.2.1 §1 步加反例 + 显式 hand-off
+
+```markdown
+### 第 1 步:这是问答还是项目请求?
+
+- **问答** —— 边界很窄:用户在问一个**事实** / **定义** / **状态**
+  - 例:"ccteam 的 Seed Gate 是什么意思?"/ "Multica 的 GitHub 地址是什么?" / "我的 todo-cli 项目跑到哪了?"
+  - 直接回答。可以用 `Bash` 调 `ccteam ls --format json` 之类拿数据
+  - **绝不**自己起 `Agent(subagent_type=...)` 做调研、检索、分析 — 那是项目请求
+- **项目请求** —— 任何"做 / 写 / 调研 / 分析 / 评估 / 看看 X 值不值得"
+  - 例:"调研 Multica" / "看看这个 idea 能不能做" / "做个 todo cli" / "X 项目市场怎么样"
+  - **不要直接干** — 进入第 2 步
+- **边界不清**:用户措辞模棱两可("X 项目怎么样?"既可能是事实询问也可能是产研请求)
+  - **问一句**:"是要我快速答你一个事实问题,还是走 product-research 团队正式产研?"
+  - 不要默默选一边
+```
+
+#### 6.2.2 §3 克制规则强化反例
+
+`§3` 已写"❌ 不要 Edit / Write 用户代码";新增显式反例:
+
+```markdown
+- ❌ **不要**自己起 `Agent(subagent_type=general-purpose)` / 调用 web 搜索工具
+  做调研、市场分析、技术对比 — 这是 product-research 团队的活,绕过 = 失去
+  6 phase pipeline + verdict 结构化判断 + 可审计调研记录
+- ✅ "调研 X" / "评估 X 值不值得" → `ccteam new --team=product-research --slug=<name> "<brief>"`
+```
+
+### 6.3 跟 F34 的协同
+
+F34 派单前确认 slug 的约束(§3.2.3)合并写在同一个 §2.4 派单段;两条改同
+一文件 `meta_agent_role.md`,**同 PR 落地**(见 §7 PR sequencing)。
+
+### 6.4 不做
+
+- 编程层强制(eg orchestrator 拦截 meta-agent 的 Agent tool call):破"meta-agent
+  是 LLM session,管理靠 prompt 不靠程序拦截"边界
+- 所有 "research X" 强制问 confirmation:误报多(用户真想要快答时)。靠决策
+  树边界 + 软约束 + 用户回弹纠错
+
+---
+
+## 7. F38 — 终端截图(PNG)
+
+### 7.1 问题 / 目标
+
+F35 enriched outbox 已带 `pane_tail`(纯文本 30 行),解决了 meta-agent 翻译
+所需的语义信号,但**用户体感缺一个直观维度** — 终端 ANSI 颜色 / progress bar /
+框线字符在文本里全失真。channel layer(M2+ Telegram / Web UI)上线后,
+PNG 是天然附件。即便 V0.2.2 没 channel adapter,outbox 里附 `screenshot_path` +
+NL 提示 "(截图 file:///path/to.png)",用户可以 `xdg-open` 立即看。
+
+也独立暴露成 MCP 工具 `mcp__ccteam__screenshot`,meta-agent / 用户的 daily-driver
+claude 可以 ad-hoc 抓一张当前 session 截图("我项目卡住了,截个图给我看看")。
+
+### 7.2 设计
+
+#### 7.2.1 渲染管线
+
+```
+tmux capture-pane -e -p -t ccteam-<slug> -S -<lines>
+        │  (stdout = ANSI-escaped 字节流;同步 query 一下 pane width)
+        ▼  in-process,纯 Rust 全栈
+vt100::Parser::new(rows, cols, 0).process(&bytes)
+        │  - 完整 VT 谱状态机(光标 / 滚动 / 颜色属性 / italic / reverse / 等)
+        │  - parser.screen().cell(r, c) → Cell { contents, fgcolor, bgcolor, italic, ... }
+        ▼
+imageproc::drawing
+        │  - 加载 TTF 字节(`ab_glyph::FontRef::try_from_slice(fs::read(path)?)`)
+        │  - 遍历 grid:每 cell 先 draw_filled_rect_mut(bg) 再 draw_text_mut(fg + char)
+        ▼
+image::ImageBuffer::save("<project>/.ccteam/screenshots/<utc>.png")
+```
+
+**纯 Rust 全栈,无 Linux system deps**(关键改进:跳过 `font-kit`,直接 `ab_glyph::FontRef::try_from_slice`
+读 TTF 字节;cargo build 不再要 `libfontconfig` + `libfreetype` 系统包)。
+
+#### 7.2.2 实施载体 — `vt100 + imageproc + image + ab_glyph` DIY(选定)
+
+```toml
+# crates/ccteam-core/Cargo.toml 新增 deps
+vt100      = "0.15"     # 解析 ANSI → 终端 cell grid(Parser / Screen / Cell)
+image      = "0.25"     # RgbImage / PNG 编码
+imageproc  = "0.25"     # draw_filled_rect_mut + draw_text_mut + text_size
+ab_glyph   = "0.2"      # FontRef + PxScale(imageproc 已经依赖,显式声明)
+```
+
+| 维度 | `vt100 + imageproc` DIY(选定) | `ansee` crate(已废) | `freeze` shell-out(已废) |
+|---|---|---|---|
+| ccteam-core 实现量 | ~200-250 LoC Rust(parser → cell grid → 渲染层 + ANSI_256 表) | ~80 LoC(crate 包装) | ~80 LoC(shell-out + degrade) |
+| 用户运行时依赖 | 0 | 0 | Go static binary 单装 |
+| **编译期系统依赖** | **0**(全纯 Rust) | Linux:`libfontconfig1-dev` + `libfreetype6-dev`(font-kit) | 0 |
+| ANSI 完整度 | **完整 VT 谱**(vt100 是 mature 终端状态机) | `ansi-parser 0.9` 早期 | freeze 自处理 |
+| 颜色覆盖 | 16 / 256 / RGB(`vt100::Color::Rgb` / `Idx` / `Default` 全 match) | 同 | 全 |
+| 字体策略 | vendored TTF + `include_bytes!`(binary 自洽);env `CCTEAM_SCREENSHOT_FONT_TTF` 运行时覆盖 | font-kit 系统查 | freeze 自处理 |
+| 字体 fallback | 单字体(env 切覆盖 CJK / emoji 字体)| 同 | freeze 自处理 |
+| 维护风险 | 自维护 ~200 LoC,跟 vt100 / imageproc 上游版本 drift | 早期 v0.1.x crate 边缘 ANSI 可能 panic | 上游 segfault 已暴露 |
+| 平台兼容 | **macOS / Linux / Windows 全 OK** | Linux 5.15 OK | **Linux 5.15 segfault** |
+| 跟 V0.2.2 patch 边界 | 边界内(单 PR ~250 LoC + 150 LoC 测试) | 边界内 | 边界内 |
+
+**选定 `vt100 + imageproc` DIY**,综合优势:
+- 用户诉求"纯 Rust"直命中,完全无 system C 库依赖(比 ansee 路径关键改进)
+- vt100 是 mature 终端状态机,ANSI 完整度高于 ansee 用的 `ansi-parser 0.9`
+- ccteam-core 完全自主可控渲染细节(cell 大小 / theme / 颜色映射)
+- 单 PR ~250 LoC 跟 F35 同量级,V0.2.2 patch 边界守住
+
+**字体获取策略**(自洽,无系统字体 API 介入):
+- **首选**:vendor `JetBrainsMono-Regular.ttf`(Apache 2.0 / OFL,~150 KB)进
+  `crates/ccteam-core/assets/fonts/`,`include_bytes!` 编译时打包进 binary
+- **运行时覆盖**:env `CCTEAM_SCREENSHOT_FONT_TTF=/path/to/other.ttf`
+  (用户 / project 想换 CJK / emoji 覆盖字体时设)
+- **不做**:`/usr/share/fonts/...` 硬编码路径(在 build host 不一定存在,影响
+  cross-compile / packaging);font-kit 系统字体查询(拉系统 C deps)
+- **license 干净**:JetBrains Mono 是 OFL(Open Font License,允许 embed +
+  redistribute);ccteam 整体 license 表加一条 third-party-fonts 注
+
+#### 7.2.3 Rust 调用路径
+
+`crates/ccteam-core/src/screenshot.rs`(新模块,~250 LoC 含 ANSI_256 表 + 字体加载):
+
+```rust
+use ab_glyph::{FontRef, PxScale};
+use image::{Rgb, RgbImage};
+use imageproc::drawing::{draw_filled_rect_mut, draw_text_mut, text_size};
+use imageproc::rect::Rect;
+use vt100::Parser;
+
+// 编译期 vendored TTF(JetBrains Mono,OFL)
+const VENDORED_TTF: &[u8] = include_bytes!("../assets/fonts/JetBrainsMono-Regular.ttf");
+
+// ANSI 256 色表(完整定义在 src/screenshot/ansi_palette.rs)
+const ANSI_256: [Rgb<u8>; 256] = [ /* ... 16 标准 + 216 立方 + 24 灰阶 ... */ ];
+
+pub fn render_screenshot(
+    paths: &CcteamPaths,
+    slug: &str,
+    lines: usize,
+) -> Result<Option<PathBuf>> {
+    // 1. capture-pane bytes(ANSI escape 保留)
+    let ansi_bytes = match capture_pane_with_ansi(slug, lines) {
+        Some(b) => b,
+        None => return Ok(None),  // tmux 不可用 → 主路径不挂
+    };
+
+    // 2. vt100 状态机:rows / cols 从 tmux display-message 查 pane 实际尺寸
+    let (rows, cols) = query_pane_dims(slug).unwrap_or((24, 80));
+    let mut parser = Parser::new(rows, cols, 0);
+    parser.process(&ansi_bytes);
+    let screen = parser.screen();
+
+    // 3. 字体加载:env 覆盖优先,缺则 vendored
+    let ttf_bytes: std::borrow::Cow<[u8]> = match std::env::var("CCTEAM_SCREENSHOT_FONT_TTF") {
+        Ok(p) => std::fs::read(&p)
+            .map(Cow::Owned)
+            .with_context(|| format!("read {p}"))?,
+        Err(_) => Cow::Borrowed(VENDORED_TTF),
+    };
+    let font = FontRef::try_from_slice(&ttf_bytes).context("parse ttf")?;
+    let scale = PxScale::from(14.0);
+
+    // 4. cell 度量:量一个 'M' 字符的实际宽高(monospace 假设)
+    let (cell_w, cell_h) = text_size(scale, &font, "M");
+    let img_w = cols as u32 * cell_w + 2 * PADDING;
+    let img_h = rows as u32 * cell_h + 2 * PADDING;
+    let mut img = RgbImage::from_pixel(img_w, img_h, Rgb([30, 30, 30])); // 默认 dark bg
+
+    // 5. 遍历 cell:画 bg 矩形 + fg 字符
+    for r in 0..rows {
+        for c in 0..cols {
+            let cell = match screen.cell(r, c) { Some(c) => c, None => continue };
+            let bg = vt100_color_to_rgb(cell.bgcolor(), Rgb([30, 30, 30]));
+            let fg = vt100_color_to_rgb(cell.fgcolor(), Rgb([204, 204, 204]));
+            let x = (PADDING + c as u32 * cell_w) as i32;
+            let y = (PADDING + r as u32 * cell_h) as i32;
+            draw_filled_rect_mut(&mut img, Rect::at(x, y).of_size(cell_w, cell_h), bg);
+            let s = cell.contents();
+            if !s.is_empty() {
+                draw_text_mut(&mut img, fg, x, y, scale, &font, s);
+            }
+        }
+    }
+
+    // 6. 保存(整步 catch_unwind 兜潜在 panic)
+    let out = paths.project_screenshot_path(slug);
+    std::fs::create_dir_all(out.parent().unwrap())?;
+    img.save(&out).context("save png")?;
+    Ok(Some(out))
+}
+
+fn vt100_color_to_rgb(c: vt100::Color, default: Rgb<u8>) -> Rgb<u8> {
+    match c {
+        vt100::Color::Default => default,
+        vt100::Color::Idx(i) => ANSI_256[i as usize],
+        vt100::Color::Rgb(r, g, b) => Rgb([r, g, b]),
+    }
+}
+```
+
+完整模块还要写:`capture_pane_with_ansi`(`tmux capture-pane -e -p ...`)+
+`query_pane_dims`(`tmux display-message -p '#{pane_height} #{pane_width}'`)+
+`ANSI_256` 调色板常量(16 标准 ANSI + 216 RGB cube + 24 灰阶 = 256 项)。
+
+graceful degrade 红线:**screenshot 永不阻塞 enriched escalate / outbox 写入**。
+任何环节失败 → 不写 `screenshot_path`,outbox 主路径仍写,F35 文本 `pane_tail`
+保留(ASCII 维度的兜底已经在)。
+
+#### 7.2.4 outbox payload 集成 / MCP 工具
+
+`needs_attention.outbox.json` 在 F35 字段基础上加 1 个:
+
+```json
+{
+  ...(F35 字段)
+  "ccteam_screenshot_path": "/abs/path/to/screenshots/2026-05-09T12-30-15Z.png"
+}
+```
+
+字段缺失 → 当次未截图(脚本不可用 / 渲染失败)。meta-agent NL 翻译时
+有路径就附"(屏幕截图:file:///<path>)",没有就跳过。
+
+新 MCP 工具 `mcp__ccteam__screenshot`:
+
+```
+input: {
+  slug: string,             // 项目 slug
+  lines?: number,           // 默认 50;capture-pane -S -<lines>
+}
+output: {
+  ok: boolean,
+  path?: string,            // 写入的 PNG 绝对路径(成功时)
+  reason?: string,          // 失败原因(脚本缺 / 字体缺 / 渲染异常)
+}
+```
+
+落 `crates/ccteam-cli/src/mcp_serve.rs`,跟现有 9 工具(ls / show / new ...)
+并列;`interfaces.md` §12 同步加。
+
+#### 7.2.5 graceful degrade 表
+
+| 失败场景 | 行为 |
+|---|---|
+| `tmux capture-pane -e` 失败(session 不存在 / tmux 未装) | log warn,返回 `Ok(None)`;outbox 不写 `screenshot_path`;MCP 工具返回 `{ok:false, reason:"tmux capture failed: ..."}` |
+| `tmux display-message` 查 pane 尺寸失败 | 同上,reason "tmux pane query failed" |
+| `vt100::Parser::process` panic(理论极小,vt100 mature) | `std::panic::catch_unwind` 兜,log warn,返回 `Ok(None)` |
+| 字体 probe 全失败(env 未配 + 预设 path 全没装) | log warn,返回 `Ok(None)`;reason "no monospace ttf found; set CCTEAM_SCREENSHOT_FONT_TTF or install jetbrains-mono / dejavu" |
+| `FontRef::try_from_slice` 解析 ttf 失败(文件损坏) | 同上,reason "ttf parse failed: ..." |
+| `imageproc::draw_text_mut` panic(罕见) | `catch_unwind` 兜,log warn |
+| 字体不覆盖输入字符(CJK / emoji 渲成 ▢) | imageproc 不感知,PNG 仍生成但视觉降级;用户层兜底 = `CCTEAM_SCREENSHOT_FONT_TTF` 切换到覆盖字体(eg `NotoSansMonoCJKsc-Regular.otf`);V0.3 评估 detect-script 自动切 |
+| 写 PNG 失败(磁盘满 / 路径权限) | log warn,返回 `Ok(None)` |
+
+不再有"缺 helper / 缺 Python / 缺 Pillow / 缺 freeze binary / 缺 system fontconfig"
+这一类失败 — vt100 / imageproc / ab_glyph / image 都是 Cargo 编译期纯 Rust 依赖,
+跟 ccteam binary 同生共死。`ccteam doctor --screenshot-smoke <slug>` 跑一次端到端
+渲染,verify PNG 可生成 + print 命中的 ttf path / 失败 reason(字体 / tmux / IO
+哪一层)。
+
+### 7.3 不做
+
+- **`freeze` shell-out**:Linux 5.15 segfault 实测不可用,直接废
+- **Pillow / Python 兜底层**:用户原始诉求"不引入 Python 依赖",兜底层会把
+  Python + Pillow + 字体三件套又拉回来,违原话;V0.2.2 选 ansee 单路径 +
+  graceful degrade 到无 PNG(F35 文本 `pane_tail` 是 ASCII 维度的天然兜底,
+  已在 outbox 写)。若 ansee 真撞 CJK / emoji ▢ 等问题,V0.3 评估"切更厚 Rust
+  栈"(`alacritty_terminal` + `cosmic-text` + `tiny-skia`,§10 deferred)而不是
+  Python 兜底
+- **PNG 直接 base64 入 outbox JSON**:大文件冗余;路径引用清晰
+- **meta-agent 自动多模态读 PNG**(Read 工具拉到 LLM context):cost / context
+  budget 重,V0.2.2 不做。channel adapter / 用户人眼是主消费者
+- **截图历史保留策略**(`<project>/.ccteam/screenshots/` 自动清理):V0.3
+  跟 channel layer 一起评估
+- **detect-script 自动切字体**(扫 ANSI 文本判断 CJK / emoji 比例 → 选 Noto
+  Sans Mono CJK SC 或 Symbola):V0.3 if 真痛
+- **vendor 字体进 ccteam release**:用户系统字体生态(font-kit / fontconfig)
+  自给自足;ccteam 不内置 ttf 文件膨胀 binary
+
+---
+
+## 8. F39 — `cct` 短前缀约定 sweep
+
+### 8.1 问题
+
+V0.1/V0.2 ship 时命名前缀都是 `ccteam-`(`ccteam` binary、`ccteam-control` skill、
+`ccteam-team-author` skill)。两个痛点:
+
+1. **冗长**:`~/.claude/skills/` listing 三个 `ccteam-*` 看一遍要扫长字符串;命令行
+   `ccteam new ...` 比 `cct new ...` 多打 4 字符 × 数百次/月
+2. **无统一约定文档化**:CLAUDE.md / README / 文档里散布"ccteam command",但是
+   "ccteam 是项目名,执行时缩写为啥"这条没明文,新用户看到 `ccteam new` 就照搬,
+   工程内部没有统一缩写约定
+
+V0.2.2 顺手做一波约定 sweep,跟 F34 加新 skill `cct-project-creator` 同步落地。
+
+### 8.2 设计
+
+#### 8.2.1 三个对象同步重命名
+
+| 对象 | 老名 | 新名 | 影响面 |
+|---|---|---|---|
+| **可执行文件** | `ccteam` | `cct` | `crates/ccteam-cli/Cargo.toml::[[bin]]` + Rust 内 `current_ccteam_bin()` 等改名 + 所有 shell-out callsite + settings.json 模板 hook 命令 |
+| **skill: control** | `ccteam-control`(M1.8 ship) | `cct-control` | skill template + Rust 函数名 + meta_agent_role.md 引用 + V0.1/V0.2 用户安装目录迁移 |
+| **skill: team-author** | `ccteam-team-author`(M0.22 ship) | `cct-team-author` | 同上 |
+
+`cct-project-creator`(F34 新增)直接用新约定 ship,无 rename。
+
+#### 8.2.2 顶层 `skills/` 目录(配套)
+
+skill markdown 从 `crates/ccteam-core/src/templates/` 迁到 **repo 根目录 `skills/`**
+(每个 skill 一个子目录 + `SKILL.md`):
+
+```
+skills/                                              # ← 新顶层目录(F39 PR 建)
+├── cct-control/SKILL.md                             # ← 从 templates/ccteam_control_skill.md 迁 + 改名
+├── cct-team-author/SKILL.md                         # ← 从 templates/ccteam_team_author_skill.md 迁 + 改名
+└── cct-project-creator/SKILL.md                     # ← F34 PR 加(F39 merge 后 follow-up)
+```
+
+`crates/ccteam-core/src/skill.rs::CCTEAM_*_SKILL_MD` 常量改用
+`include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../skills/cct-<name>/SKILL.md"))`
+跨目录引用;Rust 函数同步重命名:
+
+| 老 | 新 |
+|---|---|
+| `install_ccteam_control_skill` | `install_cct_control_skill` |
+| `install_ccteam_team_author_skill` | `install_cct_team_author_skill` |
+
+#### 8.2.3 二进制 rename — Cargo.toml + shell-out callsite
+
+```toml
+# crates/ccteam-cli/Cargo.toml
+[[bin]]
+name = "cct"            # ← 从 "ccteam" 改
+path = "src/main.rs"
+```
+
+`current_ccteam_bin()` 函数靠 `std::env::current_exe()`,binary 改名后路径仍正确,
+**函数本身可以继续叫 `current_ccteam_bin()` 不必改**(内部 API,不影响行为)。
+但为可读性建议同步改 `current_cct_bin()`。
+
+代码内 shell-out callsite 字面 `"ccteam"` 改 `"cct"` 的位置通过 grep 定位
+(预估 10-20 处,主要在 hook command 拼装 / settings.json 模板生成 / e2e tests):
+
+```bash
+git grep -nE '"ccteam"' crates/  # rust source 字面字符串
+git grep -nE '`ccteam ' docs/    # docs CLI 例子
+```
+
+#### 8.2.4 settings.json hook 命令模板
+
+`crates/ccteam-core/src/templates/settings.json` 里所有 hook command 串当前形如:
+
+```json
+"command": "/path/to/ccteam hook progress-append"
+```
+
+改成 `cct`:
+
+```json
+"command": "/path/to/cct hook progress-append"
+```
+
+**绝对路径仍由 doctor 在 install 时填入**(`current_exe()` 路径),所以模板用占位符
+`{{CCT_BIN}}` 即可。doctor 安装 hook 时把占位符替换为 `current_exe()` 的真实路径
+(已经支持,只是 binary 名字变 cct 后路径自然变)。
+
+#### 8.2.5 V0.1/V0.2 用户升级迁移
+
+**升级路径**:用户 `cargo install --path crates/ccteam-cli --force` 重装后,
+`~/.cargo/bin/ccteam` 旧文件还在(cargo 不会自动删 rename 后的 binary),
+`~/.cargo/bin/cct` 是新装的。两个都能跑(老 ccteam 是 V0.2.1 ship,新 cct 是
+V0.2.2);老的会过期,但不会崩。
+
+`cct doctor` 自动跑以下迁移:
+
+| 检测 | 行为 |
+|---|---|
+| `~/.cargo/bin/ccteam`(或同 PATH 位置)存在 | warn "old `ccteam` binary detected; safe to `rm` (V0.2.2 起命令名 = `cct`)";不主动删 |
+| 任何 `~/projects/<slug>/.claude/settings.json` 里 hook command 包含 `/ccteam ` | rewrite 为 `/cct `,使用 `current_exe()` 真实路径;atomic 写 |
+| `~/.claude/skills/ccteam-control/` 存在 | 检测 marker(`<!-- ccteam-managed -->` 或 frontmatter `name: ccteam-control`),匹配 → `rm -rf`;不匹配(用户手改)→ 保留 + warn |
+| `~/.claude/skills/ccteam-team-author/` 存在 | 同上 |
+| `~/.claude/CLAUDE.md`(全局)含 "ccteam-control" 引用 | 不动(用户管理) — F39 在 ccteam 自己产出物里改,用户全局 CLAUDE.md 由用户决策 |
+
+不加新 doctor flag,迁移逻辑放 `cct doctor`(不带 args 默认 run)+ `cct doctor
+--install-skill` / `--install-meta-agent` 触发时同步跑。跟 V0.2.0 的
+`--migrate-recommended-agents` 同模式("安装时清旧 + 新装")。
+
+#### 8.2.6 文档 sweep
+
+| 文件 | 处理 |
+|---|---|
+| `CLAUDE.md`(主仓) | F39 已加 §三 红线一条 "cct 短前缀约定" + §四 Skills 行更新 |
+| `README.md` | sweep `ccteam <cmd>` → `cct <cmd>`;install 命令 + 用法示例 |
+| `docs/tech-design.md` | sweep `ccteam ` → `cct ` (forward-looking 部分;§7 里程碑路线图 V0.2 ship 段引用 ccteam 历史名留档不动)|
+| `docs/interfaces.md` | sweep CLI 例子;§10 命令清单同步 |
+| `docs/requirements.md` | sweep |
+| `docs/v0-2-2/*.md` | 本 PRD + dev-plan + e2e-retro 全用 `cct` 写(已是新约定起点)|
+| `docs/v0-1/*` | **不动**(历史归档,反映 V0.1 ship 实情)|
+| `docs/v0-2/*` | **不动**(历史归档,反映 V0.2 ship 实情)|
+
+### 8.3 不做
+
+- **保留 `ccteam` 命令 alias / 符号链接**:不做向后兼容 alias,不写 `ln -s cct ccteam`。
+  理由:增加 sustaining 负担;真要兼容用户老脚本,他们手 `alias ccteam=cct` 在 bashrc 即可;
+  doctor 的 settings.json 迁移已自动覆盖项目内 hook 路径
+- **MCP 工具改名**:`mcp__ccteam__*` 工具命名空间是 Claude Code 配置文件里的 server name,
+  改名要碰 `~/.claude.json::mcpServers` 用户文件,风险大、收益低;V0.3 评估
+  (V0.2.2 PRD §7 F38 里写 `mcp__cct__screenshot` 是预期的,但若 MCP 命名空间
+  保留 `ccteam`,实际工具名是 `mcp__ccteam__screenshot`;以 PR 实施时定)
+- **重命名 git repo / cargo workspace 名 / crate 名**:`crates/ccteam-cli` /
+  `crates/ccteam-core` / `crates/ccteam-hooks` 是 Rust crate path,改了破依赖图 + git history,
+  V0.2.2 不动
+- **历史文档命令 sweep**:V0.1 / V0.2 子目录归档不改,反映当时 ship 实情
+
+---
+
+## 9. F40 — team 名缩短 + alias 软迁移
+
+### 9.1 问题
+
+`product-research` 是 V0.2 M3.4 起的 team 名,实际用起来三个 friction:
+
+1. **冗长**:命令行 `cct new --team product-research "<brief>"`、`~/projects/product-research-<slug>/`
+   目录,跟简短的 `dev` 对比读 / 写都繁
+2. **领域名 vs team 名混淆**:`product-research` 既是技术 team 名(state.json / slug
+   前缀 / rules 文件名),又是领域描述,两者绑死;短 team 名 + 单独 description
+   字段更清晰
+3. **V0.2 §5.4 alias 方案当时 deferred**:V0.2 PRD §5.4 已 spec 出 `team.yaml::aliases`
+   实施路径但 push 到 V0.3,本次 V0.2.2 拉回(代价 < 评估时低)
+
+### 9.2 设计 — 软 rename via alias
+
+**核心**:不动用户数据,新项目用新名,老项目继续工作。
+
+#### 9.2.1 仓内 team 重命名
+
+```
+teams/product-research/  →  teams/research/        # git mv 保 history
+└── team.yaml::
+    name: research                                  # ← 改
+    aliases: [product-research]                    # ← 新字段;老名仍可解析
+    description: |                                  # ← description 字段载全称
+      Product research team —
+      kickoff → research → verdict → next-steps;
+      用于"判断 idea 值不值得做"场景。
+    # 其他字段不变
+└── phases/                                         # 路径同
+```
+
+`teams/product-research/` 改 `teams/research/` 走 `git mv`(保 history)。phase markdown
+内容不动(它们不引用自己 team 名)。
+
+#### 9.2.2 `team.yaml::aliases` 字段语义
+
+```rust
+// crates/ccteam-core/src/team.rs
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TeamSpec {
+    pub name: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,        // ← V0.2.2 新字段
+    pub description: String,         // 已存在
+    // ...
+}
+```
+
+`team_resolver::resolve_team(name)`:
+
+```rust
+fn resolve_team(query: &str) -> Result<TeamSpec> {
+    for source in TEAM_SOURCES {
+        for entry in source.scan() {
+            let spec = entry.parse_team_yaml()?;
+            if spec.name == query || spec.aliases.iter().any(|a| a == query) {
+                return Ok(spec);
+            }
+        }
+    }
+    Err(anyhow!("team {query} not found"))
+}
+```
+
+老项目 state.json `team: "product-research"` → resolver 匹配 alias → 加载 `teams/research/team.yaml`(canonical name = "research")→ phase pipeline 正常跑。
+
+#### 9.2.3 文件系统隔离 — 不迁老项目目录
+
+| 数据 | 老项目(state.json team=product-research) | 新项目(state.json team=research) |
+|---|---|---|
+| 项目目录 | `~/projects/product-research-<slug>/`(不动)| `~/projects/research-<slug>/` |
+| `state.json::team` | `"product-research"`(不动)| `"research"` |
+| `~/.claude/rules/ccteam-lessons-*.md` | `ccteam-lessons-product-research.md`(不动)| `ccteam-lessons-research.md`(新生成)|
+| auto-memory bridge 写哪个 | rules 文件名按 `state.json::team` 字段 | 同 |
+| team 加载 | resolver alias 匹配 → `teams/research/team.yaml` | 同 |
+
+**老项目的 rules 文件 `ccteam-lessons-product-research.md`**:F40 PR 同时
+**doctor 写一份新的 `ccteam-lessons-research.md`**(从 `teams/research/team.yaml::retro_schema`
+渲染),老的留着不删(已积累的跨项目记忆有价值;`paths:` frontmatter 仍
+匹配老项目目录 `~/projects/product-research-*`,继续生效);新项目 paths:
+匹配 `~/projects/research-*`。两份文件并存,各自服务对应代际项目。
+
+#### 9.2.4 cct-project-creator skill / `cct new` UI
+
+`cct new --team` 接受 `research` 或 `product-research`;后者 stderr warn
+"deprecated alias, use 'research'"(不 fail-loud,过渡期友好)。
+
+`cct-project-creator` skill body(F34 设计的 Phase C team 选择)用 canonical
+名 `research`;描述里展示 `team.yaml::description` 全文。AskUserQuestion option:
+
+```
+{ label: "research", description: "判断 idea 值不值得做(kickoff → research → verdict → next-steps)" }
+```
+
+#### 9.2.5 测试 / 文档
+
+- `crates/ccteam-cli/tests/m3_product_research_e2e_test.rs` 改用 `research` 名
+  + 增 1 个 alias resolution 测试(`team: product-research` 也通)
+- `dev-coupling-audit.md` F-finding 列表加 F40 close 标
+- `interfaces.md` §5.5 team.yaml schema 加 `aliases` 字段
+- `tech-design.md` §3 团队抽象表更新("领域命名"目标的描述,从 V0.3 deferred 改为 V0.2.2 ship)
+- `docs/v0-2-2/feedback.md` 不动(本 finding 是用户主动追加,无原始反馈条目)
+
+### 9.3 不做
+
+- **硬 rename(touches 用户数据)**:不重命名 `~/projects/product-research-*/` 目录,
+  不改老项目 `state.json::team` 字段,不改 / 删老 rules 文件。原因:用户数据触碰
+  风险高,alias 软迁移 100% 行为兼容
+- **dev → software-development / engineering 等领域命名**:`dev` 已经短,不缩
+  (V0.2 PRD §5.4 当时也只 deferred"扩展为领域名",没说改 dev)。本次 F40 只改
+  `product-research`
+- **MCP 工具命名 namespace 改名**:同 F39 §8.3,V0.2.2 不动
+- **多 team alias mapping**(eg `product-research` / `pr` / `research` 三别名):aliases
+  数组保留,但语义 = "老名 → 新名" 单向兼容;不开放为通用 nicknames(避免歧义)
+
+---
+
+## 10. PR sequencing 与 worktree 分配
+
+5 finding 落 5 个 PR,推荐顺序与 worktree 分支:
+
+| PR # | finding | worktree 分支 | touchpoints | 依赖 |
+|---|---|---|---|---|
+| 1 | **F39** | `v0-2-2-cct-rename` | **binary**:`crates/ccteam-cli/Cargo.toml::[[bin]]name = "cct"` / Rust 函数 `current_ccteam_bin` → `current_cct_bin`(以及内部 callsite sweep)/ settings.json template hook command 用 `{{CCT_BIN}}` 占位 / **skill rename + 顶层目录**:新建 `skills/`,迁 `ccteam-control` + `ccteam-team-author` 两 skill 进 + 改名 `cct-control` / `cct-team-author`,删 `crates/ccteam-core/src/templates/ccteam_*_skill.md`,`skill.rs` 常量 + 函数同步 / **migration**:`cct doctor` 自动 detect + clean `~/.claude/skills/ccteam-{control,team-author}/`(marker 校验) + rewrite 老 settings.json hook command 路径 / **docs sweep**:README.md / tech-design.md / interfaces.md / requirements.md 全 `ccteam <cmd>` → `cct <cmd>`(historical v0-1 / v0-2 不动)/ **CLAUDE.md** §三 §四 已加(本 PR 把 PRD 驱动的 §13 "patch 流程"段也加上)| 无 |
+| 2 | **F34** + **F37** | `v0-2-2-meta-agent-and-slug` | **新 skill**:`skills/cct-project-creator/SKILL.md`(F39 已建 `skills/` 目录 + cct 命名)/ **Rust 改动**:`skill.rs::install_cct_project_creator_skill` 新增 / **CLI**:`commands.rs::run_new` 新 `--slug` / `--no-auto-slug` / `--auto-slug-model` flag + Tier 3 `claude -p` 调用 + Tier 4 `slugify_brief` 兜底 + `main.rs`(Commands::New 新字段) / `projects.rs::slugify_brief` 新函数 + `pick_unused_slug` 内部切换 / doctor `--install-skill` extend 装 3 skills / **F37 决策树**:`meta_agent_role.md` §1 自检反例 + §2 派单段改指 cct-project-creator skill + §3 克制规则加"不起 Agent 自调研"反例 | **依赖 PR #1 merge**(F39 把目录 + 命名先 ready) |
+| 3 | **F35** | `v0-2-2-silence-classifier` | `orchestrator.rs` / `progress.rs` / `tmux.rs`(提 capture_pane_tail)/ `parse_phase_end.rs`(refactor 引用)/ 新模块或 stall.rs 升级 | 无(F39 命名 sweep 不撞 F35 surface) |
+| 4 | **F36** | `v0-2-2-subagent-guard` | `orchestrator.rs::dispatch_phase_with_state` / `progress.rs::subagent_active` / 新 `<project>/.ccteam/pending-inject.json` 协议 | 软依赖 PR #3(复用 enriched outbox classification 字段) |
+| 5 | **F38** | `v0-2-2-screenshot` | 新 `crates/ccteam-core/src/screenshot.rs`(vt100 + imageproc DIY in-process)+ vendored `assets/fonts/JetBrainsMono-Regular.ttf` / `Cargo.toml` 加 `vt100 = "0.15"` + `image = "0.25"` + `imageproc = "0.25"` + `ab_glyph = "0.2"` / `mcp_serve.rs`(加 screenshot 工具,工具名取决于 mcp namespace 决议)/ `commands.rs`(`cct doctor --screenshot-smoke <slug>`)/ `tmux.rs`(共享 `capture_pane_with_ansi(-e)` helper)/ `interfaces.md` | 软依赖 PR #3(F35 outbox 加 `screenshot_path` 字段) |
+| 6 | **chore**:cargo workspace.version + CLAUDE.md §五 dev-flow 段 + docs/README.md patch 规约 + this PRD/dev-plan + e2e retro 后续 | `v0-2-2-chore` | `Cargo.toml` / `CLAUDE.md` / `docs/README.md` / `docs/v0-2-2/*.md` | 最后,V0.2.2 ship gate |
+
+PR sequencing 关键约束:**PR #1(F39)必须先 merge**,把 binary + skill 命名 + 顶层
+`skills/` 目录立起来;PR #2(F34+F37)依赖 PR #1 在新 directory + 新命名上做 follow-up。
+PR #3 / #4 / #5 跟 #1 解耦,可平行起 worktree;merge 顺序仍按 PR # 推。冲突点:
+
+- **PR #1 vs #2 — `skill.rs`**:#1 改三个老 install fn 名(team-author + control)
+  + 加 `cct-` 路径常量,#2 加 `install_cct_project_creator_skill`;按 merge 顺序 rebase
+- **`meta_agent_role.md`**:F34 + F37 同 PR(#2)解决
+- **`orchestrator.rs`**:F35 (#3) 加新 classifier 调用,F36 (#4) 改 dispatch_phase 注入路径;两段相邻但不冲突;先 merge PR #3,PR #4 rebase
+- **`progress.rs`**:F35 加 enriched outbox 写,F36 加 `subagent_active`;两段独立函数;按 merge 顺序 rebase
+- **`mcp_serve.rs`** + **`commands.rs`**:F38 (#5) 加工具 / doctor flag;跟其他 PR 不撞
+- **enriched outbox schema**:F35 (#3) 定字段,F38 (#5) 加 `screenshot_path` 字段;PR #3 先 merge,PR #5 rebase 后加
+
+每个 PR 描述映射:
+
+- `requirements.md` 痛点(F34 痛点 1 命名;F35 + F36 痛点 4 控制平面;F37 痛点 6 meta-agent 边界;F39 命名约定 sweep)
+- `tech-design.md` 章节(F35 §6.9 idle injection / §3.5 fix-loop;F36 §6.9;F37 §3.8 用户接口层 / §6.8 watchdog)
+- `dev-coupling-audit.md` F-finding 编号(F34/F35/F36/F37/F38/F39 加进去)
+- `interfaces.md` 同步(F34 加 `--slug` flag schema;F35 加 enriched outbox 字段;F36 加 pending-inject.json schema;F38 加 MCP screenshot 工具 schema;F39 全 CLI 例子 sweep)
+
+---
+
+## 10. 验收
+
+### F34
+- [ ] `cct new --slug <name> --team <team>` 创建项目用 `<team>-<name>` 或 verbatim
+- [ ] 撞名 retry 仍工作(`--slug ccteam-ui` 撞 → `dev-ccteam-ui-{4hex}`)
+- [ ] 非法 slug(含大写 / 特殊字符)fail-loud
+- [ ] **新 skill**:`skills/cct-project-creator/SKILL.md` ship +
+  `install_cct_project_creator_skill()` 落 `~/.claude/skills/`;
+  `cct doctor --install-skill` 一并安装(跟 cct-control / cct-team-author 并列)
+- [ ] skill body 用 `AskUserQuestion`(meta-agent context 允许;V0.2 §2.4 PreToolUse
+  拦截只 scope 到 project session)做 slug / team / 关键澄清的结构化选择
+- [ ] **Tier 3 智能 fallback**:`ccteam new` 无 `--slug` + 在 tty 时,shell out
+  `claude -p --model claude-haiku-4-5-20251001` 拿推荐 + Y/n 确认;15s 超时硬截
+  + 失败降级 Tier 4
+- [ ] **Tier 3 flag**:`--no-auto-slug` / `--auto-slug-model <model>` / env `CCTEAM_AUTO_SLUG=off` 全可控
+- [ ] **Tier 4 deterministic**:新函数 `slugify_brief()`(`crates/ccteam-core/src/projects.rs`),
+  token-aware + stop-word filter + dedupe + 取前 3 token;现 `slugify()` 不动
+  (meta-agent path 仍用)
+- [ ] `pick_unused_slug` 内部从 `slugify(base)` 切到 `slugify_brief(base)`
+- [ ] `meta_agent_role.md` §2 派单段改为指向 `ccteam-project-creator` skill,不再
+  inline 派单细则
+
+### F35
+- [ ] `silence_classifier`(或同等模块)4 类分类 unit 测试覆盖
+- [ ] `MidToolHung` / `SubagentRunaway` 触发 enriched outbox 写入,字段完整
+  (classification / silent_seconds / last_event / pane_tail)
+- [ ] `PostStopLimbo` / `InjectLimbo` 触发 deterministic re-inject 1 次,再触发
+  → enriched escalate(测试)
+- [ ] capture-pane helper 提到 ccteam-core,`parse_phase_end.rs` 改引用,Stop hook
+  L3 行为不变(回归测试)
+- [ ] meta-agent role prompt 加 enriched outbox NL 翻译模板
+
+### F36
+- [ ] `subagent_active(events)` unit 测试(开 / 关 / 嵌套)
+- [ ] `dispatch_phase_with_state` 检测 active subagent → pending-inject.json 落盘
+  + 不发 send-keys
+- [ ] daemon tick 在 SubagentStop event 后真发 pending-inject + 删文件
+- [ ] max-defer-minutes 兜底:超时 → enriched escalate,不无限 defer
+
+### F37
+- [ ] `meta_agent_role.md` §1 决策树加"调研 X" 反例;§3 克制规则加 "不起
+  Agent subagent 自调研" 反例
+- [ ] `ccteam doctor --install-meta-agent <handle>` 重写 CLAUDE.md 包含新 §
+
+### F39
+- [ ] `crates/ccteam-cli/Cargo.toml::[[bin]] name` 改 `cct`;`cargo build --release` 产物名变成 `cct`;`cargo install` 后 `~/.cargo/bin/cct` 在 PATH 可调
+- [ ] 顶层 `skills/` 目录建立,`cct-control` / `cct-team-author` 从 `crates/ccteam-core/src/templates/` 迁入并改名;`crates/ccteam-core/src/templates/ccteam_*_skill.md` 删除
+- [ ] `crates/ccteam-core/src/skill.rs` 三个常量 + 三个 install 函数 rename(`CCT_*_SKILL_MD` / `install_cct_*_skill`);跨目录 `include_str!` 用 `concat!(env!("CARGO_MANIFEST_DIR"), "/../../skills/cct-<name>/SKILL.md")`
+- [ ] `crates/ccteam-core/src/templates/settings.json` hook command 占位符 `{{CCT_BIN}}`;doctor install 时填 `current_exe()` 真路径
+- [ ] `cct doctor` 自动迁移 V0.1/V0.2 用户:detect + clean `~/.claude/skills/ccteam-{control,team-author}/`(marker 校验) + rewrite `~/projects/<slug>/.claude/settings.json` hook command 老路径(原子写)
+- [ ] `meta_agent_role.md` 全文 `ccteam-control` 引用替换为 `cct-control`(F37 PR 一并改)
+- [ ] **docs sweep**:README.md / docs/tech-design.md / docs/interfaces.md / docs/requirements.md `ccteam <cmd>` → `cct <cmd>`(forward-looking;`docs/v0-1/` `docs/v0-2/` 不动)
+- [ ] CLAUDE.md §三 红线 + §四 Skills 行已加 cct 约定(F39 PR 同步加 §五 dev-flow 段 — 见 §13)
+- [ ] cargo test --workspace 全绿;binary 改名后 e2e tests 调 `cct` 通过
+
+### F38
+- [ ] `Cargo.toml` 加 deps:`vt100 = "0.15"` + `image = "0.25"` + `imageproc = "0.25"` + `ab_glyph = "0.2"`
+- [ ] `crates/ccteam-core/assets/fonts/JetBrainsMono-Regular.ttf` vendor(OFL,~150 KB);
+  license 注脚加在 ccteam README + `LICENSES.md`(若无则建)
+- [ ] `crates/ccteam-core/src/screenshot.rs` 新模块,`render_screenshot(slug, lines)` API 上线
+- [ ] `ANSI_256: [Rgb<u8>; 256]` 调色板常量(16 + 216 cube + 24 grayscale,标准映射)
+- [ ] `mcp__<ns>__screenshot(slug, lines?)` MCP 工具 — 项目存在 → in-process
+  vt100 渲染,写 PNG 到 `<project>/.ccteam/screenshots/<utc>.png` 返路径(MCP namespace `ccteam` vs `cct` 取决于 F39 §8.3 的 MCP 命名空间决议;V0.2.2 默认 namespace 保留 `ccteam` 不动)
+- [ ] `CCTEAM_SCREENSHOT_FONT_TTF` env 覆盖字体(指 ttf path,eg `/usr/share/fonts/opentype/noto/NotoSansMonoCJKsc-Regular.otf`);
+  缺则用 vendored JetBrains Mono
+- [ ] graceful degrade 全覆盖:tmux 失败 / vt100 panic / ttf 解析失败 / imageproc panic /
+  IO 失败 — 全部返 `Ok(None)` + `{ok:false, reason:...}`,主路径不挂
+  (`std::panic::catch_unwind` 兜潜在 panic)
+- [ ] F35 enriched outbox 在 PR #2 merge 后 rebase 加 `screenshot_path` 字段
+  (best-effort 写入,失败 silent)
+- [ ] `ccteam doctor --screenshot-smoke <slug>` 新 flag,跑一次端到端渲染 verify
+  字体 / tmux / IO 全链路;失败 print 具体 reason
+- [ ] `interfaces.md` §12 加新 MCP 工具 schema
+- [ ] 颜色映射黄金值测试:输入预设 ANSI escape,断言 cell 颜色映射符合 ANSI_256 表
+
+### 配套
+- [ ] `Cargo.toml` `workspace.package.version` `"0.2.2"`
+- [ ] `CLAUDE.md` §五 PR 纪律加 patch 流程小节(≤ 8 行)
+- [ ] `docs/README.md` 加 patch 版本目录约定
+- [ ] `dev-coupling-audit.md` F34-F38 加条目;V0.2.2 patch 段标记 close
+- [ ] `cargo test --workspace` 不退步(baseline 511 → ≥ 511 + 新增 F34/F35/F36/F38/F39 测试)
+- [ ] clippy 不新增 warning
+
+---
+
+## 11. 不在范围 / V0.3 deferred
+
+- **slug rename**:state.json / `~/.claude/rules/` paths regex / tmux session 全条线迁移
+- **MCP 工具 `mcp__ccteam__interrupt(slug)`**:V0.3 跟 channel layer 一起评估 ergonomics
+- **autonomous meta-agent 决定 re-inject / Ctrl+C**:破红线;V0.3 评估"用户
+  opt-in 信任配置"是否值得开口子
+- **session liveness 模型重构**:F35 + F36 修的是症状,根因是"控制平面对
+  session 状态的盲区";V0.3 跟 Web UI / channel layer 一起谈 SoT
+- **强制 `--slug`**:破向后兼容
+- **新 phase YAML 字段** `idempotent_inject` 之类:不必,re-inject 已 deterministic safe
+- **F38 channel adapter 推送**(把 PNG 自动转发到 Telegram / Web UI)— V0.3 跟
+  channel layer 一起;V0.2.2 只做生成 + outbox 引用
+- **F38 多模态 meta-agent**(LLM 自己读 PNG):context cost 重,V0.2.2 不开
+- **F38 截图历史清理策略**:V0.3 channel layer 评估
+- **F38 切更厚 Rust 渲染栈**(`alacritty_terminal` + `cosmic-text` + `tiny-skia`,
+  完整 VT 谱 + 多字体 compose + emoji COLR/CPAL):若 ansee 真撞早期 crate
+  panic / CJK 渲染问题且 V0.3 升级 ansee 也救不了再切;~300-500 LoC + 3 deps
+- **F38 Pillow / Python 兜底层**:V0.2.2 明确不做(违"不引入 Python");V0.3
+  评估时也优先切 Rust 栈而非 Python
+- **F38 detect-script 自动选字体**:扫 capture-pane 内容判断 CJK / emoji 比例
+  动态切 `Font::name`;V0.3 if ansee 单字体方案真出现用户痛点
+
+---
+
+## 12. Workspace version bump
+
+`Cargo.toml::workspace.package.version` `"0.0.1"` → `"0.2.2"`。retroactive 修正
+(V0.1 / V0.2 ship 时未 sync,V0.2.1 PR 也未 sync)。新政策:每个 minor / patch
+release **必须 bump** + 在 commit message subject 一致(`v0.2.2: ...`)。
+
+未来若需要 crates 单独版本管控,改 `version.workspace = true` 为各自字面量;
+本 patch 不涉及。
+
+---
+
+## 13. CLAUDE.md dev-flow 追加段(草案)
+
+落到 `CLAUDE.md` §五 PR / 实现纪律 末尾,新增小节:
+
+```markdown
+### Patch 版本(V0.x.y)开发流程
+
+1. **doc-first**:PRD + dev-plan 落 `docs/v0-x-y/`;用户 review 后才动代码
+2. **worktree-per-PR**:每个 finding 单独 `git worktree add /tmp/ccteam-<branch> origin/main`
+3. **subagent 派工**:主 session 用 Agent 工具派每个 worktree(briefing 含
+   PRD section + 验收条目)
+4. **PR review/fix/merge**:主 session 拉 PR diff review → 退回 fix 或本地补 → merge
+5. **cargo bump**:`workspace.package.version` 同步 bump,commit subject 用 `vX.Y.Z:` 前缀
+6. **CLAUDE.md baseline 更新**:`cargo test --workspace` 通过新数后回填 §一表格
+```
+
+(主仓 main 不变 dirty;worktree 工具流详 §五"多 session 并行编辑同一仓库"段)
+
+---
+
+## Changelog
+
+- 2026-05-09:**F39 抽出独立 finding** — 用户连追三条:`ccteam-control` skill
+  前缀改 `cct-control` → 二进制 `ccteam` → `cct` → CLAUDE.md 加 `cct` 约定。三条
+  同源 = "cct 短前缀约定 sweep",归并为 F39。F39 退出 F34 scope,改成独立 PR #1
+  机械 rename 跨 binary + 全 3 skill + docs sweep + V0.1/V0.2 用户迁移逻辑。
+  F34 PR 退回到专注 slug 逻辑 + 新 `cct-project-creator` skill content,基于 F39
+  已建好的 `skills/` 目录 + 命名 follow-up。CLAUDE.md §三 红线 + §四 Skills 行
+  本次直接改(2026-05-09 写入,反映 V0.2.2 计划)
+- 2026-05-09:F34 经用户多轮迭代深化:初稿仅 `--slug` flag → 加 `slugify_brief()`
+  token-aware 算法 → 用户要求"一定要用上智能" → 加 Tier 3 `claude -p` 智能 fallback +
+  Y/n 确认 + 四层调用栈 → 用户要求"封装成 cct-project-creator skill" → 重写
+  Tier 2 为 dedicated skill(meta-agent 调用,AskUserQuestion 结构化选项)→ 用户
+  要求"所有自带 skill 移到 repo 根目录 `skills/`" → 抽到 F39 整套约定 sweep。
+  F34 最终 scope 是 slug 四层调用 + 新 skill body 内容,~200 LoC + skill 模板
+- 2026-05-09:初稿。基于 2026-05-08 用户首批 ccteam 实战反馈(F34-F37);F35
+  设计经 advisor + 用户两轮迭代敲定为"事件感知分级 + capture-pane 入 outbox +
+  meta-agent propose-confirm"(meta-agent autonomous decide 选项被红线驳回)。
+  base = origin/main `170f5a8`
+- 2026-05-09:用户追加 F38 截图(PNG)需求 — UX 增强,补 F35 enriched outbox 视觉
+  维度,也独立 MCP 工具暴露。PR sequencing 增加 PR #4(screenshot)+ PR #5
+  (chore ship gate)
+- 2026-05-09:F38 实施载体经用户 / WebFetch 反复验证迭代(5 轮):
+  - 第 1 轮:bundled Python + Pillow + 三级字体 fallback → 用户驳回 Python 依赖
+  - 第 2 轮:`vte + tiny-skia / resvg` Rust 自拼 ~300-500 LoC → 复杂度过高,patch 容不下
+  - 第 3 轮:shell out **`freeze`**(charmbracelet Go binary)→ 用户实测 Linux 5.15 segfault 不可用
+  - 第 4 轮:**`ansee` crate**(纯 Rust,ANSI→PNG)→ 验证发现拉 font-kit + Linux
+    系统 C 依赖(`libfontconfig` + `libfreetype`),且 `ansi-parser 0.9` 早期
+  - 第 5 轮(最终):用户提议 **`vt100 + imageproc + image + ab_glyph` DIY**;
+    验证 vt100 v0.16(pin 0.15 跟用户 reference)是 mature 终端状态机,imageproc
+    有 `draw_filled_rect_mut` + `draw_text_mut`,**绕过 font-kit / 系统 C 依赖**
+    (vendored JetBrains Mono TTF + `include_bytes!` 编译期打包);ccteam-core
+    +~250 LoC,license MIT 干净
+  - 最终:**vt100 + imageproc DIY in-process 单路径**,`std::panic::catch_unwind`
+    兜潜在 panic,`CCTEAM_SCREENSHOT_FONT_TTF` env 覆盖字体(用户切 CJK / emoji
+    覆盖字体时用),vendored JetBrains Mono(OFL)默认

--- a/skills/cct-control/SKILL.md
+++ b/skills/cct-control/SKILL.md
@@ -1,5 +1,6 @@
+<!-- ccteam-managed:skill begin -->
 ---
-name: ccteam-control
+name: cct-control
 description: |
   Manage ccteam projects from any Claude Code session. Use when the
   user asks about ccteam status, wants to start a new ccteam project,
@@ -10,12 +11,13 @@ description: |
 allowed-tools: [Bash]
 ---
 
-# ccteam-control
+# cct-control
 
 ccteam is an autonomous project orchestrator built on Claude Code.
-This skill makes ccteam reachable from any claude session.
+This skill makes ccteam reachable from any claude session via the
+short-prefix `cct` CLI (V0.2.2 F39).
 
-**Prefer the MCP server.** Once `ccteam doctor --install-mcp` has
+**Prefer the MCP server.** Once `cct doctor --install-mcp` has
 registered the server (M2.5), every claude session sees nine
 `mcp__ccteam__*` tools — call those first. The `Bash` + `--format
 json` path below stays as a fallback for sessions where the MCP
@@ -25,29 +27,31 @@ server isn't registered yet.
 
 | What you want | MCP tool (preferred) | Bash fallback |
 |---|---|---|
-| List all projects                | `mcp__ccteam__ls`                | `ccteam ls --format json` |
-| One project's full state         | `mcp__ccteam__show`              | `ccteam show <slug> --format json` |
-| Recent progress events           | `mcp__ccteam__progress`          | `ccteam progress <slug>` |
-| Capture session pane content     | `mcp__ccteam__peek`              | `ccteam peek <slug>` |
-| Start a new dev project          | `mcp__ccteam__new`               | `ccteam new --team=dev "<request>"` |
-| Start a product-research project | `mcp__ccteam__new`               | `ccteam new --team=product-research "<idea>"` |
-| Pause project (no kill)          | `mcp__ccteam__pause`             | `ccteam pause <slug>` |
-| Resume project                   | `mcp__ccteam__resume`            | `ccteam resume <slug>` |
+| List all projects                | `mcp__ccteam__ls`                | `cct ls --format json` |
+| One project's full state         | `mcp__ccteam__show`              | `cct show <slug> --format json` |
+| Recent progress events           | `mcp__ccteam__progress`          | `cct progress <slug>` |
+| Capture session pane content     | `mcp__ccteam__peek`              | `cct peek <slug>` |
+| Start a new dev project          | `mcp__ccteam__new`               | `cct new --team=dev "<request>"` |
+| Start a product-research project | `mcp__ccteam__new`               | `cct new --team=product-research "<idea>"` |
+| Pause project (no kill)          | `mcp__ccteam__pause`             | `cct pause <slug>` |
+| Resume project                   | `mcp__ccteam__resume`            | `cct resume <slug>` |
 | Send NL to a session inbox       | `mcp__ccteam__send_to_session`   | (write `.ccteam/inbox/msg-<ts>-NNN.md`) |
 | Inject ESCALATE-style decision   | `mcp__ccteam__inject_decision`   | (compose body manually + send_to_session) |
-| Health checks                    | (Bash only)                      | `ccteam doctor --tool-surface` |
-| Install meta-agent               | (Bash only)                      | `ccteam doctor --install-meta-agent <handle>` |
+| Health checks                    | (Bash only)                      | `cct doctor --tool-surface` |
+| Install meta-agent               | (Bash only)                      | `cct doctor --install-meta-agent <handle>` |
 
-When the MCP server is registered, `ccteam doctor --install-mcp` (run
+When the MCP server is registered, `cct doctor --install-mcp` (run
 once) wires `mcpServers.ccteam` into `~/.claude.json`. Existing claude
-sessions need `/reload-mcp`; new sessions pick it up immediately.
+sessions need `/reload-mcp`; new sessions pick it up immediately. The
+MCP server name stays `ccteam` (V0.2.2 §8.3 — namespace change is
+deferred to V0.3 to avoid touching user `~/.claude.json` files).
 
 ## Typical workflows
 
 ### A) Cross-project status report
 
 ```bash
-ccteam ls --format json | jq '.projects[] | {slug, current_phase, phase_state, cost_used_usd, age_seconds}'
+cct ls --format json | jq '.projects[] | {slug, current_phase, phase_state, cost_used_usd, age_seconds}'
 ```
 
 Then narrate the table to the user — call out anything in
@@ -79,22 +83,22 @@ When the user says "make a todo cli" but the brief is ambiguous,
 Pick the single most blocking question. Only after they answer, run:
 
 ```bash
-ccteam new --team=dev "<refined brief>"
+cct new --team=dev "<refined brief>"
 # or, if the user still seems uncertain:
-ccteam new --team=product-research "<idea>"
+cct new --team=product-research "<idea>"
 ```
 
 ### D) Stuck-project triage
 
 ```bash
-ccteam show <slug> --format json | jq '{phase: .state.current_phase, fix_count: .state.auto_loop_cycle_count, recent: .recent_events[-5:]}'
-ccteam peek <slug>
+cct show <slug> --format json | jq '{phase: .state.current_phase, fix_count: .state.auto_loop_cycle_count, recent: .recent_events[-5:]}'
+cct peek <slug>
 ```
 
 Combine the two outputs and recommend exactly **one** of:
-- `ccteam attach <slug>` — user wants to drive
-- `ccteam pause <slug>` — pause and think
-- `ccteam resume <slug>` after fixing — back to autonomous
+- `cct attach <slug>` — user wants to drive
+- `cct pause <slug>` — pause and think
+- `cct resume <slug>` after fixing — back to autonomous
 
 ## Decision principles
 
@@ -113,7 +117,7 @@ Combine the two outputs and recommend exactly **one** of:
 - It cannot edit `~/projects/<slug>/.ccteam/` metadata directly. All
   control flows through the CLI (or `~/.ccteam/control/` files for
   M2+ asynchronous control).
-- It cannot start the ccteam orchestrator daemon — that's `ccteam
+- It cannot start the ccteam orchestrator daemon — that's `cct
   start --foreground` and is an ops decision, not an agent decision.
 
 ## Meta-agent specifics
@@ -133,3 +137,4 @@ When this skill is loaded inside a ccteam meta-agent session:
    ESCALATE-style markdown payload (interfaces §4.1.1) and atomically
    writes it to the project's inbox so the orchestrator delivers it
    on the next tick.
+<!-- ccteam-managed:skill end -->

--- a/skills/cct-team-author/SKILL.md
+++ b/skills/cct-team-author/SKILL.md
@@ -1,17 +1,18 @@
+<!-- ccteam-managed:skill begin -->
 ---
-name: ccteam-team-author
+name: cct-team-author
 description: |
   Author a new ccteam team plugin via dialogue with the user. Use when
   the user asks to create / design / scaffold a team, or wants to package
   a custom phase pipeline as a Claude Code plugin. Primary consumer is
   the ccteam meta-agent session — it walks the user through phase list,
   tools, golden rules, retro schema, verdict schema, and plugin metadata,
-  then invokes `ccteam team init` / `ccteam team publish` to materialize
+  then invokes `cct team init` / `cct team publish` to materialize
   and share the result.
 allowed-tools: [Bash, Read, Write, Edit]
 ---
 
-# ccteam-team-author
+# cct-team-author
 
 ccteam ships two teams out of the box (`dev`, `product-research`). When
 the user wants a different workflow — code review only, market research
@@ -24,10 +25,10 @@ Claude Code runs.
 
 | What you want | Bash command |
 |---|---|
-| Scaffold a team from interview answers | `ccteam team init <name> --description "…"` |
-| Validate a staged team | `ccteam doctor --validate-team <name>` |
-| Publish to local marketplace        | `ccteam team publish <name> --target local` |
-| Publish to GitHub                   | `ccteam team publish <name> --target github --repo <owner>/<name>` |
+| Scaffold a team from interview answers | `cct team init <name> --description "…"` |
+| Validate a staged team | `cct doctor --validate-team <name>` |
+| Publish to local marketplace        | `cct team publish <name> --target local` |
+| Publish to GitHub                   | `cct team publish <name> --target github --repo <owner>/<name>` |
 | Inspect what was generated          | `ls ~/.config/ccteam/teams/<name>/` |
 
 Staging path: `~/.config/ccteam/teams/<name>/`. Layout mirrors a Claude
@@ -37,14 +38,14 @@ optional `agents/` `commands/` `hooks/hooks.json` `.mcp.json`).
 ## Typical workflow — interview the user, then scaffold
 
 The factory expects answers to a small set of questions before
-`ccteam team init` can produce a useful skeleton. Walk the user through
+`cct team init` can produce a useful skeleton. Walk the user through
 them one at a time — do **not** dump every question in a single turn.
 
 ### A) Plugin metadata
 
 1. Plugin / team `name` — must be ascii lowercase + `-` + digits.
    Doubles as `team.yaml.name`.
-2. One-line `description` (shown in `ccteam ls --teams`,
+2. One-line `description` (shown in `cct ls --teams`,
    `marketplace.json`).
 3. `author.name` (and optionally `author.email`).
 
@@ -67,7 +68,7 @@ them one at a time — do **not** dump every question in a single turn.
 Per phase, ask: which subagents / skills / MCP servers does this phase
 invoke? (Common subagents: `code-reviewer`, `code-architect`,
 `code-explorer`, `silent-failure-hunter`.) The factory writes
-`tools_required:` for each phase; `ccteam doctor --validate-team` then
+`tools_required:` for each phase; `cct doctor --validate-team` then
 cross-checks reachability.
 
 ### D) Golden rules (team-wide)
@@ -118,7 +119,7 @@ prefixes — `REVERT_TO_PHASE` / `NEED_USER_INPUT` / `ABORT` /
   `ESCALATE: …`) into the body — those are inject-prompt territory only
   (V0.2 M0.18).
 - **Validate before publishing.** Always run
-  `ccteam doctor --validate-team <name>` after `init` and before
+  `cct doctor --validate-team <name>` after `init` and before
   `publish`. Fix any `[FAIL]`; surface `[WARN]` to the user.
 
 ## Publish targets
@@ -146,3 +147,4 @@ prefixes — `REVERT_TO_PHASE` / `NEED_USER_INPUT` / `ABORT` /
 - It does not auto-install the plugin in any session. Publish writes the
   artifact; the user enables it in each Claude Code session that wants
   it (`/plugin enable`).
+<!-- ccteam-managed:skill end -->


### PR DESCRIPTION
## Closes
- F39 (`docs/v0-2-2/prd.md` §8)

## 改动
- binary rename `ccteam` → `cct` (`crates/ccteam-cli/Cargo.toml::[[bin]] name`)
- 顶层 `skills/` 目录建立,`cct-{control,team-author}` 迁入(SKILL.md body 加 `<!-- ccteam-managed:skill ... -->` marker 以便 V0.1/V0.2 升级清理)
- Rust API rename:`current_ccteam_bin` → `current_cct_bin`;`install_cct_*_skill` + `CCT_*_SKILL_NAME` const + 跨目录 `include_str!` 从 `skills/`
- `settings.json` 占位符 rename:`__CCTEAM_BIN__` → `{{CCT_BIN}}`
- `cct doctor --install-skill` 现在装两个 skill + 自带 V0.1/V0.2 → V0.2.2 清理迁移:
  - 检测 + 清旧 `~/.claude/skills/ccteam-{control,team-author}/`(`<!-- ccteam-managed:skill -->` marker / 规范 frontmatter `name:` 双重校验,只清 ccteam-managed 的;用户手改保留 + warn)
  - 原子 rewrite `~/projects/<slug>/.claude/settings.json` 老 hook command 路径
- forward-looking docs sweep:README.md / docs/{tech-design,interfaces,requirements}.md / CLAUDE.md / 全部 in-binary phase / role / memory-bridge 模板都从 `ccteam <cmd>` 切到 `cct <cmd>`
- CLAUDE.md:§三 加 `cct` 短前缀红线,§四 Skills 行更新,§五 加 patch 流程小节(PRD §13),§六 加 V0.2 → V0.2.2 升级条目

## 按 PRD §8.3 保留(V0.3 评估)
- MCP server name `ccteam`(`mcpServers.ccteam` in `~/.claude.json`)
- `~/.config/ccteam/` XDG dir + `~/.ccteam/` 项目状态根
- crate 名(`ccteam-{cli,core,hooks}`)
- git repo + cargo workspace 名

`docs/v0-1/` / `docs/v0-2/` 历史归档未触碰。

## 测试
- baseline: **511 → 524**(新增 13 个 F39 迁移测试:legacy skill dir detect/remove/preserve、hook command rewrite atomic / 幂等 / 不动 unrelated 命令 等)
- clippy:不新增 warning

## 红线 grep
- `git grep -nE 'ccteam-(control|team-author)' crates/ skills/ README.md CLAUDE.md` → 19 命中(全部是 F39 迁移测试 fixture / `LEGACY_SKILL_NAMES` 常量 / 文档说明,`docs/v0-1/` `docs/v0-2/` 不算)
- `git grep -nE '\bccteam (new|ls|show|attach|hook|doctor|watchdog|team)\b' README.md docs/{tech-design,interfaces,requirements}.md CLAUDE.md` → **0 命中**
- `git grep -nE '"ccteam"' crates/ccteam-cli/src/ crates/ccteam-core/src/` → 9 命中(全部是 PRD §8.3 deferred:MCP server name + XDG `~/.config/ccteam/` dir + tool_surface MCP test fixture)

## 验收(对应 PRD §10 F39 段)
- [x] `cargo build --release` 产物 = `target/release/cct`
- [x] `skills/cct-{control,team-author}/SKILL.md` ship,旧 `crates/ccteam-core/src/templates/ccteam_*_skill.md` 删
- [x] `skill.rs` 常量 + 函数 rename,`current_ccteam_bin` → `current_cct_bin`
- [x] `settings.json` 模板用 `{{CCT_BIN}}`,`render_project_settings` 替换为 `current_exe()` 真实路径
- [x] `cct doctor` 跑迁移路径无回归,marker 校验正确(自动测试 4 个分支:Removed/WouldRemove/PreservedHandEdit/NotFound)
- [x] forward-looking 文档全切 `cct <cmd>`
- [x] `cargo test --workspace` 全绿,baseline 511 → 524
- [x] clippy 不新增 warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)