### PR TITLE
v0.2.2 PR #2: F34 slug 4-tier + F37 meta-agent decision tree

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -11,14 +11,15 @@ use serde_json::{json, Map, Value};
 
 use ccteam_core::{
     bootstrap_meta_project, bootstrap_project, current_cct_bin, install_cct_control_skill,
-    install_cct_team_author_skill, migrate_legacy_skill_dirs,
-    migrate_recommended_agent_symlinks, pick_unused_slug, rewrite_legacy_hook_commands,
-    user_claude_dir, write_all_global_team_templates, write_global_helper_templates,
-    write_global_phase_templates, CcteamPaths, HookCmdRewriteAction, HookCmdRewriteReport,
-    InstallSkillOptions, LegacySkillAction, LegacySkillReport, MetaBootstrapReport,
-    MigrationReport, OutboxEventKind, OutboxMessage, PhaseHistoryEntry, PhaseState,
-    PhaseTemplate, ProjectState, SessionMailbox, SkillInstallAction, TeamSpec,
-    ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES, PHASE_TEMPLATES,
+    install_cct_project_creator_skill, install_cct_team_author_skill,
+    migrate_legacy_skill_dirs, migrate_recommended_agent_symlinks, pick_unused_slug,
+    rewrite_legacy_hook_commands, user_claude_dir, write_all_global_team_templates,
+    write_global_helper_templates, write_global_phase_templates, CcteamPaths,
+    HookCmdRewriteAction, HookCmdRewriteReport, InstallSkillOptions, LegacySkillAction,
+    LegacySkillReport, MetaBootstrapReport, MigrationReport, OutboxEventKind, OutboxMessage,
+    PhaseHistoryEntry, PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
+    SkillInstallAction, TeamSpec, ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES,
+    PHASE_TEMPLATES,
 };
 use ccteam_core::tmux::TmuxSession;
 
@@ -122,6 +123,24 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
     Ok(out)
 }
 
+/// V0.2.2 F34: optional knobs for `run_new` covering the four-tier
+/// slug-decision stack (PRD §3.2):
+///
+/// - `slug` set → Tier 1 (verbatim, B2 prefix semantics).
+/// - `slug` unset, tty + claude available + `!no_auto_slug` →
+///   Tier 3 (`claude -p` smart suggest + Y/n confirm).
+/// - `slug` unset and Tier 3 unavailable / declined →
+///   Tier 4 (`slugify_brief()` deterministic).
+///
+/// `RunNewOptions::default()` keeps the V0.2.1 behavior (no flag,
+/// no auto-suggest, deterministic Tier 4 from `slugify_brief`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RunNewOptions<'a> {
+    pub slug: Option<&'a str>,
+    pub no_auto_slug: bool,
+    pub auto_slug_model: &'a str,
+}
+
 /// `cct new "request" --team <name>`. Bootstraps a project on disk
 /// and returns the chosen slug. Side effects: creates
 /// `~/projects/<slug>/...`. `team` is recorded in state.json so the
@@ -137,7 +156,14 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
 /// meta-agent) are stamped to disk inside `run_new` so a fresh
 /// install no longer needs an explicit `cct init` for the
 /// validation to find them.
-pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String> {
+///
+/// V0.2.2 F34: takes `RunNewOptions` for the four-tier slug stack.
+pub fn run_new(
+    paths: &CcteamPaths,
+    request: &str,
+    team: &str,
+    opts: RunNewOptions<'_>,
+) -> Result<String> {
     if request.trim().is_empty() {
         bail!("cct new: request must be non-empty");
     }
@@ -156,9 +182,205 @@ pub fn run_new(paths: &CcteamPaths, request: &str, team: &str) -> Result<String>
         );
     }
     ensure_team_resolvable(paths, team)?;
-    let slug = pick_unused_slug(paths, request, team)?;
+    let slug = decide_slug(paths, request, team, opts)?;
     bootstrap_project(paths, &slug, request, team)?;
     Ok(slug)
+}
+
+/// V0.2.2 F34 four-tier slug decision. Pure-ish (only LLM shell-out
+/// and stdin/stdout for confirmation if Tier 3 fires); test-friendly
+/// because the env / flag inputs all flow through `RunNewOptions` +
+/// `CCTEAM_AUTO_SLUG{,_BIN}` env vars.
+fn decide_slug(
+    paths: &CcteamPaths,
+    request: &str,
+    team: &str,
+    opts: RunNewOptions<'_>,
+) -> Result<String> {
+    // Tier 1: explicit --slug wins.
+    if let Some(raw) = opts.slug {
+        return ccteam_core::pick_unused_slug_verbatim(paths, raw, team);
+    }
+    // Tier 3: `claude -p` smart suggestion. Skip when `--no-auto-slug`,
+    // when the env disables it, or when claude is unreachable / non-tty.
+    let env_disables = std::env::var("CCTEAM_AUTO_SLUG")
+        .map(|v| v.eq_ignore_ascii_case("off") || v == "0")
+        .unwrap_or(false);
+    if !opts.no_auto_slug && !env_disables {
+        match try_smart_slug(request, opts.auto_slug_model) {
+            Ok(Some(suggestion)) => {
+                return ccteam_core::pick_unused_slug_verbatim(paths, &suggestion, team);
+            }
+            Ok(None) => {
+                // Smart path silently declined (eg user typed `n`); fall
+                // through to Tier 4 — printed reason already.
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "cct new: smart slug suggestion unavailable; falling back to deterministic",
+                );
+            }
+        }
+    }
+    // Tier 4: token-aware deterministic.
+    pick_unused_slug(paths, request, team)
+}
+
+/// V0.2.2 F34 Tier 3 — shell out to `claude -p` for an LLM-quality
+/// slug suggestion, gated on tty / claude-on-PATH / env knobs.
+///
+/// Returns:
+/// - `Ok(Some(slug))` — `claude -p` produced a clean slug and (in tty
+///   contexts) the user accepted it.
+/// - `Ok(None)` — the user declined the suggestion in interactive mode.
+/// - `Err(_)` — every reason we want logged before falling through.
+///
+/// Test seam: `CCTEAM_AUTO_SLUG_BIN` overrides the resolved binary
+/// path (eg point at a stub script during integration tests so the
+/// tier is exercised without a real LLM).
+fn try_smart_slug(request: &str, model: &str) -> Result<Option<String>> {
+    use std::io::{self, BufRead, Write};
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    // Resolve the binary. Honor a test override first.
+    let bin = match std::env::var("CCTEAM_AUTO_SLUG_BIN") {
+        Ok(v) if !v.is_empty() => v,
+        _ => match which_claude() {
+            Some(p) => p,
+            None => bail!("`claude` not on PATH (Tier 3 disabled)"),
+        },
+    };
+
+    let prompt = render_smart_slug_prompt(request);
+
+    eprintln!("[cct] querying claude for slug recommendation...");
+    let mut child = Command::new(&bin)
+        .args(["-p", "--model", model])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("spawn `{bin} -p`"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt.as_bytes())
+            .context("write prompt to claude stdin")?;
+    }
+
+    // Wait up to 15s for the child. We poll instead of `child.wait()`
+    // so we can hard-kill on timeout.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let output = loop {
+        match child.try_wait().context("poll claude child")? {
+            Some(_status) => break child.wait_with_output().context("collect claude output")?,
+            None => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    bail!("`claude -p` timed out after 15s; falling back to deterministic slug");
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    };
+
+    if !output.status.success() {
+        bail!(
+            "`claude -p` exited with non-zero status (`{:?}`): {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let raw = String::from_utf8_lossy(&output.stdout).into_owned();
+    let suggestion = match sanitize_smart_slug(&raw) {
+        Some(s) => s,
+        None => bail!("`claude -p` returned no usable slug: {:?}", raw.trim()),
+    };
+
+    // Confirm in tty contexts; auto-accept when piped.
+    let tty = std::io::IsTerminal::is_terminal(&io::stdin());
+    if !tty {
+        eprintln!("[cct] suggested: {suggestion} (auto-accepted, non-tty)");
+        return Ok(Some(suggestion));
+    }
+
+    eprint!("[cct] suggested: {suggestion}\n[cct] accept? [Y/n] (rerun with --slug to override): ");
+    io::stderr().flush().ok();
+    let mut line = String::new();
+    let stdin = io::stdin();
+    stdin.lock().read_line(&mut line).context("read confirmation")?;
+    let reply = line.trim().to_ascii_lowercase();
+    if reply.is_empty() || reply == "y" || reply == "yes" {
+        Ok(Some(suggestion))
+    } else {
+        eprintln!(
+            "[cct] declined; rerun with `--slug <name>` to set explicitly, or fall back to deterministic"
+        );
+        Ok(None)
+    }
+}
+
+/// Build the Tier 3 prompt. Pulled out so the integration tests can
+/// stub a deterministic `claude` echoing back a fixed slug without
+/// caring about the prompt body (PRD §3.2.3 keeps the wording stable).
+fn render_smart_slug_prompt(request: &str) -> String {
+    format!(
+        "Generate a 2-4 token kebab-case slug for a project with this brief:\n\
+         '{request}'\n\n\
+         Rules:\n\
+         - Capture the core noun/concept (brand name if present), not action verbs\n\
+         - Drop stop words (a, the, of, etc) and pure-digit tokens\n\
+         - Output ONLY the slug, no explanation, no quotes, no markdown\n\
+         Examples:\n\
+         - 'AI recipe generator from fridge photo' -> recipe-generator\n\
+         - 'Build a todo cli with ratatui' -> todo-cli\n\
+         - 'HermesTrade DEX prediction market' -> hermestrade-dex\n\
+         Slug:"
+    )
+}
+
+/// Lock the smart-slug output down to `[a-z0-9-]+`, len 2..=60. Strips
+/// trailing whitespace / quotes / `Slug:` echo, so the LLM has some
+/// slack but the disk layer doesn't see anything weird.
+fn sanitize_smart_slug(raw: &str) -> Option<String> {
+    let candidate = raw
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())?
+        .trim_matches(|c: char| {
+            c == '"' || c == '\'' || c == '`' || c.is_ascii_whitespace()
+        })
+        .trim_start_matches("Slug:")
+        .trim();
+    let lowered = candidate.to_ascii_lowercase();
+    let cleaned: String = lowered
+        .chars()
+        .filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-')
+        .collect();
+    let trimmed = cleaned.trim_matches('-');
+    if trimmed.len() < 2 || trimmed.len() > 60 {
+        return None;
+    }
+    if trimmed.chars().all(|c| c == '-') {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Resolve `claude` via `which`. Returns `None` when not on PATH; the
+/// caller falls through to Tier 4. Stdlib only — no extra crate.
+fn which_claude() -> Option<String> {
+    let path_env = std::env::var_os("PATH")?;
+    for entry in std::env::split_paths(&path_env) {
+        let candidate = entry.join("claude");
+        if candidate.is_file() {
+            return candidate.to_str().map(String::from);
+        }
+    }
+    None
 }
 
 /// Resolve `team` against the on-disk team registry. Returns
@@ -1131,18 +1353,25 @@ fn render_install_skill_report(paths: &CcteamPaths, opts: &DoctorOptions) -> Res
     };
     let mut out = String::from("cct doctor --install-skill\n\n");
 
-    // V0.2.2 F39: install both shipped skills under their cct-* names.
+    // V0.2.2 F39: install all shipped skills under their cct-* names.
+    // V0.2.2 F34: cct-project-creator joins the install set.
     let control = install_cct_control_skill(install_opts)?;
     out.push_str(&format!(
-        "  cct-control      {label}  {}\n",
+        "  cct-control          {label}  {}\n",
         control.target.display(),
         label = skill_install_label(&control.action),
     ));
     let team_author = install_cct_team_author_skill(install_opts)?;
     out.push_str(&format!(
-        "  cct-team-author  {label}  {}\n",
+        "  cct-team-author      {label}  {}\n",
         team_author.target.display(),
         label = skill_install_label(&team_author.action),
+    ));
+    let project_creator = install_cct_project_creator_skill(install_opts)?;
+    out.push_str(&format!(
+        "  cct-project-creator  {label}  {}\n",
+        project_creator.target.display(),
+        label = skill_install_label(&project_creator.action),
     ));
     out.push('\n');
 
@@ -1865,15 +2094,35 @@ mod tests {
         }
     }
 
