### PR TITLE
v0.2.2 PR #4: F36 send-keys subagent guard

### DIFF
--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod inbox;
 pub mod meta_agent;
 pub mod orchestrator;
 pub mod memory_bridge;
+pub mod pending_inject;
 pub mod skill;
 pub mod paths;
 pub mod phases;
@@ -59,8 +60,9 @@ pub use skill::{
 pub use orchestrator::MAX_CONCURRENT_PROJECTS;
 pub use orchestrator::{
     append_progress_summary, build_progress_summary, check_phase_tools, decide_tick,
-    decide_tick_from_events, intersect_open_decisions_with_required_inputs, Orchestrator,
-    OrchestratorConfig, TeamRuntime, TickAction, DEFAULT_CLAUDE_MODEL,
+    decide_tick_from_events, intersect_open_decisions_with_required_inputs,
+    DrainPendingOutcome, Orchestrator, OrchestratorConfig, TeamRuntime, TickAction,
+    DEFAULT_CLAUDE_MODEL,
 };
 pub use projects::{
     bootstrap_project, pick_unused_slug, pick_unused_slug_verbatim, pre_trust_project,
@@ -72,6 +74,11 @@ pub use daemon::{
     heartbeat_path, pidfile_path, read_pidfile, remove_heartbeat, remove_pidfile,
     send_sigterm_to_pidfile, write_heartbeat, write_pidfile, DaemonHealth, HEARTBEAT_GRACE,
     HEARTBEAT_INTERVAL, HEARTBEAT_NAME, PIDFILE_NAME,
+};
+pub use pending_inject::{
+    delete as delete_pending_inject, load as load_pending_inject,
+    pending_inject_path_in, save as save_pending_inject, PendingInject,
+    DEFAULT_MAX_DEFER_MINUTES, PENDING_INJECT_FILE,
 };
 pub use silence_classifier::{
     classify as classify_silence, load_retry_count as load_limbo_retry_count,

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -33,6 +33,7 @@ use crate::inbox::{InboxMessage, SessionMailbox};
 // V0.2 §6.4 candidate 5 — evergreen-team behavior dispatches off
 // `TeamSpec::evergreen` / `cost_policy` flags instead.
 use crate::paths::CcteamPaths;
+use crate::pending_inject::{self, PendingInject, DEFAULT_MAX_DEFER_MINUTES};
 use crate::phases::{PhaseTemplate, SubSkillTrigger};
 use crate::progress;
 use crate::silence_classifier::{
@@ -63,6 +64,33 @@ pub struct TeamRuntime {
 /// meta-agent session is **not counted** — it's a permanent fixture in
 /// the User Interaction Layer.
 pub const MAX_CONCURRENT_PROJECTS: usize = 3;
+
+/// V0.2.2 F36: outcome of a single
+/// `Orchestrator::drain_pending_inject_inner` call. Production code
+/// only inspects `Drained` / `TimedOut` for log lines; tests assert
+/// the full enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DrainPendingOutcome {
+    /// No pending-inject record on disk for this slug.
+    None,
+    /// Sub-agent is still active and the budget has not been exhausted.
+    /// Try again on the next tick.
+    StillBlocked,
+    /// Pending record is older than `max_defer_minutes` — surfaced an
+    /// enriched escalate (`ccteam_classification: "inject_defer_timeout"`)
+    /// and deleted the record.
+    TimedOut,
+    /// Sub-agent has stopped and the dispatch path sent keys; pending
+    /// record removed.
+    Drained,
+    /// Sub-agent has stopped but the dispatch re-deferred (sub-agent
+    /// re-armed between the drain check and the dispatch's own check).
+    /// The fresh pending record is left on disk for the next tick.
+    Deferred,
+    /// `dispatch_phase_with_state` itself errored (e.g. tmux session
+    /// missing). Pending record left on disk for retry.
+    DispatchFailed,
+}
 
 /// Pure decision function: given the current `state` and the last
 /// progress.jsonl event, what should the orchestrator do next?
@@ -475,6 +503,16 @@ impl Orchestrator {
     /// Same as `dispatch_phase` but the caller passes the already-loaded
     /// `ProjectState`. Used inside `process_project` to avoid a redundant
     /// reload (and so meta-agent paths can pass their bespoke state).
+    ///
+    /// **V0.2.2 F36 send-keys subagent guard**: when
+    /// `progress::subagent_active` returns true, this method writes a
+    /// `<project>/.ccteam/pending-inject.json` record and returns
+    /// `Ok(())` **without** sending keys or appending a `phase_inject`
+    /// event. The orchestrator daemon tick later drains the record on
+    /// the next `SubagentStop` (or surfaces an enriched escalate after
+    /// `max_defer_minutes`). Evergreen / meta-agent projects bypass
+    /// the guard — `process_meta_project` does not call this path
+    /// today, but the early-return makes the contract explicit.
     pub fn dispatch_phase_with_state(
         &self,
         slug: &str,
@@ -487,6 +525,39 @@ impl Orchestrator {
 
         let attachments = self.attachments_for_next_phase(slug, state);
         let attachment_refs: Vec<&str> = attachments.iter().map(String::as_str).collect();
+
+        // V0.2.2 F36: defer when a sub-agent is in flight. Send-keys to
+        // the main agent's input buffer in that window gets re-routed
+        // into the sub-agent's context (Claude Code 2.x behavior,
+        // E2E 2026-05-08), so we persist the inject for the daemon
+        // drain instead. Evergreen sessions skip the guard entirely —
+        // their dispatch path doesn't route through here, but we keep
+        // the check so any future caller stays safe.
+        if !self.is_evergreen(&state.team) {
+            let recent = progress::read_all_events(&progress_path)?;
+            if progress::subagent_active(&recent) {
+                let pending = PendingInject::new(
+                    slug,
+                    phase,
+                    attachments,
+                    Utc::now(),
+                    DEFAULT_MAX_DEFER_MINUTES,
+                );
+                let pending_path = self.paths.project_pending_inject(slug);
+                pending_inject::save(&pending_path, &pending).with_context(|| {
+                    format!(
+                        "save pending-inject for slug={slug} phase={phase}",
+                    )
+                })?;
+                tracing::info!(
+                    slug,
+                    phase,
+                    max_defer_minutes = DEFAULT_MAX_DEFER_MINUTES,
+                    "F36 subagent active; deferring phase inject until SubagentStop",
+                );
+                return Ok(());
+            }
+        }
         // V0.2 M0.18: prefer the template-aware inject builder when the
         // team / phase is registered. Falls back to the legacy name-only
         // shape only when the team or template is missing (e.g. an
@@ -1443,6 +1514,20 @@ impl Orchestrator {
 
         for (slug, state) in projects {
             self.warn_if_stalled(&slug, &state, now);
+            // V0.2.2 F36: drain `pending-inject.json` before the F35
+            // silence classifier runs so a successfully-drained inject
+            // (which appends a fresh `phase_inject` event) doesn't get
+            // re-classified as `InjectLimbo`. Evergreen projects skip:
+            // they don't go through the F36 send-keys guard.
+            if !self.is_evergreen(&state.team) {
+                if let Err(err) = self.drain_pending_inject(&slug, &state, now) {
+                    tracing::warn!(
+                        slug,
+                        error = format!("{err:#}"),
+                        "F36 pending-inject drain failed; continuing",
+                    );
+                }
+            }
             // V0.2.2 F35: event-aware silence classifier. Runs in the
             // same loop as `warn_if_stalled` so evergreen projects are
             // already filtered upstream — meta-agent silence semantics
@@ -1702,6 +1787,224 @@ impl Orchestrator {
         self.classify_and_act_on_silence(slug, state, now)
     }
 
+    /// Test surface for the F36 daemon-tick drain. `poll_tick` calls
+    /// `drain_pending_inject` directly with `now = Utc::now()`; tests
+    /// pin a controlled `now` so timeout cases are deterministic.
+    pub fn drain_pending_inject_for_test(
+        &self,
+        slug: &str,
+        state: &ProjectState,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<DrainPendingOutcome> {
+        self.drain_pending_inject_inner(slug, state, now)
+    }
+
+    fn drain_pending_inject(
+        &self,
+        slug: &str,
+        state: &ProjectState,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<()> {
+        // The public surface returns the outcome; `poll_tick` doesn't
+        // need it (logging happens inline) so we discard.
+        let _ = self.drain_pending_inject_inner(slug, state, now)?;
+        Ok(())
+    }
+
+    /// V0.2.2 F36 daemon-tick drain.
+    ///
+    /// - No pending file → `DrainPendingOutcome::None`.
+    /// - Pending file + sub-agent still active + budget remaining →
+    ///   `DrainPendingOutcome::StillBlocked`.
+    /// - Pending file + budget exhausted → enriched outbox with
+    ///   `ccteam_classification: "inject_defer_timeout"`, file deleted
+    ///   → `DrainPendingOutcome::TimedOut`.
+    /// - Pending file + sub-agent idle → real
+    ///   `dispatch_phase_with_state` call, file deleted →
+    ///   `DrainPendingOutcome::Drained`. If the dispatch itself defers
+    ///   again (sub-agent restarted between read and write), the
+    ///   pending record is rewritten by the dispatch path; we surface
+    ///   `Deferred` to make that visible to tests.
+    fn drain_pending_inject_inner(
+        &self,
+        slug: &str,
+        state: &ProjectState,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<DrainPendingOutcome> {
+        // Belt-and-suspenders: caller filters evergreen, but refactors
+        // shouldn't accidentally drain a meta-agent's pending record.
+        if self.is_evergreen(&state.team) {
+            return Ok(DrainPendingOutcome::None);
+        }
+        let pending_path = self.paths.project_pending_inject(slug);
+        let Some(pending) = pending_inject::load(&pending_path)? else {
+            return Ok(DrainPendingOutcome::None);
+        };
+
+        // Timeout takes priority over the active-subagent check —
+        // even if a sub-agent is still in flight, after `max_defer_minutes`
+        // we fail loud rather than wait forever.
+        if pending.is_expired(now) {
+            let progress_path = self.paths.progress_jsonl(slug);
+            let last_event = progress::last_event(&progress_path).unwrap_or(None);
+            let silent = stall::silent_seconds(state, now);
+            self.write_inject_defer_timeout_outbox(
+                slug,
+                state,
+                &pending,
+                silent,
+                last_event.as_ref(),
+            )?;
+            // Best-effort delete; if it fails the next tick will retry
+            // the timeout path which is idempotent against a missing
+            // outbox.
+            if let Err(err) = pending_inject::delete(&pending_path) {
+                tracing::warn!(
+                    slug,
+                    error = %err,
+                    "F36 timeout: failed to delete pending-inject; will retry next tick",
+                );
+            }
+            tracing::warn!(
+                slug,
+                phase = %pending.phase,
+                max_defer_minutes = pending.max_defer_minutes,
+                "F36 pending-inject timed out; surfaced as inject_defer_timeout escalate",
+            );
+            return Ok(DrainPendingOutcome::TimedOut);
+        }
+
+        let progress_path = self.paths.progress_jsonl(slug);
+        let events = progress::read_all_events(&progress_path)?;
+        if progress::subagent_active(&events) {
+            return Ok(DrainPendingOutcome::StillBlocked);
+        }
+
+        // Sub-agent has stopped and we're inside the budget — real
+        // dispatch. Use the original phase recorded at defer time so a
+        // late state change doesn't surprise us.
+        match self.dispatch_phase_with_state(slug, &pending.phase, state) {
+            Ok(()) => {
+                // Decide if `dispatch_phase_with_state` actually sent
+                // keys or re-deferred. The race window is real: a
+                // sub-agent could emit `PreToolUse(Task)` between our
+                // `subagent_active` check and the dispatch path's own
+                // check. Either way, the pending file on disk is now
+                // up to date — if the dispatch deferred, it overwrote
+                // our record with a fresh `enqueued_at`; if it sent,
+                // the path is gone (its own write was succeeded by
+                // our delete below, or it didn't write at all). We
+                // reconcile by reading the file back.
+                let after = pending_inject::load(&pending_path)?;
+                if let Some(after) = after {
+                    if after.enqueued_at > pending.enqueued_at {
+                        // Re-deferred — leave the new record on disk
+                        // untouched.
+                        return Ok(DrainPendingOutcome::Deferred);
+                    }
+                    // File still bears our record (dispatch sent keys
+                    // without re-deferring — the normal success path).
+                    // Fall through to delete to maintain the
+                    // invariant "drain on real dispatch ⇒ no pending
+                    // file".
+                }
+                if let Err(err) = pending_inject::delete(&pending_path) {
+                    tracing::warn!(
+                        slug,
+                        error = %err,
+                        "F36 drain: failed to delete pending-inject after dispatch",
+                    );
+                }
+                tracing::info!(
+                    slug,
+                    phase = %pending.phase,
+                    "F36 pending-inject drained; phase prompt sent",
+                );
+                Ok(DrainPendingOutcome::Drained)
+            }
+            Err(err) => {
+                // Dispatch failure (e.g. tmux session missing) — leave
+                // the pending record on disk so the next tick retries.
+                // No counter to bump; the timeout path is the only
+                // give-up route.
+                tracing::warn!(
+                    slug,
+                    phase = %pending.phase,
+                    error = %err,
+                    "F36 drain: dispatch_phase_with_state failed; record left for retry",
+                );
+                Ok(DrainPendingOutcome::DispatchFailed)
+            }
+        }
+    }
+
+    /// Write the F36 `inject_defer_timeout` enriched outbox payload.
+    ///
+    /// Re-uses the F35 schema (same `schema_version`, `event_kind`,
+    /// `ccteam_classification`, `ccteam_silent_seconds`,
+    /// `ccteam_last_event`, `ccteam_pane_tail`, and `body` fields) so
+    /// the watchdog / meta-agent surface treats both classifications
+    /// uniformly.
+    fn write_inject_defer_timeout_outbox(
+        &self,
+        slug: &str,
+        state: &ProjectState,
+        pending: &PendingInject,
+        silent_seconds: u64,
+        last_event: Option<&Value>,
+    ) -> Result<()> {
+        let project_dir = self.paths.project_dir(slug);
+        let cc = project_dir.join(".ccteam");
+        std::fs::create_dir_all(&cc)
+            .with_context(|| format!("create {}", cc.display()))?;
+        let outbox_path = cc.join("needs_attention.outbox.json");
+
+        let pane = capture_pane_tail(slug, 30, false).unwrap_or_default();
+        let last_event_summary = last_event.map(LastEventSummary::from_value);
+        let reason = format!(
+            "F36 pending-inject timeout phase={phase} max_defer_minutes={budget}",
+            phase = pending.phase,
+            budget = pending.max_defer_minutes,
+        );
+        let body = format!(
+            "项目 `{slug}` 的 phase `{phase}` inject 已 defer 超过 {budget} 分钟仍未真发(子 agent 一直未停),需要人工 attach 看看到底卡哪。",
+            slug = slug,
+            phase = pending.phase,
+            budget = pending.max_defer_minutes,
+        );
+
+        let payload = json!({
+            "schema_version": 1,
+            "ts": Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            "slug": slug,
+            "event_kind": "escalation",
+            "priority": "high",
+            "reason": reason,
+            "ccteam_classification": "inject_defer_timeout",
+            "ccteam_silent_seconds": silent_seconds,
+            "ccteam_last_event": last_event_summary,
+            "ccteam_pane_tail": pane,
+            "body": body,
+        });
+
+        let pretty = serde_json::to_string_pretty(&payload)?;
+        let tmp = outbox_path.with_extension("json.tmp");
+        std::fs::write(&tmp, pretty)
+            .with_context(|| format!("write {}", tmp.display()))?;
+        std::fs::rename(&tmp, &outbox_path).with_context(|| {
+            format!("rename {} -> {}", tmp.display(), outbox_path.display())
+        })?;
+        tracing::warn!(
+            slug,
+            phase = %pending.phase,
+            current_phase = %state.current_phase,
+            classification = "inject_defer_timeout",
+            silent_seconds,
+            "F36 inject_defer_timeout outbox written",
+        );
+        Ok(())
+    }
+
     fn classify_and_act_on_silence(
         &self,
         slug: &str,
@@ -1778,6 +2081,26 @@ impl Orchestrator {
         last_event: Option<&Value>,
     ) -> Result<()> {
         let project_dir = self.paths.project_dir(slug);
+        // V0.2.2 F36 × F35 coordination: when a pending-inject record
+        // already exists, the F35 deterministic re-inject would no-op
+        // through the F36 guard (the dispatch path would just rewrite
+        // the pending file again). Burning the retry counter on a
+        // no-op breaks the "fix-loop 撞 3 次顶必 escalate" invariant
+        // (we'd cap before ever attempting a real send). Skip — the
+        // F36 daemon-tick drain owns this case and will either send
+        // on SubagentStop or surface `inject_defer_timeout` after the
+        // budget elapses.
+        let pending_path = self.paths.project_pending_inject(slug);
+        if pending_path.exists() {
+            tracing::info!(
+                slug,
+                phase = %state.current_phase,
+                class = class.discriminant(),
+                silent_seconds,
+                "F35 limbo retry skipped: F36 pending-inject in flight",
+            );
+            return Ok(());
+        }
         let retry_path = silence_classifier::retry_path_in(&project_dir);
         let mut counter =
             silence_classifier::load_retry_count(&retry_path, &state.current_phase)?;

--- a/crates/ccteam-core/src/paths.rs
+++ b/crates/ccteam-core/src/paths.rs
@@ -76,6 +76,14 @@ impl CcteamPaths {
         project_dir.join(".ccteam").join("ready")
     }
 
+    /// `<project>/.ccteam/pending-inject.json` — V0.2.2 F36 deferred
+    /// phase-inject record. See `crate::pending_inject` for shape +
+    /// lifecycle.
+    pub fn project_pending_inject(&self, slug: &str) -> PathBuf {
+        self.project_ccteam_dir(slug)
+            .join(crate::pending_inject::PENDING_INJECT_FILE)
+    }
+
     /// `<project>/.ccteam/screenshots/` — V0.2.2 F38 PNG screenshot
     /// directory. Created lazily by `screenshot::render_screenshot`.
     pub fn project_screenshots_dir(&self, slug: &str) -> PathBuf {

--- a/crates/ccteam-core/src/pending_inject.rs
+++ b/crates/ccteam-core/src/pending_inject.rs
@@ -1,0 +1,243 @@
+//! V0.2.2 F36 — pending phase-inject record.
+//!
+//! When `Orchestrator::dispatch_phase_with_state` detects an active
+//! sub-agent (`progress::subagent_active(events) == true`) it skips the
+//! tmux send-keys and instead persists a [`PendingInject`] to
+//! `<project>/.ccteam/pending-inject.json`. The orchestrator daemon
+//! tick later sees the file, re-checks `subagent_active`, and either:
+//!
+//! - drains it (subagent has stopped) → real `dispatch_phase_with_state`
+//!   call + `delete(path)`,
+//! - or, if the enqueue timestamp is older than `max_defer_minutes`,
+//!   surfaces an enriched `needs_attention.outbox.json` payload with
+//!   `ccteam_classification: "inject_defer_timeout"` and deletes the
+//!   pending record so the project does not loop forever in defer
+//!   limbo.
+//!
+//! **Single-file overwrite, not a queue**: each new defer for the
+//! project replaces the previous record. The orchestrator dispatches
+//! at most one phase prompt at a time per project, so queuing has no
+//! semantics; the latest pending phase always wins.
+//!
+//! **Red lines** (CLAUDE.md §三):
+//!
+//! - Pure file I/O — no LLM, no terminal-output parsing.
+//! - Atomic write (`<file>.json.tmp` + rename) so a crash mid-write
+//!   never leaves a half-written record on disk.
+//! - Caller must skip evergreen / meta-agent projects upstream.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Filename under `<project>/.ccteam/` carrying the deferred phase
+/// inject record.
+pub const PENDING_INJECT_FILE: &str = "pending-inject.json";
+
+/// Default ceiling on how long a phase inject can sit in defer limbo
+/// before the orchestrator gives up and surfaces an enriched escalate
+/// instead. PRD §5.2 — "10 minutes is generous; sub-agent runs ≥10
+/// min are flagged by F35 as `SubagentRunaway` independently".
+pub const DEFAULT_MAX_DEFER_MINUTES: u64 = 10;
+
+/// On-disk shape of `<project>/.ccteam/pending-inject.json`. Schema
+/// versioned so a V0.3 change (e.g. queue semantics) can read V0.2.2
+/// records.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PendingInject {
+    pub schema_version: u32,
+    pub slug: String,
+    pub phase: String,
+    /// `@`-attachment paths the deferred inject should reference once
+    /// drained — kept verbatim so the drain rebuilds the same prompt
+    /// the original dispatch would have produced (sub-skill outputs
+    /// from the prior phase).
+    #[serde(default)]
+    pub attachments: Vec<String>,
+    pub enqueued_at: DateTime<Utc>,
+    pub max_defer_minutes: u64,
+}
+
+impl PendingInject {
+    /// Construct a fresh record stamped with `now`.
+    pub fn new(
+        slug: impl Into<String>,
+        phase: impl Into<String>,
+        attachments: Vec<String>,
+        now: DateTime<Utc>,
+        max_defer_minutes: u64,
+    ) -> Self {
+        Self {
+            schema_version: 1,
+            slug: slug.into(),
+            phase: phase.into(),
+            attachments,
+            enqueued_at: now,
+            max_defer_minutes,
+        }
+    }
+
+    /// `true` once `now - enqueued_at >= max_defer_minutes`. Used by
+    /// the orchestrator drain to switch from "wait for SubagentStop"
+    /// to "fail-loud escalate".
+    pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
+        let budget = Duration::minutes(self.max_defer_minutes as i64);
+        now.signed_duration_since(self.enqueued_at) >= budget
+    }
+}
+
+/// `<project>/.ccteam/pending-inject.json` for a slug-rooted project
+/// directory. Mirrors `paths::project_state_in` shape so tests don't
+/// need a `CcteamPaths` instance.
+pub fn pending_inject_path_in(project_dir: &Path) -> PathBuf {
+    project_dir.join(".ccteam").join(PENDING_INJECT_FILE)
+}
+
+/// Persist `record` atomically to `path`. Single-file overwrite — any
+/// existing pending inject is replaced.
+pub fn save(path: &Path, record: &PendingInject) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create {}", parent.display()))?;
+    }
+    let body = serde_json::to_string_pretty(record)
+        .context("serialize pending-inject record")?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, body).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// `Ok(None)` when the file is absent (the common case). Parse
+/// failures fail-loud so a corrupt record is visible at the next tick
+/// instead of silently swallowing a deferred inject.
+pub fn load(path: &Path) -> Result<Option<PendingInject>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    if body.trim().is_empty() {
+        return Ok(None);
+    }
+    let record: PendingInject = serde_json::from_str(&body)
+        .with_context(|| format!("parse {}", path.display()))?;
+    Ok(Some(record))
+}
+
+/// Best-effort delete — missing file is not an error (the drain path
+/// races the tick: a successful real dispatch leaves the file deleted).
+pub fn delete(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err)
+            .with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use tempfile::TempDir;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).single().unwrap()
+    }
+
+    #[test]
+    fn pending_inject_path_lives_under_dot_ccteam() {
+        let p = pending_inject_path_in(Path::new("/tmp/proj"));
+        assert!(p.ends_with(".ccteam/pending-inject.json"), "got {}", p.display());
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("pending-inject.json");
+        let record = PendingInject::new(
+            "dev-x",
+            "implement",
+            vec![".ccteam/code-review.md".into()],
+            ts(1_700_000_000),
+            10,
+        );
+        save(&path, &record).unwrap();
+        let loaded = load(&path).unwrap().unwrap();
+        assert_eq!(loaded, record);
+    }
+
+    #[test]
+    fn save_overwrites_previous_record() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("pending-inject.json");
+        let first = PendingInject::new("dev-x", "plan-eng", vec![], ts(1), 10);
+        save(&path, &first).unwrap();
+        let second = PendingInject::new("dev-x", "implement", vec![], ts(2), 10);
+        save(&path, &second).unwrap();
+        let loaded = load(&path).unwrap().unwrap();
+        assert_eq!(loaded.phase, "implement");
+        assert_eq!(loaded.enqueued_at, ts(2));
+    }
+
+    #[test]
+    fn load_missing_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nope.json");
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn load_empty_file_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("empty.json");
+        std::fs::write(&path, "").unwrap();
+        assert!(load(&path).unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_removes_file_and_tolerates_missing() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("pending-inject.json");
+        let record = PendingInject::new("dev-x", "x", vec![], ts(1), 10);
+        save(&path, &record).unwrap();
+        assert!(path.exists());
+        delete(&path).unwrap();
+        assert!(!path.exists());
+        // second delete is a no-op
+        delete(&path).unwrap();
+    }
+
+    #[test]
+    fn is_expired_within_budget_is_false() {
+        let enqueued = ts(1_700_000_000);
+        let record = PendingInject::new("dev-x", "x", vec![], enqueued, 10);
+        let still_inside = enqueued + Duration::minutes(9);
+        assert!(!record.is_expired(still_inside));
+    }
+
+    #[test]
+    fn is_expired_at_or_past_budget_is_true() {
+        let enqueued = ts(1_700_000_000);
+        let record = PendingInject::new("dev-x", "x", vec![], enqueued, 10);
+        let at_cap = enqueued + Duration::minutes(10);
+        assert!(record.is_expired(at_cap));
+        let past = enqueued + Duration::minutes(11);
+        assert!(record.is_expired(past));
+    }
+
+    #[test]
+    fn schema_version_is_one_for_fresh_records() {
+        let r = PendingInject::new("dev-x", "x", vec![], ts(0), 10);
+        assert_eq!(r.schema_version, 1);
+    }
+
+    #[test]
+    fn default_max_defer_minutes_constant() {
+        assert_eq!(DEFAULT_MAX_DEFER_MINUTES, 10);
+    }
+}

--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -305,6 +305,50 @@ pub fn build_phase_prompt_with_attachments(phase: &str, attachments: &[&str]) ->
     out
 }
 
+/// V0.2.2 F36: detect whether a sub-agent (`Task` tool) is currently
+/// in flight by walking `events` from the tail and counting how many
+/// `PreToolUse(tool=Task)` openings have not yet been matched by a
+/// `SubagentStop`. Returns `true` when at least one window is open.
+///
+/// **Why count, not last-event-match**: Claude Code can launch a
+/// sub-agent (`Task`), have it spawn an inner Task, and emit two
+/// `PreToolUse(Task)` events in a row before the matching pair of
+/// `SubagentStop` events arrives. A naive "is the most recent event a
+/// `Task` PreToolUse?" check misses the second-from-top case the
+/// moment the inner sub-agent emits its own `PreToolUse`.
+///
+/// **Why scan from the tail**: every `SubagentStop` past the open
+/// window already cancelled an earlier `PreToolUse(Task)` we don't
+/// care about. We stop counting as soon as `open_windows` returns to
+/// zero — older paired sequences can't reach into the current open
+/// state.
+///
+/// Pure deterministic helper; no I/O. Honors the **"`progress.jsonl`
+/// is the only state truth"** red line — F36's send-keys guard reads
+/// progress events, never tmux pane text.
+pub fn subagent_active(events: &[Value]) -> bool {
+    let mut closes_pending: u64 = 0;
+    for event in events.iter().rev() {
+        let kind = event.get("event").and_then(|s| s.as_str()).unwrap_or("");
+        match kind {
+            "SubagentStop" => {
+                closes_pending = closes_pending.saturating_add(1);
+            }
+            "PreToolUse" => {
+                let tool = event.get("tool").and_then(|s| s.as_str()).unwrap_or("");
+                if tool == "Task" {
+                    if closes_pending == 0 {
+                        return true;
+                    }
+                    closes_pending -= 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 /// `/btw <prompt>` when claude is busy so the message queues without
 /// interrupting; bare prompt when idle.
 pub fn idle_aware_message(prompt: &str, idle: bool) -> String {
@@ -578,5 +622,80 @@ mod tests {
             json!({"event": "phase_done", "phase": "plan-eng"}), // stale
         ];
         assert!(latest_terminal_event_for_phase(&events, "implement").is_none());
+    }
+
+    // ---------------- V0.2.2 F36 subagent_active helper ----------------
+
+    fn pretool_task() -> Value {
+        json!({"event": "PreToolUse", "tool": "Task"})
+    }
+    fn pretool_other(tool: &str) -> Value {
+        json!({"event": "PreToolUse", "tool": tool})
+    }
+    fn subagent_stop() -> Value {
+        json!({"event": "SubagentStop"})
+    }
+
+    #[test]
+    fn subagent_active_empty_log_returns_false() {
+        assert!(!subagent_active(&[]));
+    }
+
+    #[test]
+    fn subagent_active_open_window_after_pretool_task() {
+        let events = [
+            json!({"event": "phase_inject", "phase": "implement"}),
+            pretool_task(),
+        ];
+        assert!(subagent_active(&events));
+    }
+
+    #[test]
+    fn subagent_active_paired_pretool_task_and_subagent_stop_returns_false() {
+        let events = [pretool_task(), subagent_stop()];
+        assert!(!subagent_active(&events));
+    }
+
+    #[test]
+    fn subagent_active_nested_task_calls_open_two_windows() {
+        // outer Task launched, inner Task launched, only one SubagentStop
+        // arrived so far → still one open window.
+        let events = [
+            pretool_task(),
+            pretool_task(),
+            subagent_stop(),
+        ];
+        assert!(subagent_active(&events));
+    }
+
+    #[test]
+    fn subagent_active_old_subagent_stop_does_not_close_new_pretool_task() {
+        // Old paired sequence (closed) followed by a fresh PreToolUse(Task)
+        // with no follow-up — the new window must register as active.
+        let events = [
+            pretool_task(),
+            subagent_stop(),
+            json!({"event": "PostToolUse", "tool": "Read"}),
+            pretool_task(),
+        ];
+        assert!(subagent_active(&events));
+    }
+
+    #[test]
+    fn subagent_active_ignores_non_task_pretool() {
+        let events = [pretool_other("Read"), pretool_other("Edit")];
+        assert!(!subagent_active(&events));
+    }
+
+    #[test]
+    fn subagent_active_extra_subagent_stops_do_not_underflow() {
+        // Defensive: stray SubagentStop events with no matching open
+        // window must not panic / wrap around.
+        let events = [
+            subagent_stop(),
+            subagent_stop(),
+            pretool_task(),
+        ];
+        assert!(subagent_active(&events));
     }
 }

--- a/crates/ccteam-core/tests/pending_inject_e2e_test.rs
+++ b/crates/ccteam-core/tests/pending_inject_e2e_test.rs
@@ -1,0 +1,486 @@
+//! V0.2.2 F36 — orchestrator integration tests for the send-keys
+//! sub-agent guard.
+//!
+//! - `dispatch_phase_with_state` writes `pending-inject.json` and skips
+//!   send-keys when a sub-agent is active (no `phase_inject` event).
+//! - Daemon-tick drain on `SubagentStop`: real dispatch + delete.
+//! - Timeout path: pending older than `max_defer_minutes` →
+//!   enriched outbox (`ccteam_classification: "inject_defer_timeout"`)
+//!   + delete.
+//! - Race fallback: F36 misses the open window → F35 `InjectLimbo`
+//!   eventually re-injects (the integration shape of "F36 + F35
+//!   coordination" PRD §5.3 spells out).
+//! - F35 `attempt_limbo_reinject` skips when a F36 pending record is
+//!   in flight (avoids burning the deterministic retry budget on a
+//!   no-op).
+//!
+//! Side-effect-free unit tests live in
+//! `crates/ccteam-core/src/pending_inject.rs::tests` and the
+//! `subagent_active` cases in `progress.rs::tests`.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use ccteam_core::tmux::{tmux_available, TmuxSession};
+use ccteam_core::{
+    limbo_retry_path_in, load_limbo_retry_count, load_pending_inject, pending_inject_path_in,
+    progress, save_pending_inject, write_global_phase_templates, CcteamPaths,
+    DrainPendingOutcome, Orchestrator, OrchestratorConfig, Parallelism, PendingInject,
+    PhaseState, ProjectState,
+};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_slug(test: &str) -> String {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("test-f36-{test}-{pid}-{n}")
+}
+
+struct ScopedSession {
+    session: TmuxSession,
+}
+
+impl ScopedSession {
+    fn for_slug(slug: &str) -> Self {
+        Self {
+            session: TmuxSession::for_slug(slug),
+        }
+    }
+}
+
+impl Drop for ScopedSession {
+    fn drop(&mut self) {
+        let _ = self.session.kill();
+    }
+}
+
+/// Identical fixture pattern as `silence_classifier_e2e_test::fixture`:
+/// real tmux pane (so `dispatch_phase_with_state` can `send-keys`),
+/// `dev` team templates, AutoLocked / `implement` phase. `silent_minutes`
+/// shifts `created_at` / `last_progress_event_at` so silence-derived
+/// classifications fire deterministically.
+fn fixture(
+    test: &str,
+    silent_minutes: i64,
+) -> Option<(TempDir, CcteamPaths, String, ScopedSession)> {
+    if !tmux_available() {
+        eprintln!("[skip] {test}: tmux not on PATH");
+        return None;
+    }
+    let tmp = TempDir::new().unwrap();
+    let paths = CcteamPaths {
+        root: tmp.path().join("home"),
+        projects_root: tmp.path().join("projects"),
+    };
+    let slug = unique_slug(test);
+    let project = paths.project_dir(&slug);
+    std::fs::create_dir_all(&project).unwrap();
+    std::fs::create_dir_all(paths.project_state(&slug).parent().unwrap()).unwrap();
+    write_global_phase_templates(&paths.root, false).unwrap();
+
+    let now = chrono::Utc::now();
+    let stale = now - chrono::Duration::seconds(silent_minutes.saturating_mul(60).max(0));
+    ProjectState {
+        slug: slug.clone(),
+        team: "dev".into(),
+        created_at: stale,
+        tmux_session: TmuxSession::for_slug(&slug).name().to_string(),
+        claude_session_id: None,
+        claude_pid: None,
+        phase_state: PhaseState::AutoLocked,
+        current_phase: "implement".into(),
+        parallelism: Parallelism::Solo,
+        phase_history: Vec::new(),
+        auto_loop_cycle_count: 0,
+        cost_used_usd: 0.0,
+        soft_warn_threshold_usd: 20.0,
+        hard_kill_threshold_usd: 200.0,
+        context_tokens_used: 0,
+        context_reset_threshold_tokens: 600_000,
+        context_reset_count: 0,
+        last_progress_event_at: Some(stale),
+        last_event_type: Some("PreToolUse".into()),
+        last_user_interaction_at: stale,
+        user_attached: false,
+        user_pause_pending: false,
+    }
+    .save(&paths.project_state(&slug))
+    .unwrap();
+
+    let scoped = ScopedSession::for_slug(&slug);
+    scoped.session.start(&project, &["sh", "-i"]).unwrap();
+    std::thread::sleep(Duration::from_millis(200));
+
+    Some((tmp, paths, slug, scoped))
+}
+
+fn write_event(progress_path: &Path, event: &Value) {
+    progress::append_event(progress_path, event).unwrap();
+}
+
+fn count_phase_inject_events(progress_path: &Path) -> usize {
+    progress::read_all_events(progress_path)
+        .unwrap()
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("phase_inject"))
+        .count()
+}
+
+fn build_orchestrator(paths: CcteamPaths) -> Orchestrator {
+    Orchestrator::new(
+        paths,
+        OrchestratorConfig {
+            tick_interval: Duration::from_millis(100),
+            ready_timeout: Duration::from_millis(50),
+            post_ready_warmup: Duration::from_millis(0),
+            claude_argv: vec!["sh".into(), "-i".into()],
+            skip_tool_check: true,
+            subskill_argv: None,
+        },
+    )
+    .unwrap()
+}
+
+fn read_outbox(project_dir: &Path) -> Value {
+    let path = project_dir.join(".ccteam").join("needs_attention.outbox.json");
+    let body = std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("expected outbox at {}", path.display()));
+    serde_json::from_str(&body).unwrap()
+}
+
+#[test]
+fn dispatch_with_active_subagent_writes_pending_inject_and_skips_send_keys() {
+    let Some((_tmp, paths, slug, _scoped)) = fixture("dispatch_defers", 0) else {
+        return;
+    };
+    let progress_path = paths.progress_jsonl(&slug);
+    let project_dir = paths.project_dir(&slug);
+
+    // Sub-agent is in flight: PreToolUse(Task) without a matching
+    // SubagentStop. F36 must defer.
+    write_event(
+        &progress_path,
+        &json!({"ts": chrono::Utc::now().to_rfc3339(), "event": "PreToolUse", "tool": "Task"}),
+    );
+    let phase_injects_before = count_phase_inject_events(&progress_path);
+
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    orch.dispatch_phase_with_state(&slug, "implement", &state).unwrap();
+
+    // No phase_inject event — the dispatch deferred.
+    assert_eq!(
+        count_phase_inject_events(&progress_path),
+        phase_injects_before,
+        "F36 deferred: no phase_inject event must be written",
+    );
+    // Pending record landed on disk with the right phase + budget.
+    let pending_path = pending_inject_path_in(&project_dir);
+    assert!(pending_path.exists(), "pending-inject.json must exist");
+    let pending = load_pending_inject(&pending_path).unwrap().unwrap();
+    assert_eq!(pending.slug, slug);
+    assert_eq!(pending.phase, "implement");
+    assert_eq!(pending.max_defer_minutes, 10);
+}
+
+#[test]
+fn drain_after_subagent_stop_dispatches_and_deletes_pending() {
+    let Some((_tmp, paths, slug, _scoped)) = fixture("drain_after_stop", 0) else {
+        return;
+    };
+    let progress_path = paths.progress_jsonl(&slug);
+    let project_dir = paths.project_dir(&slug);
+    let pending_path = pending_inject_path_in(&project_dir);
+
+    // Step 1: sub-agent active → defer.
+    write_event(
+        &progress_path,
+        &json!({"ts": chrono::Utc::now().to_rfc3339(), "event": "PreToolUse", "tool": "Task"}),
+    );
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    orch.dispatch_phase_with_state(&slug, "implement", &state).unwrap();
+    assert!(pending_path.exists());
+
+    // Step 2: SubagentStop arrives — drain must dispatch (write
+    // phase_inject) + delete pending.
+    let phase_injects_before = count_phase_inject_events(&progress_path);
+    write_event(
+        &progress_path,
+        &json!({"ts": chrono::Utc::now().to_rfc3339(), "event": "SubagentStop"}),
+    );
+    let outcome = orch
+        .drain_pending_inject_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+    assert_eq!(outcome, DrainPendingOutcome::Drained);
+    assert!(
+        !pending_path.exists(),
+        "pending-inject.json must be deleted after a successful drain",
+    );
+    assert_eq!(
+        count_phase_inject_events(&progress_path),
+        phase_injects_before + 1,
+        "drain must write exactly one phase_inject event",
+    );
+}
+
+#[test]
+fn drain_with_subagent_still_active_keeps_pending() {
+    let Some((_tmp, paths, slug, _scoped)) = fixture("drain_still_blocked", 0) else {
+        return;
+    };
+    let progress_path = paths.progress_jsonl(&slug);
+    let project_dir = paths.project_dir(&slug);
+    let pending_path = pending_inject_path_in(&project_dir);
+
+    write_event(
+        &progress_path,
+        &json!({"ts": chrono::Utc::now().to_rfc3339(), "event": "PreToolUse", "tool": "Task"}),
+    );
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    orch.dispatch_phase_with_state(&slug, "implement", &state).unwrap();
+    assert!(pending_path.exists());
+
+    // Sub-agent still active (no SubagentStop). Drain must be a no-op.
+    let phase_injects_before = count_phase_inject_events(&progress_path);
+    let outcome = orch
+        .drain_pending_inject_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+    assert_eq!(outcome, DrainPendingOutcome::StillBlocked);
+    assert!(pending_path.exists(), "pending must persist while blocked");
+    assert_eq!(
+        count_phase_inject_events(&progress_path),
+        phase_injects_before,
+        "no phase_inject must be written while blocked",
+    );
+}
+
+#[test]
+fn drain_after_max_defer_minutes_writes_inject_defer_timeout_outbox() {
+    let Some((_tmp, paths, slug, _scoped)) = fixture("drain_timeout", 0) else {
+        return;
+    };
+    let progress_path = paths.progress_jsonl(&slug);
+    let project_dir = paths.project_dir(&slug);
+    let pending_path = pending_inject_path_in(&project_dir);
+
+    // Forge a pending record from 30 minutes ago so the timeout path
+    // fires regardless of test runtime. Sub-agent is also still active
+    // — the timeout takes priority.
+    write_event(
+        &progress_path,
+        &json!({"ts": chrono::Utc::now().to_rfc3339(), "event": "PreToolUse", "tool": "Task"}),
+    );
+    let stale =
+        chrono::Utc::now() - chrono::Duration::minutes(30);
+    save_pending_inject(
+        &pending_path,
+        &PendingInject::new(slug.clone(), "implement", vec![], stale, 10),
+    )
+    .unwrap();
+
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    let outcome = orch
+        .drain_pending_inject_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+    assert_eq!(outcome, DrainPendingOutcome::TimedOut);
+    assert!(
+        !pending_path.exists(),
+        "pending-inject.json must be deleted after timeout",
+    );
+
+    let outbox = read_outbox(&project_dir);
+    assert_eq!(
+        outbox["ccteam_classification"].as_str(),
+        Some("inject_defer_timeout"),
+        "outbox classification field",
+    );
+    assert_eq!(outbox["event_kind"].as_str(), Some("escalation"));
+    assert_eq!(outbox["priority"].as_str(), Some("high"));
+    assert!(
+        outbox.get("ccteam_pane_tail").is_some(),
+        "F35 enriched schema reused: pane_tail field present",
+    );
+    assert!(
+        outbox["body"]
+            .as_str()
+            .unwrap_or("")
+            .contains("implement"),
+        "body must mention the deferred phase",
+    );
+}
+
+#[test]
+fn drain_no_pending_record_returns_none() {
+    let Some((_tmp, paths, slug, _scoped)) = fixture("drain_none", 0) else {
+        return;
+    };
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    let outcome = orch
+        .drain_pending_inject_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+    assert_eq!(outcome, DrainPendingOutcome::None);
+}
+
+#[test]
+fn drain_skips_evergreen_team() {
+    use ccteam_core::write_all_global_team_templates;
+    let Some((_tmp, paths, slug, _scoped)) = fixture("drain_evergreen_skip", 0) else {
+        return;
+    };
+    // Seed the full team set (incl. `teams/meta-agent/team.yaml`
+    // with `evergreen: true`) so `is_evergreen("meta-agent")` actually
+    // returns true. The fixture's dev-only seed isn't enough.
+    write_all_global_team_templates(&paths.root, false).unwrap();
+
+    let project_dir = paths.project_dir(&slug);
+    let pending_path = pending_inject_path_in(&project_dir);
+    save_pending_inject(
+        &pending_path,
+        &PendingInject::new(
+            slug.clone(),
+            "implement",
+            vec![],
+            chrono::Utc::now() - chrono::Duration::minutes(30),
+            10,
+        ),
+    )
+    .unwrap();
+
+    let mut state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    state.team = "meta-agent".into();
+    state.save(&paths.project_state(&slug)).unwrap();
+
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    let outcome = orch
+        .drain_pending_inject_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+    assert_eq!(
+        outcome,
+        DrainPendingOutcome::None,
+        "evergreen team must skip drain even when a pending record exists",
+    );
+    // Outbox must NOT have been written (timeout path skipped).
+    let outbox_path =
+        project_dir.join(".ccteam").join("needs_attention.outbox.json");
+    assert!(
+        !outbox_path.exists(),
+        "evergreen short-circuit must not surface inject_defer_timeout",
+    );
+    assert!(
+        pending_path.exists(),
+        "evergreen short-circuit leaves the pending record alone",
+    );
+}
+
+#[test]
+fn f36_race_miss_is_caught_by_f35_inject_limbo() {
+    // F36 race scenario PRD §5.3:
+    // - dispatch ran when no Task PreToolUse was visible (subagent_active = false)
+    // - phase_inject landed in progress.jsonl
+    // - sub-agent emerged and emitted PreToolUse(Task) only after the
+    //   send-keys (so the inject ended up in the wrong context)
+    //
+    // F35 sees: tail event = phase_inject (the meta-event PreToolUse(Task)
+    // doesn't mask it because the classifier walks back past
+    // `inbox_consumed` etc., but a real PreToolUse(Task) would). For
+    // the test we keep the tail at `phase_inject` after enough silence
+    // — F35 must classify as `InjectLimbo` and run the deterministic
+    // re-inject (counter 0 → 1).
+    let Some((_tmp, paths, slug, _scoped)) =
+        fixture("f36_race_falls_back_to_f35", 10) // > warn threshold
+    else {
+        return;
+    };
+    let progress_path = paths.progress_jsonl(&slug);
+    let project_dir = paths.project_dir(&slug);
+
+    // Direct phase_inject (simulating "F36 sent the keys"). No follow
+    // up — the assistant is blocked on a sub-agent that never emitted
+    // a PreToolUse(Task) event in time.
+    write_event(
+        &progress_path,
+        &json!({
+            "ts": chrono::Utc::now().to_rfc3339(),
+            "event": "phase_inject",
+            "phase": "implement",
+            "idle": true,
+        }),
+    );
+
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    orch.classify_and_act_on_silence_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+    let counter =
+        load_limbo_retry_count(&limbo_retry_path_in(&project_dir), "implement").unwrap();
+    assert_eq!(
+        counter.count, 1,
+        "F35 must back F36's race window: InjectLimbo deterministic re-inject ran",
+    );
+}
+
+#[test]
+fn f35_limbo_reinject_skipped_when_pending_inject_exists() {
+    // F36 × F35 coordination: when a pending-inject is already in
+    // flight (sub-agent really is busy), F35's `attempt_limbo_reinject`
+    // must NOT bump its retry counter — the deterministic budget
+    // would burn on a no-op (the dispatch path would just rewrite the
+    // pending record).
+    let Some((_tmp, paths, slug, _scoped)) =
+        fixture("f35_skips_when_f36_pending", 10)
+    else {
+        return;
+    };
+    let progress_path = paths.progress_jsonl(&slug);
+    let project_dir = paths.project_dir(&slug);
+    let pending_path = pending_inject_path_in(&project_dir);
+
+    // Plant: a Task PreToolUse so dispatch defers, plus a phase_inject
+    // tail so F35 classifies as InjectLimbo. (Order matters for tail
+    // detection: phase_inject is the final event so the classifier
+    // sees it as the tail.)
+    write_event(
+        &progress_path,
+        &json!({"ts": chrono::Utc::now().to_rfc3339(), "event": "PreToolUse", "tool": "Task"}),
+    );
+    write_event(
+        &progress_path,
+        &json!({
+            "ts": chrono::Utc::now().to_rfc3339(),
+            "event": "phase_inject",
+            "phase": "implement",
+        }),
+    );
+    save_pending_inject(
+        &pending_path,
+        &PendingInject::new(slug.clone(), "implement", vec![], chrono::Utc::now(), 10),
+    )
+    .unwrap();
+
+    let orch = build_orchestrator(paths.clone());
+    let state = ProjectState::load(&paths.project_state(&slug)).unwrap();
+    orch.classify_and_act_on_silence_for_test(&slug, &state, chrono::Utc::now())
+        .unwrap();
+
+    let retry = limbo_retry_path_in(&project_dir);
+    let count = if retry.exists() {
+        load_limbo_retry_count(&retry, "implement")
+            .unwrap()
+            .count
+    } else {
+        0
+    };
+    assert_eq!(
+        count, 0,
+        "F35 must not bump retry counter while F36 pending-inject is in flight",
+    );
+}

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1011,13 +1011,15 @@ stop_hook_active == true?
 ```
 
 **`ccteam_classification` 枚举值**(F35 silence_classifier `SilenceClass`,
-PRD §4.2.1 表):
+PRD §4.2.1 表;F36 timeout 沿用同 schema):
 
 - `subagent_runaway` — `PreToolUse(tool=Task)` 后 ≥ phase escalate 阈值,无 SubagentStop
 - `mid_tool_hung` — `PreToolUse(tool != Task)` 后 ≥ phase warn 阈值,无 PostToolUse
 - `limbo_capped` — F35 deterministic re-inject 已重试 cap 次(默认 1)仍未恢复
 - `post_stop_limbo` / `inject_limbo` — 罕见(orchestrator 通常已 re-inject 1 次,
   这两类只在 cap 之前一过性出现)
+- `inject_defer_timeout` — F36 send-keys subagent guard 已 defer 超 `max_defer_minutes`
+  (默认 10)仍未真发(子 agent 一直未停);见 §6.2.3 `pending-inject.json`
 
 `Healthy` / `Terminal` / `SubagentBusy` 不写 outbox(F35 deterministic 判定为不需要
 干预)。
@@ -1054,6 +1056,43 @@ orchestrator 重置(写入新 `phase` + `count: 0`)。
 **红线**:cap = 1 是 F35 在底层 `auto_loop` 3-cap 之上的额外兜底;两层叠加之后
 撞顶必 enriched escalate(CLAUDE.md "fix-loop 撞 3 次顶必 escalate,绝不静默
 重置")。
+
+#### 6.2.3 `pending-inject.json` schema(V0.2.2 F36)
+
+`<project>/.ccteam/pending-inject.json`:F36 send-keys subagent guard 的
+deferred phase-inject 记录。`Orchestrator::dispatch_phase_with_state` 检测到
+`progress::subagent_active(events) == true`(`PreToolUse(tool=Task)` 还有未配
+对的 `SubagentStop`)时不发 send-keys / 不写 `phase_inject` 事件,改落盘本文件;
+orchestrator daemon tick 后续在 SubagentStop 真到达 + 不再 active 时真发并删本
+文件。**单文件覆盖,不积累队列** — 每个项目同时只有一条 deferred phase 待发,
+新的覆盖旧的(`<file>.json.tmp` + rename 原子写)。
+
+```json
+{
+  "schema_version": 1,
+  "slug": "dev-x",
+  "phase": "implement",
+  "attachments": [".ccteam/code-review.md"],
+  "enqueued_at": "2026-05-09T10:00:00Z",
+  "max_defer_minutes": 10
+}
+```
+
+**生命周期**:
+
+1. dispatch 检测 active subagent → save record(`enqueued_at = now`)
+2. 后续 tick:
+   - 仍 active + 未 timeout → no-op,等下次 SubagentStop event
+   - 不再 active + 未 timeout → 真发 `dispatch_phase_with_state`,delete record
+   - timeout(`now - enqueued_at >= max_defer_minutes`) → 写 enriched outbox
+     `ccteam_classification: "inject_defer_timeout"`,delete record(主路径不挂)
+3. evergreen / meta-agent 项目 (`is_evergreen()`) 早 return,跳过 guard 与 drain
+
+**与 F35 协同**(PRD §5.3):
+- F36 主路径主动 defer;`InjectLimbo` 类(phase_inject 后 ≥ warn 阈值无 follow-up)
+  是 F36 race 漏接的兜底重发(F35 deterministic re-inject)
+- F35 `attempt_limbo_reinject` 检测到 pending-inject 在飞 → 跳过本次 retry,
+  不烧 `MAX_LIMBO_RETRY` 预算(F36 drain 路径独立兜底)
 
 `cct hook intercept-ask` 返回的 PreToolUse 决策(`hooks.ts:608-625`):
 

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -1271,6 +1271,15 @@ orchestrator 是**所有 phase 派发 + inbox 派送**的单点 — daemon 死�
   limbo 自动 deterministic re-inject 1 次(`MAX_LIMBO_RETRY = 1`,per-phase
   计数);超 cap 写 enriched `needs_attention.outbox.json` 由 watchdog +
   meta-agent 翻译给用户。**不发 Ctrl-C / 不 kill / 不 LLM**。
+- **V0.2.2 F36 send-keys subagent guard**:`dispatch_phase_with_state` 注入前
+  调 `progress::subagent_active(events)`(扫末事件:`PreToolUse(tool=Task)` 减
+  `SubagentStop` 配对 > 0 → true),发现子 agent 在飞时不发 send-keys、不写
+  `phase_inject` 事件,改落 `<project>/.ccteam/pending-inject.json`(单文件,
+  schema 详 interfaces.md §6.2.3)。daemon tick 后续在 SubagentStop 真到 + 不
+  active 时真发并删本文件;`max_defer_minutes`(默认 10)兜底,超时改写 enriched
+  outbox `ccteam_classification: "inject_defer_timeout"`。F35 `attempt_limbo_reinject`
+  发现 pending-inject 在飞时跳过本次 retry,不烧 deterministic 预算;F36 race
+  漏接(eg 子 agent 几秒后才 emit)兜底走 F35 `InjectLimbo`。
 
 ```bash
 # 注入前判断


### PR DESCRIPTION
## Closes
- F36 (`docs/v0-2-2/prd.md` §5)

## 改动
详 commit message。要点:

- `progress::subagent_active(events)` 纯 deterministic helper(`PreToolUse(Task) − SubagentStop` 配对计数)
- `Orchestrator::dispatch_phase_with_state` 注入前 guard:active subagent → 落盘 `<project>/.ccteam/pending-inject.json`(单文件覆盖,不积累队列),跳过 send-keys + 跳过 `phase_inject` 事件
- 新模块 `crates/ccteam-core/src/pending_inject.rs`:`PendingInject` 结构 + 原子 save/load/delete + `is_expired`
- daemon `poll_tick` drain(先于 F35 classifier 跑,免得真发后又被 InjectLimbo 误杀):SubagentStop event + 不再 active → 真发 + 删 pending;`max_defer_minutes`(默认 10)兜底 → enriched outbox(F35 schema,classification = `"inject_defer_timeout"`)+ 删 pending
- F35 `attempt_limbo_reinject` 检测到 F36 pending-inject 在飞 → 跳过本次 retry,不烧 deterministic 预算
- meta-agent / evergreen 项目跳过(`is_evergreen` 早 return)
- `interfaces.md` §6.2.3 加 pending-inject schema + classification 枚举更新;`tech-design.md` §6.9 加 F36 idle-injection 注

## 红线确认
- 永不 Ctrl+C / kill:F36 不发干预信号(`git grep` 0 命中)
- 控制平面无 LLM:全 deterministic match(`git grep claude.*-p` 仅命中预存在 `ClaudePRunner` 注释)
- 跟 F35 协同:`InjectLimbo` race fallback,enriched outbox schema 共用
- meta-agent skip:dispatch guard + drain 都早 return

## 测试
- baseline 603 → 628(+25):
  - `progress::subagent_active` 7 unit(开 / 关 / 嵌套 / 老事件 / 多 SubagentStop 不下溢 / 非 Task PreToolUse / 空 log)
  - `pending_inject` 10 unit(roundtrip / overwrite / 不存在 / 空文件 / delete / is_expired 边界)
  - 8 e2e:dispatch defers / drain after SubagentStop / drain blocked / timeout outbox / drain none / drain skips evergreen / F36 race miss 兜底 F35 InjectLimbo / F35 retry 跳过 when F36 pending 在飞
- clippy 无新增 warning(lib baseline 7,本 PR 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)