### PR TITLE
v0.2.2 e2e retro: F41 + F42 + F43 dust patch + retro doc

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -1070,10 +1070,16 @@ fn render_validate_team_report(
     }
 
     // Locate the phase dir on disk via the same priority order the
-    // resolver uses.
+    // resolver uses. V0.2.2 F41: walk by `spec.name` (canonical), not
+    // the user-supplied `team` arg — when `team` is an F40 alias
+    // (eg `product-research`), the team.yaml lives at the canonical
+    // `teams/research/team.yaml` path, so resolving by alias would
+    // miss it and produce a misleading "could not locate team
+    // directory" failure even though the resolver returned a valid
+    // TeamSpec.
     let team_dir = TEAM_SOURCES
         .iter()
-        .filter_map(|s| s.path_for(team, &ctx))
+        .filter_map(|s| s.path_for(&spec.name, &ctx))
         .find(|p| p.exists())
         .and_then(|p| p.parent().map(std::path::Path::to_path_buf));
     let team_dir = match team_dir {
@@ -3125,6 +3131,39 @@ mod tests {
         assert!(msg.contains("1 fail"), "expected fails counter; got: {msg}");
     }
 
+
+    #[test]
+    fn validate_team_resolves_alias_to_canonical_dir() {
+        // V0.2.2 F41 regression: when --validate-team is given an F40
+        // alias (eg `product-research`), the command should resolve to
+        // canonical TeamSpec (`research`) AND locate the phase dir at
+        // the canonical path (`teams/research/`), not at the alias arg
+        // (`teams/product-research/`, which doesn't exist after F40).
+        ensure_isolation();
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        ccteam_core::write_all_global_team_templates(&paths.root, false).unwrap();
+
+        let opts = DoctorOptions {
+            validate_team: Some("product-research".into()),
+            ..DoctorOptions::default()
+        };
+        let report = run_doctor(&paths, opts).unwrap();
+        assert!(
+            report.contains("[OK] team.yaml resolves; name=`research`"),
+            "alias should resolve to canonical name; got: {report}"
+        );
+        // Phase dir located → not the misleading "could not locate team
+        // directory" failure that F41 produced before the fix.
+        assert!(
+            !report.contains("could not locate team directory"),
+            "alias path should locate canonical team dir; got: {report}"
+        );
+        assert!(
+            report.contains("0 fail"),
+            "alias-resolve path should pass with 0 fail; got: {report}"
+        );
+    }
 
     #[test]
     fn validate_team_warns_when_phase_body_contains_protocol_literal() {

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -29,7 +29,8 @@
 F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭;**2026-05-08 V0.2 M0.23**:加 F24 + F25
 P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候选;
 **2026-05-08 V0.2.1 patch**:F26-F33 全部修复;
-**2026-05-09 V0.2.2 patch**:加 F34-F40 七条用户反馈 + 命名 sweep + UX 增强,跨 7 PR 全部修复),分布:
+**2026-05-09 V0.2.2 patch**:加 F34-F40 七条用户反馈 + 命名 sweep + UX 增强,跨 7 PR 全部修复;
+**2026-05-09 V0.2.2 e2e retro patch**:4-suite 并行 e2e 验证,撞 F41 (P1) + F42 (P1) + F43 (P2),同 PR 一波修),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
@@ -37,7 +38,7 @@ P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候�
 | **P1 该做但可后置(剩余)** | 2 | F15(M1+ block-push 时做)、F23(conditional;待 spike 重跑) |
 | **P2 边角(剩余)** | 1 | F17 |
 | **N/A 已是领域无关** | 2 | F14, F19(M3 docs sweep 后)|