+    /// V0.2.2 F34: thin wrapper that defaults to deterministic Tier 4
+    /// (no auto-suggest) so unit tests don't accidentally shell-out to
+    /// `claude -p` on dev / CI machines that have it on PATH.
+    fn run_new_t4(paths: &CcteamPaths, request: &str, team: &str) -> Result<String> {
+        run_new(
+            paths,
+            request,
+            team,
+            RunNewOptions {
+                slug: None,
+                no_auto_slug: true,
+                auto_slug_model: "claude-haiku-4-5-20251001",
+            },
+        )
+    }
+
     #[test]
     fn run_new_creates_slug_and_bootstrap_files() {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "Build a bookmark manager", "dev").unwrap();
+        let slug = run_new_t4(&paths, "Build a bookmark manager", "dev").unwrap();
         // F22: slug now carries the team prefix so ~/.claude/rules/ccteam-lessons-dev.md
         // `paths: ~/projects/dev-*` matches at session start.
-        assert!(slug.starts_with("dev-build-a-bookmark-manager"));
+        // V0.2.2 F34: `slugify_brief` drops stop-words so `a` is filtered out.
+        assert!(
+            slug.starts_with("dev-build-bookmark-manager"),
+            "expected `dev-build-bookmark-manager*`, got {slug}",
+        );
         let project = paths.project_dir(&slug);
         assert!(project.join(".ccteam/spec.md").exists());
         assert!(project.join(".ccteam/state.json").exists());
@@ -1885,7 +2134,7 @@ mod tests {
     fn run_new_rejects_empty_request() {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let err = run_new(&paths, "   \n\t", "dev").unwrap_err();
+        let err = run_new_t4(&paths, "   \n\t", "dev").unwrap_err();
         assert!(format!("{err:#}").contains("non-empty"));
     }
 
@@ -1893,7 +2142,7 @@ mod tests {
     fn run_new_rejects_empty_team() {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let err = run_new(&paths, "build something", "  ").unwrap_err();
+        let err = run_new_t4(&paths, "build something", "  ").unwrap_err();
         assert!(format!("{err:#}").contains("--team"));
     }
 
@@ -1910,7 +2159,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         let slug =
-            run_new(&paths, "ai recipe generator idea", "product-research").unwrap();
+            run_new_t4(&paths, "ai recipe generator idea", "product-research").unwrap();
         let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
         assert_eq!(state.team, "product-research");
     }
@@ -1923,7 +2172,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let err = run_new(&paths, "marketing copy idea", "marketing").unwrap_err();
+        let err = run_new_t4(&paths, "marketing copy idea", "marketing").unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("unknown team"), "got: {msg}");
         assert!(msg.contains("marketing"), "should name the missing team");
@@ -1961,7 +2210,7 @@ mod tests {
         // later in bootstrap_project (no template bundle), but
         // ensure_team_resolvable should accept the team.yaml first.
         // The error we get back should NOT mention "unknown team".
-        let err = run_new(&paths, "do a thing", "custom-team").unwrap_err();
+        let err = run_new_t4(&paths, "do a thing", "custom-team").unwrap_err();
         let msg = format!("{err:#}");
         assert!(
             !msg.contains("unknown team"),
@@ -2017,8 +2266,8 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        run_new(&paths, "demo one", "dev").unwrap();
-        run_new(&paths, "demo two", "dev").unwrap();
+        run_new_t4(&paths, "demo one", "dev").unwrap();
+        run_new_t4(&paths, "demo two", "dev").unwrap();
 
         let body = run_ls(&paths, OutputFormat::Json).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
@@ -2077,7 +2326,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo", "dev").unwrap();
+        let slug = run_new_t4(&paths, "demo", "dev").unwrap();
         let body = run_show(&paths, &slug, OutputFormat::Json).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
         assert_eq!(v["state"]["slug"], slug);
@@ -2097,7 +2346,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo", "dev").unwrap();
+        let slug = run_new_t4(&paths, "demo", "dev").unwrap();
         // simulate an escalated state
         let state_path = paths.project_state(&slug);
         let mut state = ProjectState::load(&state_path).unwrap();
@@ -2124,7 +2373,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo", "dev").unwrap();
+        let slug = run_new_t4(&paths, "demo", "dev").unwrap();
 
         let state_path = paths.project_state(&slug);
         let mut state = ProjectState::load(&state_path).unwrap();
@@ -2154,7 +2403,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo", "dev").unwrap();
+        let slug = run_new_t4(&paths, "demo", "dev").unwrap();
 
         let state_path = paths.project_state(&slug);
         let mut state = ProjectState::load(&state_path).unwrap();
@@ -2219,7 +2468,7 @@ mod tests {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
-        let slug = run_new(&paths, "demo", "dev").unwrap();
+        let slug = run_new_t4(&paths, "demo", "dev").unwrap();
         progress::append_event(
             &paths.progress_jsonl(&slug),
             &json!({"event": "session_start", "ts": "2026-05-05T00:00:00Z"}),
@@ -2465,7 +2714,7 @@ mod tests {
         let paths = fresh_paths(&tmp);
         assert!(!paths.root.join("teams").exists(), "precondition: empty global dir");
 
-        let slug = run_new(&paths, "Verify product-research bootstraps", "product-research")
+        let slug = run_new_t4(&paths, "Verify product-research bootstraps", "product-research")
             .expect("run_new must auto-seed shipped templates before validation");
         assert!(slug.starts_with("product-research-"));
         // The seed must have landed during run_new.
@@ -2840,5 +3089,130 @@ mod tests {
         assert_eq!(alerts.len(), 1);
         assert_eq!(alerts[0]["kind"], "daemon_down");
         assert!(parsed["config"].is_object());
+    }
+
+    // -------------- V0.2.2 F34 — slug --slug flag + sanitize ---------------
+
+    #[test]
+    fn run_new_with_explicit_slug_uses_verbatim_path() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let slug = run_new(
+            &paths,
+            "literally anything goes here",
+            "dev",
+            RunNewOptions {
+                slug: Some("ccteam-ui"),
+                no_auto_slug: true,
+                auto_slug_model: "claude-haiku-4-5-20251001",
+            },
+        )
+        .unwrap();
+        assert_eq!(slug, "dev-ccteam-ui");
+        assert!(paths.project_dir(&slug).join(".ccteam/spec.md").exists());
+    }
+
+    #[test]
+    fn run_new_with_explicit_slug_keeps_team_prefix_when_present() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let slug = run_new(
+            &paths,
+            "irrelevant brief",
+            "dev",
+            RunNewOptions {
+                slug: Some("dev-explicit-name"),
+                no_auto_slug: true,
+                auto_slug_model: "claude-haiku-4-5-20251001",
+            },
+        )
+        .unwrap();
+        assert_eq!(slug, "dev-explicit-name");
+    }
+
+    #[test]
+    fn run_new_with_explicit_illegal_slug_fails_loud() {
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let err = run_new(
+            &paths,
+            "irrelevant",
+            "dev",
+            RunNewOptions {
+                slug: Some("Bad Slug!"),
+                no_auto_slug: true,
+                auto_slug_model: "claude-haiku-4-5-20251001",
+            },
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("[a-z0-9-]+"),
+            "expected fail-loud regex hint, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn sanitize_smart_slug_accepts_clean_kebab() {
+        assert_eq!(
+            sanitize_smart_slug("hermestrade-dex\n"),
+            Some("hermestrade-dex".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_smart_slug_strips_quotes_and_label_prefix() {
+        assert_eq!(
+            sanitize_smart_slug("\"todo-cli\""),
+            Some("todo-cli".to_string())
+        );
+        assert_eq!(
+            sanitize_smart_slug("Slug: ai-recipe-generator"),
+            Some("ai-recipe-generator".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_smart_slug_takes_first_non_empty_line() {
+        let raw = "\n\nthe-slug\nignored explanation line\n";
+        assert_eq!(sanitize_smart_slug(raw), Some("the-slug".to_string()));
+    }
+
+    #[test]
+    fn sanitize_smart_slug_lowercases_and_drops_disallowed_chars() {
+        // Letters lowered, exclamation stripped → `hello-world`
+        assert_eq!(
+            sanitize_smart_slug("Hello-World!"),
+            Some("hello-world".to_string())
+        );
+    }
+
+    #[test]
+    fn sanitize_smart_slug_rejects_too_short_or_too_long() {
+        assert_eq!(sanitize_smart_slug("a"), None);
+        assert_eq!(sanitize_smart_slug(&"x".repeat(61)), None);
+        // Boundary: exactly 60 is fine.
+        assert_eq!(
+            sanitize_smart_slug(&"x".repeat(60)),
+            Some("x".repeat(60))
+        );
+    }
+
+    #[test]
+    fn sanitize_smart_slug_rejects_empty_or_dash_only() {
+        assert_eq!(sanitize_smart_slug(""), None);
+        assert_eq!(sanitize_smart_slug("---"), None);
+    }
+
+    #[test]
+    fn render_smart_slug_prompt_embeds_brief_and_examples() {
+        let p = render_smart_slug_prompt("Build HermesTrade DEX home");
+        assert!(p.contains("Build HermesTrade DEX home"));
+        // The example anchors keep the prompt stable for tests + audits.
+        assert!(p.contains("HermesTrade DEX prediction market"));
+        assert!(p.contains("Slug:"));
     }
 }

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -79,6 +79,26 @@ enum Command {
         /// teams (research, design, ...) land in M3.4.
         #[arg(long, default_value = "dev")]
         team: String,
+        /// V0.2.2 F34 Tier 1 — explicit slug override. When set, skips
+        /// the Tier 3 `claude -p` smart-suggest and Tier 4 deterministic
+        /// fallback. Validated `[a-z0-9-]+`, len ≤ 60. B2 prefix
+        /// semantics: if the value already starts with `<team>-` it's
+        /// kept verbatim, otherwise `<team>-` is prepended automatically
+        /// (PRD §3.2.1).
+        #[arg(long, value_name = "NAME")]
+        slug: Option<String>,
+        /// V0.2.2 F34 Tier 3 — when set, skip the `claude -p` smart-
+        /// suggest path and fall back directly to the deterministic
+        /// `slugify_brief()` Tier 4. Useful in scripts / CI where you
+        /// don't want the per-invocation LLM round trip.
+        #[arg(long, default_value_t = false)]
+        no_auto_slug: bool,
+        /// V0.2.2 F34 Tier 3 — model name passed to `claude -p` for
+        /// the smart-suggest fallback. Default `claude-haiku-4-5-20251001`
+        /// (cheapest + fastest viable). Override with eg
+        /// `claude-sonnet-4-5-20251001` for harder briefs.
+        #[arg(long, value_name = "MODEL", default_value = "claude-haiku-4-5-20251001")]
+        auto_slug_model: String,
     },
     /// List all known projects.
     Ls {
@@ -329,7 +349,14 @@ fn main() -> Result<()> {
             skip_tool_check,
             claude_argv,
         } => run_start(tick_seconds, skip_tool_check, claude_argv),
-        Command::New { request, file, team } => run_new(request, file, team),
+        Command::New {
+            request,
+            file,
+            team,
+            slug,
+            no_auto_slug,
+            auto_slug_model,
+        } => run_new(request, file, team, slug, no_auto_slug, auto_slug_model),
         Command::Ls { format } => run_ls(format),
         Command::Show { slug, format } => run_show(&slug, format),
         Command::Attach { slug } => commands::run_attach(&slug),
@@ -612,7 +639,14 @@ fn run_start(
     result
 }
 
-fn run_new(request: Option<String>, file: Option<PathBuf>, team: String) -> Result<()> {
+fn run_new(
+    request: Option<String>,
+    file: Option<PathBuf>,
+    team: String,
+    slug: Option<String>,
+    no_auto_slug: bool,
+    auto_slug_model: String,
+) -> Result<()> {
     let paths = CcteamPaths::from_env()?;
     let body = match (file, request) {
         (Some(path), _) => std::fs::read_to_string(&path)
@@ -622,7 +656,12 @@ fn run_new(request: Option<String>, file: Option<PathBuf>, team: String) -> Resu
             anyhow::bail!("cct new: provide a request as a positional arg or --file PATH")
         }
     };
-    let slug = commands::run_new(&paths, body.trim(), &team)?;
+    let opts = commands::RunNewOptions {
+        slug: slug.as_deref(),
+        no_auto_slug,
+        auto_slug_model: &auto_slug_model,
+    };
+    let slug = commands::run_new(&paths, body.trim(), &team, opts)?;
     println!("created project {slug} (team: {team})");
     println!("  spec   : {}", paths.project_ccteam_dir(&slug).join("spec.md").display());
     println!("  state  : {}", paths.project_state(&slug).display());

--- a/crates/ccteam-cli/tests/run_new_slug_flag_test.rs
+++ b/crates/ccteam-cli/tests/run_new_slug_flag_test.rs
@@ -1,0 +1,221 @@
+//! V0.2.2 F34 — CLI surface for the new slug-decision flags. Lives in
+//! integration tests rather than the lib-internal mod so env-mutating
+//! tests (`CCTEAM_AUTO_SLUG{,_BIN}` / `CCTEAM_HOME` / `HOME`) don't
+//! race other tests in the same process.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn cct_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_cct")
+}
+
+#[test]
+fn cct_new_help_advertises_slug_flags() {
+    let out = Command::new(cct_bin())
+        .args(["new", "--help"])
+        .output()
+        .expect("spawn cct new --help");
+    assert!(out.status.success(), "cct new --help should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--slug", "--no-auto-slug", "--auto-slug-model"] {
+        assert!(
+            stdout.contains(flag),
+            "cct new --help should advertise {flag}; got:\n{stdout}",
+        );
+    }
+}
+
+#[test]
+fn cct_new_with_explicit_slug_creates_project_dir() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let projects_root = tmp.path().join("projects");
+    let global = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&projects_root).unwrap();
+    std::fs::create_dir_all(&global).unwrap();
+
+    let out = Command::new(cct_bin())
+        .args([
+            "new",
+            "--slug",
+            "ccteam-ui",
+            "--team",
+            "dev",
+            "--no-auto-slug",
+            "Build the ccteam ui shell",
+        ])
+        .env("HOME", tmp.path())
+        .env("CCTEAM_HOME", &global)
+        .env("CCTEAM_PROJECTS_ROOT", &projects_root)
+        // Belt-and-suspenders: the unit-side env knob also forces Tier 4.
+        .env("CCTEAM_AUTO_SLUG", "off")
+        .output()
+        .expect("spawn cct new");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "cct new should succeed; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stdout.contains("dev-ccteam-ui"),
+        "expected slug `dev-ccteam-ui` in stdout; got:\n{stdout}",
+    );
+    let project: PathBuf = projects_root.join("dev-ccteam-ui");
+    assert!(
+        project.join(".ccteam/spec.md").is_file(),
+        "spec.md must exist under {}",
+        project.display(),
+    );
+}
+
+#[test]
+fn cct_new_rejects_explicit_slug_with_illegal_chars() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let projects_root = tmp.path().join("projects");
+    let global = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&projects_root).unwrap();
+    std::fs::create_dir_all(&global).unwrap();
+
+    let out = Command::new(cct_bin())
+        .args([
+            "new",
+            "--slug",
+            "Bad Slug!",
+            "--team",
+            "dev",
+            "--no-auto-slug",
+            "irrelevant brief",
+        ])
+        .env("HOME", tmp.path())
+        .env("CCTEAM_HOME", &global)
+        .env("CCTEAM_PROJECTS_ROOT", &projects_root)
+        .env("CCTEAM_AUTO_SLUG", "off")
+        .output()
+        .expect("spawn cct new");
+
+    assert!(!out.status.success(), "illegal slug must fail-loud");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("[a-z0-9-]+"),
+        "fail-loud should hint at the legal regex; got:\n{stderr}",
+    );
+}
+
+#[test]
+fn cct_new_tier3_reads_from_stub_claude_bin() {
+    // Stub `claude -p` shell-out: a tiny shell script that ignores
+    // its args, drains stdin, and prints a fixed slug. Verifies that
+    // Tier 3 wires through `CCTEAM_AUTO_SLUG_BIN`, sanitizes stdout,
+    // and (because stdin is the test harness's piped null, not a tty)
+    // auto-accepts the suggestion.
+    if cfg!(windows) {
+        // Plain `sh` stub won't run on Windows; skip rather than ifdef
+        // a parallel `.bat` script for one test.
+        return;
+    }
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let projects_root = tmp.path().join("projects");
+    let global = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&projects_root).unwrap();
+    std::fs::create_dir_all(&global).unwrap();
+
+    let stub = tmp.path().join("claude-stub.sh");
+    std::fs::write(
+        &stub,
+        b"#!/usr/bin/env sh\ncat > /dev/null\nprintf '%s\\n' 'tier3-stub-slug'\n",
+    )
+    .expect("write stub");
+    let mut perms = std::fs::metadata(&stub).unwrap().permissions();
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&stub, perms).expect("chmod stub");
+
+    let out = Command::new(cct_bin())
+        .args([
+            "new",
+            "--team",
+            "dev",
+            "--auto-slug-model",
+            "claude-haiku-4-5-20251001",
+            "Build a tier-3 stub project",
+        ])
+        .env("HOME", tmp.path())
+        .env("CCTEAM_HOME", &global)
+        .env("CCTEAM_PROJECTS_ROOT", &projects_root)
+        .env("CCTEAM_AUTO_SLUG_BIN", &stub)
+        // CCTEAM_AUTO_SLUG is unset so Tier 3 is allowed to fire.
+        .env_remove("CCTEAM_AUTO_SLUG")
+        .output()
+        .expect("spawn cct new");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "cct new with stub claude should succeed; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stdout.contains("dev-tier3-stub-slug"),
+        "expected stubbed slug in output; got:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        projects_root.join("dev-tier3-stub-slug/.ccteam/spec.md").is_file(),
+        "spec.md must exist under projects_root for the stubbed slug",
+    );
+}
+
+#[test]
+fn cct_new_tier3_falls_back_to_tier4_when_stub_returns_garbage() {
+    if cfg!(windows) {
+        return;
+    }
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let projects_root = tmp.path().join("projects");
+    let global = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&projects_root).unwrap();
+    std::fs::create_dir_all(&global).unwrap();
+
+    let stub = tmp.path().join("claude-garbage.sh");
+    // Empty stdout → sanitizer rejects → Tier 4 fallback.
+    std::fs::write(
+        &stub,
+        b"#!/usr/bin/env sh\ncat > /dev/null\nprintf ''\n",
+    )
+    .expect("write stub");
+    let mut perms = std::fs::metadata(&stub).unwrap().permissions();
+    use std::os::unix::fs::PermissionsExt;
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&stub, perms).expect("chmod stub");
+
+    let out = Command::new(cct_bin())
+        .args([
+            "new",
+            "--team",
+            "dev",
+            "--auto-slug-model",
+            "claude-haiku-4-5-20251001",
+            "Build the fallback widget",
+        ])
+        .env("HOME", tmp.path())
+        .env("CCTEAM_HOME", &global)
+        .env("CCTEAM_PROJECTS_ROOT", &projects_root)
+        .env("CCTEAM_AUTO_SLUG_BIN", &stub)
+        .env_remove("CCTEAM_AUTO_SLUG")
+        .output()
+        .expect("spawn cct new");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "Tier 4 fallback path must succeed even when stub LLM returns garbage",
+    );
+    // `slugify_brief("Build the fallback widget")` → tokens
+    // `[build, fallback, widget]` (stop-word `the` dropped) → exactly
+    // three tokens, joined.
+    assert!(
+        stdout.contains("dev-build-fallback-widget"),
+        "expected Tier 4 deterministic slug; got:\n{stdout}",
+    );
+}

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -48,10 +48,11 @@ pub use memory_bridge::{
     InstallMemoryBridgeOptions, MemoryBridgeAction, MemoryBridgeReport,
 };
 pub use skill::{
-    install_cct_control_skill, install_cct_team_author_skill,
-    install_into as install_skill_into, install_skill_body_into,
-    InstallSkillOptions, InstallSkillReport, SkillInstallAction,
-    CCT_CONTROL_SKILL_NAME, CCT_TEAM_AUTHOR_SKILL_NAME, LEGACY_SKILL_NAMES,
+    install_cct_control_skill, install_cct_project_creator_skill,
+    install_cct_team_author_skill, install_into as install_skill_into,
+    install_skill_body_into, InstallSkillOptions, InstallSkillReport, SkillInstallAction,
+    CCT_CONTROL_SKILL_NAME, CCT_PROJECT_CREATOR_SKILL_NAME, CCT_TEAM_AUTHOR_SKILL_NAME,
+    LEGACY_SKILL_NAMES,
 };
 pub use orchestrator::MAX_CONCURRENT_PROJECTS;
 pub use orchestrator::{
@@ -59,7 +60,10 @@ pub use orchestrator::{
     decide_tick_from_events, intersect_open_decisions_with_required_inputs, Orchestrator,
     OrchestratorConfig, TeamRuntime, TickAction, DEFAULT_CLAUDE_MODEL,
 };
-pub use projects::{bootstrap_project, pick_unused_slug, pre_trust_project, slugify};
+pub use projects::{
+    bootstrap_project, pick_unused_slug, pick_unused_slug_verbatim, pre_trust_project,
+    slugify, slugify_brief,
+};
 pub use cost::{classify as classify_cost, CostLevel, COST_MID_WARN_USD};
 pub use daemon::{
     check_health as check_daemon_health, check_health_at as check_daemon_health_at,

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -64,6 +64,71 @@ pub fn random_suffix() -> String {
     format!("{:04x}", nanos & 0xFFFF)
 }
 
+/// V0.2.2 F34 Tier 4: token-aware deterministic slug generator. Used
+/// when the meta-agent / `claude -p` tier is unavailable (no LLM,
+/// `--no-auto-slug`, env `CCTEAM_AUTO_SLUG=off`). Improves over
+/// `slugify()`'s 40-char char-level cap by:
+///
+/// 1. Reusing `slugify` for character normalization (`[a-z0-9]` +
+///    `-` collapsing).
+/// 2. Splitting on `-` into tokens; filtering out:
+///    - English stop words (`a`/`an`/`the`/`of`/`to`/`for`/`with`/
+///      `that`/`and`/`or`/`in`/`on`/`at`/`is`/`are`).
+///    - Pure-digit tokens (`v2` / `2k` are kept because they contain
+///      letters; `2` / `42` are dropped).
+///    - Tokens shorter than 2 chars.
+/// 3. De-duplicating consecutive repeats (`ccteam ccteam ui` →
+///    `ccteam ui`).
+/// 4. Taking the first 3 surviving tokens, joined by `-`.
+/// 5. If everything was filtered, falling back to the raw `slugify()`
+///    output so the caller never gets an empty slug.
+///
+/// **`slugify()` is not modified** — it still backs the meta-agent
+/// `<handle>-meta` path where the input is already a short user
+/// handle that should be used verbatim.
+pub fn slugify_brief(input: &str) -> String {
+    const STOP_WORDS: &[&str] = &[
+        "a", "an", "the", "of", "to", "for", "with", "that", "and", "or", "in", "on",
+        "at", "is", "are",
+    ];
+    const MAX_TOKENS: usize = 3;
+
+    let normalized = slugify(input);
+    if normalized == "project" {
+        // The char-level path already gave up; nothing for the
+        // token filter to do.
+        return normalized;
+    }
+
+    let mut kept: Vec<&str> = Vec::new();
+    for token in normalized.split('-') {
+        if token.len() < 2 {
+            continue;
+        }
+        if STOP_WORDS.contains(&token) {
+            continue;
+        }
+        if token.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        if kept.last().is_some_and(|prev| *prev == token) {
+            continue;
+        }
+        kept.push(token);
+        if kept.len() >= MAX_TOKENS {
+            break;
+        }
+    }
+
+    if kept.is_empty() {
+        // Everything got filtered (e.g. brief "to of and"). Fall
+        // back to the raw normalized slug so the caller still gets
+        // something usable rather than `project`.
+        return normalized;
+    }
+    kept.join("-")
+}
+
 /// Pick an unused slug under `paths.projects_root`, prefixed with the
 /// project's team name so `~/.claude/rules/ccteam-lessons-<team>.md`
 /// `paths:` frontmatter (`~/projects/<team>-*`) actually matches the
@@ -71,6 +136,13 @@ pub fn random_suffix() -> String {
 ///
 /// Tries `<team>-<base>` first, then `<team>-<base>-<suffix>` with up
 /// to 16 retries on collision.
+///
+/// V0.2.2 F34: the `base` argument is a free-text request — it gets
+/// run through `slugify_brief` (token-aware) so `<team>-<base>` stays
+/// readable. Callers that already have a deliberate slug (eg
+/// `--slug ccteam-ui`) should use [`pick_unused_slug_verbatim`] which
+/// skips token filtering and only enforces team prefix + collision
+/// retry.
 ///
 /// Meta-agent projects don't go through this function — they use
 /// `meta_slug(handle)` which hand-crafts `<handle>-meta` (suffix
@@ -80,10 +152,70 @@ pub fn pick_unused_slug(
     base: &str,
     team: &str,
 ) -> Result<String> {
-    let base = slugify(base);
+    let base = slugify_brief(base);
+    pick_unused_under_team_prefix(paths, &base, team)
+}
+
+/// V0.2.2 F34 Tier 1: pick an unused slug from a deliberate user-
+/// chosen base. Skips token filtering (the user has already named
+/// the project) and only does:
+///
+/// - Validate `[a-z0-9-]+`, length ≤ 60, no leading / trailing dash.
+/// - B2 prefix semantics: if `slug` already starts with `<team>-`
+///   keep it verbatim; otherwise prepend `<team>-`.
+/// - Collision retry via `-{4hex}` suffix (same as `pick_unused_slug`).
+pub fn pick_unused_slug_verbatim(
+    paths: &CcteamPaths,
+    slug: &str,
+    team: &str,
+) -> Result<String> {
+    let trimmed = slug.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("slug must be non-empty"));
+    }
+    if trimmed.len() > 60 {
+        return Err(anyhow!(
+            "slug too long ({} chars > 60); use a shorter name",
+            trimmed.len()
+        ));
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(anyhow!(
+            "slug must match [a-z0-9-]+; got {trimmed:?}",
+        ));
+    }
+    if trimmed.starts_with('-') || trimmed.ends_with('-') {
+        return Err(anyhow!(
+            "slug must not start or end with `-`; got {trimmed:?}",
+        ));
+    }
+    let team_prefix = format!("{team}-");
+    let prefixed = if trimmed.starts_with(&team_prefix) || trimmed == team {
+        trimmed.to_string()
+    } else {
+        format!("{team_prefix}{trimmed}")
+    };
+    pick_unused_with_prefixed(paths, &prefixed)
+}
+
+/// Internal helper: takes an already-prefixed slug, returns the same
+/// or a `-{4hex}` retry on collision. Shared between the verbatim
+/// (`--slug`) and brief-derived paths.
+fn pick_unused_under_team_prefix(
+    paths: &CcteamPaths,
+    base: &str,
+    team: &str,
+) -> Result<String> {
     let prefixed = format!("{team}-{base}");
-    if !paths.project_dir(&prefixed).exists() {
-        return Ok(prefixed);
+    pick_unused_with_prefixed(paths, &prefixed)
+}
+
+fn pick_unused_with_prefixed(paths: &CcteamPaths, prefixed: &str) -> Result<String> {
+    if !paths.project_dir(prefixed).exists() {
+        return Ok(prefixed.to_string());
     }
     for _ in 0..16 {
         let candidate = format!("{prefixed}-{}", random_suffix());
@@ -588,7 +720,9 @@ mod tests {
         let paths = pick_paths(&tmp);
         let dev = pick_unused_slug(&paths, "make a todo cli", "dev").unwrap();
         let pr = pick_unused_slug(&paths, "AI recipe generator", "product-research").unwrap();
-        assert_eq!(dev, "dev-make-a-todo-cli");
+        // V0.2.2 F34: `slugify_brief` drops stop-words (`a`) so the
+        // brief-derived base is `make-todo-cli`, not `make-a-todo-cli`.
+        assert_eq!(dev, "dev-make-todo-cli");
         assert_eq!(pr, "product-research-ai-recipe-generator");
     }
 
@@ -614,6 +748,142 @@ mod tests {
         assert_eq!(dev, "dev-shared-brief");
         assert_eq!(pr, "product-research-shared-brief");
         assert_ne!(dev, pr);
+    }
+
+    // --- V0.2.2 F34 — slugify_brief() Tier 4 deterministic ---
+
+    #[test]
+    fn slugify_brief_drops_pure_digit_tokens_and_keeps_mixed() {
+        // PRD §3.2.4 case 1:
+        // `ccteam ui — V1.2 session subagent 3` → tokens
+        // [ccteam, ui, v1, 2, session, subagent, 3] →
+        // drop `2`/`3` (pure digit), keep `v1` (letter+digit) →
+        // first 3 → `ccteam-ui-v1`.
+        assert_eq!(
+            slugify_brief("ccteam ui — V1.2 session subagent 3"),
+            "ccteam-ui-v1"
+        );
+    }
+
+    #[test]
+    fn slugify_brief_drops_stop_words() {
+        // `Build a tiny Python CLI that converts CSV to JSON` →
+        // tokens drop `a`/`that`/`to` → first 3 = build, tiny, python.
+        assert_eq!(
+            slugify_brief("Build a tiny Python CLI that converts CSV to JSON"),
+            "build-tiny-python"
+        );
+    }
+
+    #[test]
+    fn slugify_brief_keeps_brand_and_caps_at_three_tokens() {
+        assert_eq!(
+            slugify_brief("AI recipe generator from fridge photo"),
+            "ai-recipe-generator"
+        );
+        assert_eq!(slugify_brief("HermesTrade DEX home"), "hermestrade-dex-home");
+    }
+
+    #[test]
+    fn slugify_brief_handles_short_briefs_unchanged() {
+        // Three real tokens, nothing to filter.
+        assert_eq!(slugify_brief("Predict market + DEX"), "predict-market-dex");
+    }
+
+    #[test]
+    fn slugify_brief_falls_back_when_all_filtered() {
+        // Only stop-words → fall back to raw `slugify` so the caller
+        // never gets `project` from a degenerate filter pass.
+        assert_eq!(slugify_brief("to of and"), "to-of-and");
+    }
+
+    #[test]
+    fn slugify_brief_dedups_consecutive_repeats() {
+        // `ccteam ccteam ui` → token list `[ccteam, ccteam, ui]` →
+        // dedup last → `[ccteam, ui]` → joined = `ccteam-ui`.
+        assert_eq!(slugify_brief("ccteam ccteam ui"), "ccteam-ui");
+    }
+
+    #[test]
+    fn slugify_brief_drops_stop_word_do() {
+        // `do the thing` → drop `the` (stop) → `[do, thing]`.
+        // `do` is len 2 + not in stop list → kept.
+        assert_eq!(slugify_brief("do the thing"), "do-thing");
+    }
+
+    #[test]
+    fn slugify_brief_falls_back_to_project_for_empty_input() {
+        assert_eq!(slugify_brief(""), "project");
+        assert_eq!(slugify_brief("中文"), "project");
+    }
+
+    // --- V0.2.2 F34 — pick_unused_slug_verbatim (--slug flag path) ---
+
+    #[test]
+    fn verbatim_prefixes_team_when_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let s = pick_unused_slug_verbatim(&paths, "ccteam-ui", "dev").unwrap();
+        assert_eq!(s, "dev-ccteam-ui");
+    }
+
+    #[test]
+    fn verbatim_keeps_team_prefix_when_already_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let s = pick_unused_slug_verbatim(&paths, "dev-ccteam-ui", "dev").unwrap();
+        assert_eq!(s, "dev-ccteam-ui");
+    }
+
+    #[test]
+    fn verbatim_does_not_match_partial_prefix() {
+        // `dev` ≠ `product-research`, so `--slug product-research-foo
+        // --team dev` must prepend `dev-` even though the slug starts
+        // with the substring `product`. (PRD §3.2.1 row 4.)
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let s = pick_unused_slug_verbatim(&paths, "product-research-foo", "dev").unwrap();
+        assert_eq!(s, "dev-product-research-foo");
+    }
+
+    #[test]
+    fn verbatim_rejects_illegal_chars() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let err = pick_unused_slug_verbatim(&paths, "Bad Name!", "dev").unwrap_err();
+        assert!(
+            err.to_string().contains("[a-z0-9-]+"),
+            "expected fail-loud regex hint, got {err}",
+        );
+    }
+
+    #[test]
+    fn verbatim_rejects_empty_and_dash_edges() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        assert!(pick_unused_slug_verbatim(&paths, "", "dev").is_err());
+        assert!(pick_unused_slug_verbatim(&paths, "   ", "dev").is_err());
+        assert!(pick_unused_slug_verbatim(&paths, "-leading", "dev").is_err());
+        assert!(pick_unused_slug_verbatim(&paths, "trailing-", "dev").is_err());
+    }
+
+    #[test]
+    fn verbatim_rejects_too_long() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        let long = "a".repeat(61);
+        let err = pick_unused_slug_verbatim(&paths, &long, "dev").unwrap_err();
+        assert!(err.to_string().contains("too long"));
+    }
+
+    #[test]
+    fn verbatim_collision_retries_with_suffix() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = pick_paths(&tmp);
+        std::fs::create_dir_all(paths.project_dir("dev-x")).unwrap();
+        let s = pick_unused_slug_verbatim(&paths, "x", "dev").unwrap();
+        assert!(s.starts_with("dev-x-"), "expected suffix retry, got {s}");
+        assert_ne!(s, "dev-x");
     }
 
     #[test]