-| **已修复** | 35 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)、**F24 / F25(2026-05-08 M0.23 PR)**、**F26 / F27 / F28 / F29 / F30 / F31 / F32 / F33(2026-05-08 V0.2.1 patch)**、**F34 / F35 / F36 / F37 / F38 / F39 / F40(2026-05-09 V0.2.2 patch — 7 finding 跨 7 PR)** |
+| **已修复** | 38 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)、**F24 / F25(2026-05-08 M0.23 PR)**、**F26 / F27 / F28 / F29 / F30 / F31 / F32 / F33(2026-05-08 V0.2.1 patch)**、**F34 / F35 / F36 / F37 / F38 / F39 / F40(2026-05-09 V0.2.2 patch — 7 finding 跨 7 PR)**、**F41 / F42 / F43(2026-05-09 V0.2.2 e2e retro patch)** |
 
 ### V0.2 §6 反模式候选状态(docs/v0-2/prd.md)
 

--- a/docs/v0-2-2/e2e-retro.md
+++ b/docs/v0-2-2/e2e-retro.md
@@ -1,0 +1,212 @@
+# V0.2.2 E2E Retro
+
+> 范围:V0.2.2 全部 7 PR(F34-F40)post-ship end-to-end 验证。
+>
+> base = `origin/main` `b651760`(V0.2.2 ship gate);测试 baseline 628/0。
+>
+> 方法:**4 suite 并行 subagent**,各自隔离 env。**不修代码**(F41 fix 在 retro 落档后单独 follow-up patch);发现的问题写 F-finding 留 V0.2.3 评估。
+
+---
+
+## 1. 测试方法
+
+### 隔离 env
+
+每 suite 自己的 `/tmp/ccteam-e2e-suite-<X>-<pid>/` 根目录,通过 env 重定向避免污染用户真 `~/.ccteam` / `~/.claude` / `~/projects`:
+
+```bash
+export E2E_ROOT=/tmp/ccteam-e2e-suite-<X>-$$
+mkdir -p $E2E_ROOT/{ccteam-home,claude-home,projects-root,xdg-config}
+export CCTEAM_HOME=$E2E_ROOT/ccteam-home
+export CLAUDE_CONFIG_HOME=$E2E_ROOT/claude-home
+export XDG_CONFIG_HOME=$E2E_ROOT/xdg-config
+export CCTEAM_PROJECTS_ROOT=$E2E_ROOT/projects-root
+export HOME=$E2E_ROOT
+export CCTEAM_AUTO_SLUG=off  # 关 Tier 3,不烧 LLM cost
+```
+
+V0.2.1 retro F26 已修复(`mcp_serve::install_mcp` 现读 `CLAUDE_CONFIG_HOME`),
+但 `font-kit` 等系统库仍按 `HOME` 查 `~/Library/Fonts`,所以 `HOME` 兜底必设。
+
+### Suite 划分
+
+| Suite | 覆盖 | base finding |
+|---|---|---|
+| **A** 命名 / CLI / migration | F39 cct convention sweep / F34 slug 4-tier / F40 team alias | F39 / F34 / F40 |
+| **B** 控制层 | F35 silence classifier / F36 subagent guard | F35 / F36 |
+| **C** prompt + 截图 | F37 决策树加固 / F38 终端截图 PNG | F37 / F38 / cct-project-creator skill |
+| **D** 全栈 + 升级 | bootstrap pipeline / V0.1/V0.2 → V0.2.2 migration / docs 同步 + audit | 跨 finding |
+
+约束:**不烧真 LLM cost**(`CCTEAM_AUTO_SLUG=off` + `--no-auto-slug` flag);
+**不动 git state**(read-only + 隔离 env);**不动用户真 tmux**(suite C 用唯一前缀名 + 测后 kill 自己 session)。
+
+---
+
+## 2. Suite-by-Suite 结果
+
+### Suite A — 命名 / CLI / migration
+
+| # | 场景 | Verdict |
+|---|---|---|
+| A1 | `cargo build --release --bin cct` | **PASS**(`cct 0.2.2`,5 MB binary)|
+| A2 | `cct doctor --install-skill` 装 3 skills | **PASS**(全有 marker + frontmatter)|
+| A3 | F39 migration:managed legacy `ccteam-control/` 删 | **PASS** |
+| A4 | F39 migration:user-edited legacy 保留 | **PASS**(after re-staging — 见 F43)|
+| A5 | F39 migration:`settings.json` hook command rewrite | **PASS**(原子 + current_exe 路径)|
+| A6 | F34 Tier 1 `--slug` B2 prefix | **PASS** |
+| A7 | F34 Tier 1 verbatim 已带前缀 | **PASS** |
+| A8 | F34 Tier 4 `slugify_brief` token 裁剪 | **PASS**(`Build a tiny Python CLI...` → `dev-build-tiny-python` 3 token)|
+| A9 | F34 非法 slug 拒绝 | **PASS** |
+| A10 | F40 alias warn + passthrough | **PASS**(state.team = `product-research` 字面入)|
+| A11 | F40 canonical 不 warn | **PASS** |
+| A12 | F40 alias 解析到 canonical via `--validate-team` | **FAIL**(F41) |
+| A13 | F39 forward-looking docs sweep | **PASS**(0 命中;historical V0.1/V0.2 109 命中预期)|
+| A14 | F39 templates 旧路径不存在 | **PASS** |
+
+**Suite A verdict:minor-followups**(F41 P1 + F43 P2 docs nit)
+
+### Suite B — 控制层
+
+| # | 场景 | Verdict |
+|---|---|---|
+| B1 | `cargo test --workspace` baseline | **PASS**(628/0)|
+| B2 | silence_classifier 7-class unit 全过 | **PASS**(21 unit)|
+| B3 | pending_inject unit + e2e 全过 | **PASS**(10 unit + 8 e2e)|
+| B4 | F35 enriched outbox 4 字段完整 | **PASS** |
+| B5 | F36 pending-inject.json schema parse | **PASS**(serde round-trip)|
+| B6 | F36 race coordination 测试 | **PASS**(`f36_race_miss_is_caught_by_f35_inject_limbo` + `f35_limbo_reinject_skipped_when_pending_inject_exists`)|
+| B7 | F35 limbo retry counter cap = 1 | **PASS**(`MAX_LIMBO_RETRY=1`,2nd-tick `limbo_capped` outbox)|
+| B8 | F35 capture_pane_tail with_ansi=false | **PASS**(纯文本入 outbox)|
+| B9 | F38 capture_pane_with_ansi for PNG | **PASS**(独立函数,功能复用)|
+| B10 | meta-agent 跳过 classifier(red line) | **PASS**(3 处 `is_evergreen` early-return) |
+| B11 | F35 outbox 跟 V0.2 M0.19 L3 共存 | **PASS**(additive schema)|
+| B12 | F36 max_defer_minutes default + timeout outbox | **PASS**(`DEFAULT_MAX_DEFER_MINUTES=10`,classification = `inject_defer_timeout`)|
+
+**Suite B verdict:PASS**(0 finding)
+
+### Suite C — prompt + 截图
+
+| # | 场景 | Verdict |
+|---|---|---|
+| C1 | §1 决策树 "调研 X = 项目请求" 反例 | **PASS** |
+| C2 | §3 克制规则 "❌ 不起 Agent 自调研" 反例 | **PASS** |
+| C3 | §2 派单段改指 cct-project-creator skill | **PASS** |
+| C4 | F39 cct binary 命名跟进 | **PASS**(`ccteam <cmd>` 0 命中,`cct <cmd>` 10+)|
+| C5 | F40 research canonical 跟进 | **PASS**(`research 团队`/`--team=research` 4 hits;`product-research` 仅 alias 教育段)|
+| C6 | skill 文件存在 | **PASS**(6.6 KB)|
+| C7 | frontmatter `name: cct-project-creator` | **PASS** |
+| C8 | ccteam-managed marker | **PASS**(begin/end 双标)|
+| C9 | Phase A/B/C/D 段全在 | **PASS** |
+| C10 | AskUserQuestion 用法 | **PASS**(9 处)|
+| C11 | meta-agent context 强调 | **PASS** |
+| C12 | F38 vendored TTF | **PASS**(`JetBrainsMono-Regular.ttf` 273.9 KB)|
+| C13 | F38 LICENSES.md OFL | **PASS** |
+| C14 | F38 ANSI_256 调色板完整 | **PASS**(256 项,test asserted)|
+| C15 | F38 真 tmux 跑截图 | **PASS — 真 PNG 39329 字节,954 × 758 px 8-bit RGB** |
+| C16 | F38 graceful degrade — tmux 失败 | **PASS-with-note**(exit 0 是设计,brief 期望错;详 §4)|
+| C17 | F38 catch_unwind 防 panic | **PASS** |
+| C18 | F38 MCP namespace 保留 ccteam | **PASS**(per PRD §8.3)|
+
+**Suite C verdict:minor-followups**(F42 — skill body `product-research` 漂移)
+
+### Suite D — 全栈 + 升级
+
+| # | 场景 | Verdict |
+|---|---|---|
+| D1 | dev project bootstrap | **PASS**(state.json + settings.json + spec.md 全 well-formed)|
+| D2 | settings.json hook commands 全 `cct hook` | **PASS**(11 commands,0 处 `ccteam hook`)|
+| D3 | dev project state.json 字段 | **PASS** |
+| D4 | research project bootstrap | **PASS** |
+| D5 | product-research alias bootstrap + warn | **PASS**(slug + state.team 字面 passthrough)|
+| D6 | doctor --install-skill 触发 migration | **PASS** |
+| D7 | 老 ccteam-control(marker)被删 | **PASS** |
+| D8 | 老 ccteam-team-author(frontmatter `name:`)被删 | **PASS** |
+| D9 | 用户手改 `ccteam-handcrafted` 保留 | **PASS** |
+| D10 | legacy settings.json hook command rewrite | **PASS**(absolute path + atomic + idempotent)|
+| D11 | dev-coupling-audit.md F34-F40 全 close | **PASS**(7 条 section 全含 "已修复")|
+| D12 | audit 计数到 35 | **PASS** |
+| D13 | docs/v0-2-2/ 完整 4 文件 | **PASS**(prd 67KB / dev-plan 53KB / README 1.9KB / feedback 4.5KB)|
+| D14 | CLAUDE.md baseline 628 + version 0.2.2 | **PASS** |
+| D15 | docs/README.md V0.2.2 行 + Patch 目录约定 | **PASS** |
+
+**Suite D verdict:PASS**(0 finding) — fully shippable, no regressions.
+
+---
+
+## 3. 发现的 bugs / inconsistencies(F-finding)
+
+按优先级聚类(沿用 `dev-coupling-audit.md` 编号方案):
+
+| F | 标题 | 优先级 | 来源 |
+|---|---|---|---|
+| **F41** | `cct doctor --validate-team <alias>` resolve OK 后目录定位用原 alias 而非 canonical 误报 FAIL | **P1** | Suite A A12 |
+| **F42** | `skills/cct-project-creator/SKILL.md` 5 处仍硬编 `product-research`,跟 F40 canonical `research` 漂移 | **P1** | Suite C |
+| **F43** | PRD §8.2.5 detection signal 说明可补一句"测试 staging 模拟用户手改时需 strip both signals(marker + frontmatter `name:`)" | P2 docs nit | Suite A A4 |
+
+### Need-real-claude-smoke(subagent 不能验,留 user)
+
+无新增 NRS。F38 真 tmux 截图 Suite C 已通过;V0.1/V0.2 用户升级 migration Suite D smoke 已通过(simulated)。
+
+---
+
+## 4. PRD / interfaces / dev-plan inconsistencies
+
+| # | 来源 | 描述 | 修正方向 |
+|---|---|---|---|
+| 1 | Suite C C16 brief 期望 | brief 写"tmux 失败 → exit code != 0",但 PRD §7.2.5 红线"rendering NEVER aborts the enclosing path"明文 graceful degrade 是退 0;brief 期望与设计冲突,**brief 错** | retro doc 内勘误,不算 finding |
+| 2 | F43 — PRD §8.2.5 detection 双信号说明 | marker OR frontmatter `name:` 是 by design 的 OR 关系 — 测试 staging 模拟用户手改时需 strip both,PRD 应补一句免得 retro/test 设计者踩 | 改 PRD;P2 |
+
+---
+
+## 5. Verdict
+
+| 维度 | 数 |
+|---|---|
+| **Ship-blocking issues** | **0** |
+| **P1 V0.2.3 候选** | **2**(F41 / F42)|
+| **P2 docs nit** | **1**(F43)|
+| **Need-real-claude-smoke** | **0**(本轮全自跑覆盖)|
+| Suites with all-PASS | **2**(B 控制层,D 全栈)|
+| Suites with minor-followups | **2**(A 命名,C prompt + 截图)|
+
+V0.2.2 **可 ship**(实际已 ship 在 main `b651760`)。e2e 主路径(命名约定 sweep / 控制层 classifier+guard / decision tree + 截图 PNG / 全栈 bootstrap + migration)全部 PASS 或 PASS-with-note。
+
+发现的 P1 全部是收尾向问题,**不影响 V0.2.2 用户首日 onboarding**:
+
+- F41(`--validate-team` alias 误报):用户走 canonical 名 `research` 完全 OK;走 alias `product-research` 时 doctor 报告说"FAIL"但实际 alias 解析正确,误导而非真 break;一行 fix
+- F42(skill body `product-research` 漂移):派单到 `product-research` alias 仍 work(F40 alias 兼容),只是 skill `AskUserQuestion` 给用户的 label 老名;`AskUserQuestion` 内部一致性问题,不破坏功能
+
+---
+
+## 6. V0.2.3 patch 计划(若 ship 单独 patch)
+
+按工作量 + 影响排序:
+
+| Patch | F | 工作量 | 描述 |
+|---|---|---|---|
+| **P1** | F41 | <30 min | `commands.rs:1074-1078` `team` → `&spec.name`;加 `validate_team_resolves_alias_to_canonical_dir` 测试 |
+| **P2** | F42 | <30 min | `skills/cct-project-creator/SKILL.md` 5 处 `product-research` → `research`;C段 default-toward 段加 alias 教育一句 |
+| **P3** | F43 | <15 min | `docs/v0-2-2/prd.md §8.2.5` 加测试 staging 双信号说明 |
+
+**实际:F41+F42+F43 + 本 retro 文档** 同 PR 一波 ship(无须单独 V0.2.3 patch round;落 v0-2-2-retro-and-dust 单 PR)。
+
+---
+
+## 7. Numbers
+
+- **Suite 数**:4(并行)
+- **场景数**:59(A:14 / B:12 / C:18 / D:15)
+- **PASS**:56
+- **PASS w/ note**:2(C16 — exit code 期望与设计 / A4 — staging 双信号)
+- **FAIL**:1(A12 — F41)
+- **F-finding**:3(F41 P1 / F42 P1 / F43 P2)
+- **耗时**:~30 min(4 subagent 并行 wall-clock,主 session retro 综合 + fix ~15 min)
+- **Real LLM cost burned**:0(`CCTEAM_AUTO_SLUG=off` 关 Tier 3)
+- **Real `~/.ccteam/` `~/.claude/` 污染**:0(全 isolated env;Suite C tmux 用唯一前缀名 + 测后 kill server)
+- **PNG 截图实测**:39329 字节 / 954×758 8-bit RGB(F38 端到端跑通)
+
+---
+
+## Changelog
+
+- 2026-05-09:初版。基于 4 subagent 并行 e2e 报告 + 主 session 综合 + F41/F42/F43 fix。base = `origin/main` `b651760`(V0.2.2 ship gate)。

--- a/docs/v0-2-2/prd.md
+++ b/docs/v0-2-2/prd.md
@@ -931,6 +931,13 @@ V0.2.2);老的会过期,但不会崩。
 --install-skill` / `--install-meta-agent` 触发时同步跑。跟 V0.2.0 的
 `--migrate-recommended-agents` 同模式("安装时清旧 + 新装")。
 
+> **测试 staging 注**(V0.2.2 e2e retro F43):detection 是 `marker OR
+> frontmatter name:` 的 OR 关系(intentional belt-and-suspenders;V0.2.0
+> 早期 install 不带 marker,只能靠 frontmatter `name:` 命中)。模拟"用户
+> 手改 skill"做 e2e 测试时,需**同时 strip 两个 signal**(去 marker `<!--
+> ccteam-managed:skill -->` + 改 frontmatter `name: <other>`),任一保留都
+> 会命中 detection 视为 ccteam-managed → 误删。
+
 #### 8.2.6 文档 sweep
 
 | 文件 | 处理 |

--- a/skills/cct-project-creator/SKILL.md
+++ b/skills/cct-project-creator/SKILL.md
@@ -102,8 +102,8 @@ Apply the `meta_agent_role.md` §2 decision tree:
 | User says | Recommend |
 |---|---|
 | "做个 X / 帮我写 X / 来个 X" + brief is actionable | `dev` |
-| "我想做 Y 但不确定 / 值不值 / 该不该" | `product-research` |
-| "调研 Z / 这个想法有人做过吗 / 这个值得做吗" | `product-research` |
+| "我想做 Y 但不确定 / 值不值 / 该不该" | `research` |
+| "调研 Z / 这个想法有人做过吗 / 这个值得做吗" | `research` |
 
 If the recommendation is unambiguous, propose it directly with one
 `AskUserQuestion` for confirmation. If it's borderline:
@@ -114,15 +114,16 @@ AskUserQuestion({
   options: [
     { label: "dev",
       description: "立即开发(plan-eng → implement → … → ship)" },
-    { label: "product-research",
+    { label: "research",
       description: "先调研判断 idea 值不值得做(verdict + next-steps)" },
   ]
 })
 ```
 