--- a/crates/ccteam-core/src/skill.rs
+++ b/crates/ccteam-core/src/skill.rs
@@ -31,6 +31,13 @@ pub const CCT_CONTROL_SKILL_NAME: &str = "cct-control";
 /// V0.2.2 F39: renamed from `ccteam-team-author`.
 pub const CCT_TEAM_AUTHOR_SKILL_NAME: &str = "cct-team-author";
 
+/// V0.2.2 F34 — `cct-project-creator` skill name. Walks the
+/// meta-agent through the four-phase project-creation dialogue
+/// (clarify brief → recommend slug → pick team → dispatch via
+/// `cct new`). Replaces the inline `meta_agent_role.md` §2 dispatch
+/// flow with a structured AskUserQuestion-driven UX.
+pub const CCT_PROJECT_CREATOR_SKILL_NAME: &str = "cct-project-creator";
+
 /// V0.2.2 F39: legacy V0.1/V0.2 skill directory names that
 /// `cct doctor` migrates. Exposed so the migration helper can scan
 /// for stale installs without re-declaring the names.
@@ -50,6 +57,12 @@ pub const CCT_CONTROL_SKILL_MD: &str = include_str!(concat!(
 pub const CCT_TEAM_AUTHOR_SKILL_MD: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../skills/cct-team-author/SKILL.md"
+));
+
+/// Embedded `SKILL.md` body for the project-creator skill (V0.2.2 F34).
+pub const CCT_PROJECT_CREATOR_SKILL_MD: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../skills/cct-project-creator/SKILL.md"
 ));
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -92,6 +105,23 @@ pub fn install_cct_team_author_skill(
         &claude,
         CCT_TEAM_AUTHOR_SKILL_NAME,
         CCT_TEAM_AUTHOR_SKILL_MD,
+        opts,
+    )
+}
+
+/// V0.2.2 F34: install the `cct-project-creator` skill into
+/// `~/.claude/skills/cct-project-creator/SKILL.md`. Same idempotent
+/// semantics as `install_cct_control_skill`. Carries the four-phase
+/// project-creation dialogue the meta-agent now invokes instead of
+/// inlining dispatch logic in `meta_agent_role.md` §2.
+pub fn install_cct_project_creator_skill(
+    opts: InstallSkillOptions,
+) -> Result<InstallSkillReport> {
+    let claude = user_claude_dir().context("resolve ~/.claude/")?;
+    install_skill_body_into(
+        &claude,
+        CCT_PROJECT_CREATOR_SKILL_NAME,
+        CCT_PROJECT_CREATOR_SKILL_MD,
         opts,
     )
 }
@@ -247,6 +277,62 @@ mod tests {
             tmp.path(),
             CCT_TEAM_AUTHOR_SKILL_NAME,
             CCT_TEAM_AUTHOR_SKILL_MD,
+            InstallSkillOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(r2.action, SkillInstallAction::AlreadyPresent);
+    }
+
+    // -------------- V0.2.2 F34 project-creator skill --------------
+
+    #[test]
+    fn project_creator_skill_installs_with_marker_and_phases() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let report = install_skill_body_into(
+            tmp.path(),
+            CCT_PROJECT_CREATOR_SKILL_NAME,
+            CCT_PROJECT_CREATOR_SKILL_MD,
+            InstallSkillOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(report.action, SkillInstallAction::Wrote);
+        let body = std::fs::read_to_string(&report.target).unwrap();
+        assert!(
+            body.contains("<!-- ccteam-managed:skill begin -->"),
+            "must carry the ccteam-managed begin marker (F39 migration prerequisite)",
+        );
+        assert!(
+            body.contains("<!-- ccteam-managed:skill end -->"),
+            "must carry the ccteam-managed end marker",
+        );
+        assert!(body.contains("name: cct-project-creator"));
+        // The four-phase dialogue is the body's main contract; if any
+        // disappears, the meta-agent silently loses behavior.
+        for phase in [
+            "Phase A — Clarify",
+            "Phase B — Recommend",
+            "Phase C — Pick a team",
+            "Phase D — Dispatch",
+        ] {
+            assert!(body.contains(phase), "missing phase: {phase}");
+        }
+        assert!(body.contains("AskUserQuestion"));
+    }
+
+    #[test]
+    fn project_creator_skill_install_is_idempotent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        install_skill_body_into(
+            tmp.path(),
+            CCT_PROJECT_CREATOR_SKILL_NAME,
+            CCT_PROJECT_CREATOR_SKILL_MD,
+            InstallSkillOptions::default(),
+        )
+        .unwrap();
+        let r2 = install_skill_body_into(
+            tmp.path(),
+            CCT_PROJECT_CREATOR_SKILL_NAME,
+            CCT_PROJECT_CREATOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -20,58 +20,43 @@
 
 ### 第 1 步:这是问答还是项目请求?
 
-- **问答** —— 例:"ccteam 的 Seed Gate 是什么意思?"/"我的 todo-cli 项目跑到哪了?"
+- **问答** —— **边界很窄**:用户在问一个**事实** / **定义** / **状态**
+  - 例:"ccteam 的 Seed Gate 是什么意思?" / "Multica 的 GitHub 地址是什么?" / "我的 todo-cli 项目跑到哪了?"
   - 直接回答。可以用 `Bash` 调 `cct ls --format json` / `cct show <slug> --format json` 拿数据
-  - 不要派单
-- **项目请求** —— 例:"做一个 todo cli"/"帮我写个书签管理器"
-  - 进入第 2 步
+  - **绝不**自己起 `Agent(subagent_type=...)` 做调研、检索、分析 —— **那不是问答,那是项目请求**
+- **项目请求** —— 任何"做 / 写 / 调研 / 分析 / 评估 / 看看 X 值不值得"
+  - 例:"做一个 todo cli" / "帮我写个书签管理器" / "调研 Multica" / "看看这个 idea 能不能做" / "X 项目市场怎么样"
+  - **不要直接干** —— 进入第 2 步走 `cct-project-creator` skill 派单
+- **边界不清**:用户措辞模棱两可("X 项目怎么样?"既可能是事实询问也可能是产研请求)
+  - **问一句**:"是要我快速答你一个事实问题,还是走 product-research 团队正式产研?"
+  - 不要默默选一边
 
-### 第 2 步:团队选择
+### 第 2 步:走 `cct-project-creator` skill 派单
 
-M3 起 ccteam 支持 **dev** 与 **product-research** 两支团队。先判断用户的请求形态:
+确认是项目请求后,**走 `cct-project-creator` skill**(已自动装好,在
+`~/.claude/skills/cct-project-creator/`)。该 skill 会引导你跑完整流程:
+
+1. **Phase A —— 需求澄清**:brief 单词级时用 `AskUserQuestion` 问一个最关键的澄清(只一个,不连珠炮)
+2. **Phase B —— slug 推荐**:基于 brief 算 2-4 token kebab-case slug,用 `AskUserQuestion` 给用户三选一(推荐 / 我来定 / 再来一个)
+3. **Phase C —— team 选择**:按下面"团队启发"决策默认推断;不确定时 `AskUserQuestion` 二选一
+4. **Phase D —— 派单**:`cct new --slug <slug> --team <team> "<refined brief>"`,然后在 outbox 写 `event_kind: reply` 告诉用户
+
+skill body 里详细约束 + 反例你都能直接读;遇到 mode 1 ad-hoc("先别建项目,直接帮我写一段")**不要**走 skill,直接对话回应即可。
+
+**团队启发**(skill Phase C 用):
 
 | 用户语气 | 派给哪支 | 启发信号 |
 |---|---|---|
 | "做个 X / 帮我写 X / 来个 X" + brief 看起来 actionable | **dev** | 用户已经决定要做,需要的是构建 |
 | "我想做个 Y,但不确定要不要做 / 听起来值不值 / 应不应该做" | **product-research** | 用户在判断 idea 是否值得做 |
 | "调研下 Z 的市场 / 这个想法有人做过吗 / 这个值得做吗" | **product-research** | 价值判断而非构建 |
-| 用户**说要做**但 brief 极薄(单词级,如"做个 todo")| 看下面"边界"节决定 | 拍板还是先调研? |
+| 用户**说要做**但 brief 极薄(单词级,如"做个 todo")| skill Phase A 先澄清,再走 Phase C | 拍板还是先调研? |
 
 **默认偏向**:不确定时优先派 `product-research`——产研代价低(几小时),可以否决坏 idea;直接派 dev 才是真烧钱。但**不要**对每条 brief 都自动 product-research,那样对明显可建的需求是浪费。
 
-**边界**:用户对话里出现"先帮我看看"/"想了解一下"/"靠谱吗"——明显是探索 → product-research;出现"赶紧做一版"/"先跑起来再说" → dev,brief 不全在 plan-eng phase 内反向面试。
-
-不确定时**问一句**:"这是要立刻开发,还是先做产品调研判断要不要做?"——meta-agent 的克制规则允许问一句话。
-
 未来 M5+ 会扩展 marketing / ops 等团队;扩展后本节会自动重写,不必担心。
 
-### 第 3 步:pre-flight CLARIFY(必要时)
-
-如果用户的 brief 缺关键信息(web 还是 cli?目标语言?要不要 PWA?),**问一个**最关键的澄清问题。**只问一个**——一次问太多用户会嫌烦。
-
-边界:
-- 你只问 **brief 完整性**(技术形态、必备特性、约束)
-- **dev 路径**:不替 plan-eng 提前判可行性 / 价值
-- **product-research 路径**:不替 verdict phase 提前判 idea 值不值——那是该团队 6 phase 的活
-- 用户回答后回到第 4 步
-
-### 第 4 步:派单
-
-通过 `Bash` 调 cct-control skill 文档里的命令——按第 2 步选定的团队:
-
-```bash
-# dev 路径
-cct new --team=dev "用户最终确认的 brief"
-
-# product-research 路径(产研判断 idea 值不值得做)
-cct new --team=product-research "用户最终确认的 brief"
-```
-
-派完之后,在 outbox 写一条 `event_kind: reply` 告诉用户:
-- 项目 slug + 派的团队
-- 预计第一个里程碑:dev 是 plan-eng(~30 分钟);product-research 是 kickoff 反向面试(可能立即问问题)
-- 后续怎么跟踪(`cct show <slug>` / `cct attach <slug>`)
-- product-research 路径:**告知用户预期产物**——verdict.md 给出 PASS/CONCERN/REJECT/CLARIFY 判断,以及 next-steps.md 提示是否派 dev 团队
+派单后**不支持改名**(state.json / `~/.claude/rules/` paths / tmux session 名都要重命名,V0.3 评估)。一次派对最重要。
 
 ## 3. 克制规则(dispatcher not worker)
 
@@ -80,21 +65,26 @@ cct new --team=product-research "用户最终确认的 brief"
 - ❌ **不要**自己 `Edit` / `Write` 用户的项目代码
 - ❌ **不要**自己 `Bash` 跑 `git clone` / `npm init` / `cargo new` 起项目骨架
 - ❌ **不要**自己写完一份代码再"派给 ccteam"——那等于绕开整套 phase pipeline
-- ✅ 识别项目级请求时,**默认走 `cct new` 派单**,让对应团队 session 干活
+- ❌ **不要**自己起 `Agent(subagent_type=general-purpose)` / 调用 web 搜索工具做调研、市场分析、技术对比 —— 这是 product-research 团队的活,绕过 = 失去 6 phase pipeline + verdict 结构化判断 + 可审计调研记录
+- ✅ 识别项目级请求时,**默认走 `cct-project-creator` skill 派单**,让对应团队 session 干活
+- ✅ "调研 X" / "评估 X 值不值得" → 走 skill,skill 调 `cct new --team=product-research --slug=<name> "<brief>"`
 - ✅ 只有用户**明确说"你直接帮我写 X"**(例:"先别建项目,你直接写一段 yaml 给我看")时才走 worker 路径——这种情况下你做完直接回答即可,不进 ccteam pipeline
 
 为什么?ccteam 的全套机制(progress.jsonl / phase 边界 / cost 累计 / context reset / Seed Gate / Critic)只在项目 session 里生效。你绕开它 = 失去这一切保障 = 退回到普通 claude 的体验。
 
 ## 4. 派单工具(M1 用 Bash;M2.8+ 切 ccteam-mcp MCP)
 
-M1 阶段用 `Bash` 工具调 ccteam CLI(经 cct-control skill 启发):
+**派单走 `cct-project-creator` skill**(§2 已定),它内部用 `Bash` 调
+`cct new --slug <slug> --team <team> "<brief>"`。下面是 raw CLI 入口
+(skill 内部用,你也能在不需要 skill 流程时直接调,例:用户已给齐
+slug + team + brief):
 
 ```bash
-# 立项 —— dev 路径
-cct new --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
+# 立项 —— dev 路径(skill 内部 / 用户已给齐参数)
+cct new --slug todo-cli --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
 
 # 立项 —— product-research 路径(产研判断 idea 值不值得做)
-cct new --team=product-research "AI 菜谱生成器,拍冰箱照片自动写菜谱"
+cct new --slug ai-recipe-generator --team=product-research "AI 菜谱生成器,拍冰箱照片自动写菜谱"
 
 # 看一项目
 cct show <slug> --format json | jq
@@ -105,6 +95,12 @@ cct ls --format json | jq
 # 看一项目实时输出
 cct progress <slug> --tail   # 流式;通常你不需要,因为关键事件会经 inbox 推到你这
 ```
+
+`--slug` 显式给定时跳过自动 slug 生成(Tier 1 PRD §3.2.1);不传 `--slug`
+时 `cct new` 在 tty 上下文会 shell-out `claude -p haiku` 智能推一个
++ Y/n 确认(Tier 3),非 tty 自动接受;`--no-auto-slug` / 环境变量
+`CCTEAM_AUTO_SLUG=off` 强制走 deterministic Tier 4。skill 流程里
+**默认显式传 `--slug`**(用户在 Phase B 已确认),不再走 Tier 3。
 
 M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具——比 shell parse 更鲁棒。届时本文件会被自动重写,你不必担心兼容。
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1200,9 +1200,25 @@ cct mcp-serve                       # M2+:作为 ccteam-mcp 跑 stdio MCP 协议
 
 ```bash
 cct new "需求文本"
-cct new -f spec.md                  # 从文件提
-cct new --mode yolo "需求"          # 覆盖默认 trust_mode
+cct new -f spec.md                            # 从文件提
+cct new --mode yolo "需求"                    # 覆盖默认 trust_mode
+
+# V0.2.2 F34 — slug 决策四层:
+cct new --slug ccteam-ui --team dev "..."     # Tier 1:显式 slug(B2 前缀语义);
+                                              #   `dev-ccteam-ui` 或 verbatim
+cct new --no-auto-slug "..."                  # Tier 4:跳过 LLM 智能 fallback,
+                                              #   走 deterministic `slugify_brief`
+cct new --auto-slug-model claude-sonnet-4-5-20251001 "..."
+                                              # Tier 3:override 默认 haiku
+                                              #   (env CCTEAM_AUTO_SLUG=off 全局禁)
 ```
+
+**slug 决定优先级**(PRD `docs/v0-2-2/prd.md` §3.2):
+
+1. **Tier 1**:`--slug` 显式(零延迟,确定;B2 prefix — 已带 team prefix verbatim)
+2. **Tier 2**:meta-agent 派单工作流的 `cct-project-creator` skill 推荐 + 用户确认(零额外 LLM call)
+3. **Tier 3**:`cct new` 不带 `--slug` 时 shell-out `claude -p haiku`(2-5s,~$0.0001)+ Y/n,非 tty auto-accept
+4. **Tier 4**:LLM 不可用 / `--no-auto-slug` / env `CCTEAM_AUTO_SLUG=off` → `slugify_brief()` deterministic 兜底
 
 ### 10.3 查询状态
 

--- a/skills/cct-project-creator/SKILL.md
+++ b/skills/cct-project-creator/SKILL.md
@@ -1,0 +1,169 @@
+<!-- ccteam-managed:skill begin -->
+---
+name: cct-project-creator
+description: |
+  When the user wants to create a new ccteam project — walk a four-phase
+  dialogue: clarify the brief, recommend a slug, pick a team, and dispatch
+  via `cct new`. Use when the user says "新项目" / "建一个 X" / "做个 X" /
+  "做一个 X" / "调研 X" / "评估 X 值不值" / "看看 X 能不能做". Primary
+  consumer is the ccteam meta-agent session; the skill assumes
+  `AskUserQuestion` is available (which is true inside the meta-agent
+  context — the V0.2 PreToolUse intercept runs in project sessions only,
+  not the meta-agent).
+allowed-tools: [Bash, AskUserQuestion]
+---
+
+# cct-project-creator
+
+You are a **project-creation dialogue guide**, not a worker. After this
+skill finishes, you call `cct new --slug <slug> --team <team>
+"<refined brief>"` to dispatch the project to a fresh ccteam session.
+**You do not write code, do not scaffold, do not run `git init` /
+`cargo new` — the dispatched session does all of that.**
+
+## Boundary check before you start
+
+- This skill runs **only inside the ccteam meta-agent session**. Project
+  sessions cannot reach it (their PreToolUse hook denies
+  `AskUserQuestion`, V0.2 §2.4).
+- If the user is asking a **fact / definition / status** question, do not
+  invoke this skill. Drop back to plain Q&A. (See `meta_agent_role.md`
+  §1: "调研 X" is a project request, but "X 是什么意思?" is a fact.)
+- If you already have a deliberate `--slug` from the user (eg they said
+  "用 hermestrade-home 这个名字"), skip Phase B and use it verbatim.
+
+## Phase A — Clarify the brief
+
+Read the user's original brief. **Information density check** — does the
+brief carry ≥ 2 sentences with a clear technical form / goal / constraint?
+
+- **Yes** → skip Phase A, jump to Phase B.
+- **No, single-token brief** (eg "做个 todo") → ask **one** clarifying
+  question with `AskUserQuestion` and typical options + an "Other" slot:
+
+  ```
+  AskUserQuestion({
+    question: "项目什么形态?",
+    options: [
+      { label: "Web 应用", description: "浏览器跑,带前端" },
+      { label: "CLI 工具", description: "命令行,纯文本" },
+      { label: "移动端", description: "iOS / Android" },
+      { label: "其他", description: "我下面会描述" },
+    ]
+  })
+  ```
+
+**Only ask one question.** Do not fire a second clarifier — the
+dispatched team's first phase (`plan-eng` / `kickoff`) will handle deeper
+requirements gathering. Your job is to surface enough signal to pick the
+right team + name the project.
+
+## Phase B — Recommend a slug + confirm
+
+Compose a recommended slug from the brief + Phase A answer:
+
+**Rules**:
+- **Prefer brand / proper nouns** the user mentioned ("HermesTrade DEX"
+  → `hermestrade-dex`).
+- **No verb-leading**: use `todo-cli`, not `build-todo-cli`.
+- **2-4 tokens, kebab-case, `[a-z0-9-]+`, ≤ 60 chars.**
+- **Do not include the team prefix** — `cct new` adds it automatically
+  (B2 prefix semantics, PRD §3.2.1).
+
+Confirm with `AskUserQuestion`:
+
+```
+AskUserQuestion({
+  question: "项目 slug 用什么?",
+  options: [
+    { label: "<recommended-slug>",
+      description: "基于 brief 的 <核心词>;推荐用这个" },
+    { label: "我来定",
+      description: "选这个我下面问你想用什么 slug" },
+    { label: "再来一个",
+      description: "换一个角度重算" },
+  ]
+})
+```
+
+- User picks the recommended slug → Phase C.
+- User picks "我来定" → ask plain NL: "你想用什么 slug?(eg
+  `hermestrade-home`)"; validate `[a-z0-9-]+` and length ≤ 60; if it
+  fails, surface the error and re-ask.
+- User picks "再来一个" → re-derive a different slug from a different
+  angle (eg drop the action verb, take the user-mentioned brand,
+  combine domain + form factor) and re-ask once. After a second decline,
+  fall through to "我来定".
+
+## Phase C — Pick a team
+
+Apply the `meta_agent_role.md` §2 decision tree:
+
+| User says | Recommend |
+|---|---|
+| "做个 X / 帮我写 X / 来个 X" + brief is actionable | `dev` |
+| "我想做 Y 但不确定 / 值不值 / 该不该" | `product-research` |
+| "调研 Z / 这个想法有人做过吗 / 这个值得做吗" | `product-research` |
+
+If the recommendation is unambiguous, propose it directly with one
+`AskUserQuestion` for confirmation. If it's borderline:
+
+```
+AskUserQuestion({
+  question: "派给哪支团队?",
+  options: [
+    { label: "dev",
+      description: "立即开发(plan-eng → implement → … → ship)" },
+    { label: "product-research",
+      description: "先调研判断 idea 值不值得做(verdict + next-steps)" },
+  ]
+})
+```
+
+Default toward `product-research` when in doubt — research is cheap, dev
+is expensive. But do not auto-research every brief; obvious build asks
+should go straight to dev.
+
+## Phase D — Dispatch + notify
+
+Run the CLI:
+
+```bash
+cct new --slug <slug> --team <team> "<refined brief>"
+```
+
+Use the brief from Phase A (incorporating the user's clarification) as
+the request body. The slug is whatever Phase B settled on; `--slug`
+makes `cct new` skip the Tier 3 `claude -p` smart-suggestion path.
+
+After dispatch, write an outbox `event_kind: reply` (per
+`meta_agent_role.md` §8) telling the user:
+
+- The project slug (`<team>-<slug>`) and the team it landed on.
+- The first milestone they should expect:
+  - **dev** → `plan-eng` runs first, ~30 min, may surface clarify
+    questions you'll see in the decisions queue.
+  - **product-research** → `kickoff` runs first and may immediately
+    reverse-interview before doing any research.
+- Follow-up commands: `cct show <slug>` for state, `cct attach <slug>`
+  for live tmux.
+
+Do **not** announce the dispatch before `cct new` returns successfully —
+if the CLI errors out (eg unknown team), surface the error to the user
+and re-run Phase C with the corrected team.
+
+## Hard limits — what this skill never does
+
+- ❌ Never edits or writes user code (that's the dispatched session's
+  job).
+- ❌ Never runs `git clone`, `cargo new`, `npm init` itself.
+- ❌ Never dispatches more than one project per invocation.
+- ❌ Never asks the user > 1 clarifying question per phase.
+- ❌ Never bypasses `cct new` — even if the user says "just do it" the
+  ccteam pipeline is the only path that gets progress / cost / context
+  / Seed Gate / Critic guarantees.
+
+If the user explicitly says "先别建项目,直接帮我写一段代码" (mode 1 ad-hoc),
+do **not** invoke this skill. Drop back to plain conversation; the
+meta-agent role prompt §3 covers that exception.
+<!-- ccteam-managed:skill end -->


### PR DESCRIPTION
## Closes

- **F34** (`docs/v0-2-2/prd.md` §3) — slug naming control
- **F37** (`docs/v0-2-2/prd.md` §6) — meta-agent decision tree hardening

Both findings touch `meta_agent_role.md` so they ride a single PR per dev-plan §3.

## Changes

### F34 — four-tier slug stack

- **Tier 1** `cct new --slug <name>` flag + B2 prefix semantics (verbatim if already prefixed with `<team>-`, otherwise prepend). New `pick_unused_slug_verbatim` keeps the user's slug intact; existing `pick_unused_slug` brief path is unchanged for callers that don't pass `--slug`.
- **Tier 2** `skills/cct-project-creator/SKILL.md` ships the four-phase meta-agent dialogue (clarify brief → recommend slug → pick team → dispatch). Uses `AskUserQuestion` for structured choices.
- **Tier 3** `cct new` without `--slug` shells out to `claude -p haiku` (15s timeout, sanitize stdout to `[a-z0-9-]+` len 2..=60, Y/n confirm in tty / auto-accept when piped). `--no-auto-slug` flag + env `CCTEAM_AUTO_SLUG=off` disable; test seam `CCTEAM_AUTO_SLUG_BIN` lets integration tests stub the binary.
- **Tier 4** new `slugify_brief()` is token-aware (stop-word filter, pure-digit drop, dedup, top-3 tokens, fallback). Legacy char-level `slugify()` is **unchanged** — meta-agent's `<handle>-meta` path still uses it verbatim.

### F37 — meta-agent decision tree

- `meta_agent_role.md` §1 narrows 问答 to `事实 / 定义 / 状态` only; adds explicit "调研 X / 评估 X" → project request examples + the "绝不自起 Agent 做调研" anti-pattern.
- §2 replaces the inline dispatch flow with "走 `cct-project-creator` skill"; team-selection heuristics stay as background context for the skill's Phase C.
- §3 (克制规则) adds the explicit ❌ for self-spawned `Agent(subagent_type=general-purpose)` / web-search research, and the matching ✅ "调研 X → `cct new --team=product-research`".

### Docs

- `interfaces.md` §10.2 lists the new slug flags + four-tier order.
- `cct doctor --install-skill` now installs **three** skills (`cct-control`, `cct-team-author`, `cct-project-creator`); F39 migration logic unchanged.

## Tests

- **524 → 556** (`cargo test --workspace`, all green)
- New: 8× `slugify_brief` (PRD §3.2.4 table), 7× `pick_unused_slug_verbatim`, 7× sanitize/prompt, 3× `run_new` Tier 1, 2× project-creator skill install, 5× CLI integration (`cct new --help`, explicit slug, illegal fail-loud, Tier 3 stub bin, Tier 3 garbage→Tier 4 fallback).
- Clippy: no new warnings (9 baseline, 9 after).

## Test plan

- [ ] `cargo test --workspace` is green
- [ ] `cargo clippy --workspace --all-targets` no new warnings
- [ ] `cct new --slug ccteam-ui --team dev "..."` → creates `~/projects/dev-ccteam-ui/`
- [ ] `cct new --slug "Bad Name!" --team dev "..."` fails loud (regex hint)
- [ ] `cct new --slug dev-x --team dev "..."` keeps verbatim
- [ ] `cct new "..."` without flags + claude on PATH + tty: shows suggestion + Y/n
- [ ] `cct new --no-auto-slug "..."` skips Tier 3, uses `slugify_brief`
- [ ] `cct doctor --install-skill` writes three SKILL.md files under `~/.claude/skills/cct-{control,team-author,project-creator}/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)