-Default toward `product-research` when in doubt — research is cheap, dev
-is expensive. But do not auto-research every brief; obvious build asks
-should go straight to dev.
+Default toward `research` when in doubt — research is cheap, dev is
+expensive. But do not auto-research every brief; obvious build asks
+should go straight to dev. (V0.2.2 F40 起 `product-research` 是兼容
+alias,canonical 名是 `research`;新派单一律用 `research`。)
 
 ## Phase D — Dispatch + notify
 
@@ -143,7 +144,7 @@ After dispatch, write an outbox `event_kind: reply` (per
 - The first milestone they should expect:
   - **dev** → `plan-eng` runs first, ~30 min, may surface clarify
     questions you'll see in the decisions queue.
-  - **product-research** → `kickoff` runs first and may immediately
+  - **research** → `kickoff` runs first and may immediately
     reverse-interview before doing any research.
 - Follow-up commands: `cct show <slug>` for state, `cct attach <slug>`
   for live tmux.


### PR DESCRIPTION
## Closes
- F41 (\`docs/dev-coupling-audit.md\` F41 entry — V0.2.2 e2e retro Suite A A12)
- F42 (\`docs/dev-coupling-audit.md\` F42 entry — V0.2.2 e2e retro Suite C)
- F43 (\`docs/dev-coupling-audit.md\` F43 entry — V0.2.2 e2e retro Suite A A4 docs nit)

## 改动
- **F41 fix**: \`crates/ccteam-cli/src/commands.rs:1074-1078\` walk by \`&spec.name\` (canonical) instead of user-supplied \`team\` arg. + new \`validate_team_resolves_alias_to_canonical_dir\` unit test
- **F42 sweep**: \`skills/cct-project-creator/SKILL.md\` 5 处 \`product-research\` → \`research\`,加 alias-education 段
- **F43 docs**: \`docs/v0-2-2/prd.md §8.2.5\` 加测试 staging 双信号注脚
- **New \`docs/v0-2-2/e2e-retro.md\`** (4-suite verdict + 3 finding 完整记录)
- **\`docs/dev-coupling-audit.md\`** F41/F42/F43 完整条目 + summary 更新到 已修复 38 条

## 测试
\`cargo test --workspace\` 628 → 629(+1 F41 alias regression test);clippy 无新增

## 红线确认
- 控制平面无 LLM:F41/F42 都是 deterministic 修复
- 永不主动 kill:无新 kill / Ctrl+C 路径
- ccteam-core 不出现 team 字面量:F42 sweep 在 skill body / docs,不进 ccteam-core
- F40 alias 接续:F41 fix 让 doctor 走 canonical path,符合 F40 软迁移哲学

🤖 Generated with [Claude Code](https://claude.com/claude-code)