### PR TITLE
v0.2.2 PR #8: F44 revert F39 cct convention sweep — restore ccteam binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,14 @@
 | 仓库根 | `~/workplace/agents/ccteam` |
 | 主分支 main HEAD | **以 `git rev-parse origin/main` 为准**(V0.2.2 ship 后) |
 | Workspace version | **`0.2.2`**(V0.2.2 起跟版同步;V0.1/V0.2 ship 时 `0.0.1` 未跟,V0.2.2 retroactive 修正)|
-| 测试 baseline | **628 全绿**(`cargo test --workspace`)|
+| 测试 baseline | **631 全绿**(`cargo test --workspace`;F44 加 2 个反向迁移测试)|
 | Clippy | 4 pre-existing errors(非本仓引入,sweep 时确认相同基线) |
 | 代码规模 | ~12 kLOC across `ccteam-core` / `ccteam-cli` / `ccteam-hooks` |
-| 已 ship 里程碑 | **V0.1**:M0 / M0.5 / M1 / M2 / M2.3 / M3 / M4.1-M4.4 — 详 `docs/v0-1/README.md`<br>**V0.2**:M0.16-M0.23(8 个 milestone:反模式清理 / 团队布局 + plugin 模型 / phase prompt 协议外移 / 自循环 + AskUserQuestion 拦截 / plugin pipeline / daemon supervision / watchdog / team factory)— 详 `docs/v0-2/README.md`<br>**V0.2.2**:F34-F40(7 finding 跨 7 PR:cct convention sweep / slug 4-tier + 决策树加固 / silence classifier / subagent guard / 截图 PNG / team alias)— 详 `docs/v0-2-2/README.md` |
+| 已 ship 里程碑 | **V0.1**:M0 / M0.5 / M1 / M2 / M2.3 / M3 / M4.1-M4.4 — 详 `docs/v0-1/README.md`<br>**V0.2**:M0.16-M0.23(8 个 milestone)— 详 `docs/v0-2/README.md`<br>**V0.2.2**:F34-F40 + F44(F39 cct convention sweep 已被 F44 反向回滚 / slug 4-tier + 决策树加固 / silence classifier / subagent guard / 截图 PNG / team alias)— 详 `docs/v0-2-2/README.md` |
 | 当前 next | V0.3 候选方向待定,deferred 项见 `docs/v0-2/README.md` 末尾 + `docs/v0-2-2/prd.md §11` |
 | 永久 deferred | M2.2 agent_team enablement(spike A,Claude Code 无 first-class CLI surface — 见 `docs/v0-1/m2-agent-team-spike.md`)|
 
-**ccteam 是 Claude Code 之上的元工具,不是独立 AI 系统**:每个项目一个 Claude Code 长 session(tmux 守护,hooks 上报,MCP 接外部);Rust orchestrator 编排(binary 名 `cct`,F39 起);用户通过 meta-agent(常驻 ccteam-managed claude session)+ `cct-control` skill / `ccteam` MCP server(`mcp__ccteam__*` 命名空间)用自然语言对话操作。详见 `docs/tech-design.md` §2.1 三层架构。
+**ccteam 是 Claude Code 之上的元工具,不是独立 AI 系统**:每个项目一个 Claude Code 长 session(tmux 守护,hooks 上报,MCP 接外部);Rust orchestrator 编排(binary 名 `ccteam`);用户通过 meta-agent(常驻 ccteam-managed claude session)+ `ccteam-control` skill / `ccteam` MCP server(`mcp__ccteam__*` 命名空间)用自然语言对话操作。详见 `docs/tech-design.md` §2.1 三层架构。
 
 ---
 
@@ -60,7 +60,6 @@
 - **retro 写 `~/.claude/rules/ccteam-lessons-<team>.md` 必须限 marked section**:`<!-- ccteam-managed:lessons begin/end -->` 包裹,不污染用户其他段;phase prompt 严格约束,doctor `--install-memory-bridge` 只重写自己段(幂等)
 - **新建项目目录走 `~/projects/<team>-<slug>/` 约定**(F22 后):`pick_unused_slug` 强制 team 前缀;meta-agent 仍 `<handle>-meta` 后缀(独立路径)
 - **`ccteam-core` 不出现 team 名字面量**:strategic doc §3 红线;团队特定行为靠 `team.yaml` 数据驱动
-- **`cct` 短前缀约定**(V0.2.2 F39):binary 名 `cct`,自带 skill `cct-control` / `cct-team-author`,顶层 `skills/` 目录是 SoT;**项目名仍叫 ccteam**(`crates/ccteam-{cli,core,hooks}` / `~/.ccteam/` / git repo / MCP 命名空间 `mcp__ccteam__*` 不动 — 详 PRD §8.3)。`cct doctor` 自带 V0.1/V0.2 → V0.2.2 迁移逻辑;新代码 / phase prompt / docs 一律用 `cct`
 
 ---
 
@@ -69,7 +68,7 @@
 | 机制 | 用途 | 文档 |
 |---|---|---|
 | **CLAUDE.md** | 项目级 / 用户级持久指令 | best-practices §4.1 |
-| **Skills** | `cct-control`(M1.8 ✅,V0.2.2 F39 改名)/ `cct-team-author`(M0.22 ✅)/ `ccgram-messaging`(M3+ 多 orchestrator);自带 skill SoT 在 repo 根 `skills/` | tech-design §6.7 |
+| **Skills** | `ccteam-control`(M1.8 ✅)/ `ccteam-team-author`(M0.22 ✅)/ `ccteam-project-creator`(V0.2.2 F34 ✅)/ `ccgram-messaging`(M3+ 多 orchestrator);自带 skill SoT 在 repo 根 `skills/` | tech-design §6.7 |
 | **MCP** | `ccteam-mcp`(M2 ✅,9 tools)/ `claude-mem`(M4 可选) | tech-design §6.4 |
 | **Subagents** | phase 内 `Task(subagent_type=...)` 节流;`code-reviewer` 等 8 个 plugin agent 已 ln -sf | best-practices §6.3 |
 | **Hooks** | `progress.jsonl append` / `parse-phase-end` / `cost-accumulate` 已 ship;`Stop`/`SubagentStop`/`SessionEnd` 都进 idle 列表(F1+F2 修复) | tech-design §6.2 |
@@ -111,7 +110,7 @@
 
 ## 六、易踩的坑(实战累积)
 
-- **不要给 ccteam 自己加 ccteam 风格的 hook/orchestrator** — 循环引用排错地狱。本仓库用 Claude Code 默认行为开发,只产出物(`~/projects/<team>-<slug>/`)挂 cct 自己的 hook
+- **不要给 ccteam 自己加 ccteam 风格的 hook/orchestrator** — 循环引用排错地狱。本仓库用 Claude Code 默认行为开发,只产出物(`~/projects/<team>-<slug>/`)挂 ccteam 自己的 hook
 - **`.claude/settings.json` 的 `bypassPermissions` 是开发态便利** — 产品形态是 `--dangerously-skip-permissions` + 容器隔离,语义不同(best-practices §4.2 三选一)
 - **phase prompt 别写太长** — 单条 send-keys 装得下;复杂内容用 `@文件引用`(best-practices §3)
 - **`claude-plugins-official` 是参考实现,不是依赖** — 别 vendor 一份;按 §3.7 三粒度选(@引用 / 拷贝改 / 整 plugin install)
@@ -121,6 +120,6 @@
 - **跨 session 协作时见到主仓 dirty 状态** → `git stash push -m "<owner-session> WIP"` 再切,别盲目 `git checkout -- .`
 - **改了 `ccteam-core` 公共 API**(如 `pick_unused_slug` 签名)→ grep 全 caller(包括 tests / mcp_serve.rs / commands.rs)
 - **F22 后 slug 带 team 前缀**:`run_new` test 期望 `dev-<base>` 而非 `<base>`;改新 slug 路径时验证 rules `paths:` 还匹配
-- **V0.1 → V0.2 升级一次性迁移**:M0.20 后 plugin agent 通过 spawned session `enabledPlugins` 启用,不再 ln -sf 进 `~/.claude/agents/`。V0.1 用户首次升级 V0.2 时跑 `cct doctor --migrate-recommended-agents` 清理旧 ln -sf(只删 ccteam 自己创建的 marketplace symlink,用户手写 agent 不动)
-- **V0.2 → V0.2.2 升级一次性迁移**(F39):binary `ccteam` → `cct`,skill `ccteam-{control,team-author}` → `cct-{control,team-author}`。`cct doctor --install-skill` / `--install-meta-agent` 自动检测 + 清旧 skill dir(marker 校验,只清 ccteam-managed 的;用户手改保留 + warn) + rewrite `~/projects/<slug>/.claude/settings.json` 老 hook command 路径(原子写)
+- **V0.1 → V0.2 升级一次性迁移**:M0.20 后 plugin agent 通过 spawned session `enabledPlugins` 启用,不再 ln -sf 进 `~/.claude/agents/`。V0.1 用户首次升级 V0.2 时跑 `ccteam doctor --migrate-recommended-agents` 清理旧 ln -sf(只删 ccteam 自己创建的 marketplace symlink,用户手写 agent 不动)
+- **V0.2.2 (F39) → V0.2.2 (F44) 反向迁移**:用户从 F39'd V0.2.2 升级到 F44'd V0.2.2 时,`ccteam doctor` 自动检测 `~/.local/bin/cct` 旧 symlink、`~/.claude/skills/cct-{control,team-author,project-creator}/` 旧 skill dir(marker 校验,只清 ccteam-managed 的;用户手改保留 + warn)、`~/projects/<slug>/.claude/settings.json` 老 hook command 路径(`cct` → `ccteam`,原子写)。原因:F39 选 `cct` 二进制名时未检查 namespace,Ubuntu `proj-bin` 已占 `/usr/bin/cct`(PROJ 工具),`~/.local/bin/cct` 在标准 PATH 上会静默 shadow GIS 工具
 - **本文件不超过 250 行** — CLAUDE.md 越长 cache 越贵,Claude 越忽略(best-practices §4.1 + §8)

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -10,7 +10,7 @@ or repository, with their respective licenses.
 
 - **Vendored at**: `crates/ccteam-core/assets/fonts/JetBrainsMono-Regular.ttf`
 - **Used by**: V0.2.2 F38 — terminal screenshot pipeline. Baked into the
-  `cct` binary via `include_bytes!` so screenshot rendering has zero
+  `ccteam` binary via `include_bytes!` so screenshot rendering has zero
   system-font dependencies. Users can override at runtime by setting
   the `CCTEAM_SCREENSHOT_FONT_TTF` environment variable.
 - **Upstream**: <https://github.com/JetBrains/JetBrainsMono>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You talk to a **meta-agent** — a permanent Claude Code session that understand
 ```
 You:    "Make a Rust CLI for managing bookmarks, SQLite-backed."
 Meta:   "I'll dispatch the dev team. Slug = dev-bookmark-cli-rust-sqlite.
-         Tracking via `cct show dev-bookmark-cli-rust-sqlite`."
+         Tracking via `ccteam show dev-bookmark-cli-rust-sqlite`."
 [~30 minutes later]
 Meta:   "dev-bookmark-cli-rust-sqlite shipped. 22 tests green, $4.80
          cost, retro lessons appended to ~/.claude/rules/ccteam-lessons-dev.md."
@@ -35,7 +35,7 @@ You:    "I want a team for iterating an existing app: new requirement →
          feasibility → architecture → implementation → tests → release."
 Meta:   "Drafting a custom team. Plugin manifest + 6 phase markdowns
          under ~/.config/ccteam/teams/iter-app/. Run
-         `cct team publish iter-app --target local` when ready."
+         `ccteam team publish iter-app --target local` when ready."
 ```
 
 ## Why ccteam
@@ -75,23 +75,23 @@ ccteam --version
 One-time setup (idempotent — re-runs are no-ops):
 
 ```bash
-cct init                                       # ~/.ccteam/ skeleton
-cct doctor --install-skill                     # cct-control skill (any claude session reaches ccteam)
-cct doctor --install-mcp                       # 9-tool MCP server in ~/.claude.json
-cct doctor --install-memory-bridge             # ~/.claude/rules/ccteam-lessons-<team>.md placeholders
-cct doctor --install-meta-agent <your-handle>  # bootstrap your meta-agent project
-cct doctor --tool-surface                      # health check (must be green)
+ccteam init                                       # ~/.ccteam/ skeleton
+ccteam doctor --install-skill                     # ccteam-control skill (any claude session reaches ccteam)
+ccteam doctor --install-mcp                       # 9-tool MCP server in ~/.claude.json
+ccteam doctor --install-memory-bridge             # ~/.claude/rules/ccteam-lessons-<team>.md placeholders
+ccteam doctor --install-meta-agent <your-handle>  # bootstrap your meta-agent project
+ccteam doctor --tool-surface                      # health check (must be green)
 ```
 
 `<your-handle>` is whatever you want to call yourself — snake_case, e.g. `rob` or `alice`.
 
-> **Upgrading from a pre-2026-05 ccteam?** Run `cct doctor --migrate-recommended-agents` once after the upgrade. Spawned project sessions now resolve plugin agents through Claude Code's plugin pipeline, so the legacy `~/.claude/agents/<name>.md` symlinks ccteam used to create are obsolete; this command removes them. User-authored agents are preserved.
+> **Upgrading from a pre-2026-05 ccteam?** Run `ccteam doctor --migrate-recommended-agents` once after the upgrade. Spawned project sessions now resolve plugin agents through Claude Code's plugin pipeline, so the legacy `~/.claude/agents/<name>.md` symlinks ccteam used to create are obsolete; this command removes them. User-authored agents are preserved.
 
 ## Quick start
 
 ```bash
 # Terminal A — start the orchestrator (foreground; keep this open)
-cct start --foreground
+ccteam start --foreground
 
 # Terminal B — talk to the meta-agent
 tmux attach -t ccteam-meta-<your-handle>
@@ -112,7 +112,7 @@ claude
 # Or:   "Dispatch a dev team to make a todo CLI in Python."
 ```
 
-The meta-agent uses the `cct-control` skill plus the `ccteam-mcp` 9-tool MCP server you installed, so any Claude Code session understands ccteam.
+The meta-agent uses the `ccteam-control` skill plus the `ccteam-mcp` 9-tool MCP server you installed, so any Claude Code session understands ccteam.
 
 ## Built-in teams
 
@@ -131,11 +131,11 @@ To author a custom team, ask the meta-agent:
 The meta-agent walks you through phase definition, tools required, golden-rule constraints, and retro-schema fields, then scaffolds the plugin under `~/.config/ccteam/teams/<name>/`. Publish with:
 
 ```bash
-cct team publish <name> --target local              # link into ccteam-local marketplace
-cct team publish <name> --target github --repo ...  # push to a GitHub repo as a shareable plugin
+ccteam team publish <name> --target local              # link into ccteam-local marketplace
+ccteam team publish <name> --target github --repo ...  # push to a GitHub repo as a shareable plugin
 ```
 
-Anyone who installs your team-plugin via Claude Code's plugin commands gets a fully-functional cct team.
+Anyone who installs your team-plugin via Claude Code's plugin commands gets a fully-functional ccteam team.
 
 ## How it works
 

--- a/crates/ccteam-cli/Cargo.toml
+++ b/crates/ccteam-cli/Cargo.toml
@@ -4,10 +4,10 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-description = "cct (ccteam) command-line tool: orchestrator daemon, project management, and hook subcommands."
+description = "ccteam command-line tool: orchestrator daemon, project management, and hook subcommands."
 
 [[bin]]
-name = "cct"
+name = "ccteam"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -10,8 +10,8 @@ use chrono::Utc;
 use serde_json::{json, Map, Value};
 
 use ccteam_core::{
-    bootstrap_meta_project, bootstrap_project, current_cct_bin, install_cct_control_skill,
-    install_cct_project_creator_skill, install_cct_team_author_skill,
+    bootstrap_meta_project, bootstrap_project, current_ccteam_bin, install_ccteam_control_skill,
+    install_ccteam_project_creator_skill, install_ccteam_team_author_skill,
     migrate_legacy_skill_dirs, migrate_recommended_agent_symlinks, pick_unused_slug,
     rewrite_legacy_hook_commands, user_claude_dir, write_all_global_team_templates,
     write_global_helper_templates, write_global_phase_templates, CcteamPaths,
@@ -29,7 +29,7 @@ pub enum OutputFormat {
     Json,
 }
 
-/// Options passed from the `cct init` argument parser.
+/// Options passed from the `ccteam init` argument parser.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct InitOptions {
     /// Overwrite existing global phase templates instead of skipping
@@ -37,7 +37,7 @@ pub struct InitOptions {
     pub force: bool,
 }
 
-/// `cct init`. Creates `~/.ccteam/{phases,progress,inbox,control,
+/// `ccteam init`. Creates `~/.ccteam/{phases,progress,inbox,control,
 /// queue,memory,state}`, unpacks the embedded phase templates into
 /// `~/.ccteam/phases/`, and runs a quick health check. Returns a
 /// human-readable report.
@@ -80,7 +80,7 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
         )
     })?;
 
-    let bin = current_cct_bin().ok();
+    let bin = current_ccteam_bin().ok();
 
     let claude = Command::new("claude").arg("--version").output();
     let tmux = Command::new("tmux").arg("-V").output();
@@ -118,8 +118,8 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
     }
 
     out.push_str("\nnext:\n");
-    out.push_str("  cct new \"<your one-line request>\"\n");
-    out.push_str("  cct start --foreground   # in another terminal\n");
+    out.push_str("  ccteam new \"<your one-line request>\"\n");
+    out.push_str("  ccteam start --foreground   # in another terminal\n");
     Ok(out)
 }
 
@@ -141,7 +141,7 @@ pub struct RunNewOptions<'a> {
     pub auto_slug_model: &'a str,
 }
 
-/// `cct new "request" --team <name>`. Bootstraps a project on disk
+/// `ccteam new "request" --team <name>`. Bootstraps a project on disk
 /// and returns the chosen slug. Side effects: creates
 /// `~/projects/<slug>/...`. `team` is recorded in state.json so the
 /// orchestrator can route this project through the matching phase set.
@@ -149,12 +149,12 @@ pub struct RunNewOptions<'a> {
 /// **M3.3 fail-fast**: non-dev teams require a `team.yaml` to be
 /// loadable from `~/.ccteam/teams/<team>/team.yaml`. The dev team is
 /// grandfathered in (no team.yaml required) so legacy installs
-/// without `cct init` still work. Meta-agent is also allowed
+/// without `ccteam init` still work. Meta-agent is also allowed
 /// without a team.yaml — its bootstrap path is bespoke.
 ///
 /// V0.2 §6.4 candidate 3: shipped seeds (dev / product-research /
 /// meta-agent) are stamped to disk inside `run_new` so a fresh
-/// install no longer needs an explicit `cct init` for the
+/// install no longer needs an explicit `ccteam init` for the
 /// validation to find them.
 ///
 /// V0.2.2 F34: takes `RunNewOptions` for the four-tier slug stack.
@@ -165,20 +165,20 @@ pub fn run_new(
     opts: RunNewOptions<'_>,
 ) -> Result<String> {
     if request.trim().is_empty() {
-        bail!("cct new: request must be non-empty");
+        bail!("ccteam new: request must be non-empty");
     }
     if team.trim().is_empty() {
-        bail!("cct new: --team must be non-empty");
+        bail!("ccteam new: --team must be non-empty");
     }
     // Self-heal shipped seeds before validating — without this, a
-    // first-time `cct new --team research` against a freshly-installed
+    // first-time `ccteam new --team research` against a freshly-installed
     // binary would fail with "unknown team". force=false preserves
     // operator hand-edits.
     if let Err(err) = ccteam_core::write_all_global_team_templates(&paths.root, false) {
         tracing::warn!(
             error = %err,
             root = %paths.root.display(),
-            "cct new: could not seed shipped team templates",
+            "ccteam new: could not seed shipped team templates",
         );
     }
     ensure_team_resolvable(paths, team)?;
@@ -192,7 +192,7 @@ pub fn run_new(
     if let Some(canonical) = find_alias_canonical(paths, team) {
         if canonical != team {
             eprintln!(
-                "cct new: `--team {team}` is a deprecated alias for `{canonical}`; \
+                "ccteam new: `--team {team}` is a deprecated alias for `{canonical}`; \
                  prefer `--team {canonical}` going forward",
             );
         }
@@ -233,7 +233,7 @@ fn decide_slug(
             Err(err) => {
                 tracing::warn!(
                     error = %err,
-                    "cct new: smart slug suggestion unavailable; falling back to deterministic",
+                    "ccteam new: smart slug suggestion unavailable; falling back to deterministic",
                 );
             }
         }
@@ -270,7 +270,7 @@ fn try_smart_slug(request: &str, model: &str) -> Result<Option<String>> {
 
     let prompt = render_smart_slug_prompt(request);
 
-    eprintln!("[cct] querying claude for slug recommendation...");
+    eprintln!("[ccteam] querying claude for slug recommendation...");
     let mut child = Command::new(&bin)
         .args(["-p", "--model", model])
         .stdin(Stdio::piped())
@@ -318,11 +318,11 @@ fn try_smart_slug(request: &str, model: &str) -> Result<Option<String>> {
     // Confirm in tty contexts; auto-accept when piped.
     let tty = std::io::IsTerminal::is_terminal(&io::stdin());
     if !tty {
-        eprintln!("[cct] suggested: {suggestion} (auto-accepted, non-tty)");
+        eprintln!("[ccteam] suggested: {suggestion} (auto-accepted, non-tty)");
         return Ok(Some(suggestion));
     }
 
-    eprint!("[cct] suggested: {suggestion}\n[cct] accept? [Y/n] (rerun with --slug to override): ");
+    eprint!("[ccteam] suggested: {suggestion}\n[ccteam] accept? [Y/n] (rerun with --slug to override): ");
     io::stderr().flush().ok();
     let mut line = String::new();
     let stdin = io::stdin();
@@ -332,7 +332,7 @@ fn try_smart_slug(request: &str, model: &str) -> Result<Option<String>> {
         Ok(Some(suggestion))
     } else {
         eprintln!(
-            "[cct] declined; rerun with `--slug <name>` to set explicitly, or fall back to deterministic"
+            "[ccteam] declined; rerun with `--slug <name>` to set explicitly, or fall back to deterministic"
         );
         Ok(None)
     }
@@ -418,7 +418,7 @@ fn ensure_team_resolvable(paths: &CcteamPaths, team: &str) -> Result<()> {
     let yaml_path = paths.root.join("teams").join(team).join("team.yaml");
     if yaml_path.exists() {
         TeamSpec::load(&yaml_path).with_context(|| {
-            format!("cct new: failed to load {}", yaml_path.display())
+            format!("ccteam new: failed to load {}", yaml_path.display())
         })?;
         return Ok(());
     }
@@ -429,9 +429,9 @@ fn ensure_team_resolvable(paths: &CcteamPaths, team: &str) -> Result<()> {
         .ok()
         .filter(|t| !t.is_empty())
         .map(|t| t.join(", "))
-        .unwrap_or_else(|| "(none yet — run `cct doctor --reset-shipped-teams`)".into());
+        .unwrap_or_else(|| "(none yet — run `ccteam doctor --reset-shipped-teams`)".into());
     bail!(
-        "cct new: unknown team `{team}` — \
+        "ccteam new: unknown team `{team}` — \
          create {} (see docs/interfaces.md §5.5 for schema), \
          then re-run.\n\
          Teams currently on disk: {known}.",
@@ -488,7 +488,7 @@ fn list_disk_teams(paths: &CcteamPaths) -> Result<Vec<String>> {
     Ok(out)
 }
 
-/// `cct ls`. Returns either a human table or the interfaces.md §10.3
+/// `ccteam ls`. Returns either a human table or the interfaces.md §10.3
 /// JSON shape (a single string, not printed — caller decides).
 pub fn run_ls(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
     let projects = collect_projects(paths)?;
@@ -499,7 +499,7 @@ pub fn run_ls(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
     })
 }
 
-/// `cct show <slug>`. Renders the full project view per
+/// `ccteam show <slug>`. Renders the full project view per
 /// interfaces.md §10.3 (json) or a human-readable summary (text).
 pub fn run_show(paths: &CcteamPaths, slug: &str, format: OutputFormat) -> Result<String> {
     let state_path = paths.project_state(slug);
@@ -516,7 +516,7 @@ pub fn run_show(paths: &CcteamPaths, slug: &str, format: OutputFormat) -> Result
     })
 }
 
-/// `cct attach <slug>`. Execs `tmux attach -t ccteam-<slug>`. Exits
+/// `ccteam attach <slug>`. Execs `tmux attach -t ccteam-<slug>`. Exits
 /// successfully when the user detaches; non-zero on error.
 pub fn run_attach(slug: &str) -> Result<()> {
     let session = TmuxSession::for_slug(slug);
@@ -533,7 +533,7 @@ pub fn run_attach(slug: &str) -> Result<()> {
     Ok(())
 }
 
-/// `cct peek <slug>`. Returns the contents of the session's first
+/// `ccteam peek <slug>`. Returns the contents of the session's first
 /// pane via `tmux capture-pane -p`.
 pub fn run_peek(slug: &str) -> Result<String> {
     let session = TmuxSession::for_slug(slug);
@@ -551,7 +551,7 @@ pub fn run_peek(slug: &str) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-/// `cct progress <slug>`. With `tail = false`, returns the entire
+/// `ccteam progress <slug>`. With `tail = false`, returns the entire
 /// progress.jsonl as text. With `tail = true`, reads + writes to
 /// stdout in a polling loop until Ctrl-C.
 pub fn run_progress(paths: &CcteamPaths, slug: &str, tail: bool) -> Result<()> {
@@ -588,7 +588,7 @@ pub fn run_progress(paths: &CcteamPaths, slug: &str, tail: bool) -> Result<()> {
     }
 }
 
-/// `cct resume <slug>`. M0 minimum: clears any user_pause flag, drops
+/// `ccteam resume <slug>`. M0 minimum: clears any user_pause flag, drops
 /// the escalation marker if present, and sets phase_state back to idle so
 /// the daemon's next tick re-dispatches the current phase. Real
 /// `--resume` (claude session continuation) is M1+.
@@ -632,7 +632,7 @@ pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
     Ok(())
 }
 
-/// One row in the cross-project decisions queue (`cct decisions`).
+/// One row in the cross-project decisions queue (`ccteam decisions`).
 ///
 /// A "decision" = an outbox file in any project's `.ccteam/outbox/` whose
 /// front matter has `event_kind: clarify` or `event_kind: escalation`.
@@ -651,7 +651,7 @@ pub struct DecisionRow {
     pub summary: String,
 }
 
-/// `cct decisions`. Aggregate the cross-project decisions queue and
+/// `ccteam decisions`. Aggregate the cross-project decisions queue and
 /// render it. interfaces.md §5.6.4 — meta-agent uses this as the
 /// surface for "你有 N 条待决策" UX. M1 follow-up increment.
 pub fn run_decisions(paths: &CcteamPaths, format: OutputFormat) -> Result<String> {
@@ -868,7 +868,7 @@ fn ellipsize(s: &str, max: usize) -> String {
     }
 }
 
-/// `cct doctor` flags. Each mode is a separate boolean / option so
+/// `ccteam doctor` flags. Each mode is a separate boolean / option so
 /// they can be combined (e.g. `--install-meta-agent rob` implies
 /// `--install-skill` automatically).
 #[derive(Debug, Clone, Default)]
@@ -876,10 +876,11 @@ pub struct DoctorOptions {
     pub dry_run: bool,
     pub force: bool,
     pub tool_surface: bool,
-    /// M1.8 (V0.2.2 F39): install `~/.claude/skills/cct-control/SKILL.md`
-    /// and `~/.claude/skills/cct-team-author/SKILL.md`, plus run the
-    /// V0.1/V0.2 → V0.2.2 cleanup migration (legacy skill dirs and
-    /// stale settings.json hook command paths).
+    /// M1.8: install `~/.claude/skills/ccteam-control/SKILL.md`
+    /// and `~/.claude/skills/ccteam-team-author/SKILL.md`, plus run the
+    /// V0.2.2 (F39'd) → V0.2.2 (F44'd) reverse migration (cleanup of
+    /// legacy `cct-*` skill dirs and stale settings.json hook command
+    /// paths).
     pub install_skill: bool,
     /// M1.0: bootstrap a meta-agent project for the given user handle.
     /// `Some("rob")` ⇒ creates `~/projects/rob-meta/` and triggers
@@ -918,7 +919,7 @@ pub struct DoctorOptions {
     pub screenshot_smoke: Option<String>,
 }
 
-/// `cct doctor` dispatch. Returns a human-readable report so unit
+/// `ccteam doctor` dispatch. Returns a human-readable report so unit
 /// tests don't need to capture stdout.
 pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     let any_mode = opts.tool_surface
@@ -932,15 +933,15 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         || opts.screenshot_smoke.is_some();
     if !any_mode {
         return Ok(String::from(
-            "cct doctor: pass at least one mode flag.\n\
+            "ccteam doctor: pass at least one mode flag.\n\
              \n\
              modes:\n  \
              --tool-surface\n      \
              cross-check phase templates' tools_required against current reachability — \
              plugin-pipeline-aware (V0.2 M0.20).\n  \
              --install-skill [--force]\n      \
-             write ~/.claude/skills/cct-{control,team-author}/SKILL.md (M1.8 + V0.2.2 F39); \
-             also runs the V0.1/V0.2 → V0.2.2 cleanup (legacy `ccteam-*` skill dirs + \
+             write ~/.claude/skills/ccteam-{control,team-author,project-creator}/SKILL.md (M1.8); \
+             also runs the V0.2.2 (F39'd) → V0.2.2 (F44'd) reverse migration (legacy `cct-*` skill dirs + \
              stale settings.json hook command paths).\n  \
              --install-meta-agent <user-handle>\n      \
              bootstrap a meta-agent project for the given user (M1.0). Implies --install-skill.\n  \
@@ -988,7 +989,7 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         // or plugin-section) → non-zero exit so CI can gate on it.
         if fails > 0 {
             anyhow::bail!(
-                "cct doctor --validate-team {team}: {fails} fail(s) — \
+                "ccteam doctor --validate-team {team}: {fails} fail(s) — \
                  see report above\n\n{out}",
             );
         }
@@ -1024,7 +1025,7 @@ fn render_validate_team_report(
         TeamResolveContext, TEAM_SOURCES,
     };
 
-    let mut out = format!("cct doctor --validate-team {team}\n\n");
+    let mut out = format!("ccteam doctor --validate-team {team}\n\n");
     // F30 — accumulate every [FAIL] line into a single counter so the
     // top-level Summary and the `run_doctor` exit code agree. Phase-
     // section findings sum into this same counter below.
@@ -1087,7 +1088,7 @@ fn render_validate_team_report(
         None => {
             out.push_str(
                 "[FAIL] could not locate team directory after resolve — \
-                 run `cct doctor --reset-shipped-teams`\n",
+                 run `ccteam doctor --reset-shipped-teams`\n",
             );
             fails += 1;
             out.push_str(&format!("\nSummary: 0 ok, 0 warn, {fails} fail\n"));
@@ -1279,7 +1280,7 @@ pub fn run_phase_show(
     let template = found_template.ok_or_else(|| {
         anyhow::anyhow!(
             "team `{team}` has no phase `{phase}` under {} — \
-             check `cct doctor --validate-team {team}` for the phase list",
+             check `ccteam doctor --validate-team {team}` for the phase list",
             phase_dir.display(),
         )
     })?;
@@ -1325,7 +1326,7 @@ fn render_reset_shipped_teams_report(
     opts: &DoctorOptions,
 ) -> Result<String> {
     ccteam_core::write_all_global_team_templates(&paths.root, opts.force)?;
-    let mut out = String::from("cct doctor --reset-shipped-teams\n\n");
+    let mut out = String::from("ccteam doctor --reset-shipped-teams\n\n");
     if opts.force {
         out.push_str(
             "  Re-wrote every shipped team's team.yaml + phase markdowns under \
@@ -1344,7 +1345,7 @@ fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions
     // V0.2 §6.4 candidate 3: bridge teams are now discovered by
     // scanning `~/.ccteam/teams/<name>/team.yaml`. Make sure shipped
     // seeds are present before the scan so a fresh install (no
-    // `cct init` yet) still lays down dev / product-research
+    // `ccteam init` yet) still lays down dev / product-research
     // bridges. force=false preserves operator hand-edits.
     if !opts.dry_run {
         ccteam_core::write_all_global_team_templates(&paths.root, false)?;
@@ -1354,9 +1355,9 @@ fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions
     };
     let reports = ccteam_core::install_memory_bridge(&paths.root, install_opts)?;
     let mut out = if opts.dry_run {
-        String::from("cct doctor --install-memory-bridge (dry-run)\n\n")
+        String::from("ccteam doctor --install-memory-bridge (dry-run)\n\n")
     } else {
-        String::from("cct doctor --install-memory-bridge\n\n")
+        String::from("ccteam doctor --install-memory-bridge\n\n")
     };
     for r in &reports {
         let label = match &r.action {
@@ -1385,7 +1386,7 @@ fn render_install_memory_bridge_report(paths: &CcteamPaths, opts: &DoctorOptions
 
 fn render_install_mcp_report() -> Result<String> {
     let path = crate::mcp_serve::install_mcp()?;
-    let mut out = String::from("cct doctor --install-mcp\n\n");
+    let mut out = String::from("ccteam doctor --install-mcp\n\n");
     out.push_str(&format!("  registered ccteam MCP server in {}\n", path.display()));
     out.push_str("  tools surface : 9 (interfaces §12.2)\n");
     out.push_str("  consumers     : daily-driver claude + meta-agent\n");
@@ -1416,57 +1417,57 @@ fn render_install_skill_report(paths: &CcteamPaths, opts: &DoctorOptions) -> Res
         force: opts.force,
         dry_run: opts.dry_run,
     };
-    let mut out = String::from("cct doctor --install-skill\n\n");
+    let mut out = String::from("ccteam doctor --install-skill\n\n");
 
-    // V0.2.2 F39: install all shipped skills under their cct-* names.
-    // V0.2.2 F34: cct-project-creator joins the install set.
-    let control = install_cct_control_skill(install_opts)?;
+    // V0.2.2 F44: install all shipped skills under their canonical
+    // ccteam-* names (reverting F39's `cct-*` rename).
+    let control = install_ccteam_control_skill(install_opts)?;
     out.push_str(&format!(
-        "  cct-control          {label}  {}\n",
+        "  ccteam-control          {label}  {}\n",
         control.target.display(),
         label = skill_install_label(&control.action),
     ));
-    let team_author = install_cct_team_author_skill(install_opts)?;
+    let team_author = install_ccteam_team_author_skill(install_opts)?;
     out.push_str(&format!(
-        "  cct-team-author      {label}  {}\n",
+        "  ccteam-team-author      {label}  {}\n",
         team_author.target.display(),
         label = skill_install_label(&team_author.action),
     ));
-    let project_creator = install_cct_project_creator_skill(install_opts)?;
+    let project_creator = install_ccteam_project_creator_skill(install_opts)?;
     out.push_str(&format!(
-        "  cct-project-creator  {label}  {}\n",
+        "  ccteam-project-creator  {label}  {}\n",
         project_creator.target.display(),
         label = skill_install_label(&project_creator.action),
     ));
     out.push('\n');
 
-    // V0.2.2 F39 migration: clean up legacy V0.1/V0.2 skill dirs and
-    // rewrite stale settings.json hook command paths so users upgrading
-    // from V0.2.1 don't end up with duplicate `ccteam-*` + `cct-*` skill
-    // directories or hook commands pointing at a renamed binary.
-    out.push_str(&render_f39_migration(paths, opts)?);
+    // V0.2.2 F44 reverse migration: clean up F39-era `cct-*` skill dirs
+    // and rewrite stale settings.json hook command paths so users
+    // upgrading from F39'd V0.2.2 to F44'd V0.2.2 don't end up with
+    // duplicate `cct-*` + `ccteam-*` skill directories or hook commands
+    // pointing at the F39 `cct` binary that no longer exists.
+    out.push_str(&render_f44_migration(paths, opts)?);
 
     Ok(out)
 }
 
-/// V0.2.2 F39: detect-and-clean V0.1/V0.2 install artifacts so users
-/// who upgrade `ccteam → cct` don't end up with both naming
-/// conventions live at once. Runs as a side effect of `--install-skill`
-/// and `--install-meta-agent` (PRD §8.2.5 — "no new doctor flag,
-/// migration runs alongside install").
-fn render_f39_migration(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<String> {
+/// V0.2.2 F44: detect-and-clean F39-era install artifacts so users who
+/// revert from `cct → ccteam` don't end up with both naming conventions
+/// live at once. Runs as a side effect of `--install-skill` and
+/// `--install-meta-agent`.
+fn render_f44_migration(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<String> {
     let mut out = String::new();
     let claude = match user_claude_dir() {
         Ok(c) => c,
         Err(_) => {
-            // No claude dir — no V0.1/V0.2 install to clean up.
+            // No claude dir — no F39-era install to clean up.
             return Ok(out);
         }
     };
 
-    out.push_str("F39 migration (V0.1/V0.2 → V0.2.2 cleanup)\n\n");
+    out.push_str("F44 reverse migration (V0.2.2 F39 → V0.2.2 F44 cleanup)\n\n");
 
-    // 1. Legacy skill dirs.
+    // 1. Legacy `cct-*` skill dirs.
     let skill_reports = migrate_legacy_skill_dirs(&claude, opts.dry_run)?;
     let any_skill_action = skill_reports
         .iter()
@@ -1476,13 +1477,13 @@ fn render_f39_migration(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<Str
             out.push_str(&render_legacy_skill_line(r, opts.dry_run));
         }
     } else {
-        out.push_str("  legacy skills    no `~/.claude/skills/ccteam-*` dirs found — nothing to do.\n");
+        out.push_str("  legacy skills    no `~/.claude/skills/cct-*` dirs found — nothing to do.\n");
     }
 
     // 2. Stale settings.json hook command paths. Use the orchestrator's
     // resolved projects root so test fixtures get the tempdir; tests
     // don't otherwise mutate `~/projects/`.
-    let new_bin = current_cct_bin().ok();
+    let new_bin = current_ccteam_bin().ok();
     if let Some(bin) = new_bin.as_ref() {
         let hook_reports =
             scan_project_settings_for_hook_rewrite(&paths.projects_root, bin, opts.dry_run)?;
@@ -1504,7 +1505,7 @@ fn render_f39_migration(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<Str
                 // All NoChangeNeeded — collapse the table to a single
                 // friendly summary instead of dumping every project.
                 out.clear();
-                out.push_str("F39 migration (V0.1/V0.2 → V0.2.2 cleanup)\n\n");
+                out.push_str("F44 reverse migration (V0.2.2 F39 → V0.2.2 F44 cleanup)\n\n");
                 for r in &skill_reports {
                     out.push_str(&render_legacy_skill_line(r, opts.dry_run));
                 }
@@ -1515,7 +1516,7 @@ fn render_f39_migration(paths: &CcteamPaths, opts: &DoctorOptions) -> Result<Str
             }
         }
     } else {
-        out.push_str("  legacy hooks     could not resolve `cct` binary — skipped.\n");
+        out.push_str("  legacy hooks     could not resolve `ccteam` binary — skipped.\n");
     }
     out.push('\n');
     Ok(out)
@@ -1587,7 +1588,7 @@ fn scan_project_settings_for_hook_rewrite(
 
 fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> Result<String> {
     let report: MetaBootstrapReport = bootstrap_meta_project(paths, user_handle)?;
-    let mut out = String::from("cct doctor --install-meta-agent\n\n");
+    let mut out = String::from("ccteam doctor --install-meta-agent\n\n");
     out.push_str(&format!("  user handle      {user_handle}\n"));
     out.push_str(&format!("  project slug     {}\n", report.slug));
     out.push_str(&format!("  project dir      {}\n", report.project_dir.display()));
@@ -1605,7 +1606,7 @@ fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> R
         "attach with      tmux attach -t ccteam-meta-{}\n",
         ccteam_core::meta_slug(user_handle)?.trim_end_matches("-meta"),
     ));
-    out.push_str("\nrun `cct start --foreground` (in another terminal) to wake the meta session.\n");
+    out.push_str("\nrun `ccteam start --foreground` (in another terminal) to wake the meta session.\n");
     Ok(out)
 }
 
@@ -1614,9 +1615,9 @@ fn render_migrate_recommended_agents_report(opts: &DoctorOptions) -> Result<Stri
     let reports = migrate_recommended_agent_symlinks(&claude, opts.dry_run)?;
     let mut out = String::new();
     out.push_str(if opts.dry_run {
-        "cct doctor --migrate-recommended-agents (dry-run)\n"
+        "ccteam doctor --migrate-recommended-agents (dry-run)\n"
     } else {
-        "cct doctor --migrate-recommended-agents\n"
+        "ccteam doctor --migrate-recommended-agents\n"
     });
     out.push('\n');
     if reports.is_empty() {
@@ -1661,7 +1662,7 @@ fn render_migration_line(r: &MigrationReport, dry_run: bool) -> String {
 /// and surfaces either the resulting PNG path + size or the
 /// degrade reason (tmux missing / vt100 panic / IO failure).
 fn render_screenshot_smoke_report(paths: &CcteamPaths, slug: &str) -> Result<String> {
-    let mut out = String::from("cct doctor --screenshot-smoke\n\n");
+    let mut out = String::from("ccteam doctor --screenshot-smoke\n\n");
     out.push_str(&format!("  slug:        {slug}\n"));
     match ccteam_core::probe_screenshot_font() {
         Ok(label) => out.push_str(&format!("  font probe:  ok  ({label})\n")),
@@ -1691,7 +1692,7 @@ fn render_screenshot_smoke_report(paths: &CcteamPaths, slug: &str) -> Result<Str
             out.push_str("  render:      degraded  (no PNG written)\n\n");
             out.push_str(
                 "rendering returned Ok(None). Common causes:\n  \
-                 - the tmux session `ccteam-<slug>` does not exist (start with `cct start`).\n  \
+                 - the tmux session `ccteam-<slug>` does not exist (start with `ccteam start`).\n  \
                  - tmux is not installed on this host.\n  \
                  - vt100 / imageproc panicked on a malformed input (unusual; check daemon stderr).\n  \
                  - IO error writing the PNG file.\n\n\
@@ -1708,7 +1709,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
     let templates = load_local_phase_templates(paths)?;
 
     let mut out = String::new();
-    out.push_str("cct doctor --tool-surface\n");
+    out.push_str("ccteam doctor --tool-surface\n");
     out.push_str(&format!(
         "\nclaude dir       : {}\n",
         claude.display()
@@ -1729,7 +1730,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
 
     if templates.is_empty() {
         out.push_str(
-            "no phase templates under ~/.ccteam/phases/ — run `cct init` first.\n",
+            "no phase templates under ~/.ccteam/phases/ — run `ccteam init` first.\n",
         );
         return Ok(out);
     }
@@ -1780,7 +1781,7 @@ fn render_tool_surface_report(paths: &CcteamPaths) -> Result<String> {
     if any_missing {
         out.push_str(
             "**Verdict:** at least one phase has a missing tool. \
-             `cct start` will refuse until they're installed (or pass --skip-tool-check).\n",
+             `ccteam start` will refuse until they're installed (or pass --skip-tool-check).\n",
         );
     } else {
         out.push_str("**Verdict:** all phase tool dependencies reachable.\n");
@@ -1893,12 +1894,12 @@ pub fn collect_recent_events(
 /// Collect every `.md` artifact under `<project>/.ccteam/` so non-dev
 /// teams (e.g. product-research with `verdict.md` / `rationale.md` /
 /// `next-steps.md` / `brief.md` / `market-survey.md`) get listed in
-/// `cct show <slug> --format json` without ccteam-cli holding a
+/// `ccteam show <slug> --format json` without ccteam-cli holding a
 /// per-team artifact whitelist (F8 fix, 2026-05-07).
 ///
 /// Key = file stem with `-` → `_` (e.g. `plan-eng.md` → `plan_eng`)
 /// so existing JSON consumers (the meta-agent dispatch tree, the
-/// cct-control skill) keep working without a schema migration.
+/// ccteam-control skill) keep working without a schema migration.
 /// Sub-directories under `.ccteam/` (e.g. `outbox/`, `inbox/`) are
 /// not enumerated — those have dedicated views.
 ///
@@ -1943,7 +1944,7 @@ fn render_ls_text(projects: &[ProjectSummary], daemon_up: bool) -> String {
     ));
     if projects.is_empty() {
         out.push_str(
-            "(no projects under ~/projects/. start one with `cct new \"<request>\"`.)\n",
+            "(no projects under ~/projects/. start one with `ccteam new \"<request>\"`.)\n",
         );
         return out;
     }
@@ -1962,7 +1963,7 @@ fn render_ls_text(projects: &[ProjectSummary], daemon_up: bool) -> String {
     out
 }
 
-/// `current_phase` is empty between `cct new` and the first
+/// `current_phase` is empty between `ccteam new` and the first
 /// dispatch; surface that as `pending` instead of a blank column so
 /// `ls` and `show` are readable on fresh projects.
 fn display_phase(phase: &str) -> &str {
@@ -2114,7 +2115,7 @@ fn truncate(s: &str, n: usize) -> &str {
     }
 }
 
-/// `cct watchdog scan` (V0.2 M0.21). Reads `~/.ccteam/watchdog.yaml`
+/// `ccteam watchdog scan` (V0.2 M0.21). Reads `~/.ccteam/watchdog.yaml`
 /// (or defaults), scans every project + the daemon heartbeat, and
 /// renders the resulting alerts. With `push_to_user_handle: Some(<h>)`
 /// each alert that survives filtering is also written to the meta-agent
@@ -2265,7 +2266,7 @@ mod tests {
         // `run_new` self-heals shipped seeds first, so
         // `product-research`'s yaml lands at
         // ~/.ccteam/teams/product-research/team.yaml during this
-        // call — no manual `cct init` needed.
+        // call — no manual `ccteam init` needed.
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
@@ -2479,7 +2480,7 @@ mod tests {
     #[test]
     fn run_resume_appends_resumed_history_after_escalated_entry() {
         // E2E 2026-05-06 F8: an escalated `phase_history` entry leaves
-        // `Dag::is_terminal_state` permanently true. `cct resume`
+        // `Dag::is_terminal_state` permanently true. `ccteam resume`
         // must append a paired `"resumed"` entry so future ticks
         // dispatch again. Append-only — the original escalated entry
         // stays intact for audit.
@@ -2665,14 +2666,14 @@ mod tests {
         assert_eq!(state.team, "meta-agent");
         assert_eq!(state.tmux_session, "ccteam-meta-rob");
 
-        // Skill landed under the redirected ~/.claude/. V0.2.2 F39 →
-        // both shipped skills should be written under cct-* names.
-        let control = tmp.path().join("skills/cct-control/SKILL.md");
-        assert!(control.is_file(), "cct-control SKILL.md not written: {}", control.display());
-        let team_author = tmp.path().join("skills/cct-team-author/SKILL.md");
+        // Skill landed under the redirected ~/.claude/. F44 reverts F39:
+        // both shipped skills are written under canonical ccteam-* names.
+        let control = tmp.path().join("skills/ccteam-control/SKILL.md");
+        assert!(control.is_file(), "ccteam-control SKILL.md not written: {}", control.display());
+        let team_author = tmp.path().join("skills/ccteam-team-author/SKILL.md");
         assert!(
             team_author.is_file(),
-            "cct-team-author SKILL.md not written: {}",
+            "ccteam-team-author SKILL.md not written: {}",
             team_author.display(),
         );
 
@@ -2695,29 +2696,29 @@ mod tests {
         assert!(report.contains("install-skill"));
         assert!(!report.contains("install-meta-agent"));
 
-        // V0.2.2 F39: both shipped skills land under cct-* names.
-        assert!(tmp.path().join("skills/cct-control/SKILL.md").is_file());
-        assert!(tmp.path().join("skills/cct-team-author/SKILL.md").is_file());
+        // F44 reverts F39: shipped skills land under canonical ccteam-* names.
+        assert!(tmp.path().join("skills/ccteam-control/SKILL.md").is_file());
+        assert!(tmp.path().join("skills/ccteam-team-author/SKILL.md").is_file());
         std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
 
     #[test]
-    fn run_doctor_install_skill_runs_f39_legacy_skill_cleanup() {
-        // V0.2.2 F39: --install-skill detects + removes any
-        // ~/.claude/skills/ccteam-{control,team-author}/ left over from
-        // V0.1/V0.2 installs whose body still carries the
+    fn run_doctor_install_skill_runs_f44_legacy_skill_cleanup() {
+        // V0.2.2 F44: --install-skill detects + removes any
+        // ~/.claude/skills/cct-{control,team-author,project-creator}/ left
+        // over from F39'd V0.2.2 installs whose body still carries the
         // ccteam-managed marker (or canonical frontmatter).
         ensure_isolation();
         let _guard = env_lock().lock().unwrap();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
-        // Stage a V0.2.x install.
-        let legacy = tmp.path().join("skills/ccteam-control");
+        // Stage an F39'd install (V0.2.2 PR #1 era).
+        let legacy = tmp.path().join("skills/cct-control");
         std::fs::create_dir_all(&legacy).unwrap();
         std::fs::write(
             legacy.join("SKILL.md"),
-            "---\nname: ccteam-control\n---\n# legacy body\n",
+            "---\nname: cct-control\n---\n# legacy body\n",
         )
         .unwrap();
 
@@ -2726,24 +2727,24 @@ mod tests {
             ..DoctorOptions::default()
         };
         let report = run_doctor(&paths, opts).unwrap();
-        assert!(report.contains("F39 migration"), "F39 report header missing: {report}");
-        assert!(report.contains("ccteam-control/"), "legacy entry missing: {report}");
-        assert!(!legacy.exists(), "legacy ccteam-control dir survived");
-        // New name still landed.
-        assert!(tmp.path().join("skills/cct-control/SKILL.md").is_file());
+        assert!(report.contains("F44 reverse migration"), "F44 report header missing: {report}");
+        assert!(report.contains("cct-control/"), "legacy entry missing: {report}");
+        assert!(!legacy.exists(), "legacy cct-control dir survived");
+        // New (canonical) name still landed.
+        assert!(tmp.path().join("skills/ccteam-control/SKILL.md").is_file());
         std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
 
     #[test]
     fn run_doctor_install_skill_preserves_user_hand_edited_legacy_skill() {
-        // F39: a legacy directory whose SKILL.md was hand-edited
+        // F44: a legacy `cct-*` directory whose SKILL.md was hand-edited
         // (no marker, no canonical frontmatter) is preserved.
         ensure_isolation();
         let _guard = env_lock().lock().unwrap();
         let tmp = TempDir::new().unwrap();
         let paths = fresh_paths(&tmp);
         std::env::set_var("CLAUDE_CONFIG_HOME", tmp.path().to_str().unwrap());
-        let legacy = tmp.path().join("skills/ccteam-team-author");
+        let legacy = tmp.path().join("skills/cct-team-author");
         std::fs::create_dir_all(&legacy).unwrap();
         std::fs::write(
             legacy.join("SKILL.md"),
@@ -2756,7 +2757,7 @@ mod tests {
             ..DoctorOptions::default()
         };
         let report = run_doctor(&paths, opts).unwrap();
-        assert!(report.contains("preserved"), "F39 should report preserve: {report}");
+        assert!(report.contains("preserved"), "F44 should report preserve: {report}");
         assert!(legacy.exists(), "hand-edited legacy dir was unexpectedly removed");
         std::env::remove_var("CLAUDE_CONFIG_HOME");
     }
@@ -2825,8 +2826,8 @@ mod tests {
 
     #[test]
     fn run_new_self_heals_shipped_seeds_for_first_time_install() {
-        // V0.2 §6.4 candidate 3: a fresh install (no `cct init`) where
-        // ~/.ccteam/teams/ is empty must still let `cct new --team
+        // V0.2 §6.4 candidate 3: a fresh install (no `ccteam init`) where
+        // ~/.ccteam/teams/ is empty must still let `ccteam new --team
         // research` succeed because run_new self-heals.
         // V0.2.2 F40: canonical name is `research`.
         ensure_isolation();
@@ -2843,7 +2844,7 @@ mod tests {
 
     #[test]
     fn run_new_accepts_legacy_alias_product_research_with_deprecation_warn() {
-        // V0.2.2 F40 — `cct new --team product-research` still works
+        // V0.2.2 F40 — `ccteam new --team product-research` still works
         // (alias resolution against shipped `teams/research/team.yaml`).
         // The slug carries the typed-team prefix so the project lands at
         // ~/projects/product-research-<base>; state.json::team also
@@ -2867,7 +2868,7 @@ mod tests {
         assert_eq!(state.team, "product-research");
     }
 
-    // -------- cct decisions (M1 follow-up) --------
+    // -------- ccteam decisions (M1 follow-up) --------
 
     /// Helper: write an outbox file with caller-controlled front matter
     /// to `<projects_root>/<slug>/.ccteam/outbox/<filename>`. Uses

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -1,4 +1,4 @@
-//! `cct` binary entry point (V0.2.2 F39 renamed from `ccteam`).
+//! `ccteam` binary entry point.
 
 mod commands;
 mod mcp_serve;
@@ -15,7 +15,7 @@ use commands::{InitOptions, OutputFormat};
 
 #[derive(Parser)]
 #[command(
-    name = "cct",
+    name = "ccteam",
     version,
     about = "Autonomous AI development orchestrator built on Claude Code",
 )]
@@ -133,13 +133,13 @@ enum Command {
         format: OutputFormat,
     },
     /// M2.5: run the ccteam MCP server (stdio JSON-RPC). Wired into
-    /// `~/.claude.json` `mcpServers.ccteam` by `cct doctor
+    /// `~/.claude.json` `mcpServers.ccteam` by `ccteam doctor
     /// --install-mcp` so daily-driver claude sessions and the meta
     /// agent both see the 9-tool surface (interfaces §12).
     McpServe,
     /// Stop the running orchestrator daemon. Sends SIGTERM via the
     /// pidfile so the loop drains gracefully. Does **not** kill any
-    /// tmux sessions — `cct start` reattaches to them on next launch
+    /// tmux sessions — `ccteam start` reattaches to them on next launch
     /// (M1.5).
     Stop,
     /// Health checks + tool-surface maintenance.
@@ -157,14 +157,14 @@ enum Command {
         /// agents/skills + MCP servers) and print a markdown report.
         #[arg(long, default_value_t = false)]
         tool_surface: bool,
-        /// Install the `cct-control` skill at
-        /// `~/.claude/skills/cct-control/SKILL.md` (M1.8). Idempotent.
+        /// Install the `ccteam-control` skill at
+        /// `~/.claude/skills/ccteam-control/SKILL.md` (M1.8). Idempotent.
         #[arg(long, default_value_t = false)]
         install_skill: bool,
         /// Bootstrap a meta-agent project (M1.0) for the given user
         /// handle. Creates `~/projects/<handle>-meta/` with the
         /// dispatcher role prompt + inbox/outbox dirs and (always)
-        /// installs the `cct-control` skill. Pass the user handle as
+        /// installs the `ccteam-control` skill. Pass the user handle as
         /// the value (e.g. `--install-meta-agent rob`).
         #[arg(long, value_name = "HANDLE")]
         install_meta_agent: Option<String>,
@@ -231,7 +231,7 @@ enum Command {
         #[command(subcommand)]
         cmd: WatchdogCommand,
     },
-    /// V0.2 M0.22: author + publish a cct team as a Claude Code
+    /// V0.2 M0.22: author + publish a ccteam team as a Claude Code
     /// plugin. `init` scaffolds the staging tree under
     /// `~/.config/ccteam/teams/<name>/`; `publish` links it into the
     /// `ccteam-local` marketplace or pushes it to a GitHub repo.
@@ -483,14 +483,14 @@ fn run_stop() -> Result<()> {
     let paths = CcteamPaths::from_env()?;
     match ccteam_core::send_sigterm_to_pidfile(&paths)? {
         Some(pid) => {
-            println!("cct stop: SIGTERM sent to orchestrator pid {pid}");
+            println!("ccteam stop: SIGTERM sent to orchestrator pid {pid}");
             println!(
-                "tmux sessions are NOT killed — `cct start` will reattach to them.",
+                "tmux sessions are NOT killed — `ccteam start` will reattach to them.",
             );
             Ok(())
         }
         None => {
-            println!("cct stop: no running orchestrator (pidfile absent or stale).");
+            println!("ccteam stop: no running orchestrator (pidfile absent or stale).");
             Ok(())
         }
     }
@@ -557,21 +557,21 @@ fn run_start(
     // start. force=false skips existing files so operator hand-edits
     // are preserved; the call still ensures `~/.ccteam/teams/<name>/team.yaml`
     // exists for every shipped team (dev / product-research /
-    // meta-agent) — without this, a fresh install missing `cct init`
+    // meta-agent) — without this, a fresh install missing `ccteam init`
     // would leave `is_evergreen("meta-agent") == false` and the
     // dispatcher would fall into the phase-DAG path.
     if let Err(err) = ccteam_core::write_all_global_team_templates(&paths.root, false) {
         tracing::warn!(
             error = %err,
             root = %paths.root.display(),
-            "cct start: could not seed shipped team templates; \
-             run `cct doctor --reset-shipped-teams` if teams are missing",
+            "ccteam start: could not seed shipped team templates; \
+             run `ccteam doctor --reset-shipped-teams` if teams are missing",
         );
     }
 
     if !paths.phases_dir().exists() {
         eprintln!(
-            "ccteam: phases dir {} not found.\n  run `cct init` once to unpack templates, then come back.",
+            "ccteam: phases dir {} not found.\n  run `ccteam init` once to unpack templates, then come back.",
             paths.phases_dir().display()
         );
     }
@@ -581,7 +581,7 @@ fn run_start(
             .unwrap_or(true)
     {
         eprintln!(
-            "ccteam: no projects under {} yet.\n  start one in another terminal: cct new \"<your idea>\"",
+            "ccteam: no projects under {} yet.\n  start one in another terminal: ccteam new \"<your idea>\"",
             paths.projects_root.display()
         );
     }
@@ -601,7 +601,7 @@ fn run_start(
         }
     }
     // Write the pidfile *before* constructing the orchestrator so a
-    // second `cct start` against the same root errors out cleanly
+    // second `ccteam start` against the same root errors out cleanly
     // before either side has touched tmux.
     let pidfile = ccteam_core::write_pidfile(&paths)?;
     tracing::info!(pidfile = %pidfile.display(), "orchestrator pidfile written");
@@ -631,7 +631,7 @@ fn run_start(
                     };
                     tokio::select! {
                         _ = tokio::signal::ctrl_c() => tracing::info!("ctrl+c received"),
-                        _ = sigterm.recv() => tracing::info!("SIGTERM received (cct stop)"),
+                        _ = sigterm.recv() => tracing::info!("SIGTERM received (ccteam stop)"),
                     }
                 }
                 #[cfg(not(unix))]
@@ -661,7 +661,7 @@ fn run_new(
             .with_context(|| format!("read {}", path.display()))?,
         (None, Some(text)) => text,
         (None, None) => {
-            anyhow::bail!("cct new: provide a request as a positional arg or --file PATH")
+            anyhow::bail!("ccteam new: provide a request as a positional arg or --file PATH")
         }
     };
     let opts = commands::RunNewOptions {
@@ -674,7 +674,7 @@ fn run_new(
     println!("  spec   : {}", paths.project_ccteam_dir(&slug).join("spec.md").display());
     println!("  state  : {}", paths.project_state(&slug).display());
     println!("  config : {}", paths.project_dir(&slug).join(".claude/settings.json").display());
-    println!("\nrun `cct start --foreground` (in another terminal) to dispatch the first phase.");
+    println!("\nrun `ccteam start --foreground` (in another terminal) to dispatch the first phase.");
     Ok(())
 }
 

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -48,7 +48,7 @@ const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
 const SERVER_NAME: &str = "ccteam";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Run `cct mcp-serve`. Reads JSON-RPC requests one per line from
+/// Run `ccteam mcp-serve`. Reads JSON-RPC requests one per line from
 /// stdin; writes responses one per line to stdout. Returns when stdin
 /// closes (clean shutdown when the parent disconnects).
 pub async fn run_mcp_serve(paths: CcteamPaths) -> Result<()> {
@@ -688,7 +688,7 @@ pub fn install_mcp_into(claude_json: &std::path::Path, ccteam_bin: &std::path::P
             .with_context(|| format!("create {}", parent.display()))?;
     }
     let mut tmp_os = claude_json.as_os_str().to_owned();
-    tmp_os.push(".cct-mcp.tmp");
+    tmp_os.push(".ccteam-mcp.tmp");
     let tmp = std::path::PathBuf::from(tmp_os);
     {
         let mut f = std::fs::File::create(&tmp)
@@ -709,7 +709,7 @@ pub fn install_mcp_into(claude_json: &std::path::Path, ccteam_bin: &std::path::P
 /// `--install-memory-bridge`) already honor through `user_claude_dir()`.
 pub fn install_mcp() -> Result<std::path::PathBuf> {
     let claude_json = ccteam_core::projects::resolve_claude_json_path()?;
-    let bin = ccteam_core::current_cct_bin()?;
+    let bin = ccteam_core::current_ccteam_bin()?;
     install_mcp_into(&claude_json, &bin)?;
     Ok(claude_json)
 }
@@ -761,16 +761,15 @@ mod tests {
 
     #[test]
     fn install_mcp_into_writes_command_args_env_for_ccteam_server() {
-        // V0.2.2 F39: binary is `cct` but the MCP server name stays
-        // `ccteam` (PRD §8.3 — server-name rename deferred to V0.3 to
-        // avoid touching every user's `~/.claude.json`).
+        // MCP server name is `ccteam` (the binary name and the server
+        // name match again post-F44).
         let tmp = tempfile::TempDir::new().unwrap();
         let claude_json = tmp.path().join(".claude.json");
-        let cct_bin = std::path::PathBuf::from("/usr/local/bin/cct");
-        install_mcp_into(&claude_json, &cct_bin).unwrap();
+        let ccteam_bin = std::path::PathBuf::from("/usr/local/bin/ccteam");
+        install_mcp_into(&claude_json, &ccteam_bin).unwrap();
         let body = std::fs::read_to_string(&claude_json).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/cct");
+        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/ccteam");
         assert_eq!(v["mcpServers"]["ccteam"]["args"][0], "mcp-serve");
     }
 
@@ -783,11 +782,11 @@ mod tests {
             r#"{"userID": "rob", "mcpServers": {"playwright": {"command": "npx"}}}"#,
         )
         .unwrap();
-        install_mcp_into(&claude_json, &std::path::PathBuf::from("/x/cct")).unwrap();
+        install_mcp_into(&claude_json, &std::path::PathBuf::from("/x/ccteam")).unwrap();
         let v: Value = serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
         assert_eq!(v["userID"], "rob");
         assert_eq!(v["mcpServers"]["playwright"]["command"], "npx");
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/x/cct");
+        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/x/ccteam");
     }
 
     #[test]

--- a/crates/ccteam-cli/src/team_factory_cli.rs
+++ b/crates/ccteam-cli/src/team_factory_cli.rs
@@ -1,10 +1,10 @@
-//! V0.2 M0.22 — `cct team {init,publish}` CLI handlers.
+//! V0.2 M0.22 — `ccteam team {init,publish}` CLI handlers.
 //!
 //! `init` is intentionally lightweight: it stamps a single-phase
 //! starter staging tree (`<staging>/.claude-plugin/plugin.json` +
 //! `team.yaml` + `phases/01-intake.md` + `README.md`). The team author
 //! then either edits the staging files directly or runs the meta-agent
-//! `cct-team-author` skill, which interview-mode produces the same
+//! `ccteam-team-author` skill, which interview-mode produces the same
 //! tree with N phases instead of one.
 //!
 //! `publish` calls `ccteam_core::publish_team` for the local target.

--- a/crates/ccteam-cli/tests/doctor_validate_team_fail_loud_test.rs
+++ b/crates/ccteam-cli/tests/doctor_validate_team_fail_loud_test.rs
@@ -16,7 +16,7 @@ fn run_doctor_validate(
     xdg: &std::path::Path,
     team: &str,
 ) -> std::process::Output {
-    let bin = env!("CARGO_BIN_EXE_cct");
+    let bin = env!("CARGO_BIN_EXE_ccteam");
     Command::new(bin)
         .arg("doctor")
         .arg("--validate-team")

--- a/crates/ccteam-cli/tests/install_mcp_claude_config_home_test.rs
+++ b/crates/ccteam-cli/tests/install_mcp_claude_config_home_test.rs
@@ -32,7 +32,7 @@ fn install_mcp_writes_to_claude_config_home_when_set() {
     let fake_home = tmp.path().join("fake-home");
     std::fs::create_dir_all(&fake_home).unwrap();
 
-    let bin = env!("CARGO_BIN_EXE_cct");
+    let bin = env!("CARGO_BIN_EXE_ccteam");
     let out = Command::new(bin)
         .args(["doctor", "--install-mcp"])
         .env("CLAUDE_CONFIG_HOME", &claude_dir)

--- a/crates/ccteam-cli/tests/m3_product_research_e2e_test.rs
+++ b/crates/ccteam-cli/tests/m3_product_research_e2e_test.rs
@@ -1,10 +1,10 @@
 //! M3.5 research E2E (mock claude / state-machine drive).
 //!
-//! M3 唯一验收: `cct new --team=research "AI 菜谱生成器"` runs
+//! M3 唯一验收: `ccteam new --team=research "AI 菜谱生成器"` runs
 //! through the 6-phase pipeline → verdict=REJECT, produces verdict.md /
 //! rationale.md / next-steps.md; progress.jsonl includes ≥1
 //! decision_mode=async outbox + ≥1 team-specific ESCALATE prefix +
-//! ≥1 PHASE_DONE_PENDING; `cct decisions` sees the project's
+//! ≥1 PHASE_DONE_PENDING; `ccteam decisions` sees the project's
 //! pending decisions.
 //!
 //! V0.2.2 F40 — team renamed from `product-research` to `research`
@@ -509,7 +509,7 @@ fn decisions_queue_lists_clarify_outbox_from_product_research_project() {
 /// CCTEAM_HOME / CCTEAM_PROJECTS_ROOT redirected to the test sandbox.
 /// Returns the captured stdout on success.
 fn run_ccteam_subcommand(paths: &CcteamPaths, args: &[&str]) -> anyhow::Result<String> {
-    let bin = env!("CARGO_BIN_EXE_cct");
+    let bin = env!("CARGO_BIN_EXE_ccteam");
     let out = Command::new(bin)
         .args(args)
         .env("CCTEAM_HOME", paths.root.as_os_str())

--- a/crates/ccteam-cli/tests/mcp_e2e_test.rs
+++ b/crates/ccteam-cli/tests/mcp_e2e_test.rs
@@ -26,7 +26,7 @@ struct McpServer {
 
 impl McpServer {
     fn spawn(home: &std::path::Path, projects: &std::path::Path) -> Self {
-        let bin = env!("CARGO_BIN_EXE_cct");
+        let bin = env!("CARGO_BIN_EXE_ccteam");
         let mut child = Command::new(bin)
             .arg("mcp-serve")
             .env("CCTEAM_HOME", home)

--- a/crates/ccteam-cli/tests/run_new_slug_flag_test.rs
+++ b/crates/ccteam-cli/tests/run_new_slug_flag_test.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn cct_bin() -> &'static str {
-    env!("CARGO_BIN_EXE_cct")
+    env!("CARGO_BIN_EXE_ccteam")
 }
 
 #[test]
@@ -15,13 +15,13 @@ fn cct_new_help_advertises_slug_flags() {
     let out = Command::new(cct_bin())
         .args(["new", "--help"])
         .output()
-        .expect("spawn cct new --help");
-    assert!(out.status.success(), "cct new --help should exit 0");
+        .expect("spawn ccteam new --help");
+    assert!(out.status.success(), "ccteam new --help should exit 0");
     let stdout = String::from_utf8_lossy(&out.stdout);
     for flag in ["--slug", "--no-auto-slug", "--auto-slug-model"] {
         assert!(
             stdout.contains(flag),
-            "cct new --help should advertise {flag}; got:\n{stdout}",
+            "ccteam new --help should advertise {flag}; got:\n{stdout}",
         );
     }
 }
@@ -50,13 +50,13 @@ fn cct_new_with_explicit_slug_creates_project_dir() {
         // Belt-and-suspenders: the unit-side env knob also forces Tier 4.
         .env("CCTEAM_AUTO_SLUG", "off")
         .output()
-        .expect("spawn cct new");
+        .expect("spawn ccteam new");
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         out.status.success(),
-        "cct new should succeed; stdout:\n{stdout}\nstderr:\n{stderr}",
+        "ccteam new should succeed; stdout:\n{stdout}\nstderr:\n{stderr}",
     );
     assert!(
         stdout.contains("dev-ccteam-ui"),
@@ -93,7 +93,7 @@ fn cct_new_rejects_explicit_slug_with_illegal_chars() {
         .env("CCTEAM_PROJECTS_ROOT", &projects_root)
         .env("CCTEAM_AUTO_SLUG", "off")
         .output()
-        .expect("spawn cct new");
+        .expect("spawn ccteam new");
 
     assert!(!out.status.success(), "illegal slug must fail-loud");
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -148,13 +148,13 @@ fn cct_new_tier3_reads_from_stub_claude_bin() {
         // CCTEAM_AUTO_SLUG is unset so Tier 3 is allowed to fire.
         .env_remove("CCTEAM_AUTO_SLUG")
         .output()
-        .expect("spawn cct new");
+        .expect("spawn ccteam new");
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         out.status.success(),
-        "cct new with stub claude should succeed; stdout:\n{stdout}\nstderr:\n{stderr}",
+        "ccteam new with stub claude should succeed; stdout:\n{stdout}\nstderr:\n{stderr}",
     );
     assert!(
         stdout.contains("dev-tier3-stub-slug"),
@@ -204,7 +204,7 @@ fn cct_new_tier3_falls_back_to_tier4_when_stub_returns_garbage() {
         .env("CCTEAM_AUTO_SLUG_BIN", &stub)
         .env_remove("CCTEAM_AUTO_SLUG")
         .output()
-        .expect("spawn cct new");
+        .expect("spawn ccteam new");
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(

--- a/crates/ccteam-cli/tests/start_claude_argv_flag_test.rs
+++ b/crates/ccteam-cli/tests/start_claude_argv_flag_test.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 #[test]
 fn ccteam_start_help_advertises_claude_argv_flag() {
-    let bin = env!("CARGO_BIN_EXE_cct");
+    let bin = env!("CARGO_BIN_EXE_ccteam");
     let out = Command::new(bin)
         .args(["start", "--help"])
         .output()

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -2,6 +2,7 @@
 //! and hook-shared schemas. Consumed by `ccteam-cli` (binary entry) and
 //! `ccteam-hooks` (hook handlers invoked via `ccteam hook ...`).
 
+
 pub mod cost;
 pub mod daemon;
 pub mod dag;
@@ -51,10 +52,10 @@ pub use memory_bridge::{
     InstallMemoryBridgeOptions, MemoryBridgeAction, MemoryBridgeReport,
 };
 pub use skill::{
-    install_cct_control_skill, install_cct_project_creator_skill,
-    install_cct_team_author_skill, install_into as install_skill_into,
+    install_ccteam_control_skill, install_ccteam_project_creator_skill,
+    install_ccteam_team_author_skill, install_into as install_skill_into,
     install_skill_body_into, InstallSkillOptions, InstallSkillReport, SkillInstallAction,
-    CCT_CONTROL_SKILL_NAME, CCT_PROJECT_CREATOR_SKILL_NAME, CCT_TEAM_AUTHOR_SKILL_NAME,
+    CCTEAM_CONTROL_SKILL_NAME, CCTEAM_PROJECT_CREATOR_SKILL_NAME, CCTEAM_TEAM_AUTHOR_SKILL_NAME,
     LEGACY_SKILL_NAMES,
 };
 pub use orchestrator::MAX_CONCURRENT_PROJECTS;
@@ -115,7 +116,7 @@ pub use team_resolver::{
     TeamSource, TEAM_SOURCES,
 };
 pub use templates::{
-    current_cct_bin, project_phase_filename, render_project_settings,
+    current_ccteam_bin, project_phase_filename, render_project_settings,
     write_all_global_team_templates, write_global_helper_templates,
     write_global_phase_templates, write_project_phase_templates,
     write_project_phase_templates_for_team, write_project_settings,

--- a/crates/ccteam-core/src/skill.rs
+++ b/crates/ccteam-core/src/skill.rs
@@ -1,17 +1,14 @@
-//! `cct-control` + `cct-team-author` skill installation (M1.8 + M0.22.1).
+//! `ccteam-control` + `ccteam-team-author` skill installation (M1.8 + M0.22.1).
 //!
 //! Skills live at `~/.claude/skills/<name>/SKILL.md` (or under a plugin
-//! tree). The `cct-control` and `cct-team-author` skill bodies are
+//! tree). The `ccteam-control` and `ccteam-team-author` skill bodies are
 //! shipped inside the binary and written to disk by
-//! `cct doctor --install-skill`. The `--install-meta-agent` path also
+//! `ccteam doctor --install-skill`. The `--install-meta-agent` path also
 //! calls this so a freshly-bootstrapped meta-agent has both skills on
 //! first launch.
 //!
-//! V0.2.2 F39: skill names migrated from `ccteam-{control,team-author}`
-//! to `cct-{control,team-author}`; the markdown bodies live under the
-//! repo-root `skills/` directory (cross-dir `include_str!` into the
-//! ccteam-core binary). Migration of V0.1/V0.2 user installs is handled
-//! by `cct doctor` (see `migrate_legacy_skill_dirs` in tool_surface).
+//! The markdown bodies live under the repo-root `skills/` directory
+//! (cross-dir `include_str!` into the ccteam-core binary).
 
 use std::path::{Path, PathBuf};
 
@@ -20,49 +17,51 @@ use anyhow::{Context, Result};
 use crate::tool_surface::user_claude_dir;
 
 /// Skill directory name. Embedded SKILL.md ships under this folder
-/// inside `~/.claude/skills/`. V0.2.2 F39: `ccteam-control` → `cct-control`.
-pub const CCT_CONTROL_SKILL_NAME: &str = "cct-control";
+/// inside `~/.claude/skills/`.
+pub const CCTEAM_CONTROL_SKILL_NAME: &str = "ccteam-control";
 
-/// V0.2 M0.22.1 — `cct-team-author` skill name. Walks the
+/// V0.2 M0.22.1 — `ccteam-team-author` skill name. Walks the
 /// meta-agent through the team-factory dialogue (phase list, tools,
 /// golden rules, retro / verdict schema, plugin metadata) before
-/// invoking `cct team init`.
-///
-/// V0.2.2 F39: renamed from `ccteam-team-author`.
-pub const CCT_TEAM_AUTHOR_SKILL_NAME: &str = "cct-team-author";
+/// invoking `ccteam team init`.
+pub const CCTEAM_TEAM_AUTHOR_SKILL_NAME: &str = "ccteam-team-author";
 
-/// V0.2.2 F34 — `cct-project-creator` skill name. Walks the
+/// V0.2.2 F34 — `ccteam-project-creator` skill name. Walks the
 /// meta-agent through the four-phase project-creation dialogue
 /// (clarify brief → recommend slug → pick team → dispatch via
-/// `cct new`). Replaces the inline `meta_agent_role.md` §2 dispatch
+/// `ccteam new`). Replaces the inline `meta_agent_role.md` §2 dispatch
 /// flow with a structured AskUserQuestion-driven UX.
-pub const CCT_PROJECT_CREATOR_SKILL_NAME: &str = "cct-project-creator";
+pub const CCTEAM_PROJECT_CREATOR_SKILL_NAME: &str = "ccteam-project-creator";
 
-/// V0.2.2 F39: legacy V0.1/V0.2 skill directory names that
-/// `cct doctor` migrates. Exposed so the migration helper can scan
-/// for stale installs without re-declaring the names.
-pub const LEGACY_SKILL_NAMES: &[&str] = &["ccteam-control", "ccteam-team-author"];
+/// V0.2.2 F44: legacy V0.2.2 (F39'd) skill directory names that
+/// `ccteam doctor` migrates back. Exposed so the migration helper can
+/// scan for stale `cct-*` installs without re-declaring the names.
+pub const LEGACY_SKILL_NAMES: &[&str] = &[
+    "cct-control",
+    "cct-team-author",
+    "cct-project-creator",
+];
 
 /// Embedded `SKILL.md` body. Written verbatim during install.
 ///
-/// V0.2.2 F39: skill bodies live at `<repo>/skills/cct-<name>/SKILL.md`
+/// Skill bodies live at `<repo>/skills/ccteam-<name>/SKILL.md`
 /// (top-level `skills/` directory) so they're authoritative outside
 /// the Rust source tree.
-pub const CCT_CONTROL_SKILL_MD: &str = include_str!(concat!(
+pub const CCTEAM_CONTROL_SKILL_MD: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../../skills/cct-control/SKILL.md"
+    "/../../skills/ccteam-control/SKILL.md"
 ));
 
 /// Embedded `SKILL.md` body for the team-author skill (V0.2 M0.22.1).
-pub const CCT_TEAM_AUTHOR_SKILL_MD: &str = include_str!(concat!(
+pub const CCTEAM_TEAM_AUTHOR_SKILL_MD: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../../skills/cct-team-author/SKILL.md"
+    "/../../skills/ccteam-team-author/SKILL.md"
 ));
 
 /// Embedded `SKILL.md` body for the project-creator skill (V0.2.2 F34).
-pub const CCT_PROJECT_CREATOR_SKILL_MD: &str = include_str!(concat!(
+pub const CCTEAM_PROJECT_CREATOR_SKILL_MD: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
-    "/../../skills/cct-project-creator/SKILL.md"
+    "/../../skills/ccteam-project-creator/SKILL.md"
 ));
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -88,40 +87,40 @@ pub enum SkillInstallAction {
     DryRun { would_write: bool },
 }
 
-/// Install the `cct-control` skill into `~/.claude/skills/cct-control/SKILL.md`.
-pub fn install_cct_control_skill(opts: InstallSkillOptions) -> Result<InstallSkillReport> {
+/// Install the `ccteam-control` skill into `~/.claude/skills/ccteam-control/SKILL.md`.
+pub fn install_ccteam_control_skill(opts: InstallSkillOptions) -> Result<InstallSkillReport> {
     let claude = user_claude_dir().context("resolve ~/.claude/")?;
     install_into(&claude, opts)
 }
 
-/// V0.2 M0.22.1: install the `cct-team-author` skill into
-/// `~/.claude/skills/cct-team-author/SKILL.md`. Same idempotent
-/// semantics as `install_cct_control_skill`.
-pub fn install_cct_team_author_skill(
+/// V0.2 M0.22.1: install the `ccteam-team-author` skill into
+/// `~/.claude/skills/ccteam-team-author/SKILL.md`. Same idempotent
+/// semantics as `install_ccteam_control_skill`.
+pub fn install_ccteam_team_author_skill(
     opts: InstallSkillOptions,
 ) -> Result<InstallSkillReport> {
     let claude = user_claude_dir().context("resolve ~/.claude/")?;
     install_skill_body_into(
         &claude,
-        CCT_TEAM_AUTHOR_SKILL_NAME,
-        CCT_TEAM_AUTHOR_SKILL_MD,
+        CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+        CCTEAM_TEAM_AUTHOR_SKILL_MD,
         opts,
     )
 }
 
-/// V0.2.2 F34: install the `cct-project-creator` skill into
-/// `~/.claude/skills/cct-project-creator/SKILL.md`. Same idempotent
-/// semantics as `install_cct_control_skill`. Carries the four-phase
+/// V0.2.2 F34: install the `ccteam-project-creator` skill into
+/// `~/.claude/skills/ccteam-project-creator/SKILL.md`. Same idempotent
+/// semantics as `install_ccteam_control_skill`. Carries the four-phase
 /// project-creation dialogue the meta-agent now invokes instead of
 /// inlining dispatch logic in `meta_agent_role.md` §2.
-pub fn install_cct_project_creator_skill(
+pub fn install_ccteam_project_creator_skill(
     opts: InstallSkillOptions,
 ) -> Result<InstallSkillReport> {
     let claude = user_claude_dir().context("resolve ~/.claude/")?;
     install_skill_body_into(
         &claude,
-        CCT_PROJECT_CREATOR_SKILL_NAME,
-        CCT_PROJECT_CREATOR_SKILL_MD,
+        CCTEAM_PROJECT_CREATOR_SKILL_NAME,
+        CCTEAM_PROJECT_CREATOR_SKILL_MD,
         opts,
     )
 }
@@ -131,8 +130,8 @@ pub fn install_cct_project_creator_skill(
 pub fn install_into(claude_dir: &Path, opts: InstallSkillOptions) -> Result<InstallSkillReport> {
     install_skill_body_into(
         claude_dir,
-        CCT_CONTROL_SKILL_NAME,
-        CCT_CONTROL_SKILL_MD,
+        CCTEAM_CONTROL_SKILL_NAME,
+        CCTEAM_CONTROL_SKILL_MD,
         opts,
     )
 }
@@ -191,17 +190,19 @@ mod tests {
         assert_eq!(report.action, SkillInstallAction::Wrote);
         assert!(report.target.exists());
         let body = std::fs::read_to_string(&report.target).unwrap();
-        // V0.2.2 F39: bodies are wrapped in `<!-- ccteam-managed:skill begin/end -->`
-        // markers; the YAML front matter follows the open marker.
+        // Bodies are wrapped in `<!-- ccteam-managed:skill begin/end -->`
+        // markers so the F44 reverse migration can detect ccteam-managed
+        // installs (vs. user hand-edits) when sweeping legacy `cct-*`
+        // skill directories.
         assert!(
             body.contains("<!-- ccteam-managed:skill begin -->"),
-            "must contain ccteam-managed begin marker (F39 migration prerequisite)",
+            "must contain ccteam-managed begin marker (F44 migration prerequisite)",
         );
         assert!(
             body.contains("<!-- ccteam-managed:skill end -->"),
             "must contain ccteam-managed end marker",
         );
-        assert!(body.contains("---\nname: cct-control"));
+        assert!(body.contains("---\nname: ccteam-control"));
         assert!(body.contains("allowed-tools: [Bash]"));
         // Required body chapters per interfaces §11.3.
         for required in ["Capability index", "Typical workflows", "Decision principles", "What this skill cannot do"] {
@@ -221,12 +222,12 @@ mod tests {
     fn force_overwrites_existing_file() {
         let tmp = tempfile::TempDir::new().unwrap();
         install_into(tmp.path(), InstallSkillOptions::default()).unwrap();
-        let target = tmp.path().join("skills/cct-control/SKILL.md");
+        let target = tmp.path().join("skills/ccteam-control/SKILL.md");
         std::fs::write(&target, "tampered\n").unwrap();
         let r = install_into(tmp.path(), InstallSkillOptions { force: true, dry_run: false }).unwrap();
         assert_eq!(r.action, SkillInstallAction::Replaced);
         let body = std::fs::read_to_string(&target).unwrap();
-        assert!(body.contains("name: cct-control"));
+        assert!(body.contains("name: ccteam-control"));
     }
 
     #[test]
@@ -247,19 +248,19 @@ mod tests {
     // ---------------- V0.2 M0.22.1 team-author skill ----------------
 
     #[test]
-    fn team_author_skill_installs_under_cct_team_author_dir() {
+    fn team_author_skill_installs_under_ccteam_team_author_dir() {
         let tmp = tempfile::TempDir::new().unwrap();
         let report = install_skill_body_into(
             tmp.path(),
-            CCT_TEAM_AUTHOR_SKILL_NAME,
-            CCT_TEAM_AUTHOR_SKILL_MD,
+            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+            CCTEAM_TEAM_AUTHOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
         assert_eq!(report.action, SkillInstallAction::Wrote);
         let body = std::fs::read_to_string(&report.target).unwrap();
         assert!(body.contains("<!-- ccteam-managed:skill begin -->"));
-        assert!(body.contains("name: cct-team-author"));
+        assert!(body.contains("name: ccteam-team-author"));
         assert!(body.contains("Capability index"));
     }
 
@@ -268,15 +269,15 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         install_skill_body_into(
             tmp.path(),
-            CCT_TEAM_AUTHOR_SKILL_NAME,
-            CCT_TEAM_AUTHOR_SKILL_MD,
+            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+            CCTEAM_TEAM_AUTHOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
         let r2 = install_skill_body_into(
             tmp.path(),
-            CCT_TEAM_AUTHOR_SKILL_NAME,
-            CCT_TEAM_AUTHOR_SKILL_MD,
+            CCTEAM_TEAM_AUTHOR_SKILL_NAME,
+            CCTEAM_TEAM_AUTHOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
@@ -290,8 +291,8 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let report = install_skill_body_into(
             tmp.path(),
-            CCT_PROJECT_CREATOR_SKILL_NAME,
-            CCT_PROJECT_CREATOR_SKILL_MD,
+            CCTEAM_PROJECT_CREATOR_SKILL_NAME,
+            CCTEAM_PROJECT_CREATOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
@@ -299,13 +300,13 @@ mod tests {
         let body = std::fs::read_to_string(&report.target).unwrap();
         assert!(
             body.contains("<!-- ccteam-managed:skill begin -->"),
-            "must carry the ccteam-managed begin marker (F39 migration prerequisite)",
+            "must carry the ccteam-managed begin marker (F44 migration prerequisite)",
         );
         assert!(
             body.contains("<!-- ccteam-managed:skill end -->"),
             "must carry the ccteam-managed end marker",
         );
-        assert!(body.contains("name: cct-project-creator"));
+        assert!(body.contains("name: ccteam-project-creator"));
         // The four-phase dialogue is the body's main contract; if any
         // disappears, the meta-agent silently loses behavior.
         for phase in [
@@ -324,15 +325,15 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         install_skill_body_into(
             tmp.path(),
-            CCT_PROJECT_CREATOR_SKILL_NAME,
-            CCT_PROJECT_CREATOR_SKILL_MD,
+            CCTEAM_PROJECT_CREATOR_SKILL_NAME,
+            CCTEAM_PROJECT_CREATOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();
         let r2 = install_skill_body_into(
             tmp.path(),
-            CCT_PROJECT_CREATOR_SKILL_NAME,
-            CCT_PROJECT_CREATOR_SKILL_MD,
+            CCTEAM_PROJECT_CREATOR_SKILL_NAME,
+            CCTEAM_PROJECT_CREATOR_SKILL_MD,
             InstallSkillOptions::default(),
         )
         .unwrap();

--- a/crates/ccteam-core/src/templates.rs
+++ b/crates/ccteam-core/src/templates.rs
@@ -1,12 +1,9 @@
 //! Embedded ccteam templates rendered into produced-project trees by
-//! `cct new` and the global `~/.ccteam/` skeleton produced by
-//! `cct init`. The settings.json source uses the placeholder
-//! `{{CCT_BIN}}` for the binary path so we can rewrite hook commands
+//! `ccteam new` and the global `~/.ccteam/` skeleton produced by
+//! `ccteam init`. The settings.json source uses the placeholder
+//! `__CCTEAM_BIN__` for the binary path so we can rewrite hook commands
 //! to absolute paths at install time (otherwise hook subprocesses
-//! inherit Claude Code's PATH and silently fail to find `cct`).
-//!
-//! V0.2.2 F39: placeholder renamed from `__CCTEAM_BIN__` (binary now
-//! `cct`); the substitution semantics are unchanged.
+//! inherit Claude Code's PATH and silently fail to find `ccteam`).
 
 use std::path::Path;
 
@@ -14,10 +11,10 @@ use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 
 /// Per-project `.claude/settings.json` template. The template uses
-/// `{{CCT_BIN}}` everywhere a real install would name the absolute
-/// `cct` binary path; we substitute the running binary's absolute path
+/// `__CCTEAM_BIN__` everywhere a real install would name the absolute
+/// `ccteam` binary path; we substitute the running binary's absolute path
 /// at write time so hook subprocesses don't depend on the user's PATH
-/// (which Claude Code inherits and may not include the cct install dir).
+/// (which Claude Code inherits and may not include the ccteam install dir).
 pub const PROJECT_SETTINGS_JSON: &str = include_str!("templates/settings.json");
 
 /// Phase template payloads — `(global_filename_with_index_prefix, body)`.
@@ -77,7 +74,7 @@ const RESEARCH_PHASE_TEMPLATES: &[(&str, &str)] = &[
 /// Embedded `team.yaml` files keyed by team name. M3.4 ships dev +
 /// research (V0.2.2 F40 renamed from `product-research`; alias
 /// preserved on the yaml so old projects still resolve). V0.2 M0.16
-/// adds meta-agent (evergreen). `cct init` writes these to
+/// adds meta-agent (evergreen). `ccteam init` writes these to
 /// `~/.ccteam/teams/<name>/team.yaml`. The orchestrator reads them at
 /// startup to resolve `phase_dir`, registered ESCALATE prefixes, the
 /// V0.2 `evergreen` / `cost_policy` flags, and (eventually) team-wide
@@ -95,7 +92,7 @@ const META_AGENT_PHASE_TEMPLATES: &[(&str, &str)] = &[];
 
 /// One team's compile-time bundle: a `team.yaml` body + the phase
 /// markdowns to stamp into the project's `<project>/.ccteam/phases/`
-/// dir on `cct new`. Looking up by team name keeps every
+/// dir on `ccteam new`. Looking up by team name keeps every
 /// per-team artifact in one place — adding a team is a config change.
 ///
 /// V0.2 §6.4 candidate 3: `pub(crate)` — runtime code paths now read
@@ -170,7 +167,7 @@ pub(crate) fn team_bundle(team: &str) -> Option<TeamTemplateBundle> {
 }
 
 /// M2.4: helper templates that phase markdown can `@`-reference. Shipped
-/// inside the binary so a fresh install (or `cct doctor`) can stamp
+/// inside the binary so a fresh install (or `ccteam doctor`) can stamp
 /// them into `~/.ccteam/templates/` without an external git checkout.
 ///
 /// `(on_disk_filename, body)` — phase markdown references them as
@@ -208,13 +205,10 @@ pub fn project_phase_filename(global: &str) -> &str {
     }
 }
 
-/// Resolve the path to the running cct binary. Falls back from
+/// Resolve the path to the running ccteam binary. Falls back from
 /// canonicalized to raw `current_exe()` because `canonicalize` rejects
 /// some `/proc/self/exe`-style paths in container test environments.
-///
-/// V0.2.2 F39: function renamed from `current_ccteam_bin` (binary
-/// renamed to `cct`); behavior is unchanged.
-pub fn current_cct_bin() -> Result<std::path::PathBuf> {
+pub fn current_ccteam_bin() -> Result<std::path::PathBuf> {
     let raw = std::env::current_exe().context("std::env::current_exe")?;
     Ok(raw.canonicalize().unwrap_or(raw))
 }
@@ -242,25 +236,25 @@ pub struct EnabledPluginsSetting {
     pub plugin_ids: std::collections::BTreeSet<String>,
 }
 
-/// Render `PROJECT_SETTINGS_JSON` with `{{CCT_BIN}}` replaced by the
+/// Render `PROJECT_SETTINGS_JSON` with `__CCTEAM_BIN__` replaced by the
 /// given absolute binary path, `extra_env` merged into the top-level
 /// `env` block, and `enabled` written under `enabledPlugins`. Validates
 /// that the rewritten body is still valid JSON so a path with
 /// shell-hostile characters can't silently corrupt the settings file.
 pub fn render_project_settings(
-    cct_bin: &Path,
+    ccteam_bin: &Path,
     extra_env: &SettingsEnv,
     enabled: &EnabledPluginsSetting,
 ) -> Result<String> {
-    let bin = cct_bin
+    let bin = ccteam_bin
         .to_str()
-        .ok_or_else(|| anyhow!("cct binary path not valid UTF-8: {}", cct_bin.display()))?;
+        .ok_or_else(|| anyhow!("ccteam binary path not valid UTF-8: {}", ccteam_bin.display()))?;
     if bin.contains('"') || bin.contains('\\') {
         return Err(anyhow!(
-            "cct binary path contains characters that can't be embedded in settings.json: {bin}"
+            "ccteam binary path contains characters that can't be embedded in settings.json: {bin}"
         ));
     }
-    let body = PROJECT_SETTINGS_JSON.replace("{{CCT_BIN}}", bin);
+    let body = PROJECT_SETTINGS_JSON.replace("__CCTEAM_BIN__", bin);
     let mut v: Value = serde_json::from_str(&body)
         .with_context(|| format!("rendered settings.json is not valid JSON (bin={bin})"))?;
     if let Some(env) = v.get_mut("env").and_then(|e| e.as_object_mut()) {
@@ -287,11 +281,11 @@ pub fn render_project_settings(
 }
 
 /// Write `<project_dir>/.claude/settings.json` with hook commands
-/// pointing at the running cct binary by absolute path, the
+/// pointing at the running ccteam binary by absolute path, the
 /// effective `CCTEAM_HOME` / `CCTEAM_PROJECTS_ROOT` baked into `env`,
 /// and the spawned-session `enabledPlugins` set. Creates the parent
 /// dir if missing. Idempotent — overwrites any prior render so
-/// re-running after a cct upgrade refreshes paths and the
+/// re-running after a ccteam upgrade refreshes paths and the
 /// plugin set.
 pub fn write_project_settings(
     project_dir: &Path,
@@ -301,7 +295,7 @@ pub fn write_project_settings(
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("create {}", dir.display()))?;
     let path = dir.join("settings.json");
-    let bin = current_cct_bin()?;
+    let bin = current_ccteam_bin()?;
     let extra = SettingsEnv {
         ccteam_home: std::env::var("CCTEAM_HOME").ok(),
         ccteam_projects_root: std::env::var("CCTEAM_PROJECTS_ROOT").ok(),
@@ -361,7 +355,7 @@ pub fn write_project_phase_templates_for_team(
 }
 
 /// Write each `PHASE_TEMPLATES` entry into `<global_dir>/phases/` under
-/// its full prefixed name (e.g. `02-plan-eng.md`). Used by `cct init`
+/// its full prefixed name (e.g. `02-plan-eng.md`). Used by `ccteam init`
 /// so the orchestrator can load + validate templates from `~/.ccteam/`.
 /// `force == false` skips files already on disk so an operator can hand-
 /// edit a global template and not lose it on re-init.
@@ -437,9 +431,9 @@ pub fn write_all_global_team_templates(global_dir: &Path, force: bool) -> Result
 /// `@~/.ccteam/templates/<filename>` reference resolves. Idempotent;
 /// `force == false` preserves operator hand-edits.
 ///
-/// Called by `cct init` (global skeleton) and `bootstrap_project`
-/// (defensive — covers the user who jumps straight to `cct new`
-/// without `cct init`). The two callers don't conflict because
+/// Called by `ccteam init` (global skeleton) and `bootstrap_project`
+/// (defensive — covers the user who jumps straight to `ccteam new`
+/// without `ccteam init`). The two callers don't conflict because
 /// the writer is a no-op when files are already in place.
 pub fn write_global_helper_templates(global_dir: &Path, force: bool) -> Result<()> {
     let dir = global_dir.join("templates");
@@ -494,7 +488,7 @@ mod tests {
         // entry for `AskUserQuestion` so the hook can deny the call
         // before the assistant blocks waiting on an offline user.
         let body = render_project_settings(
-            Path::new("/usr/local/bin/cct"),
+            Path::new("/usr/local/bin/ccteam"),
             &SettingsEnv::default(),
             &EnabledPluginsSetting::default(),
         )
@@ -506,13 +500,13 @@ mod tests {
             .find(|e| e.get("matcher").and_then(|m| m.as_str()) == Some("AskUserQuestion"))
             .expect("PreToolUse must have an AskUserQuestion matcher entry");
         let cmd = intercept["hooks"][0]["command"].as_str().unwrap();
-        assert_eq!(cmd, "/usr/local/bin/cct hook intercept-ask");
+        assert_eq!(cmd, "/usr/local/bin/ccteam hook intercept-ask");
     }
 
     #[test]
-    fn template_session_start_uses_absolute_cct_path() {
+    fn template_session_start_uses_absolute_ccteam_path() {
         let body = render_project_settings(
-            Path::new("/usr/local/bin/cct"),
+            Path::new("/usr/local/bin/ccteam"),
             &SettingsEnv::default(),
             &EnabledPluginsSetting::default(),
         )
@@ -526,30 +520,30 @@ mod tests {
         assert_eq!(
             cmds,
             vec![
-                "/usr/local/bin/cct hook load-context",
-                "/usr/local/bin/cct hook progress-append session_start"
+                "/usr/local/bin/ccteam hook load-context",
+                "/usr/local/bin/ccteam hook progress-append session_start"
             ],
         );
     }
 
     #[test]
-    fn raw_template_uses_placeholder_not_bare_cct() {
-        // Guard against accidentally re-introducing `"command": "cct …"`
+    fn raw_template_uses_placeholder_not_bare_ccteam() {
+        // Guard against accidentally re-introducing `"command": "ccteam …"`
         // — the un-substituted form makes hook subprocesses depend on PATH,
         // which Claude Code inherits from its parent and which often does
-        // not include the cct install dir.
+        // not include the ccteam install dir.
         assert!(
-            PROJECT_SETTINGS_JSON.contains("{{CCT_BIN}}"),
-            "template should reference {{CCT_BIN}} placeholder",
+            PROJECT_SETTINGS_JSON.contains("__CCTEAM_BIN__"),
+            "template should reference __CCTEAM_BIN__ placeholder",
         );
         assert!(
-            !PROJECT_SETTINGS_JSON.contains("\"cct hook"),
-            "template should not embed bare `cct hook` — see render_project_settings",
+            !PROJECT_SETTINGS_JSON.contains("\"ccteam hook"),
+            "template should not embed bare `ccteam hook` — see render_project_settings",
         );
-        // F39 sweep guard: legacy placeholder must not return.
+        // F44 sweep guard: F39's `{{CCT_BIN}}` placeholder must not return.
         assert!(
-            !PROJECT_SETTINGS_JSON.contains("__CCTEAM_BIN__"),
-            "template should not embed legacy __CCTEAM_BIN__ placeholder (F39)",
+            !PROJECT_SETTINGS_JSON.contains("{{CCT_BIN}}"),
+            "template should not embed F39-era `{{CCT_BIN}}` placeholder (F44)",
         );
     }
 

--- a/crates/ccteam-core/src/templates/memory_bridge_dev.md
+++ b/crates/ccteam-core/src/templates/memory_bridge_dev.md
@@ -9,7 +9,7 @@ paths:
 
 Auto-populated by the ccteam `ship` phase retro segment. The retro segment
 overwrites only the marked block below — anything you write outside of it is
-preserved across `cct doctor --install-memory-bridge` re-runs.
+preserved across `ccteam doctor --install-memory-bridge` re-runs.
 
 Field layout matches `teams/dev.yaml.retro_schema`:
 

--- a/crates/ccteam-core/src/templates/memory_bridge_research.md
+++ b/crates/ccteam-core/src/templates/memory_bridge_research.md
@@ -9,7 +9,7 @@ paths:
 
 Auto-populated by the ccteam `verdict` phase retro segment (REJECT branch).
 The retro segment overwrites only the marked block below — anything you write
-outside of it is preserved across `cct doctor --install-memory-bridge`
+outside of it is preserved across `ccteam doctor --install-memory-bridge`
 re-runs.
 
 > **V0.2.2 F40 alias note**: `product-research` is the legacy team

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — ccteam meta-agent (__USER_HANDLE__)
 
 > 本文件是 ccteam 自动生成的 meta-agent role prompt(__GENERATED_AT__)。
-> 不要手改 — 下次 `cct doctor --install-meta-agent __USER_HANDLE__` 会覆盖。
+> 不要手改 — 下次 `ccteam doctor --install-meta-agent __USER_HANDLE__` 会覆盖。
 
 ## 1. 你是谁
 
@@ -11,7 +11,7 @@
 
 身份要点:
 - 你看到的工具列表里有 `Task` / `Bash` / `Read` / `Edit` / `Write` 等通用工具,但你**默认不调用 Edit/Write 改用户代码**——那是项目 session(L2)的活
-- cct-control skill 已经为你装好(`~/.claude/skills/cct-control/`),里面是 ccteam CLI 命令清单与典型工作流
+- ccteam-control skill 已经为你装好(`~/.claude/skills/ccteam-control/`),里面是 ccteam CLI 命令清单与典型工作流
 - 你的对话历史会在 context 接近 60% 时被压缩到本文件的"当前进度"节,新 session 启动后自动加载
 
 ## 2. 决策树(每次收到用户请求都跑一遍)
@@ -22,24 +22,24 @@
 
 - **问答** —— **边界很窄**:用户在问一个**事实** / **定义** / **状态**
   - 例:"ccteam 的 Seed Gate 是什么意思?" / "Multica 的 GitHub 地址是什么?" / "我的 todo-cli 项目跑到哪了?"
-  - 直接回答。可以用 `Bash` 调 `cct ls --format json` / `cct show <slug> --format json` 拿数据
+  - 直接回答。可以用 `Bash` 调 `ccteam ls --format json` / `ccteam show <slug> --format json` 拿数据
   - **绝不**自己起 `Agent(subagent_type=...)` 做调研、检索、分析 —— **那不是问答,那是项目请求**
 - **项目请求** —— 任何"做 / 写 / 调研 / 分析 / 评估 / 看看 X 值不值得"
   - 例:"做一个 todo cli" / "帮我写个书签管理器" / "调研 Multica" / "看看这个 idea 能不能做" / "X 项目市场怎么样"
-  - **不要直接干** —— 进入第 2 步走 `cct-project-creator` skill 派单
+  - **不要直接干** —— 进入第 2 步走 `ccteam-project-creator` skill 派单
 - **边界不清**:用户措辞模棱两可("X 项目怎么样?"既可能是事实询问也可能是产研请求)
   - **问一句**:"是要我快速答你一个事实问题,还是走 research 团队正式产研?"
   - 不要默默选一边
 
-### 第 2 步:走 `cct-project-creator` skill 派单
+### 第 2 步:走 `ccteam-project-creator` skill 派单
 
-确认是项目请求后,**走 `cct-project-creator` skill**(已自动装好,在
-`~/.claude/skills/cct-project-creator/`)。该 skill 会引导你跑完整流程:
+确认是项目请求后,**走 `ccteam-project-creator` skill**(已自动装好,在
+`~/.claude/skills/ccteam-project-creator/`)。该 skill 会引导你跑完整流程:
 
 1. **Phase A —— 需求澄清**:brief 单词级时用 `AskUserQuestion` 问一个最关键的澄清(只一个,不连珠炮)
 2. **Phase B —— slug 推荐**:基于 brief 算 2-4 token kebab-case slug,用 `AskUserQuestion` 给用户三选一(推荐 / 我来定 / 再来一个)
 3. **Phase C —— team 选择**:按下面"团队启发"决策默认推断;不确定时 `AskUserQuestion` 二选一
-4. **Phase D —— 派单**:`cct new --slug <slug> --team <team> "<refined brief>"`,然后在 outbox 写 `event_kind: reply` 告诉用户
+4. **Phase D —— 派单**:`ccteam new --slug <slug> --team <team> "<refined brief>"`,然后在 outbox 写 `event_kind: reply` 告诉用户
 
 skill body 里详细约束 + 反例你都能直接读;遇到 mode 1 ad-hoc("先别建项目,直接帮我写一段")**不要**走 skill,直接对话回应即可。
 
@@ -70,38 +70,38 @@ ccteam V0.2.2 起 canonical team 名:**dev** + **research**。`product-research`
 - ❌ **不要**自己 `Bash` 跑 `git clone` / `npm init` / `cargo new` 起项目骨架
 - ❌ **不要**自己写完一份代码再"派给 ccteam"——那等于绕开整套 phase pipeline
 - ❌ **不要**自己起 `Agent(subagent_type=general-purpose)` / 调用 web 搜索工具做调研、市场分析、技术对比 —— 这是 research 团队的活,绕过 = 失去 6 phase pipeline + verdict 结构化判断 + 可审计调研记录
-- ✅ 识别项目级请求时,**默认走 `cct-project-creator` skill 派单**,让对应团队 session 干活
-- ✅ "调研 X" / "评估 X 值不值得" → 走 skill,skill 调 `cct new --team=research --slug=<name> "<brief>"`
+- ✅ 识别项目级请求时,**默认走 `ccteam-project-creator` skill 派单**,让对应团队 session 干活
+- ✅ "调研 X" / "评估 X 值不值得" → 走 skill,skill 调 `ccteam new --team=research --slug=<name> "<brief>"`
 - ✅ 只有用户**明确说"你直接帮我写 X"**(例:"先别建项目,你直接写一段 yaml 给我看")时才走 worker 路径——这种情况下你做完直接回答即可,不进 ccteam pipeline
 
 为什么?ccteam 的全套机制(progress.jsonl / phase 边界 / cost 累计 / context reset / Seed Gate / Critic)只在项目 session 里生效。你绕开它 = 失去这一切保障 = 退回到普通 claude 的体验。
 
 ## 4. 派单工具(M1 用 Bash;M2.8+ 切 ccteam-mcp MCP)
 
-**派单走 `cct-project-creator` skill**(§2 已定),它内部用 `Bash` 调
-`cct new --slug <slug> --team <team> "<brief>"`。下面是 raw CLI 入口
+**派单走 `ccteam-project-creator` skill**(§2 已定),它内部用 `Bash` 调
+`ccteam new --slug <slug> --team <team> "<brief>"`。下面是 raw CLI 入口
 (skill 内部用,你也能在不需要 skill 流程时直接调,例:用户已给齐
 slug + team + brief):
 
 ```bash
 # 立项 —— dev 路径(skill 内部 / 用户已给齐参数)
-cct new --slug todo-cli --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
+ccteam new --slug todo-cli --team=dev "做一个 todo cli,本地存储,Rust + ratatui"
 
 # 立项 —— research 路径(产研判断 idea 值不值得做)
-cct new --slug ai-recipe-generator --team=research "AI 菜谱生成器,拍冰箱照片自动写菜谱"
+ccteam new --slug ai-recipe-generator --team=research "AI 菜谱生成器,拍冰箱照片自动写菜谱"
 
 # 看一项目
-cct show <slug> --format json | jq
+ccteam show <slug> --format json | jq
 
 # 全局态
-cct ls --format json | jq
+ccteam ls --format json | jq
 
 # 看一项目实时输出
-cct progress <slug> --tail   # 流式;通常你不需要,因为关键事件会经 inbox 推到你这
+ccteam progress <slug> --tail   # 流式;通常你不需要,因为关键事件会经 inbox 推到你这
 ```
 
 `--slug` 显式给定时跳过自动 slug 生成(Tier 1 PRD §3.2.1);不传 `--slug`
-时 `cct new` 在 tty 上下文会 shell-out `claude -p haiku` 智能推一个
+时 `ccteam new` 在 tty 上下文会 shell-out `claude -p haiku` 智能推一个
 + Y/n 确认(Tier 3),非 tty 自动接受;`--no-auto-slug` / 环境变量
 `CCTEAM_AUTO_SLUG=off` 强制走 deterministic Tier 4。skill 流程里
 **默认显式传 `--slug`**(用户在 Phase B 已确认),不再走 Tier 3。
@@ -110,11 +110,11 @@ M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具�
 
 ## 5. 监控规则
 
-你**不展示 progress 细节**——那是 `cct show` / `cct progress` 的活。你向用户汇报的只有**关键事件**:
+你**不展示 progress 细节**——那是 `ccteam show` / `ccteam progress` 的活。你向用户汇报的只有**关键事件**:
 
 | 事件 | 你怎么说 |
 |---|---|
-| 派单成功 | "已派 dev 团队,slug = `<slug>`,跟踪用 `cct show <slug>`" |
+| 派单成功 | "已派 dev 团队,slug = `<slug>`,跟踪用 `ccteam show <slug>`" |
 | escalation(项目卡住) | 用 NL 描述卡点 + 列 ccteam 推荐的 2-3 条出路;让用户回 NL 选一条 |
 | shipped(项目完成) | 一句话总结 + 项目目录路径 |
 | stall 软告警 | "项目 X 静默 5/15/30 分钟,看起来卡了,要不要 attach 看看?" |
@@ -126,16 +126,16 @@ M2.8 之后会切到 `mcp__ccteam__new` / `mcp__ccteam__ls` 等结构化工具�
 ccteam 跨项目聚合所有 `event_kind: clarify | escalation` 的 outbox 文件成一个**决策队列**。命令:
 
 ```bash
-cct decisions                 # 表格视图
-cct decisions --format json   # 结构化,适合你 jq 筛选
+ccteam decisions                 # 表格视图
+ccteam decisions --format json   # 结构化,适合你 jq 筛选
 ```
 
 **你必须主动用这个**——这是 mode 2(用户离线时)异步决策机制的入口(interfaces.md §5.6.4)。具体规则:
 
-- **session 启动 / context reset 后**:第一件事跑一次 `cct decisions --format json`,看有没有用户离开期间堆积的决策。**有则主动汇报**,例:"刚回来发现 3 个项目在等你拍板:bookmark-mgr 问 SQLite 还是 Postgres?todo-cli 报 max_clarify_rounds 撞顶。先处理哪个?"
-- **用户 NL 说"批一下今天的决策" / "看看 pending"**:跑 `cct decisions`,逐条 NL 化展示,等用户每条 NL 答复
-- **每次用户答复某条决策后**:用 `cct-control` 把答案写到对应 project session 的 inbox(`Bash` 调 `cct new`-style 路径,M2.8 后改 `ccteam__send_to_session` MCP 工具)
-- **绝不**主动 tail 单个项目的 outbox —— 用全局 `cct decisions` 一站式聚合
+- **session 启动 / context reset 后**:第一件事跑一次 `ccteam decisions --format json`,看有没有用户离开期间堆积的决策。**有则主动汇报**,例:"刚回来发现 3 个项目在等你拍板:bookmark-mgr 问 SQLite 还是 Postgres?todo-cli 报 max_clarify_rounds 撞顶。先处理哪个?"
+- **用户 NL 说"批一下今天的决策" / "看看 pending"**:跑 `ccteam decisions`,逐条 NL 化展示,等用户每条 NL 答复
+- **每次用户答复某条决策后**:用 `ccteam-control` 把答案写到对应 project session 的 inbox(`Bash` 调 `ccteam new`-style 路径,M2.8 后改 `ccteam__send_to_session` MCP 工具)
+- **绝不**主动 tail 单个项目的 outbox —— 用全局 `ccteam decisions` 一站式聚合
 
 **与 mode 1 的关系**:用户已经 `tmux attach` 到具体 project session 时,phase 内 claude 用 AskUserQuestion 直接问,**不**走 outbox 也**不**进决策队列。决策队列只装 mode 2(异步)写出来的 clarify / escalation。
 
@@ -166,7 +166,7 @@ content_type: text
 
 ## 7. Watchdog 角色(V0.2 M0.21)
 
-你的另一面身份是 **cct watchdog** —— 把 orchestrator / 各项目埋的低层信号
+你的另一面身份是 **ccteam watchdog** —— 把 orchestrator / 各项目埋的低层信号
 "翻译"成用户能读懂的 NL 通知。这是 **translation only** 角色,严格红线:
 
 - ❌ **不做技术决策**(不替项目 session 拍板"该不该重启"/"该不该 kill"/"该不该改方案")
@@ -190,32 +190,32 @@ deterministic re-inject 已经由 orchestrator 自己执行(`PostStopLimbo` /
 
 | classification | NL 模板(填进 outbox `body` 字段或直接复述) |
 |---|---|
-| `mid_tool_hung` | "项目 X 在 phase Y 第 Z 分钟卡在 `Tool(...)` 后无 PostToolUse,看起来 tool hang 而非子 agent 慢工。要不要 (a) `cct attach <slug>` 自看 (b) 让我等再 5 min 重看 (c) 这条不管了?" |
+| `mid_tool_hung` | "项目 X 在 phase Y 第 Z 分钟卡在 `Tool(...)` 后无 PostToolUse,看起来 tool hang 而非子 agent 慢工。要不要 (a) `ccteam attach <slug>` 自看 (b) 让我等再 5 min 重看 (c) 这条不管了?" |
 | `subagent_runaway` | "项目 X 子 agent (PreToolUse(Task)) 已经跑 Z 分钟没 SubagentStop,可能 hung。要 (a) attach 看 (b) 再等等 (c) 不管?" |
 | `limbo_capped` | "项目 X 在 phase Y 静默 Z 分钟,F35 deterministic re-inject 已重试 1 次仍无新事件。需要你 attach 看一眼 — orchestrator 的兜底用完了。" |
 | `post_stop_limbo` / `inject_limbo`(罕见,通常 orchestrator 已 re-inject) | "项目 X 静默 Z 分钟(`<class>`),orchestrator 刚重发了一次 phase prompt。等一两分钟看效果,要 attach 现在看吗?" |
 
 **propose-confirm 三选一**(每条至少给):
-- (a) `cct attach <slug>` 自看
+- (a) `ccteam attach <slug>` 自看
 - (b) 等 N 分钟再看(N 由你按情况估)
 - (c) 这条不管了 / 用户接管
 
 **永远不要**:
 - ❌ 替用户决定 attach 还是 kill(见 §7 红线)
-- ❌ 自己发 `Bash` 调 `tmux send-keys` / `Ctrl-C` / `cct kill`
+- ❌ 自己发 `Bash` 调 `tmux send-keys` / `Ctrl-C` / `ccteam kill`
 - ❌ 改 `state.json` 或写 `progress.jsonl`
 - ❌ 推断技术原因(eg "这肯定是 OOM"):你看到的 pane_tail 只有 30 行,做不了真的诊断 — surface,不 diagnose
 
-如果用户回 (a):你把 `cct attach <slug>` 命令打出来即可。回 (b):记一下时间,下个周期再扫。回 (c):删掉这条 outbox(用户授权后)。
+如果用户回 (a):你把 `ccteam attach <slug>` 命令打出来即可。回 (b):记一下时间,下个周期再扫。回 (c):删掉这条 outbox(用户授权后)。
 
 ### 7.1 watchdog 数据源(`Bash` 调 ccteam,纯只读)
 
 ```bash
 # 一次扫所有信号(daemon health + 全项目)
-cct watchdog scan --format json | jq
+ccteam watchdog scan --format json | jq
 
 # 同时把高/普 priority alert 写进自己 outbox
-cct watchdog scan --push --user __USER_HANDLE__
+ccteam watchdog scan --push --user __USER_HANDLE__
 ```
 
 四个信号源:
@@ -243,8 +243,8 @@ notify_mode: normal               # quiet / normal / verbose
 
 按下面顺序跑(允许跳过若该信号本次为空):
 
-1. 跑 `cct watchdog scan --format json` 看是否有 alert
-2. **`daemon_down` 必报**: 立即 NL 告知用户 "orchestrator 守护进程似乎挂了, MCP 命令现在失效, 要 `cct start --foreground` 重启吗?"
+1. 跑 `ccteam watchdog scan --format json` 看是否有 alert
+2. **`daemon_down` 必报**: 立即 NL 告知用户 "orchestrator 守护进程似乎挂了, MCP 命令现在失效, 要 `ccteam start --foreground` 重启吗?"
 3. **其他 alert 按 priority 处理**:
    - `cost_overrun` (priority=high): "X 项目 cost = $Y 已超你配的 $Z 阈值, 还烧吗?"
    - `needs_attention` (priority=high): "X 项目 phase 卡死(第二次 Stop 都没正常收尾),pane tail: <30 行>。要不要 attach 看看?"

--- a/crates/ccteam-core/src/templates/settings.json
+++ b/crates/ccteam-core/src/templates/settings.json
@@ -10,16 +10,16 @@
     "SessionStart": [
       {
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook load-context", "timeout": 5},
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append session_start", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook load-context", "timeout": 5},
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append session_start", "async": true}
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook parse-phase-end", "timeout": 10},
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append Stop", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook parse-phase-end", "timeout": 10},
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append Stop", "async": true}
         ]
       }
     ],
@@ -27,42 +27,42 @@
       {
         "matcher": "idle_prompt|permission_prompt",
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append notification", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append notification", "async": true}
         ]
       }
     ],
     "PreToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append PreToolUse", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append PreToolUse", "async": true}
         ]
       },
       {
         "matcher": "AskUserQuestion",
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook intercept-ask", "timeout": 5}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook intercept-ask", "timeout": 5}
         ]
       }
     ],
     "PostToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append PostToolUse", "async": true},
-          {"type": "command", "command": "{{CCT_BIN}} hook cost-accumulate", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append PostToolUse", "async": true},
+          {"type": "command", "command": "__CCTEAM_BIN__ hook cost-accumulate", "async": true}
         ]
       }
     ],
     "SubagentStop": [
       {
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append SubagentStop", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append SubagentStop", "async": true}
         ]
       }
     ],
     "SessionEnd": [
       {
         "hooks": [
-          {"type": "command", "command": "{{CCT_BIN}} hook progress-append SessionEnd", "async": true}
+          {"type": "command", "command": "__CCTEAM_BIN__ hook progress-append SessionEnd", "async": true}
         ]
       }
     ]

--- a/crates/ccteam-core/src/tool_surface.rs
+++ b/crates/ccteam-core/src/tool_surface.rs
@@ -400,10 +400,10 @@ pub struct MigrationReport {
     pub removed: bool,
 }
 
-/// V0.2.2 F39: outcome of a single legacy skill directory check.
+/// V0.2.2 F44: outcome of a single legacy skill directory check.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LegacySkillAction {
-    /// Directory absent — V0.1/V0.2 user never installed this skill, or
+    /// Directory absent — user never installed this F39-era skill, or
     /// already cleaned up. Reported as "no-op".
     NotFound,
     /// Body carried the `<!-- ccteam-managed:skill … -->` marker (or the
@@ -417,27 +417,29 @@ pub enum LegacySkillAction {
     PreservedHandEdit,
 }
 
-/// V0.2.2 F39: report for one `~/.claude/skills/<legacy>/` directory.
+/// V0.2.2 F44: report for one `~/.claude/skills/<legacy>/` directory.
 #[derive(Debug, Clone)]
 pub struct LegacySkillReport {
     /// `<claude_dir>/skills/<legacy_name>/`.
     pub target: PathBuf,
-    /// One of the V0.1/V0.2 `LEGACY_SKILL_NAMES` entries.
+    /// One of the F39-era `LEGACY_SKILL_NAMES` entries (`cct-*`).
     pub legacy_name: String,
     pub action: LegacySkillAction,
 }
 
-/// V0.2.2 F39: detect and (when safe) remove `~/.claude/skills/ccteam-{control,team-author}/`
-/// dirs left over from V0.1/V0.2 installs. The cct doctor migration
-/// path calls this after the new `cct-{control,team-author}` skills
-/// have been installed so users can collapse to a single skill set.
+/// V0.2.2 F44: detect and (when safe) remove
+/// `~/.claude/skills/cct-{control,team-author,project-creator}/` dirs
+/// left over from V0.2.2 (F39'd) installs. The `ccteam doctor` migration
+/// path calls this after the canonical `ccteam-{control,team-author,
+/// project-creator}` skills have been installed so users can collapse
+/// to a single skill set.
 ///
-/// **Safety contract (PRD §8.2.5)**: only removes a legacy directory
-/// whose `SKILL.md` body still carries the `<!-- ccteam-managed:skill ... -->`
-/// marker or the matching `name: ccteam-{control,team-author}` YAML
-/// frontmatter. Operator hand-edits (no marker, no canonical frontmatter)
-/// are preserved as-is — the user must remove them manually if they
-/// want a clean tree.
+/// **Safety contract**: only removes a legacy directory whose `SKILL.md`
+/// body still carries the `<!-- ccteam-managed:skill ... -->` marker or
+/// the matching `name: cct-{control,team-author,project-creator}` YAML
+/// frontmatter. Operator hand-edits (no marker, no canonical
+/// frontmatter) are preserved as-is — the user must remove them
+/// manually if they want a clean tree.
 ///
 /// `dry_run=true` reports without touching the filesystem.
 pub fn migrate_legacy_skill_dirs(
@@ -462,9 +464,9 @@ pub fn migrate_legacy_skill_dirs(
         }
 
         // Body must carry the ccteam-managed marker (the body we shipped
-        // through V0.1/V0.2 plus the V0.2.2 wrapper) **or** the
-        // canonical frontmatter `name: ccteam-…` so we can be sure it's
-        // the unedited shipped skill. Either signal alone is enough.
+        // through V0.2.2 F39) **or** the canonical frontmatter
+        // `name: cct-…` so we can be sure it's the unedited shipped
+        // skill. Either signal alone is enough.
         let body = std::fs::read_to_string(&skill_md).unwrap_or_default();
         let canonical_frontmatter = format!("name: {legacy}");
         let is_managed = body.contains("<!-- ccteam-managed:skill begin -->")
@@ -498,13 +500,13 @@ pub fn migrate_legacy_skill_dirs(
     Ok(out)
 }
 
-/// V0.2.2 F39: outcome of a single project's settings.json hook
-/// command rewrite (legacy `… ccteam hook …` → `<current_exe> hook …`).
+/// V0.2.2 F44: outcome of a single project's settings.json hook
+/// command rewrite (legacy `… cct hook …` → `<current_exe> hook …`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HookCmdRewriteAction {
     /// File absent — nothing to do.
     NotFound,
-    /// File present, no hook command referenced a legacy `ccteam`
+    /// File present, no hook command referenced an F39-era `cct`
     /// binary path. Idempotent re-run after a successful migration
     /// hits this branch.
     NoChangeNeeded,
@@ -514,23 +516,23 @@ pub enum HookCmdRewriteAction {
     Rewrote { entries: usize },
 }
 
-/// V0.2.2 F39: report for one `~/projects/<slug>/.claude/settings.json`.
+/// V0.2.2 F44: report for one `~/projects/<slug>/.claude/settings.json`.
 #[derive(Debug, Clone)]
 pub struct HookCmdRewriteReport {
     pub target: PathBuf,
     pub action: HookCmdRewriteAction,
 }
 
-/// V0.2.2 F39: rewrite legacy `… /ccteam hook …` (or `ccteam hook …`
+/// V0.2.2 F44: rewrite F39-era `… /cct hook …` (or `cct hook …`
 /// without an absolute prefix) entries in a project's settings.json
-/// so they invoke the new `cct` binary at the running ccteam
+/// so they invoke the canonical `ccteam` binary at the running
 /// process's `current_exe()` path. Idempotent — re-runs after success
 /// hit `NoChangeNeeded`.
 ///
-/// Detection rule: any `command` string that ends with the legacy
-/// segment `/ccteam hook ` or starts with `ccteam hook ` (no slash).
-/// The replacement substitutes everything up through the binary path
-/// with the new binary path. Hook subcommands (e.g. `progress-append
+/// Detection rule: any `command` string that ends with the F39 segment
+/// `/cct hook ` or starts with `cct hook ` (no slash). The replacement
+/// substitutes everything up through the binary path with the new
+/// binary path. Hook subcommands (e.g. `progress-append
 /// session_start`) are preserved verbatim so this works for every hook
 /// in `templates/settings.json`.
 pub fn rewrite_legacy_hook_commands(
@@ -547,10 +549,10 @@ pub fn rewrite_legacy_hook_commands(
 
     let new_bin_str = new_bin
         .to_str()
-        .ok_or_else(|| anyhow!("cct binary path not valid UTF-8: {}", new_bin.display()))?;
+        .ok_or_else(|| anyhow!("ccteam binary path not valid UTF-8: {}", new_bin.display()))?;
     if new_bin_str.contains('"') || new_bin_str.contains('\\') {
         return Err(anyhow!(
-            "cct binary path contains characters that can't be embedded in settings.json: {new_bin_str}"
+            "ccteam binary path contains characters that can't be embedded in settings.json: {new_bin_str}"
         ));
     }
 
@@ -607,7 +609,7 @@ pub fn rewrite_legacy_hook_commands(
     let body = serde_json::to_string_pretty(&v).context("serialize updated settings.json")?;
     // Atomic write: write to `<path>.tmp` then rename so a crash mid-
     // write can't leave a half-rewritten settings.json on disk.
-    let tmp = settings_path.with_extension("json.cct-migrate.tmp");
+    let tmp = settings_path.with_extension("json.ccteam-migrate.tmp");
     std::fs::write(&tmp, &body)
         .with_context(|| format!("write {}", tmp.display()))?;
     std::fs::rename(&tmp, settings_path)
@@ -618,24 +620,23 @@ pub fn rewrite_legacy_hook_commands(
     })
 }
 
-/// V0.2.2 F39: rewrite one hook `command` string. Returns `None` when
-/// the command does not look like a legacy `ccteam hook …` invocation
+/// V0.2.2 F44: rewrite one hook `command` string. Returns `None` when
+/// the command does not look like an F39-era `cct hook …` invocation
 /// (so the caller can leave it alone — preserves operator-authored
 /// hooks). Otherwise returns the rewritten string with the binary path
-/// swapped to `new_bin`.
+/// swapped to `new_bin` (the canonical `ccteam` binary).
 fn rewrite_one_hook_command(cmd: &str, new_bin: &str) -> Option<String> {
-    // Already pointing at the new `cct` binary? Idempotency.
-    if cmd.contains("/cct hook ") || cmd.starts_with("cct hook ") {
+    // Already pointing at the canonical `ccteam` binary? Idempotency.
+    if cmd.contains("/ccteam hook ") || cmd.starts_with("ccteam hook ") {
         return None;
     }
-    // Absolute path ending with `/ccteam hook …`.
-    if let Some(idx) = cmd.find("/ccteam hook ") {
-        let tail = &cmd[idx + "/ccteam".len()..];
+    // Absolute path ending with `/cct hook …` (F39 binary name).
+    if let Some(idx) = cmd.find("/cct hook ") {
+        let tail = &cmd[idx + "/cct".len()..];
         return Some(format!("{new_bin}{tail}"));
     }
-    // Bare `ccteam hook …` with no path prefix (uncommon but legal in
-    // V0.1 templates).
-    if let Some(rest) = cmd.strip_prefix("ccteam hook ") {
+    // Bare `cct hook …` with no path prefix (uncommon but legal).
+    if let Some(rest) = cmd.strip_prefix("cct hook ") {
         return Some(format!("{new_bin} hook {rest}"));
     }
     None
@@ -852,7 +853,7 @@ mod tests {
         assert!(stale.symlink_metadata().unwrap().file_type().is_symlink());
     }
 
-    // -------------------- V0.2.2 F39 migration helpers --------------------
+    // -------------------- V0.2.2 F44 reverse-migration helpers --------------------
 
     fn write_legacy_skill(claude: &Path, name: &str, body: &str) -> PathBuf {
         let dir = claude.join("skills").join(name);
@@ -867,7 +868,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let claude = tmp.path().join(".claude");
         let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
-        assert_eq!(reports.len(), 2);
+        assert_eq!(reports.len(), 3);
         for r in &reports {
             assert_eq!(r.action, LegacySkillAction::NotFound);
         }
@@ -879,34 +880,34 @@ mod tests {
         let claude = tmp.path().join(".claude");
         let dir = write_legacy_skill(
             &claude,
-            "ccteam-control",
-            "<!-- ccteam-managed:skill begin -->\n---\nname: ccteam-control\n---\n# body\n<!-- ccteam-managed:skill end -->\n",
+            "cct-control",
+            "<!-- ccteam-managed:skill begin -->\n---\nname: cct-control\n---\n# body\n<!-- ccteam-managed:skill end -->\n",
         );
         let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
         let ctrl = reports
             .iter()
-            .find(|r| r.legacy_name == "ccteam-control")
+            .find(|r| r.legacy_name == "cct-control")
             .unwrap();
         assert_eq!(ctrl.action, LegacySkillAction::Removed);
         assert!(!dir.exists());
     }
 
     #[test]
-    fn migrate_legacy_skill_dirs_removes_v0_2_install_via_frontmatter() {
-        // V0.2.0 / V0.2.1 shipped the skill body without the
-        // ccteam-managed marker (the marker is V0.2.2 F39 prep). Detect
-        // it by frontmatter `name:` instead.
+    fn migrate_legacy_skill_dirs_removes_via_frontmatter_only() {
+        // F39 always shipped the marker, but if a user installed the
+        // body via some other path that stripped the comment marker,
+        // detect via frontmatter `name:` instead.
         let tmp = tempfile::TempDir::new().unwrap();
         let claude = tmp.path().join(".claude");
         let dir = write_legacy_skill(
             &claude,
-            "ccteam-team-author",
-            "---\nname: ccteam-team-author\n---\n# body\n",
+            "cct-team-author",
+            "---\nname: cct-team-author\n---\n# body\n",
         );
         let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
         let ta = reports
             .iter()
-            .find(|r| r.legacy_name == "ccteam-team-author")
+            .find(|r| r.legacy_name == "cct-team-author")
             .unwrap();
         assert_eq!(ta.action, LegacySkillAction::Removed);
         assert!(!dir.exists());
@@ -918,13 +919,13 @@ mod tests {
         let claude = tmp.path().join(".claude");
         let dir = write_legacy_skill(
             &claude,
-            "ccteam-control",
+            "cct-control",
             "---\nname: my-custom-fork\n---\n# user wrote this\n",
         );
         let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
         let ctrl = reports
             .iter()
-            .find(|r| r.legacy_name == "ccteam-control")
+            .find(|r| r.legacy_name == "cct-control")
             .unwrap();
         assert_eq!(ctrl.action, LegacySkillAction::PreservedHandEdit);
         assert!(dir.exists());
@@ -936,16 +937,54 @@ mod tests {
         let claude = tmp.path().join(".claude");
         let dir = write_legacy_skill(
             &claude,
-            "ccteam-control",
-            "<!-- ccteam-managed:skill begin -->\n---\nname: ccteam-control\n---\n",
+            "cct-control",
+            "<!-- ccteam-managed:skill begin -->\n---\nname: cct-control\n---\n",
         );
         let reports = migrate_legacy_skill_dirs(&claude, true).unwrap();
         let ctrl = reports
             .iter()
-            .find(|r| r.legacy_name == "ccteam-control")
+            .find(|r| r.legacy_name == "cct-control")
             .unwrap();
         assert_eq!(ctrl.action, LegacySkillAction::WouldRemove);
         assert!(dir.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_handles_project_creator() {
+        // F39 added cct-project-creator (F34); F44 must clean it up too.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        let dir = write_legacy_skill(
+            &claude,
+            "cct-project-creator",
+            "<!-- ccteam-managed:skill begin -->\n---\nname: cct-project-creator\n---\n",
+        );
+        let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
+        let pc = reports
+            .iter()
+            .find(|r| r.legacy_name == "cct-project-creator")
+            .unwrap();
+        assert_eq!(pc.action, LegacySkillAction::Removed);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn migrate_legacy_skill_dirs_idempotent_after_first_run() {
+        // Running F44 migration twice is a no-op the second time.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let claude = tmp.path().join(".claude");
+        write_legacy_skill(
+            &claude,
+            "cct-control",
+            "<!-- ccteam-managed:skill begin -->\n---\nname: cct-control\n---\n",
+        );
+        // First pass removes.
+        migrate_legacy_skill_dirs(&claude, false).unwrap();
+        // Second pass is a no-op (everything reports NotFound).
+        let reports = migrate_legacy_skill_dirs(&claude, false).unwrap();
+        for r in &reports {
+            assert_eq!(r.action, LegacySkillAction::NotFound);
+        }
     }
 
     fn legacy_settings_json(legacy_bin: &str) -> String {
@@ -970,22 +1009,22 @@ mod tests {
     fn rewrite_legacy_hook_commands_swaps_absolute_path() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("settings.json");
-        std::fs::write(&path, legacy_settings_json("/home/u/.cargo/bin/ccteam")).unwrap();
-        let new_bin = PathBuf::from("/home/u/.cargo/bin/cct");
+        std::fs::write(&path, legacy_settings_json("/home/u/.cargo/bin/cct")).unwrap();
+        let new_bin = PathBuf::from("/home/u/.cargo/bin/ccteam");
         let rep = rewrite_legacy_hook_commands(&path, &new_bin, false).unwrap();
         assert_eq!(rep.action, HookCmdRewriteAction::Rewrote { entries: 3 });
         let body = std::fs::read_to_string(&path).unwrap();
-        assert!(body.contains("/home/u/.cargo/bin/cct hook load-context"), "got: {body}");
-        assert!(!body.contains("/ccteam hook"), "legacy path survived: {body}");
+        assert!(body.contains("/home/u/.cargo/bin/ccteam hook load-context"), "got: {body}");
+        assert!(!body.contains("/cct hook"), "F39-era path survived: {body}");
     }
 
     #[test]
     fn rewrite_legacy_hook_commands_dry_run_does_not_write() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("settings.json");
-        let original = legacy_settings_json("/home/u/.cargo/bin/ccteam");
+        let original = legacy_settings_json("/home/u/.cargo/bin/cct");
         std::fs::write(&path, &original).unwrap();
-        let new_bin = PathBuf::from("/home/u/.cargo/bin/cct");
+        let new_bin = PathBuf::from("/home/u/.cargo/bin/ccteam");
         let rep = rewrite_legacy_hook_commands(&path, &new_bin, true).unwrap();
         assert_eq!(rep.action, HookCmdRewriteAction::WouldRewrite { entries: 3 });
         let body = std::fs::read_to_string(&path).unwrap();
@@ -993,11 +1032,11 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_legacy_hook_commands_idempotent_when_already_cct() {
+    fn rewrite_legacy_hook_commands_idempotent_when_already_ccteam() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("settings.json");
-        std::fs::write(&path, legacy_settings_json("/home/u/.cargo/bin/cct")).unwrap();
-        let new_bin = PathBuf::from("/home/u/.cargo/bin/cct");
+        std::fs::write(&path, legacy_settings_json("/home/u/.cargo/bin/ccteam")).unwrap();
+        let new_bin = PathBuf::from("/home/u/.cargo/bin/ccteam");
         let rep = rewrite_legacy_hook_commands(&path, &new_bin, false).unwrap();
         assert_eq!(rep.action, HookCmdRewriteAction::NoChangeNeeded);
     }
@@ -1006,24 +1045,24 @@ mod tests {
     fn rewrite_legacy_hook_commands_handles_missing_file() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("settings.json");
-        let new_bin = PathBuf::from("/usr/local/bin/cct");
+        let new_bin = PathBuf::from("/usr/local/bin/ccteam");
         let rep = rewrite_legacy_hook_commands(&path, &new_bin, false).unwrap();
         assert_eq!(rep.action, HookCmdRewriteAction::NotFound);
     }
 
     #[test]
-    fn rewrite_one_hook_command_handles_bare_ccteam_prefix() {
-        let got = rewrite_one_hook_command("ccteam hook progress-append PreToolUse", "/x/cct");
+    fn rewrite_one_hook_command_handles_bare_cct_prefix() {
+        let got = rewrite_one_hook_command("cct hook progress-append PreToolUse", "/x/ccteam");
         assert_eq!(
             got.as_deref(),
-            Some("/x/cct hook progress-append PreToolUse"),
+            Some("/x/ccteam hook progress-append PreToolUse"),
         );
     }
 
     #[test]
     fn rewrite_one_hook_command_returns_none_for_unrelated_commands() {
         assert!(
-            rewrite_one_hook_command("/usr/bin/jq .progress[]", "/x/cct").is_none(),
+            rewrite_one_hook_command("/usr/bin/jq .progress[]", "/x/ccteam").is_none(),
             "should not touch operator-authored hooks",
         );
     }

--- a/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
+++ b/crates/ccteam-core/tests/m1_dispatch_e2e_test.rs
@@ -1,15 +1,15 @@
 //! M1.3 acceptance test (end-to-end meta-agent dispatch).
 //!
 //! Production flow we're modeling:
-//!   1. `cct doctor --install-meta-agent <user>` lays down the
-//!      meta-agent project + role prompt + cct-control skill.
+//!   1. `ccteam doctor --install-meta-agent <user>` lays down the
+//!      meta-agent project + role prompt + ccteam-control skill.
 //!   2. orchestrator brings up `ccteam-meta-<user>` tmux session.
 //!   3. user / channel adapter writes an inbox file with a project
 //!      request.
 //!   4. orchestrator's inbox watcher injects the body into the meta
 //!      session via send-keys (idle path, since the session is fresh).
 //!   5. inside the session, claude reads the body, decides to
-//!      `cct new --team=dev` (we mock this — see below).
+//!      `ccteam new --team=dev` (we mock this — see below).
 //!   6. meta writes an outbox `event_kind: reply` confirming the
 //!      dispatch.
 //!
@@ -24,7 +24,7 @@ use std::time::Duration;
 
 use ccteam_core::tmux::{tmux_available, TmuxSession};
 use ccteam_core::{
-    bootstrap_meta_project, current_cct_bin, disable_tool_surface_bootstrap_for_tests,
+    bootstrap_meta_project, current_ccteam_bin, disable_tool_surface_bootstrap_for_tests,
     inbox_filename, install_skill_into, write_global_phase_templates, CcteamPaths, InboxFrontMatter,
     InboxMessage, InstallSkillOptions, Orchestrator, OrchestratorConfig, OutboxEventKind,
     OutboxFrontMatter, OutboxMessage, OutboxPriority, ProjectState, SessionMailbox,
@@ -50,35 +50,34 @@ fn meta_dispatch_e2e_inbox_to_outbox() {
         eprintln!("[skip] tmux not on PATH");
         return;
     }
-    // Note: in the test binary `current_cct_bin()` returns the test
-    // binary itself (which doesn't speak `cct new`). Cross-crate
-    // CARGO_BIN_EXE_cct isn't exported either, so we model the
+    // Note: in the test binary `current_ccteam_bin()` returns the test
+    // binary itself (which doesn't speak `ccteam new`). Cross-crate
+    // CARGO_BIN_EXE_ccteam isn't exported either, so we model the
     // dispatch by laying down a project directory + state.json
     // directly inside the shell stand-in. The real meta-agent binds
-    // its `Bash("cct new ...")` call in production; that subshell
+    // its `Bash("ccteam new ...")` call in production; that subshell
     // execution path is covered by the dedicated `commands::run_new`
     // unit tests.
-    let _ = current_cct_bin().ok();
+    let _ = current_ccteam_bin().ok();
     isolation();
 
     let tmp = TempDir::new().unwrap();
     let paths = fresh_paths(&tmp);
     write_global_phase_templates(&paths.root, true).unwrap();
 
-    // Step 1: install meta-agent + cct-control skill (M1.0 + M1.8 +
-    // V0.2.2 F39 rename).
+    // Step 1: install meta-agent + ccteam-control skill (M1.0 + M1.8).
     let user = format!("e2e-{}", std::process::id());
     let report = bootstrap_meta_project(&paths, &user).unwrap();
     let claude_root = tmp.path().join("claude-home");
     install_skill_into(&claude_root, InstallSkillOptions::default()).unwrap();
-    assert!(claude_root.join("skills/cct-control/SKILL.md").is_file());
+    assert!(claude_root.join("skills/ccteam-control/SKILL.md").is_file());
 
     // Step 2/3: prepare a stand-in for claude that, on first run,
     // (a) touches the ready marker so ensure_session unblocks,
     // (b) waits for the inbox-injected message body to arrive on
     //     stdin (we approximate this by polling for the orchestrator's
     //     `inbox_consumed` progress event),
-    // (c) executes `cct new --team=dev "<brief>"` to dispatch,
+    // (c) executes `ccteam new --team=dev "<brief>"` to dispatch,
     // (d) writes the meta outbox reply file.
     //
     // The orchestrator's send-keys will land "做一个 todo cli\n" in
@@ -94,11 +93,11 @@ fn meta_dispatch_e2e_inbox_to_outbox() {
     let dispatched_slug_dir = paths.projects_root.join("todo-cli");
     let dispatched_str = dispatched_slug_dir.to_string_lossy().to_string();
 
-    // Shell stand-in for `claude` running cct-control via Bash:
+    // Shell stand-in for `claude` running ccteam-control via Bash:
     //   1. touch ready marker
     //   2. read first line from the pane (orchestrator's send-keys
     //      delivers the inbox body)
-    //   3. simulate `cct new --team=dev "<brief>"` by laying down
+    //   3. simulate `ccteam new --team=dev "<brief>"` by laying down
     //      `<projects>/todo-cli/.ccteam/state.json`
     //   4. write meta outbox `event_kind: reply` confirming dispatch
     //   5. stay alive so the test can attach.

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -679,7 +679,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **文件:行号**:`crates/ccteam-core/src/projects.rs::pick_unused_slug` 字符级 slugify(40-char cap,无 token / 语义层裁剪);`crates/ccteam-cli/src/main.rs::Commands::New` 缺 `--slug` 接口
 - **现状**:brief 整段 slugify 撞死冗长 slug(`dev-ccteam-ui-ccteam-1-2-session-subagent-3` ≠ 用户原话 `ccteam-ui`);meta-agent 派单前不确认项目名,用户后悔无路(slug 重命名不支持)。
 - **是否真 dev-specific**:**否——通用 UX 缺陷**。
-- **解耦方案**:四层调用栈 — Tier 1 `cct new --slug X`(B2 prefix 自动加 team-)/ Tier 2 `cct-project-creator` skill(meta-agent 调,带 AskUserQuestion 结构化选项)/ Tier 3 `claude -p haiku` 智能 fallback(15s timeout,Y/n 确认 / `--no-auto-slug` env 控)/ Tier 4 deterministic `slugify_brief()`(token-aware + stop-word + dedup + 取前 3 token)。
+- **解耦方案**:四层调用栈 — Tier 1 `ccteam new --slug X`(B2 prefix 自动加 team-)/ Tier 2 `ccteam-project-creator` skill(meta-agent 调,带 AskUserQuestion 结构化选项)/ Tier 3 `claude -p haiku` 智能 fallback(15s timeout,Y/n 确认 / `--no-auto-slug` env 控)/ Tier 4 deterministic `slugify_brief()`(token-aware + stop-word + dedup + 取前 3 token)。
 - **优先级**:**P1**(用户日常摩擦点)。
 - **来源**:2026-05-08 用户实战反馈 issue #1+#2(`docs/v0-2-2/feedback.md` / `docs/v0-2-2/prd.md §3`)。
 
@@ -701,12 +701,12 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **优先级**:**P0** ship-blocker(实际 bug,V0.1/V0.2 用户已撞)。
 - **来源**:2026-05-08 用户实战反馈 issue #4(`docs/v0-2-2/feedback.md` / `docs/v0-2-2/prd.md §5`)。
 
-### F37 — meta-agent 绕开 pipeline 自调研(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #2 决策树加固 + cct-project-creator skill)**)
+### F37 — meta-agent 绕开 pipeline 自调研(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #2 决策树加固 + ccteam-project-creator skill)**)
 
 - **文件:行号**:`crates/ccteam-core/src/templates/meta_agent_role.md` §1 决策树边界不严("调研 X" 被错误归入"问答"分支)+ §3 克制规则缺"❌ 不起 Agent subagent 自调研"反例。
 - **现状**:用户要求"调研 Multica",meta-agent 没派 product-research,而是自起 `Agent(subagent_type=general-purpose)` 做 Web 搜索 + 直出结论;product-research 6-phase pipeline(kickoff / research / verdict / next-steps)被绕过,无可审计调研记录。
 - **是否真 dev-specific**:**否——meta-agent 决策树软约束被漂移**。
-- **解耦方案**:`meta_agent_role.md` §1 加 "调研 X = 项目请求" 反例(项目请求段含"调研 / 评估 / 分析 / 看看 X 值不值得");§3 克制规则加 "❌ 不要自起 `Agent(subagent_type=general-purpose)` / 调用 web 搜索做调研" 反例;§2 派单段 inline rules 抽出,改"走 `cct-project-creator` skill"(skill body 接 Phase A/B/C/D — 需求澄清 / slug 推荐 / team 选择 / 派单);F34 + F37 同 PR 落地。
+- **解耦方案**:`meta_agent_role.md` §1 加 "调研 X = 项目请求" 反例(项目请求段含"调研 / 评估 / 分析 / 看看 X 值不值得");§3 克制规则加 "❌ 不要自起 `Agent(subagent_type=general-purpose)` / 调用 web 搜索做调研" 反例;§2 派单段 inline rules 抽出,改"走 `ccteam-project-creator` skill"(skill body 接 Phase A/B/C/D — 需求澄清 / slug 推荐 / team 选择 / 派单);F34 + F37 同 PR 落地。
 - **优先级**:**P1**(决策树漂移影响 UX 一致性)。
 - **来源**:2026-05-08 用户实战反馈 issue #6(`docs/v0-2-2/feedback.md` / `docs/v0-2-2/prd.md §6`)。
 
@@ -715,18 +715,26 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **文件:行号**:无(新功能)。F35 enriched outbox `pane_tail` 是文本维度,`channel adapter` / 用户人眼缺直观视觉维度。
 - **现状**:meta-agent 通知用户项目状态时只能给文本 `pane_tail`(30 行 capture-pane);ANSI 颜色 / progress bar / 框线字符在文本里失真。
 - **是否真 dev-specific**:**否——通用 UX 增强**。
-- **解耦方案**:`tmux capture-pane -e` → `vt100::Parser` cell grid → `imageproc::drawing::{draw_filled_rect_mut, draw_text_mut}`(`ab_glyph` 字体)→ `image` PNG。**纯 Rust 全栈**(vendored JetBrainsMono-Regular.ttf OFL via `include_bytes!`,绕过 font-kit / fontconfig 系统依赖);`ANSI_256` 调色板常量(16 + 216 cube + 24 grayscale);`mcp__ccteam__screenshot(slug, lines?)` MCP 工具(namespace 保留 ccteam,V0.3 评估改名);`cct doctor --screenshot-smoke <slug>` flag;`std::panic::catch_unwind` 兜 vt100 / imageproc 边缘 panic;`CCTEAM_SCREENSHOT_FONT_TTF` env 覆盖字体。F35 enriched outbox 后续可加 `screenshot_path` 字段(本 PR ship MCP 工具 + smoke,outbox 集成留 follow-up)。
+- **解耦方案**:`tmux capture-pane -e` → `vt100::Parser` cell grid → `imageproc::drawing::{draw_filled_rect_mut, draw_text_mut}`(`ab_glyph` 字体)→ `image` PNG。**纯 Rust 全栈**(vendored JetBrainsMono-Regular.ttf OFL via `include_bytes!`,绕过 font-kit / fontconfig 系统依赖);`ANSI_256` 调色板常量(16 + 216 cube + 24 grayscale);`mcp__ccteam__screenshot(slug, lines?)` MCP 工具(namespace 保留 ccteam,V0.3 评估改名);`ccteam doctor --screenshot-smoke <slug>` flag;`std::panic::catch_unwind` 兜 vt100 / imageproc 边缘 panic;`CCTEAM_SCREENSHOT_FONT_TTF` env 覆盖字体。F35 enriched outbox 后续可加 `screenshot_path` 字段(本 PR ship MCP 工具 + smoke,outbox 集成留 follow-up)。
 - **优先级**:**P2**(UX 增强,补 F35 视觉维度;非阻塞)。
 - **来源**:用户 2026-05-09 追加(`docs/v0-2-2/prd.md §7`);载体经 5 轮迭代:Pillow → vte+tiny-skia → freeze(Linux 5.15 segfault) → ansee(font-kit deps)→ vt100+imageproc DIY(选定)。
 
-### F39 — `cct` 短前缀约定 sweep(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #1 cct convention sweep)**)
+### F39 — `cct` 短前缀约定 sweep(2026-05-09 加;**已修复→后被 F44 反向**:2026-05-09 PR #1 落地;2026-05-10 PR #8 反向回滚 — 详 F44)
 
-- **文件:行号**:`crates/ccteam-cli/Cargo.toml::[[bin]] name = "ccteam"`(老);`crates/ccteam-core/src/templates/{ccteam_control,ccteam_team_author}_skill.md`(老 skill 模板);全 `ccteam <cmd>` 命令字面量(README / docs / phase / role / memory-bridge templates);`crates/ccteam-core/src/templates/settings.json` hook command 老 `ccteam` 路径。
-- **现状**:V0.1/V0.2 ship 时命名前缀都是 `ccteam-`,跟简短 `dev` / `cct-slash` / `ccgram` 等周边工具命名风格不一致;`~/.claude/skills/` listing 三 `ccteam-*` 长字符;命令行 `ccteam new ...` 比 `cct new ...` 多打 4 字符。
-- **是否真 dev-specific**:**否——命名约定**。
-- **解耦方案**:三对象同步重命名:binary `ccteam` → `cct`(`Cargo.toml::[[bin]] name`)+ skill `ccteam-{control,team-author}` → `cct-{control,team-author}` + 顶层 `skills/` 目录(SoT);Rust 常量 + 函数同步(`CCT_*_SKILL_NAME` / `install_cct_*_skill` / `current_cct_bin`);settings.json 占位符 `{{CCT_BIN}}`(doctor 安装时填 `current_exe()`);`cct doctor` 自动迁移 V0.1/V0.2 用户(检测 + 清旧 `~/.claude/skills/ccteam-*/` marker 校验 + rewrite 老 settings.json hook 命令路径,原子写)。**保留**(per PRD §8.3):MCP server name `ccteam`(`mcpServers.ccteam`)+ `~/.config/ccteam/` XDG dir + `~/.ccteam/` 项目根 + crate 名 + git repo + workspace 名。CLAUDE.md §三红线 + §四 Skills 行 + §五 patch 流程 + §六 升级条目同步加。
-- **优先级**:**P3**(cleanup;非阻塞)。
-- **来源**:用户 2026-05-09 追加(`docs/v0-2-2/prd.md §8`);初为 F34 skill 重构子项,后抽出独立 finding(机械 rename 跟逻辑变更解耦,先 merge)。
+- **文件:行号**:`crates/ccteam-cli/Cargo.toml::[[bin]] name`、`skills/cct-*/SKILL.md`、`crates/ccteam-core/src/templates/settings.json` 占位符。
+- **现状(F39 实施时)**:V0.1/V0.2 ship 时命名前缀都是 `ccteam-`;F39 把 binary 改 `cct`、skill 改 `cct-*`、占位符改 `{{CCT_BIN}}`、Rust API 改 `current_cct_bin` / `install_cct_*` / `CCT_*_SKILL_NAME`。
+- **后续**:**F44 把 F39 全部反向**。原因:`/usr/bin/cct` 已被 Ubuntu `proj-bin`(PROJ Coordinate Conversion / GIS)占用,`~/.local/bin/cct` 在标准 PATH 上会静默 shadow 系统工具。
+- **优先级**:已实施 → 已反向。
+- **来源**:用户 2026-05-09 追加;反向决策 2026-05-10。
+
+### F44 — 反向 F39 cct convention sweep,恢复 ccteam 二进制(2026-05-10 加;**已修复:2026-05-10(V0.2.2 PR #8)**)
+
+- **文件:行号**:全 F39 触及面(binary、skill、Rust API、placeholder、docs sweep、CLAUDE.md §三/§四/§六)反向回滚到 ccteam-* 命名。
+- **现状**:F39 选 `cct` 二进制名时未检查 namespace;Ubuntu `proj-bin` 包提供 `/usr/bin/cct`(PROJ 工具),与 ccteam 同名碰撞,`~/.local/bin/cct` 在标准 PATH 上前置会静默 shadow 系统 GIS 工具。
+- **是否真 dev-specific**:**否——命名碰撞修复**。
+- **解耦方案**:逐一反向:binary `cct` → `ccteam`、skill `cct-*` → `ccteam-*`、Rust `current_cct_bin` → `current_ccteam_bin` / `install_cct_*_skill` → `install_ccteam_*_skill`、placeholder `{{CCT_BIN}}` → `__CCTEAM_BIN__`、docs sweep。`ccteam doctor` 加 F39 → F44 反向迁移(检测 `~/.claude/skills/cct-{control,team-author,project-creator}/` marker + frontmatter 校验,匹配则 rm -rf;rewrite `~/projects/<slug>/.claude/settings.json` 内 `cct hook` → `ccteam hook` 原子写)。**保留**(per F39 §8.3):MCP server name `ccteam`、`~/.ccteam/` 项目根、crate 名、git repo / workspace 名 — 这些 F39 本就没动。
+- **优先级**:**P0**(silent-substitute footgun)。
+- **来源**:用户 2026-05-10 反馈 + 实证 `dpkg -S /usr/bin/cct` 命中 `proj-bin`。
 
 ### F40 — `product-research` team 名冗长 + 领域名缺位(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #6 alias 软迁移)**)
 
@@ -735,7 +743,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   `team_resolver.rs::resolve_team` / `templates.rs::TEAM_BUNDLES` /
   `memory_bridge.rs::lookup_bridge_template` /
   `crates/ccteam-cli/src/commands.rs::ensure_team_resolvable` 等)。
-- **现状**:`product-research` 又长又冗(命令行 `cct new --team
+- **现状**:`product-research` 又长又冗(命令行 `ccteam new --team
   product-research "<brief>"`、`~/projects/product-research-<slug>/`
   目录前缀、`~/.claude/rules/ccteam-lessons-product-research.md` rules
   文件名),跟简短的 `dev` 对比读 / 写都繁;领域名 vs team 名混淆
@@ -749,7 +757,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
   `ensure_team_resolvable` 全 alias-aware(name miss → walk
   `aliases:`);老项目 `state.json::team = "product-research"` 字面 +
   `~/projects/product-research-*` 目录 + 老 rules 文件全不动;新项目走
-  `state.team = "research"` + `~/projects/research-*`;`cct new --team
+  `state.team = "research"` + `~/projects/research-*`;`ccteam new --team
   product-research` stderr warn deprecated 但仍工作。
 - **优先级**:**P2**(命名;不阻塞功能,但持续摩擦用户体验)。
 - **来源**:`docs/v0-2-2/prd.md §9`(F40 全文,~110 行)。

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -305,7 +305,7 @@ event_kind: reply                             # reply | progress | escalation | 
 
 # NL reply body
 
-收到了。我已经用 `cct new` 派单给 dev 团队,slug = bookmark-mgr-a3f9。
+收到了。我已经用 `ccteam new` 派单给 dev 团队,slug = bookmark-mgr-a3f9。
 预计 30 分钟内 plan-eng 完成,有 escalation 我会同步。
 ```
 
@@ -399,7 +399,7 @@ interfaces §3.4.3"。具体写哪些事件:
 | `ESCALATE: NEED_USER_INPUT — <questions>` | `need_user_input` | `null` | 写 escalation.md,inbox 等用户 |
 | `ESCALATE: ABORT — <reason>` | `abort` | `null` | 项目永久标 escalated,M0 等同 NEED_USER_INPUT |
 | `ESCALATE: INSUFFICIENT_CLARIFICATION — <last_question>` | `insufficient_clarification` | `null` | M2.3+:phase 已撞 `max_clarify_rounds` 上限,best-effort artifact 已产出;orchestrator 写 escalation.md,outbox `event_kind: escalation`,等用户决定继续 / 接受 / abort(详见 §5.6.2) |
-| `ESCALATE: PHASE_DONE_PENDING — <reason>` | (special — emits standalone `phase_done_pending` event, not `escalate`) | `null` | M3.6 ✅:phase 产出 required_outputs 但部分子任务 defer。Stop hook 从 reason 解析 outbox 文件名(`reply-*.md` / `clarify-*.md` / `escalation-*.md`),写 `event: "phase_done_pending"` 含 `phase` / `open_decisions[]` / `reason` 三字段;orchestrator 走 `TickAction::AdvancePhasePending`,看下 phase `required_inputs` 与 `open_decisions` 静态交集决定 advance / 切 `PhaseState::DonePending` 阻塞(`cct resume` 清除) |
+| `ESCALATE: PHASE_DONE_PENDING — <reason>` | (special — emits standalone `phase_done_pending` event, not `escalate`) | `null` | M3.6 ✅:phase 产出 required_outputs 但部分子任务 defer。Stop hook 从 reason 解析 outbox 文件名(`reply-*.md` / `clarify-*.md` / `escalation-*.md`),写 `event: "phase_done_pending"` 含 `phase` / `open_decisions[]` / `reason` 三字段;orchestrator 走 `TickAction::AdvancePhasePending`,看下 phase `required_inputs` 与 `open_decisions` 静态交集决定 advance / 切 `PhaseState::DonePending` 阻塞(`ccteam resume` 清除) |
 | `ESCALATE: <free text>`(无前缀) | `need_user_input` | `null` | 等同显式 NEED_USER_INPUT,reason 是整段文本 |
 
 分隔符:em dash `—`(U+2014)、`--`、` - `(单 dash 必须前后有空格——这是为了不切碎 `plan-eng` 这类 phase 名)。
@@ -595,7 +595,7 @@ confidence: 0.0-1.0
 
 ### 5.4 `tools_required` 字段语义(M0.5+)
 
-声明 phase 模板里会用到的工具,orchestrator 启动时枚举本机可达项 + 交叉比对,缺谁报谁 + 给修复命令(`cct start` 直接 fail-fast,除非加 `--skip-tool-check`)。
+声明 phase 模板里会用到的工具,orchestrator 启动时枚举本机可达项 + 交叉比对,缺谁报谁 + 给修复命令(`ccteam start` 直接 fail-fast,除非加 `--skip-tool-check`)。
 
 | 子字段 | 名字来源 | "可达"判定 |
 |---|---|---|
@@ -607,7 +607,7 @@ confidence: 0.0-1.0
 
 `bootstrap_project` 已在 §1.2 项目创建路径里自动写 `enabledPlugins` + 占位 skills 目录,所以 happy path 上模板要的工具默认都有;只有用户手工编辑模板加了非推荐工具时才会触发本节的校验失败。
 
-V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `cct doctor --migrate-recommended-agents` 一次性清理。
+V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `ccteam doctor --migrate-recommended-agents` 一次性清理。
 
 ---
 
@@ -630,14 +630,14 @@ V0.1 → V0.2 升级:V0.1 用户的 `~/.claude/agents/<name>.md` ln -sf 由 `cct
   `Orchestrator::team_runtime` / `team_bundle` / `ensure_team_resolvable` 的
   alias 解析路径,实现"软 rename"(`product-research` → `research` 是 V0.2.2
   首例,`teams/research/team.yaml` 列 `aliases: [product-research]`)。老项目
-  state.json::team 字面 / 项目目录名 / 老 rules 文件全不动;`cct new --team
+  state.json::team 字面 / 项目目录名 / 老 rules 文件全不动;`ccteam new --team
   product-research` 仍工作并 stderr warn deprecated。详 PRD §9。
 
 ```yaml
 # ~/.ccteam/teams/research/team.yaml — 完整字段示例(V0.2.2 起 canonical 名 `research`)
 name: research                          # 必填。snake-case [a-z0-9_-]+,与 --team / state.json.team 对齐
 aliases: [product-research]             # 可选(V0.2.2 F40)。老项目 state.json::team 仍可解析;同 charset 规则,不能与 name 重叠
-description: |                          # 可选。`cct ls --teams`(M3.4)显示
+description: |                          # 可选。`ccteam ls --teams`(M3.4)显示
   Product research team —
   kickoff → research → verdict → next-steps;
   用于"判断 idea 值不值得做"场景。
@@ -745,7 +745,7 @@ claude_md_template: |
 <staging>/
   .claude-plugin/
     plugin.json                       # Claude Code plugin manifest(严格 schema)
-  team.yaml                           # cct team 配置(plugin loader unknown,zod strip)
+  team.yaml                           # ccteam team 配置(plugin loader unknown,zod strip)
   phases/
     01-<phase>.md                     # 同 §5.1 frontmatter
     ...
@@ -791,7 +791,7 @@ V0.3 candidate)。
 §2.7)。`team.yaml` 不会污染 plugin 加载,ccteam 通过
 `team_resolver::resolve_team` 直接读。
 
-**校验**(`cct doctor --validate-team <name>`,M0.22.4 在 M0.18.5
+**校验**(`ccteam doctor --validate-team <name>`,M0.22.4 在 M0.18.5
 基础上扩展):
 1. `.claude-plugin/plugin.json` 解析 + `PluginManifest::validate`
    (name / description / author.name 非空,name 字符集合法)
@@ -802,7 +802,7 @@ V0.3 candidate)。
 **实现位置**:`crates/ccteam-core/src/team_factory.rs`(`PluginManifest` /
 `PluginAuthor` / `init_team_staging` / `validate_staged_team` /
 `publish_team`)。CLI 入口在 `crates/ccteam-cli/src/team_factory_cli.rs`
-`cct team {init,publish}`。
+`ccteam team {init,publish}`。
 
 ---
 
@@ -844,9 +844,9 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 - `sync` mode → 不写任何 outbox(用 AskUserQuestion 直接对话)
 - `async` / `hybrid` mode → 写 `clarify`(还想问)或 `escalation`(过 max_clarify_rounds 或 verdict=REJECT)
 
-#### 5.6.4 与 `cct decisions` CLI 的关系(M1 收尾增量)
+#### 5.6.4 与 `ccteam decisions` CLI 的关系(M1 收尾增量)
 
-`cct decisions` 扫所有 `~/projects/*/.ccteam/outbox/*.md` 过滤 `event_kind: clarify | escalation`,聚合成跨项目决策队列。**用户在 meta session attach 时,meta-agent 主动汇报队列**(role prompt 启发,M1.0 已落)。
+`ccteam decisions` 扫所有 `~/projects/*/.ccteam/outbox/*.md` 过滤 `event_kind: clarify | escalation`,聚合成跨项目决策队列。**用户在 meta session attach 时,meta-agent 主动汇报队列**(role prompt 启发,M1.0 已落)。
 
 ---
 
@@ -854,7 +854,7 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 
 ### 6.1 项目 `.claude/settings.json` 完整模板
 
-> **D1 备注**:所有 hook 都是 `ccteam` 单 binary 的子命令(`cct hook <name>`),不再是独立 bash/python 脚本——零运行时依赖,与 orchestrator 共享 serde schema。debug 时可手动跑 `cct hook <subcmd>` 喂 stdin JSON(详见 §10.6)。
+> **D1 备注**:所有 hook 都是 `ccteam` 单 binary 的子命令(`ccteam hook <name>`),不再是独立 bash/python 脚本——零运行时依赖,与 orchestrator 共享 serde schema。debug 时可手动跑 `ccteam hook <subcmd>` 喂 stdin JSON(详见 §10.6)。
 >
 > **M0 备注**:M0.4 渲染的模板是下面 JSON 的一个真子集——**不含** `PostToolUse(Bash:git push.*)` 拦截分支(M1+ 才补上 `block-push` 子命令实现)。M0 渲染源在 `crates/ccteam-core/src/templates/settings.json`。
 
@@ -871,16 +871,16 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
     "SessionStart": [
       {
         "hooks": [
-          {"type": "command", "command": "cct hook load-context", "timeout": 5},
-          {"type": "command", "command": "cct hook progress-append session_start", "async": true}
+          {"type": "command", "command": "ccteam hook load-context", "timeout": 5},
+          {"type": "command", "command": "ccteam hook progress-append session_start", "async": true}
         ]
       }
     ],
     "Stop": [
       {
         "hooks": [
-          {"type": "command", "command": "cct hook parse-phase-end", "timeout": 10},
-          {"type": "command", "command": "cct hook progress-append Stop", "async": true}
+          {"type": "command", "command": "ccteam hook parse-phase-end", "timeout": 10},
+          {"type": "command", "command": "ccteam hook progress-append Stop", "async": true}
         ]
       }
     ],
@@ -888,48 +888,48 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
       {
         "matcher": "idle_prompt|permission_prompt",
         "hooks": [
-          {"type": "command", "command": "cct hook progress-append notification", "async": true}
+          {"type": "command", "command": "ccteam hook progress-append notification", "async": true}
         ]
       }
     ],
     "PreToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "cct hook progress-append PreToolUse", "async": true}
+          {"type": "command", "command": "ccteam hook progress-append PreToolUse", "async": true}
         ]
       },
       {
         "matcher": "AskUserQuestion",
         "hooks": [
-          {"type": "command", "command": "cct hook intercept-ask", "timeout": 5}
+          {"type": "command", "command": "ccteam hook intercept-ask", "timeout": 5}
         ]
       }
     ],
     "PostToolUse": [
       {
         "hooks": [
-          {"type": "command", "command": "cct hook progress-append PostToolUse", "async": true},
-          {"type": "command", "command": "cct hook cost-accumulate", "async": true}
+          {"type": "command", "command": "ccteam hook progress-append PostToolUse", "async": true},
+          {"type": "command", "command": "ccteam hook cost-accumulate", "async": true}
         ]
       },
       {
         "matcher": "Bash:git push.*",
         "hooks": [
-          {"type": "command", "command": "cct hook block-push"}
+          {"type": "command", "command": "ccteam hook block-push"}
         ]
       }
     ],
     "SubagentStop": [
       {
         "hooks": [
-          {"type": "command", "command": "cct hook progress-append SubagentStop", "async": true}
+          {"type": "command", "command": "ccteam hook progress-append SubagentStop", "async": true}
         ]
       }
     ],
     "SessionEnd": [
       {
         "hooks": [
-          {"type": "command", "command": "cct hook progress-append SessionEnd", "async": true}
+          {"type": "command", "command": "ccteam hook progress-append SessionEnd", "async": true}
         ]
       }
     ]
@@ -946,7 +946,7 @@ phase 内累计 CLARIFY 轮次(每个 outbox `event_kind: clarify` 文件 + 对�
 | `Notification:idle_prompt` | claude 显式等待用户输入 → idle 信号 |
 | `Notification:permission_prompt` | 不应出现(`--dangerously-skip-permissions` 兜底);出现说明配置失效 |
 | `PreToolUse`(通用) | append 工具调用事件;活跃信号(stall 检测反向判断) |
-| `PreToolUse(matcher: AskUserQuestion)` | **V0.2 M0.19.3**:`cct hook intercept-ask` 返回 `permissionDecision: deny`,assistant 改写 outbox。机制详见 `docs/v0-2/alignment-review.md` §3.2 |
+| `PreToolUse(matcher: AskUserQuestion)` | **V0.2 M0.19.3**:`ccteam hook intercept-ask` 返回 `permissionDecision: deny`,assistant 改写 outbox。机制详见 `docs/v0-2/alignment-review.md` §3.2 |
 | `PostToolUse`(通用) | append 事件;`cost-accumulate.sh` 累加 token / cost 到 `state.json` |
 | `PostToolUse(Bash matcher)` | 拦截危险命令(`git push` / `rm -rf /` / deploy 脚本) |
 | `SubagentStop` | 子 agent 退出(仅 Agent Teams phase 内相关) |
@@ -1094,7 +1094,7 @@ orchestrator daemon tick 后续在 SubagentStop 真到达 + 不再 active 时真
 - F35 `attempt_limbo_reinject` 检测到 pending-inject 在飞 → 跳过本次 retry,
   不烧 `MAX_LIMBO_RETRY` 预算(F36 drain 路径独立兜底)
 
-`cct hook intercept-ask` 返回的 PreToolUse 决策(`hooks.ts:608-625`):
+`ccteam hook intercept-ask` 返回的 PreToolUse 决策(`hooks.ts:608-625`):
 
 ```json
 {
@@ -1302,26 +1302,26 @@ fork_timeout_hours: 24            # L3 默认通过超时(careful 模式忽略)
 ### 10.1 启动 / 停止
 
 ```bash
-cct start                           # 启动 orchestrator(前台)
-cct start --daemon                  # 启动并 daemonize
-cct stop                            # 优雅停机(保留 tmux session)
-cct stop --kill-sessions            # 同时关闭所有 tmux session(慎用)
-cct mcp-serve                       # M2+:作为 ccteam-mcp 跑 stdio MCP 协议(详见 §12)
+ccteam start                           # 启动 orchestrator(前台)
+ccteam start --daemon                  # 启动并 daemonize
+ccteam stop                            # 优雅停机(保留 tmux session)
+ccteam stop --kill-sessions            # 同时关闭所有 tmux session(慎用)
+ccteam mcp-serve                       # M2+:作为 ccteam-mcp 跑 stdio MCP 协议(详见 §12)
 ```
 
 ### 10.2 提交需求
 
 ```bash
-cct new "需求文本"
-cct new -f spec.md                            # 从文件提
-cct new --mode yolo "需求"                    # 覆盖默认 trust_mode
+ccteam new "需求文本"
+ccteam new -f spec.md                            # 从文件提
+ccteam new --mode yolo "需求"                    # 覆盖默认 trust_mode
 
 # V0.2.2 F34 — slug 决策四层:
-cct new --slug ccteam-ui --team dev "..."     # Tier 1:显式 slug(B2 前缀语义);
+ccteam new --slug ccteam-ui --team dev "..."     # Tier 1:显式 slug(B2 前缀语义);
                                               #   `dev-ccteam-ui` 或 verbatim
-cct new --no-auto-slug "..."                  # Tier 4:跳过 LLM 智能 fallback,
+ccteam new --no-auto-slug "..."                  # Tier 4:跳过 LLM 智能 fallback,
                                               #   走 deterministic `slugify_brief`
-cct new --auto-slug-model claude-sonnet-4-5-20251001 "..."
+ccteam new --auto-slug-model claude-sonnet-4-5-20251001 "..."
                                               # Tier 3:override 默认 haiku
                                               #   (env CCTEAM_AUTO_SLUG=off 全局禁)
 ```
@@ -1329,24 +1329,24 @@ cct new --auto-slug-model claude-sonnet-4-5-20251001 "..."
 **slug 决定优先级**(PRD `docs/v0-2-2/prd.md` §3.2):
 
 1. **Tier 1**:`--slug` 显式(零延迟,确定;B2 prefix — 已带 team prefix verbatim)
-2. **Tier 2**:meta-agent 派单工作流的 `cct-project-creator` skill 推荐 + 用户确认(零额外 LLM call)
-3. **Tier 3**:`cct new` 不带 `--slug` 时 shell-out `claude -p haiku`(2-5s,~$0.0001)+ Y/n,非 tty auto-accept
+2. **Tier 2**:meta-agent 派单工作流的 `ccteam-project-creator` skill 推荐 + 用户确认(零额外 LLM call)
+3. **Tier 3**:`ccteam new` 不带 `--slug` 时 shell-out `claude -p haiku`(2-5s,~$0.0001)+ Y/n,非 tty auto-accept
 4. **Tier 4**:LLM 不可用 / `--no-auto-slug` / env `CCTEAM_AUTO_SLUG=off` → `slugify_brief()` deterministic 兜底
 
 ### 10.3 查询状态
 
 ```bash
-cct ls                              # 所有项目状态(human 表格)
-cct ls --format json                # JSON 输出(给 LLM / 脚本用)
-cct show <slug>                     # 单项目详情(含 session 状态、cost、最近 progress)
-cct show <slug> --format json       # JSON 输出
-cct progress <slug> --tail          # 实时 tail progress.jsonl
-cct progress <slug> --phase implement  # 看特定 phase 事件
+ccteam ls                              # 所有项目状态(human 表格)
+ccteam ls --format json                # JSON 输出(给 LLM / 脚本用)
+ccteam show <slug>                     # 单项目详情(含 session 状态、cost、最近 progress)
+ccteam show <slug> --format json       # JSON 输出
+ccteam progress <slug> --tail          # 实时 tail progress.jsonl
+ccteam progress <slug> --phase implement  # 看特定 phase 事件
 ```
 
 **`--format json` 是 M0 强制项**——所有查询命令必须支持,以让"用户自带 claude"路径(详见 [tech-design.md §3.8](./tech-design.md#38-用户接口层))通过 Bash 工具调时无需解析表格。
 
-#### `cct ls --format json` schema
+#### `ccteam ls --format json` schema
 
 ```json
 {
@@ -1372,7 +1372,7 @@ cct progress <slug> --phase implement  # 看特定 phase 事件
 }
 ```
 
-#### `cct show <slug> --format json` schema
+#### `ccteam show <slug> --format json` schema
 
 是 §2.1 项目级 state.json 的全量 + 派生字段:
 
@@ -1399,23 +1399,23 @@ cct progress <slug> --phase implement  # 看特定 phase 事件
 ### 10.4 进入项目
 
 ```bash
-cct attach <slug>                   # tmux attach 到项目 master session
-cct attach <slug> --sub backend-api # multi-session 项目 attach 到子模块 session(M3+)
-cct peek <slug>                     # tmux capture-pane 一次性看当前屏,不 attach
+ccteam attach <slug>                   # tmux attach 到项目 master session
+ccteam attach <slug> --sub backend-api # multi-session 项目 attach 到子模块 session(M3+)
+ccteam peek <slug>                     # tmux capture-pane 一次性看当前屏,不 attach
 ```
 
 ### 10.5 控制
 
 ```bash
 ccteam reject <slug>                   # 否决
-cct pause <slug>                    # 暂停(不杀 session)
-cct resume <slug>                   # 恢复自动调度(接管 attach 后的暂停)
+ccteam pause <slug>                    # 暂停(不杀 session)
+ccteam resume <slug>                   # 恢复自动调度(接管 attach 后的暂停)
 ccteam answer <slug> "回答内容"          # 响应 clarify
-cct decisions                       # M1 收尾增量:跨项目决策队列(扫 outbox event_kind: clarify|escalation)
-cct decisions --format json         # JSON 输出(meta-agent 主消费;详见 §5.6.4)
-cct watchdog scan                   # V0.2 M0.21 translation-only 健康巡检(详见 §12.5)
-cct watchdog scan --format json     # 结构化输出(meta-agent 主消费)
-cct watchdog scan --push --user <handle>  # 把 alert 写进 meta-agent outbox
+ccteam decisions                       # M1 收尾增量:跨项目决策队列(扫 outbox event_kind: clarify|escalation)
+ccteam decisions --format json         # JSON 输出(meta-agent 主消费;详见 §5.6.4)
+ccteam watchdog scan                   # V0.2 M0.21 translation-only 健康巡检(详见 §12.5)
+ccteam watchdog scan --format json     # 结构化输出(meta-agent 主消费)
+ccteam watchdog scan --push --user <handle>  # 把 alert 写进 meta-agent outbox
 ccteam fork-reply <slug> A             # L3 fork 决策(M1+;A/B/C)
 ccteam fork-reply <slug> B "去掉云同步"  # tweak
 ccteam kick <slug>                     # 软重启项目 session(claude --resume)
@@ -1428,46 +1428,46 @@ ccteam kick <slug>                     # 软重启项目 session(claude --resume
 # 直接编辑 ~/.claude/rules/ccteam-lessons-<team>.md 看 / 改跨项目 lessons。
 # ccteam 不提供 memory 子命令(无自建索引,无东西可 rebuild)。
 ccteam config edit                                # 改全局配置
-cct doctor                                     # 体检:列出可用 mode flags
-cct doctor --tool-surface                      # phase tools_required 交叉表(plugin pipeline 感知,V0.2 M0.20)
-cct doctor --install-skill                     # M1.8 写 cct-control skill
-cct doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
-cct doctor --install-mcp                       # M2.5 在 ~/.claude.json 注册 mcpServers.ccteam(详见 §12)
-cct doctor --install-memory-bridge             # M4.2 写 ~/.claude/rules/ccteam-lessons-{dev,product-research}.md 占位 + paths frontmatter scope
-cct doctor --migrate-recommended-agents        # V0.2 M0.20 一次性清理 V0.1 ln -sf 残留 (~/.claude/agents/ 下指向 marketplace 的 symlink)
-cct hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
+ccteam doctor                                     # 体检:列出可用 mode flags
+ccteam doctor --tool-surface                      # phase tools_required 交叉表(plugin pipeline 感知,V0.2 M0.20)
+ccteam doctor --install-skill                     # M1.8 写 ccteam-control skill
+ccteam doctor --install-meta-agent <user-handle>  # M1.0 创建 meta-agent 项目(含 --install-skill)
+ccteam doctor --install-mcp                       # M2.5 在 ~/.claude.json 注册 mcpServers.ccteam(详见 §12)
+ccteam doctor --install-memory-bridge             # M4.2 写 ~/.claude/rules/ccteam-lessons-{dev,product-research}.md 占位 + paths frontmatter scope
+ccteam doctor --migrate-recommended-agents        # V0.2 M0.20 一次性清理 V0.1 ln -sf 残留 (~/.claude/agents/ 下指向 marketplace 的 symlink)
+ccteam hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
                                                   # subcmd ∈ {progress-append, parse-phase-end,
                                                   # cost-accumulate, load-context, block-push}
 ```
 
-#### `cct stop` 行为契约(M1.5)
+#### `ccteam stop` 行为契约(M1.5)
 
-`cct stop` 通过 `~/.ccteam/state/orchestrator.pid` 找到正在跑的
-orchestrator,发 SIGTERM。**不杀任何 tmux session**——`cct start`
+`ccteam stop` 通过 `~/.ccteam/state/orchestrator.pid` 找到正在跑的
+orchestrator,发 SIGTERM。**不杀任何 tmux session**——`ccteam start`
 下次启动时通过 `discover_projects` + `ensure_session` 自动 reattach
-所有活跃 session(meta + 项目)。pidfile 由 `cct start` 写入,
-退出时清理;若 pidfile 指向的 PID 已死,`cct start` 自动重新认领。
+所有活跃 session(meta + 项目)。pidfile 由 `ccteam start` 写入,
+退出时清理;若 pidfile 指向的 PID 已死,`ccteam start` 自动重新认领。
 
 ---
 
-## 11. `cct-control` skill(M1+)
+## 11. `ccteam-control` skill(M1+)
 
 让用户在自己的 Claude Code session 里调度 ccteam。架构论证见 [tech-design.md §3.8 / §6.7](./tech-design.md#38-用户接口层)。
 
 ### 11.1 安装位置
 
 ```
-~/.claude/skills/cct-control/
+~/.claude/skills/ccteam-control/
 └── SKILL.md
 ```
 
-由 ccteam M1 release 通过 `cct doctor --install-skill` 写入,或手动 `cp` from binary unpack。装一次,所有 claude session 自动可见。
+由 ccteam M1 release 通过 `ccteam doctor --install-skill` 写入,或手动 `cp` from binary unpack。装一次,所有 claude session 自动可见。
 
 ### 11.2 SKILL.md 字段约定
 
 ```yaml
 ---
-name: cct-control
+name: ccteam-control
 description: |
   Manage ccteam projects from any Claude Code session.
   Use when the user asks about ccteam status, wants to start a new ccteam project,
@@ -1500,7 +1500,7 @@ M1 时 skill 让 claude 用 Bash 工具 + `--format json` 调 CLI。M2 ccteam-mc
 
 ### 11.5 Meta-agent role prompt(M1.0)
 
-`cct doctor --install-meta-agent <user>` 落地两件事:
+`ccteam doctor --install-meta-agent <user>` 落地两件事:
 
 1. **项目骨架** `~/projects/<user>-meta/` —— 通过 `bootstrap_project(team=meta-agent)`
    生成,然后把 `state.json.tmux_session` 改成 `ccteam-meta-<user>`(注:与项目
@@ -1540,24 +1540,24 @@ orchestrator 识别 `state.team == "meta-agent"` 走 `process_meta_project` 分�
 }
 ```
 
-由 `cct doctor --install-mcp` 写入(M2 release)。`cct mcp-serve` 是 binary 子命令,stdio 协议。
+由 `ccteam doctor --install-mcp` 写入(M2 release)。`ccteam mcp-serve` 是 binary 子命令,stdio 协议。
 
 ### 12.2 暴露的 tool 清单(M2.5 起 9 tool;V0.2.2 F38 起 10 tool)
 
 | Tool 名 | 对应 CLI / 行为 | 入参 | 返回 |
 |---|---|---|---|
-| `ccteam__ls` | `cct ls --format json` | `{}` | §10.3 ls JSON schema(扩 `team`) |
-| `ccteam__show` | `cct show <slug> --format json` | `{slug: string}` | §10.3 show JSON schema |
-| `ccteam__new` | `cct new "..."` | `{prompt: string, team?: string}` | `{slug: string, workspace: string}` |
-| `ccteam__peek` | `cct peek <slug>` | `{slug: string}` | tmux capture-pane stdout 字符串 |
-| `ccteam__progress` | `cct progress <slug>` | `{slug: string, last_n?: number}` | `{events: [...]}` |
+| `ccteam__ls` | `ccteam ls --format json` | `{}` | §10.3 ls JSON schema(扩 `team`) |
+| `ccteam__show` | `ccteam show <slug> --format json` | `{slug: string}` | §10.3 show JSON schema |
+| `ccteam__new` | `ccteam new "..."` | `{prompt: string, team?: string}` | `{slug: string, workspace: string}` |
+| `ccteam__peek` | `ccteam peek <slug>` | `{slug: string}` | tmux capture-pane stdout 字符串 |
+| `ccteam__progress` | `ccteam progress <slug>` | `{slug: string, last_n?: number}` | `{events: [...]}` |
 | `ccteam__pause` | 设 `state.user_pause_pending=true` | `{slug: string}` | `{ok: bool, slug: string, user_pause_pending: bool}` |
-| `ccteam__resume` | `cct resume <slug>` | `{slug: string}` | `{ok: bool, slug: string}` |
+| `ccteam__resume` | `ccteam resume <slug>` | `{slug: string}` | `{ok: bool, slug: string}` |
 | `ccteam__send_to_session`(M2.5 新)| 原子写 `<session>/.ccteam/inbox/msg-<ts>-NNN.md`(§3.4.2)| `{session: string, body: string, content_type?: "text"\|"markdown"}` | `{ok: bool, session: string, inbox_file: string}` |
 | `ccteam__inject_decision`(M2.5 新)| 构造 ESCALATE-shape payload(§4.1.1),走 `send_to_session` 落 inbox | `{slug: string, escalate_kind: "revert_to_phase"\|"need_user_input"\|"abort"\|"insufficient_clarification"\|"phase_done_pending", args?: {target_phase?: string, reason?: string}}` | `{ok: bool, slug: string, inbox_file: string}` |
 | `ccteam__screenshot`(V0.2.2 F38)| `tmux capture-pane -e` → `vt100::Parser` → `imageproc` → 写 `<project>/.ccteam/screenshots/<utc>.png` | `{slug: string, lines?: number}`(`lines` 默认 50) | 成功:`{ok: true, slug: string, path: string}`;graceful degrade:`{ok: false, slug: string, reason: string}` |
 
-V0.2.2 F38 红线:`screenshot` 是**只读**(daemon-independent),与 `peek` 同档,失败永不阻塞主路径(catch_unwind 兜 vt100/imageproc panic;tmux/font/IO 失败一律 `Ok(None)` → `{ok:false, reason}`)。截图字节流仅用于渲染,**不进入** `progress.jsonl` / `state.json` / state machine(CLAUDE.md §三红线"永不解析 tmux 终端输出")。字体走 vendored JetBrains Mono Regular(OFL,见 `LICENSES.md`),`CCTEAM_SCREENSHOT_FONT_TTF` env 可运行时覆盖(eg 切到 CJK / emoji 覆盖字体)。`cct doctor --screenshot-smoke <slug>` 跑端到端验证。
+V0.2.2 F38 红线:`screenshot` 是**只读**(daemon-independent),与 `peek` 同档,失败永不阻塞主路径(catch_unwind 兜 vt100/imageproc panic;tmux/font/IO 失败一律 `Ok(None)` → `{ok:false, reason}`)。截图字节流仅用于渲染,**不进入** `progress.jsonl` / `state.json` / state machine(CLAUDE.md §三红线"永不解析 tmux 终端输出")。字体走 vendored JetBrains Mono Regular(OFL,见 `LICENSES.md`),`CCTEAM_SCREENSHOT_FONT_TTF` env 可运行时覆盖(eg 切到 CJK / emoji 覆盖字体)。`ccteam doctor --screenshot-smoke <slug>` 跑端到端验证。
 
 `send_to_session` / `inject_decision` 是 M2.5 增量(meta-agent 主消费者):
 让 meta-agent 把用户的回复 / 决策推送回项目 session,**adapter 进程内不做
@@ -1569,10 +1569,10 @@ V0.2.2 F38 红线:`screenshot` 是**只读**(daemon-independent),与 `peek` 同�
 
 ### 12.3 不暴露的(M2 显式排除)
 
-- `cct attach` — tty 交互,MCP 协议不适合
-- `cct start / stop` — orchestrator 生命周期管理是 ops 决策,不让 LLM 误调
+- `ccteam attach` — tty 交互,MCP 协议不适合
+- `ccteam start / stop` — orchestrator 生命周期管理是 ops 决策,不让 LLM 误调
 - ~~`ccteam memory rebuild`~~ — M4 简化后无自建索引,该命令不存在
-- `cct doctor --install-*` — 单机配置变更,走 CLI(避免 MCP server 给 LLM 改 ~/.claude.json 的能力)
+- `ccteam doctor --install-*` — 单机配置变更,走 CLI(避免 MCP server 给 LLM 改 ~/.claude.json 的能力)
 
 ### 12.4 双消费者
 
@@ -1613,7 +1613,7 @@ V0.2.2 F38 红线:`screenshot` 是**只读**(daemon-independent),与 `peek` 同�
 
 ### 12.5.4 Alert 输出契约
 
-`cct watchdog scan --format json` 输出 schema:
+`ccteam watchdog scan --format json` 输出 schema:
 
 ```json
 {
@@ -1684,27 +1684,27 @@ V0.2.2 F38 红线:`screenshot` 是**只读**(daemon-independent),与 `peek` 同�
 ```rust
 // crates/ccteam-core/src/lib.rs(示意签名,实际可调整)
 
-/// 读单项目状态(对应 §2.1 state.json 的全量结构 + 派生字段;§10.3 `cct show --format json` 的内核)。
+/// 读单项目状态(对应 §2.1 state.json 的全量结构 + 派生字段;§10.3 `ccteam show --format json` 的内核)。
 pub fn get_state(slug: &str) -> Result<ProjectState, CoreError>;
 
-/// 列所有项目摘要(§10.3 `cct ls --format json` 的内核)。
+/// 列所有项目摘要(§10.3 `ccteam ls --format json` 的内核)。
 pub fn list_projects() -> Result<Vec<ProjectSummary>, CoreError>;
 
 /// 提交控制信号——写 §3.3 `~/.ccteam/control/` 文件,orchestrator 下一轮扫到生效。
 /// `ControlSignal` 枚举覆盖 reject / pause / resume / answer / boost / fork-reply。
 pub fn submit_control(slug: &str, signal: ControlSignal) -> Result<(), CoreError>;
 
-/// 一次性读取 progress.jsonl 末尾 N 条事件(§10.3 `cct progress --tail` 的非流式入口)。
+/// 一次性读取 progress.jsonl 末尾 N 条事件(§10.3 `ccteam progress --tail` 的非流式入口)。
 pub fn tail_progress(slug: &str, last_n: usize) -> Result<Vec<Event>, CoreError>;
 
 /// 流式订阅 progress.jsonl(`tokio` Stream;inotify 监听末尾)。
 /// TUI / web dashboard 实时事件推送的主接口。
 pub fn attach_progress(slug: &str) -> Result<impl Stream<Item = Result<Event, CoreError>>, CoreError>;
 
-/// 提交新需求(对应 §10.2 `cct new`),返回分配的 slug 与项目目录。
+/// 提交新需求(对应 §10.2 `ccteam new`),返回分配的 slug 与项目目录。
 pub fn submit_inbox(spec: InboxSpec) -> Result<NewProjectHandle, CoreError>;
 
-/// 一次性 capture 项目 tmux pane 当前屏(§10.4 `cct peek` 的内核;不 attach)。
+/// 一次性 capture 项目 tmux pane 当前屏(§10.4 `ccteam peek` 的内核;不 attach)。
 pub fn peek_pane(slug: &str, lines: Option<usize>) -> Result<PaneCapture, CoreError>;
 ```
 
@@ -1712,8 +1712,8 @@ pub fn peek_pane(slug: &str, lines: Option<usize>) -> Result<PaneCapture, CoreEr
 
 | `ccteam-core` 类型 | wire 格式(CLI `--format json` / MCP tool 返回) | 来源章节 |
 |---|---|---|
-| `ProjectState` | `cct show --format json` 全量 | §2.1 + §10.3 |
-| `ProjectSummary` | `cct ls --format json` `projects[]` 元素 | §10.3 |
+| `ProjectState` | `ccteam show --format json` 全量 | §2.1 + §10.3 |
+| `ProjectSummary` | `ccteam ls --format json` `projects[]` 元素 | §10.3 |
 | `Event` | progress.jsonl 单行 | §4.1 |
 | `ControlSignal` | `~/.ccteam/control/` 文件命名约定 | §3.3 |
 | `InboxSpec` | `~/.ccteam/inbox/*.md` front matter + body | §3.1 |

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -137,7 +137,7 @@ session + 每个项目 session)是独立 OS 进程;Rust orchestrator 是另一�
 **为什么用 tmux 长 session 而非每 phase 一个 `claude -p` 子进程？**
 
 - **prompt cache 复用**：Anthropic prompt cache TTL 5 分钟，命中后费用降到约 10%。每 phase 起新子进程意味着重读 CLAUDE.md / spec / 上游产物，反复触发冷启动；同 session 跨 phase 共享缓存，长跑项目（数小时-数天）累计省下大量成本。
-- **可观测性天然解决**：tmux 是终端 UI，用户 `cct attach <slug>` 立刻看到 Claude 在做什么；headless 子进程必须靠解析 stream-json 才能知情。
+- **可观测性天然解决**：tmux 是终端 UI，用户 `ccteam attach <slug>` 立刻看到 Claude 在做什么；headless 子进程必须靠解析 stream-json 才能知情。
 - **可中断 / 可注入**：用户 attach 后直接键入指令纠偏（"等等，先别用 SQLite"），Ctrl+C 中断推理；headless 模式没有这个能力。
 - **detach 即守护**：tmux session 在用户断开后继续运行——这是 tmux 的本质优势，刚好契合"关掉电脑团队继续跑"。
 - **不限制 max_turns / max_budget**：长 session 模式下不再硬封顶（理由见 §6.8）；只保留 stall 检测作为软告警。
@@ -154,7 +154,7 @@ session + 每个项目 session)是独立 OS 进程;Rust orchestrator 是另一�
 
 **写入端**（多种异步入口）：
 - **Telegram bot**：用户发消息 → bot 写文件
-- **`cct new "做一个书签管理器"`**：CLI 直接写文件
+- **`ccteam new "做一个书签管理器"`**：CLI 直接写文件
 - **手动 `echo` / 编辑器**：完全降级路径
 
 **文件格式**：
@@ -254,7 +254,7 @@ TeamSpec.evergreen,**不许**回到 `state.team == META_TEAM_NAME` 字面量
 V0.3 真要 cost 追踪不杀时再定义具体行为)。
 
 `teams/meta-agent.yaml` 是首个 evergreen 范例,V0.2 起作为 shipped seed
-随 binary 发布;`Orchestrator::new` / `cct start` / `cct doctor
+随 binary 发布;`Orchestrator::new` / `ccteam start` / `ccteam doctor
 --reset-shipped-teams` 都会把它写到 `~/.ccteam/teams/meta-agent/team.yaml`。
 
 #### 3.2.2 Team layout + TEAM_SOURCES(V0.2 §5.1 / §5.2)
@@ -443,7 +443,7 @@ re-inject 1 次(`MAX_LIMBO_RETRY`,per-phase 计数器存
 
 #### V0.2 M0.19.3 — PreToolUse 拦截 AskUserQuestion
 
-`AskUserQuestion` 是 LLM 内部同步阻塞,Stop hook 不会触发。bootstrap 写 `<project>/.claude/settings.json` 时配 `PreToolUse` matcher `AskUserQuestion`,跑 `cct hook intercept-ask` 返回 `permissionDecision: deny`(reason 指引去 outbox)。LLM 收到 deny 立即改写 outbox。pair 的 prompt-layer 软约束在 team.yaml `golden_rules.protocol.forbid_ask_user_question` —— inject prompt 把 directive 文字写进协议红线段(progress.rs `build_phase_prompt_for_template_with_team`)。
+`AskUserQuestion` 是 LLM 内部同步阻塞,Stop hook 不会触发。bootstrap 写 `<project>/.claude/settings.json` 时配 `PreToolUse` matcher `AskUserQuestion`,跑 `ccteam hook intercept-ask` 返回 `permissionDecision: deny`(reason 指引去 outbox)。LLM 收到 deny 立即改写 outbox。pair 的 prompt-layer 软约束在 team.yaml `golden_rules.protocol.forbid_ask_user_question` —— inject prompt 把 directive 文字写进协议红线段(progress.rs `build_phase_prompt_for_template_with_team`)。
 
 ### 3.6 三层防御协议（Defense in Depth）
 
@@ -555,7 +555,7 @@ L1 → L2 → L3，不并联。L2 启动前 L1 已通过；L3 启动前 L2 已�
 
 **ccteam 实际改动量**(已 ship,M4.1–M4.4):
 - M4.1 retro phase prompt(纯 markdown)
-- M4.2 `cct doctor --install-memory-bridge`(创建 rules 占位文件 + marked section + path frontmatter,**唯一一段 ccteam 代码**)
+- M4.2 `ccteam doctor --install-memory-bridge`(创建 rules 占位文件 + marked section + path frontmatter,**唯一一段 ccteam 代码**)
 - M4.3 Seed/verdict phase prompt(纯 markdown,含 conversation continuity——M4.6 已折叠进 M4.3)
 - M4.4 容器 bind-mount `~/.claude/` spike(已验证 rules + claude-mem hook 在 `--dangerously-skip-permissions` 容器内可见)
 
@@ -575,8 +575,8 @@ ccteam 全系统 6 类 claude 会出现的位置:
 |---|---|---|---|
 | **L0 Channel Layer** | **不是**(各 channel 适配器进程,无内嵌 LLM,Symphony 反模式禁止) | 适配器进程随用户配置启动 | M2+ stub,大概率复用开源方案 |
 | **L0.5 meta-agent session** | **是**(ccteam-managed 常驻 tmux + claude) | 常驻、永不 terminal | 已 ship(M1) |
-| **L1 编排层**(orchestrator daemon) | 不是(Rust) | 常驻 | cct start 后 |
-| **L2 项目级 claude**(每项目一个 tmux session) | 是 | 常驻(长 session,直到 ship/abort) | cct new 后 |
+| **L1 编排层**(orchestrator daemon) | 不是(Rust) | 常驻 | ccteam start 后 |
+| **L2 项目级 claude**(每项目一个 tmux session) | 是 | 常驻(长 session,直到 ship/abort) | ccteam new 后 |
 | **L3 phase 内 agent team / subagent** | 是(Task 工具启动) | 短命(phase 内,跑完返回总结即销毁) | subagent 已 ship(M2);agent_team 永久 deferred(spike A,docs/v0-1/m2-agent-team-spike.md) |
 | **L4 multi_session 子模块 claude** | 是(每子模块一个完整 session) | 常驻 | 未 ship(M4.8) |
 | **L5 横切短命 claude**(cost-watcher / scope-watcher / drift-detector) | 是 | 短命(Stop hook 触发,跑完即退) | 已 ship(M1) |
@@ -592,33 +592,33 @@ dumb router。这条贯彻到底,避免 Symphony 多层 agent 反模式
 |---|---|---|
 | 生命周期 | 永不 terminal,跟用户 ccteam 实例同寿 | ship / abort 即终态 |
 | 行为模式 | 事件循环(等输入→处理→等输入)| phase DAG(plan-eng → ... → ship) |
-| 主要工具 | `cct-control` skill(已 ship,M1.8)/ `ccteam-mcp`(已 ship,M2.8)/ 跨项目 lessons(已 ship,M4 走 `~/.claude/rules/` + auto-memory)| 项目级文件操作 / 内嵌 plugin agents(已 ship,V0.2 M0.20 改走 `enabledPlugins` 写到 `<project>/.claude/settings.json`,Claude Code in-memory plugin pipeline 自动 namespace `<plugin>:<name>`,不再 ln -sf 进 `~/.claude/agents/`) |
+| 主要工具 | `ccteam-control` skill(已 ship,M1.8)/ `ccteam-mcp`(已 ship,M2.8)/ 跨项目 lessons(已 ship,M4 走 `~/.claude/rules/` + auto-memory)| 项目级文件操作 / 内嵌 plugin agents(已 ship,V0.2 M0.20 改走 `enabledPlugins` 写到 `<project>/.claude/settings.json`,Claude Code in-memory plugin pipeline 自动 namespace `<plugin>:<name>`,不再 ln -sf 进 `~/.claude/agents/`) |
 | context reset | 60% 阈值时桥接 CLAUDE.md(M0.10 已 ship);跨项目记忆通过 `~/.claude/rules/ccteam-lessons-<user>-meta.md` 滚动累积(M4 路径,无独立 conversation-log) | 60% 阈值时把当前 phase 进度写 CLAUDE.md(已 ship,M0.10) |
 | 用户 attach | `tmux attach -t ccteam-meta-<user>`,直接 NL 对话 | `tmux attach -t ccteam-<team>-<slug>`,可介入项目执行 |
 
 #### CLI(已 ship,M0)
 
 ```bash
-cct new "做一个本地书签管理器"     # 写 inbox(无 LLM,纯薄壳)
-cct ls                              # 查所有项目状态
-cct show <slug>                     # 详情
-cct progress <slug> --tail          # 实时 tail progress.jsonl
+ccteam new "做一个本地书签管理器"     # 写 inbox(无 LLM,纯薄壳)
+ccteam ls                              # 查所有项目状态
+ccteam show <slug>                     # 详情
+ccteam progress <slug> --tail          # 实时 tail progress.jsonl
 ccteam answer <slug> "用 PWA"          # 回应 clarify 问题
-cct attach <slug> / peek <slug>     # 介入 / 瞄一眼
-cct start / stop                    # orchestrator 生命周期
+ccteam attach <slug> / peek <slug>     # 介入 / 瞄一眼
+ccteam start / stop                    # orchestrator 生命周期
 ```
 
 **关键约束**:CLI 必须输出 LLM 友好的结构化数据——所有查询命令支持 `--format json`(详见 [interfaces.md §10](./interfaces.md#10-cli-命令签名))。理由:让用户自带 claude 通过 Bash 工具调时不用解析表格。
 
-#### meta-agent session + inbox/outbox 协议 + cct-control skill(已 ship,M1)
+#### meta-agent session + inbox/outbox 协议 + ccteam-control skill(已 ship,M1)
 
 > **架构沿革**:原 M1 把"Telegram bot 实现"列为核心任务。现在
 > Telegram bot **下沉到 Channel Layer(M2+ stub)**;M1 只交付能跑 NL 对话
-> 的最小集合:meta-agent 长会话 + inbox/outbox 文件协议 + cct-control
+> 的最小集合:meta-agent 长会话 + inbox/outbox 文件协议 + ccteam-control
 > skill。
 
 - **meta-agent session**(已 ship,M1.0):ccteam-managed 常驻 tmux session,
-  跑 `claude --dangerously-skip-permissions`,装 `cct-control` skill。
+  跑 `claude --dangerously-skip-permissions`,装 `ccteam-control` skill。
   用户用 `tmux attach -t ccteam-meta-<user>` 在终端 NL 对话,meta-agent
   调 ccteam CLI 派单 / 查项目 / 跨项目召回(详见 development-plan §3 M1)
 - **inbox/outbox 文件协议**(已 ship,M1.1):`<session>/.ccteam/inbox/msg-<n>.md`
@@ -626,9 +626,9 @@ cct start / stop                    # orchestrator 生命周期
   inbox,触发 send-keys 注入到对应 session;session 写 outbox,
   Channel Layer(M2+ stub)读 outbox 推到对应 channel。**M1 不实现具体
   channel,只把协议钉死**
-- **cct-control skill**(已 ship,M1.8):描述 ccteam CLI 命令清单 +
+- **ccteam-control skill**(已 ship,M1.8):描述 ccteam CLI 命令清单 +
   典型工作流。**首要 consumer 是 meta-agent session,次要 consumer
-  是用户自己的 daily-driver claude**(详见 [interfaces.md §11](./interfaces.md#11-cct-control-skillm1))
+  是用户自己的 daily-driver claude**(详见 [interfaces.md §11](./interfaces.md#11-ccteam-control-skillm1))
 - **CLARIFY 多轮**(推至 channel 层):channel 层落地后再设计;当前用
   "tmux attach 直接对话"覆盖
 
@@ -658,13 +658,13 @@ cct start / stop                    # orchestrator 生命周期
    session,channel 是 dumb router
 
 **用户自带 daily-driver claude 仍然有用**:用户在自己电脑前已经开了一
-个 claude 处理别的事,装 `cct-control` skill 后随时可调度 ccteam,
+个 claude 处理别的事,装 `ccteam-control` skill 后随时可调度 ccteam,
 这条**作为辅助路径保留**,但不是 ccteam 的核心入口。核心入口是
 meta-agent session + Channel Layer。
 
 #### Web 仪表盘——不在主线
 
-曾考虑过 M2 Web 仪表盘。**剥离主线**——`cct ls --format json` + 用户自带 claude 的对话能力已覆盖"用人话汇报"需求。Web 仪表盘永远在 backlog,不进里程碑(参见 §11 / development-plan §2.2)。
+曾考虑过 M2 Web 仪表盘。**剥离主线**——`ccteam ls --format json` + 用户自带 claude 的对话能力已覆盖"用人话汇报"需求。Web 仪表盘永远在 backlog,不进里程碑(参见 §11 / development-plan §2.2)。
 
 #### 前端层(可插拔)
 
@@ -693,7 +693,7 @@ ccteam 核心(orchestrator + tmux + hooks)是 **headless 状态引擎**——所
 +----------------------------------------------------------+
 ```
 
-**Warp / iTerm2 / Alacritty 等本地终端 = 用户终端选择,不是 ccteam 集成对象**。`cct attach <slug>` 在任何 tmux 兼容终端里行为完全一致——ccteam 透明兼容,无需特殊适配。用户偏好哪个终端就用哪个,与 ccteam 无关。
+**Warp / iTerm2 / Alacritty 等本地终端 = 用户终端选择,不是 ccteam 集成对象**。`ccteam attach <slug>` 在任何 tmux 兼容终端里行为完全一致——ccteam 透明兼容,无需特殊适配。用户偏好哪个终端就用哪个,与 ccteam 无关。
 
 **前端档位**:
 
@@ -707,7 +707,7 @@ ccteam 核心(orchestrator + tmux + hooks)是 **headless 状态引擎**——所
 
 任何前端(CLI / TUI / web dashboard)**不得**在 ccteam 内引入新 LLM 层。
 
-- ✅ web dashboard 通过 xterm.js + WebSocket 桥**直通到 tmux 内的项目级 claude**——等价于"远程版 `cct attach`"。用户在浏览器键入 = 通过 send-keys 注入 tmux,不经任何 ccteam 中介 LLM
+- ✅ web dashboard 通过 xterm.js + WebSocket 桥**直通到 tmux 内的项目级 claude**——等价于"远程版 `ccteam attach`"。用户在浏览器键入 = 通过 send-keys 注入 tmux,不经任何 ccteam 中介 LLM
 - ✅ web 介入触发 `PreToolUse` hook 检测 user_attach,自动暂停 phase(与本地 attach 语义一致)
 - ❌ 不在 ccteam 层起 meta-claude / 自实现聊天 UI / 翻译用户 prompt(已被否决的 `ccteam chat` 路径复活)
 
@@ -761,14 +761,14 @@ notify_mode: normal               # quiet / normal / verbose
 `quiet` 模式只放行 `cost_overrun` + `daemon_down`(钱 / 守护死必报);
 `verbose` 不去重,每次扫描都重发 `needs_attention`。
 
-**触发**(M0.21):**手动**——meta-agent 自己跑 `cct watchdog scan` 这条命令。
+**触发**(M0.21):**手动**——meta-agent 自己跑 `ccteam watchdog scan` 这条命令。
 M2+ channel layer 上线后会有 cron-style 自动触发(60s 默认推荐;
 当前 milestone 不实现自动 timer)。
 
 **实施要点**:
 - 全部代码在 `crates/ccteam-core/src/watchdog.rs`(单文件,~600 行)
 - `crates/ccteam-cli/src/main.rs::Command::Watchdog::Scan` 暴露 CLI:
-  `cct watchdog scan [--push --user <handle>]`
+  `ccteam watchdog scan [--push --user <handle>]`
 - meta-agent role prompt(§3.8 引用)新增 §7 描述 watchdog 角色边界
 - `crates/ccteam-core/src/orchestrator.rs` **零** watchdog 引用
   (grep `watchdog` 命中 0 次是核心红线)
@@ -863,7 +863,7 @@ if running_count < config.max_concurrent_projects:
 | fix-cycle 撞 3 次顶 | escalate，附三次诊断 + capture-pane 快照 |
 | Seed REJECT | 终态，归档 + 通知 |
 | explicit `ESCALATE: ...` 输出 / escalation.md | 终态，转发给用户 |
-| 用户 attach 中手动介入 | 自动暂停 phase 推进，等 detach 或 `cct resume <slug>` |
+| 用户 attach 中手动介入 | 自动暂停 phase 推进，等 detach 或 `ccteam resume <slug>` |
 
 ---
 
@@ -950,12 +950,12 @@ fi
 #### 用户介入
 
 ```bash
-cct attach <slug>     # = tmux attach -t ccteam-<team>-<slug>
+ccteam attach <slug>     # = tmux attach -t ccteam-<team>-<slug>
 # 用户键入文本 → claude 当作 prompt 接收
 # Ctrl+B D 离开（claude 继续跑）
 ```
 
-orchestrator 通过 `PreToolUse` hook 检测最近一次输入源：若来自人（vs. 来自 send-keys 时盖的 marker），自动暂停 phase 推进，等 `cct resume <slug>` 或用户 detach 超过 N 分钟（视为放权）。
+orchestrator 通过 `PreToolUse` hook 检测最近一次输入源：若来自人（vs. 来自 send-keys 时盖的 marker），自动暂停 phase 推进，等 `ccteam resume <slug>` 或用户 detach 超过 N 分钟（视为放权）。
 
 #### 关键约束
 
@@ -973,7 +973,7 @@ orchestrator 通过 `PreToolUse` hook 检测最近一次输入源：若来自人
 
 **为什么 hooks 是 ccteam 可观测性命脉**:Claude Code hooks 是 deterministic 的(详见 claude-code-best-practices §4.5)——同一事件触发同一脚本,这是把"AI 的随机推理"转成"系统可处理的事件流"的桥。ccteam 把所有 phase 边界 / 工具调用 / 退出信号都通过 hooks 落到 progress.jsonl,orchestrator 据此做状态转移,完全不解析 tmux 终端文本。
 
-**实现形态**:hook 实现是 `cct hook <name>` 子命令(如 `cct hook progress-append` / `cct hook parse-phase-end` / `cct hook cost-accumulate`)——单 binary 分发,与 orchestrator 共享同一份 serde schema(progress.jsonl 事件定义、state.json 字段),不再依赖独立 bash / python 脚本运行时。official plugin 自带的 hook(如 `security_reminder_hook.py`)通过 shell shim 包装挂上,不直接依赖。
+**实现形态**:hook 实现是 `ccteam hook <name>` 子命令(如 `ccteam hook progress-append` / `ccteam hook parse-phase-end` / `ccteam hook cost-accumulate`)——单 binary 分发,与 orchestrator 共享同一份 serde schema(progress.jsonl 事件定义、state.json 字段),不再依赖独立 bash / python 脚本运行时。official plugin 自带的 hook(如 `security_reminder_hook.py`)通过 shell shim 包装挂上,不直接依赖。
 
 **Hook 写作纪律**(实现 PR 必须遵守):
 - append 类必须 `async: true`——别拖慢主流程
@@ -1070,7 +1070,7 @@ agent（本节）= 在 phase 内或后台**并行**跑的 multi-agent；sub-skil
 
 完整 tool schema 与协议见 [interfaces.md §12](./interfaces.md#12-ccteam-mcp-mcp-server-m2)。**M0 / M1 走 CLI `--format json` 兜底路径**——用户的 claude 用 Bash 工具调即可;M2 后 MCP 路径作为首选,CLI 仍然保留作为脚本化入口。
 
-**实现形态**:`ccteam-mcp` 与 `ccteam-core` 同 crate(workspace 内 lib + 多 binary),通过 `cct mcp-serve` 子命令暴露——读写同一份 state.json / progress.jsonl,**为将来 `ccteam tui`(未 ship,M4.9) / `ccteam serve` web 前端(backlog)预留同一状态读写 API**。三种前端共用 `ccteam-core` lib API(详见 §3.8 前端层小节),MCP 只是把这套 API 套上 MCP wire protocol 给外部 LLM 消费。
+**实现形态**:`ccteam-mcp` 与 `ccteam-core` 同 crate(workspace 内 lib + 多 binary),通过 `ccteam mcp-serve` 子命令暴露——读写同一份 state.json / progress.jsonl,**为将来 `ccteam tui`(未 ship,M4.9) / `ccteam serve` web 前端(backlog)预留同一状态读写 API**。三种前端共用 `ccteam-core` lib API(详见 §3.8 前端层小节),MCP 只是把这套 API 套上 MCP wire protocol 给外部 LLM 消费。
 
 #### Plugin pipeline(V0.2 M0.20,候选 7)
 
@@ -1147,22 +1147,22 @@ ccteam 出两个 skill:
 
 用户在自己的 Claude Code 里手动喊 `/ccteam-implement` 等,跑单 phase——作为不起 daemon 的 fallback。product-research team 的 phase 序列(`01-kickoff` / `02-market-survey` / `03-differentiation-analysis` / `04-value-proposition` / `05-feasibility` / `06-verdict`)走 `phases-product-research/` 子目录。
 
-#### `cct-control`(已 ship,M1+,用户自带 claude 调度 ccteam 的入口)
+#### `ccteam-control`(已 ship,M1+,用户自带 claude 调度 ccteam 的入口)
 
 ```
-~/.claude/skills/cct-control/
+~/.claude/skills/ccteam-control/
 └── SKILL.md           # CLI 命令清单 + 典型工作流 + 何时 attach vs peek
 ```
 
 **用途**:用户在任意目录开 `claude` → skill 自动激活 → claude 知道:
-- 怎么调 `cct ls --format json` 看跨项目状态
-- 怎么调 `cct new "..."` 立项(并先多轮澄清)
-- 卡住时综合 `cct peek <slug>` + `cct progress <slug> --tail` 给用户一句可贴的纠偏 prompt
-- 何时该建议用户 `cct attach`(自己介入)vs `cct pause`(暂停后再决定)
+- 怎么调 `ccteam ls --format json` 看跨项目状态
+- 怎么调 `ccteam new "..."` 立项(并先多轮澄清)
+- 卡住时综合 `ccteam peek <slug>` + `ccteam progress <slug> --tail` 给用户一句可贴的纠偏 prompt
+- 何时该建议用户 `ccteam attach`(自己介入)vs `ccteam pause`(暂停后再决定)
 
 这是 §3.8"用户自带 claude 当入口"路径的实现。M2 已上 ccteam-mcp MCP server(§6.4),skill 仍保留作为发现 / 引导层。
 
-完整 SKILL.md 内容契约见 [interfaces.md §11](./interfaces.md#11-cct-control-skillm1)。
+完整 SKILL.md 内容契约见 [interfaces.md §11](./interfaces.md#11-ccteam-control-skillm1)。
 
 ### 6.8 透明度与可观测性
 
@@ -1170,7 +1170,7 @@ ccteam 长跑场景下"看不到 AI 在干什么"是首要担忧。三层透明�
 
 #### 第一层：tmux session（给人看，零延迟）
 
-`cct attach <slug>` 立即看到完整 claude 交互界面：
+`ccteam attach <slug>` 立即看到完整 claude 交互界面：
 - 当前 thinking
 - 上一次 tool call 的输入与结果
 - 文件 diff
@@ -1198,7 +1198,7 @@ orchestrator 监听 progress.jsonl 最新事件时间戳：
 | 静默时长 | 动作 |
 |---|---|
 | < 5 min | 正常（推理 / 长 Bash / 网络等待） |
-| 5–15 min | 第一次软告警："项目 X 看起来卡了，要不要 `cct attach`？" |
+| 5–15 min | 第一次软告警："项目 X 看起来卡了，要不要 `ccteam attach`？" |
 | 15–30 min | 标记 `suspicious`，但**仍不 kill**；告警升级 |
 | > 30 min | 升级为 escalation，由用户决定 |
 
@@ -1215,7 +1215,7 @@ orchestrator 监听 progress.jsonl 最新事件时间戳：
 | 项目累计 $50 | 再次软告警 + 触发 retro 评估 |
 | 项目累计 $200 | 物理上限，kill + escalate |
 
-阈值都在 `~/.ccteam/config.yml` 里可调；CLI `cct show <slug>` 可实时查询。
+阈值都在 `~/.ccteam/config.yml` 里可调；CLI `ccteam show <slug>` 可实时查询。
 
 #### Daemon 健康监督（M0.23.1)
 
@@ -1223,7 +1223,7 @@ orchestrator 是**所有 phase 派发 + inbox 派送**的单点 — daemon 死�
 
 | 文件 | 谁写 | 谁读 | 语义 |
 |---|---|---|---|
-| `~/.ccteam/state/orchestrator.pid` | daemon 启动时写 | `cct stop` | PID(已有,M1.5) |
+| `~/.ccteam/state/orchestrator.pid` | daemon 启动时写 | `ccteam stop` | PID(已有,M1.5) |
 | `~/.ccteam/state/orchestrator.heartbeat` | daemon 每 30s 写 | MCP 入口 / meta-agent skill | mtime 是 liveness 唯一来源 |
 
 **判定**:`now - mtime ≤ 60s` → healthy;否则 stale(grace 是 2× heartbeat 间隔,容忍单次 GC pause / 阻塞 IO)。文件不存在 → no_heartbeat(daemon 未启动)。
@@ -1387,13 +1387,13 @@ meta-agent ───────────►  CLI/factory ──────�
   (skill)                              ~/.config/ccteam/teams/<name>/
 ```
 
-1. **Interview** — 元 agent 跑 `cct-team-author` skill,跟用户对话收集 metadata(name / description / author)+ phase 列表 + tools + golden_rules + retro_schema + verdict_schema。一次一题,默认值能用就用。
-2. **Init** — `cct team init <name>` 落 staging 树到 `~/.config/ccteam/teams/<name>/`,内含:
+1. **Interview** — 元 agent 跑 `ccteam-team-author` skill,跟用户对话收集 metadata(name / description / author)+ phase 列表 + tools + golden_rules + retro_schema + verdict_schema。一次一题,默认值能用就用。
+2. **Init** — `ccteam team init <name>` 落 staging 树到 `~/.config/ccteam/teams/<name>/`,内含:
    - `.claude-plugin/plugin.json`(Claude Code plugin manifest 严格 schema:`name` / `description` / `author`)
-   - `team.yaml`(cct team 配置,作为 plugin 顶级 unknown 字段;zod 默认 strip,plugin pipeline 加载时忽略)
+   - `team.yaml`(ccteam team 配置,作为 plugin 顶级 unknown 字段;zod 默认 strip,plugin pipeline 加载时忽略)
    - `phases/<NN>-<phase>.md`(frontmatter + 正文领域模板;**正文不写 `PHASE_DONE:` / `ESCALATE:`**——M0.18 D 方案,协议关键字仅由 orchestrator inject prompt 注入)
    - `README.md`
-3. **Publish** — `cct team publish <name> --target {local|github}`:
+3. **Publish** — `ccteam team publish <name> --target {local|github}`:
    - `local`:软链 staging 到 `~/.claude/plugins/marketplaces/ccteam-local/plugins/<name>/`,产出 directory-source 标识 `<name>@ccteam-local`(用户 `claude /plugin enable` 启用)
    - `github`:`gh repo create` + push,产出 GitHub URL(用户 `claude /plugin add <owner>/<repo>` 拉取)
 
@@ -1418,7 +1418,7 @@ meta-agent ───────────►  CLI/factory ──────�
 
 - `crates/ccteam-core/src/team_factory.rs` — `init_team_staging` / `publish_team` / `validate_staged_team` 主路径;`PluginManifest` / `PhaseScaffold` / `PublishTarget` 数据类型。
 - `crates/ccteam-core/src/templates/ccteam_team_author_skill.md` — meta-agent 用的 dialogue skill。
-- `crates/ccteam-cli/src/team_factory_cli.rs` — `cct team init` / `cct team publish` CLI 包装。
+- `crates/ccteam-cli/src/team_factory_cli.rs` — `ccteam team init` / `ccteam team publish` CLI 包装。
 - `crates/ccteam-cli/src/commands.rs` — `--validate-team` 加 plugin manifest 段。
 - `docs/v0-2/team-factory-userguide.md` — 用户实操指引。
 

--- a/docs/v0-2-2/README.md
+++ b/docs/v0-2-2/README.md
@@ -1,12 +1,21 @@
 # V0.2.2 文档索引
 
 V0.2.2 是首个**单独目录的 patch 版本**(V0.2.1 折在 `v0-2/e2e-retro.md`)。
-本轮 7 finding(F34-F40)+ 3 配套,7 PR sequencing,实现量超 V0.2.1 dust patch
-量级,docs 单独维护。
+本轮 7 finding(F34-F40)+ 3 配套 + e2e retro F41-F43 + reverse-rollback F44,
+共 8 PR sequencing(F44 为 PR #8,反向 F39),docs 单独维护。
 
 **已 ship**(2026-05-09):base 起点 = `origin/main` `170f5a8`(V0.2.1);
 ship 终点 = workspace `0.2.2` 起点(`Cargo.toml::workspace.package.version`);
 测试 baseline 起点 511 / ship 628(+117 测试 across 7 PRs,0 退步)。
+
+**Reverse-rollback 补丁**(2026-05-10,PR #8):F44 反向 F39 cct convention
+sweep — F39 选 `cct` 二进制名时未发现 Ubuntu `proj-bin` 已占用 `/usr/bin/cct`
+(PROJ Coordinate Conversion / GIS 工具),`~/.local/bin/cct` 在标准 PATH
+上前置会静默 shadow 系统工具。F44 把所有 F39 改动逐项反向(binary、skill、
+Rust API、placeholder、docs sweep、CLAUDE.md 红线/Skills 行/迁移条目),并加
+F39 → F44 反向迁移逻辑(`ccteam doctor --install-skill` 自动检测 + 清旧 `cct-*`
+skill dir + rewrite settings.json 老 hook 路径)。Test count 628 → 631
+(+2 反向迁移测试)。
 
 ## 文档清单
 
@@ -25,8 +34,9 @@ ship 终点 = workspace `0.2.2` 起点(`Cargo.toml::workspace.package.version`);
 | F36 send-keys subagent guard | ship-blocker(/btw 路由 bug)| P0 | 4(软依赖 #3)|
 | F37 meta-agent 决策树加固 | UX 关键 | P1 | 2(同 F34) |
 | F38 终端截图 PNG | UX 增强 | P2 | 5(软依赖 #3)|
-| F39 `cct` 短前缀约定 sweep | cleanup | P3 | **1**(先 merge,机械 rename)|
+| F39 `cct` 短前缀约定 sweep | cleanup | P3 | **1**(先 merge,机械 rename;**已被 F44 反向**)|
 | F40 team 名缩短 + alias | cleanup | P3 | 6(独立)|
+| F44 反向 F39 cct convention sweep | bugfix(silent-shadow footgun) | P0 | 8(单独 PR;`/usr/bin/cct` namespace 碰撞)|
 
 ## 配套
 
@@ -36,6 +46,6 @@ ship 终点 = workspace `0.2.2` 起点(`Cargo.toml::workspace.package.version`);
 
 ## 跟其他文档关系
 
-- 主仓 `CLAUDE.md` §三 红线 + §四 Skills 行 已加 cct 约定(F39 驱动)
+- 主仓 `CLAUDE.md` §三 红线(F39 cct 约定那条已 F44 删除)+ §四 Skills 行(skill 名回到 `ccteam-*`,F44 同步)+ §六 反向迁移条目(F44 加)
 - 完整 PR sequencing + 冲突点矩阵 见 `prd.md §10`
 - 跨版本 SoT(`tech-design` / `interfaces`)在 V0.2.2 ship 各 PR merge 时同步更新

--- a/docs/v0-2-2/dev-plan.md
+++ b/docs/v0-2-2/dev-plan.md
@@ -1088,14 +1088,78 @@ EOF
 | #5 F38 | 631 | +~20(ANSI_256 / vt100_color / render smoke / degrade)| ~651 |
 | #6 F40 | 651 | +~10(alias resolution / deprecation warn)| ~661 |
 | #7 chore | 661 | 0(配套不加测试,跑全集)| **~661** |
+| #8 F44 | 628(post-retro) | +2(反向迁移测试;F39 13 个 forward 测试 in-place flip 不计净增)| **631** |
 
-**V0.2.2 ship 测试 baseline 预估:~660+**(对照 V0.2.1 = 511,+ ~150)。clippy
-不新增 warning(4 pre-existing 不算)。
+**V0.2.2 ship 测试 baseline 实测**:628(F41-F43 dust patch 后)→ F44 ship 631。
+clippy 不新增 warning(4 pre-existing 不算)。
+
+---
+
+## 13. PR #8 — F44 revert F39 cct convention sweep
+
+> **目标**:整体反向 PR #1 (F39) 的所有改动 — binary 名 `cct` → `ccteam`、
+> skill `cct-*` → `ccteam-*`、Rust API、placeholder、docs sweep + V0.2.2(F39'd)
+> → V0.2.2(F44'd) 反向迁移逻辑。**不 bump workspace.version**(继续 `0.2.2`,
+> 跟 F41-F43 dust patch 同 umbrella)。
+
+**关联 PRD**:§11(F44 全文)+ §8(F39 全文,不修改作为历史记录)
+
+### 任务
+
+- [x] **#8.1** binary rename 反向
+  - `crates/ccteam-cli/Cargo.toml::[[bin]] name` `"cct"` → `"ccteam"`
+  - Rust 内 `current_cct_bin()` 改回 `current_ccteam_bin()`(全 callsite)
+  - `Makefile` 早已是 `BIN_NAME := ccteam`(F39 漏改),F44 不动
+- [x] **#8.2** 顶层 `skills/` 目录反向 rename
+  - `git mv skills/cct-{control,team-author,project-creator}/ skills/ccteam-{control,team-author,project-creator}/`
+  - SKILL.md frontmatter `name:` 字段 + body 内字面 `cct` 命令例子全 sweep
+- [x] **#8.3** Rust 常量 / 函数名反向
+  - `CCT_*_SKILL_{NAME,MD}` → `CCTEAM_*_SKILL_{NAME,MD}`
+  - `install_cct_*_skill` → `install_ccteam_*_skill`
+  - `LEGACY_SKILL_NAMES` 内容反向(`ccteam-*` → `cct-*`,变成 F39 era 的反向迁移目标)
+- [x] **#8.4** placeholder 反向
+  - `crates/ccteam-core/src/templates/settings.json` `{{CCT_BIN}}` → `__CCTEAM_BIN__`
+  - `crates/ccteam-core/src/templates.rs::render_project_settings` 替换串同步
+- [x] **#8.5** F39 → F44 反向迁移逻辑(`ccteam doctor`)
+  - 检测 `~/.claude/skills/cct-{control,team-author,project-creator}/` marker / frontmatter,匹配则 `rm -rf`,不匹配保留 + warn
+  - `~/projects/<slug>/.claude/settings.json` hook command `/cct hook ` → `/ccteam hook `(原子写,`json.ccteam-migrate.tmp` 临时文件)
+  - 检测 `~/.local/bin/cct` / `~/.cargo/bin/cct` 旧 symlink — warn,不主动删
+- [x] **#8.6** 测试反向
+  - `tool_surface.rs` 内 13 个 F39 migration 测试 fixtures `ccteam-*` → `cct-*` flip(in-place,test 数量不变)
+  - 加 2 反向专属测试:`migrate_legacy_skill_dirs_handles_project_creator`、`migrate_legacy_skill_dirs_idempotent_after_first_run`
+  - `commands.rs` 内 doctor F39 测试改名 → F44(逻辑相同,fixtures 反向)
+- [x] **#8.7** docs sweep 反向
+  - `README.md` / `docs/{tech-design,interfaces,requirements,dev-coupling-audit}.md`:`cct <cmd>` → `ccteam <cmd>`(forward-looking 段)
+  - `crates/ccteam-core/src/templates/{meta_agent_role,memory_bridge_*}.md`:全 `cct` → `ccteam`
+  - `CLAUDE.md` 三处:§三 删除 cct 红线、§四 Skills 行回到 `ccteam-*`、§六 V0.2 → V0.2.2 entry 改为 F39 → F44 反向迁移
+  - `docs/v0-2-2/{prd.md,dev-plan.md,README.md}`:加 F44 章节(本节);F39 §8 / PR #1 §2 全文不动作为历史
+  - `docs/v0-1/` / `docs/v0-2/` 历史归档不动
+  - `docs/v0-2-2/e2e-retro.md` 不动(F39 ship 时的快照,反映当时实情)
+
+### 验收
+
+- [x] `crates/ccteam-cli/Cargo.toml::[[bin]] name = "ccteam"`,`cargo build --release` 产物 = `ccteam`
+- [x] `skills/ccteam-{control,team-author,project-creator}/SKILL.md` 三个 ship,frontmatter `name:` = `ccteam-*`,body 命令字面量 `ccteam <cmd>`
+- [x] `skill.rs` 三常量 + 三 install 函数全反向 rename
+- [x] `settings.json` 模板用 `__CCTEAM_BIN__`,`render_project_settings` 替换正确
+- [x] `git grep -nE '\bcct\b' -- ':!docs/v0-2-2/prd.md' ':!docs/v0-2-2/dev-plan.md' ':!docs/v0-2-2/README.md' ':!docs/v0-2-2/e2e-retro.md' ':!docs/dev-coupling-audit.md' ':!docs/v0-1' ':!docs/v0-2/'` 在 forward-looking 源码 / 文档命中 0(F44 PRD / dev-plan / README + dev-coupling-audit F39 历史 + tool_surface.rs 反向迁移逻辑内 `cct-*` 检测字符串除外)
+- [x] `cargo test --workspace` 全绿,628 → 631(F39 in-place flip 不计净增,纯加 2 测试)
+- [x] clippy 不新增 warning
+
+### 文档同步
+
+- `CLAUDE.md` §一 baseline 表格 `628 → 631`、§六 反向迁移条目
+- `docs/v0-2-2/{README,prd,dev-plan}.md` 三个加 F44
+- `docs/dev-coupling-audit.md` F39 标 "已 F44 反向" + F44 新增条目
+- `docs/v0-2-2/e2e-retro.md` 不动(历史 e2e 快照)
 
 ---
 
 ## Changelog
 
+- 2026-05-10:**F44 PR #8 追加** — 用户 2026-05-10 反馈 `/usr/bin/cct` 已被
+  Ubuntu `proj-bin`(PROJ GIS)占用 → F39 整体反向回滚为 PR #8。本 dev-plan
+  加 §13 PR #8 任务清单 + 测试 baseline 表加一行。F39 PR #1 (§2) 全文不动。
 - 2026-05-09:初稿。基于 `docs/v0-2-2/prd.md` + V0.2 dev-plan 风格参考拆 7 PR
   (F39 / F34+F37 / F35 / F36 / F38 / F40 / chore),~1.65 kLOC / ~3 周。每 PR
   worktree subagent briefing 模板就位,subagent 拿到模板 + 进 worktree 即可开干。

--- a/docs/v0-2-2/prd.md
+++ b/docs/v0-2-2/prd.md
@@ -1205,7 +1205,68 @@ PR #3 / #4 / #5 跟 #1 解耦,可平行起 worktree;merge 顺序仍按 PR # 推�
 
 ---
 
-## 11. 不在范围 / V0.3 deferred
+## 11. F44 — 反向 F39 cct convention sweep,恢复 ccteam 二进制
+
+> **追加**:2026-05-10。本节作为 F39 的反向回滚 ship 记录;§8 F39 PRD 全文保
+> 留作历史,不修改。F44 是 V0.2.2 umbrella 的第 8 个 finding(PR #8),不 bump
+> workspace version(继续 0.2.2)。
+
+### 11.1 问题
+
+`/usr/bin/cct` 已被 Ubuntu `proj-bin` 包占用(PROJ — Coordinate Conversion
+and Transformation,标准 GIS 工具)。F39 (PR #1, 2026-05-09) 选 `cct` 二进制名
+时未检查这个 namespace。在标准 Ubuntu PATH(`~/.local/bin` 在 `/usr/bin` 之
+前)上,`~/.local/bin/cct` 会**静默 shadow** 系统 PROJ 工具 — 任何跑 GIS
+作业的用户都会被 ccteam binary 替换掉真正的 PROJ `cct`。这是隐蔽的 silent-
+substitute footgun。用户 2026-05-10 实测命中,决定 F39 整体反向回滚。
+
+### 11.2 设计 — 全反向 F39 四类改动
+
+四个类目逐项 mirror-image 反向(详 §8.2.1-§8.2.6):
+
+| F39 改动 | F44 反向 |
+|---|---|
+| `[[bin]] name = "cct"` | → `name = "ccteam"` |
+| skill `cct-{control,team-author,project-creator}/` | → `ccteam-{control,team-author,project-creator}/` |
+| Rust API `current_cct_bin` / `install_cct_*_skill` / `CCT_*_SKILL_NAME` | → `current_ccteam_bin` / `install_ccteam_*_skill` / `CCTEAM_*_SKILL_NAME` |
+| placeholder `{{CCT_BIN}}` | → `__CCTEAM_BIN__`(回到 F39 之前的命名)|
+| docs sweep `cct <cmd>` | → `ccteam <cmd>` |
+| CLAUDE.md §三 cct 红线 / §四 Skills 行 / §六 升级条目 | → 红线删除、Skills 行回到 ccteam-*、迁移条目改为 F39 → F44 反向 |
+
+### 11.3 反向迁移(`ccteam doctor`)
+
+镜像 F39 的 V0.1/V0.2 → V0.2.2 迁移逻辑,加一份 F39'd V0.2.2 → F44'd V0.2.2 反向:
+
+| 检测 | 行为 |
+|---|---|
+| `~/.local/bin/cct`(或 `~/.cargo/bin/cct`)指向 ccteam binary | warn "old `cct` binary detected; safe to `rm` (V0.2.2 F44 起命令名回退到 `ccteam`)";不主动删 |
+| `~/.claude/skills/cct-control/` 存在 | marker (`<!-- ccteam-managed:skill -->`) **OR** 顶 frontmatter `name: cct-control` 命中 → `rm -rf`;均不命中(用户手改)→ 保留 + warn |
+| `~/.claude/skills/cct-team-author/` 同上 | 同上 |
+| `~/.claude/skills/cct-project-creator/` 同上 | 同上 |
+| `~/projects/<slug>/.claude/settings.json` hook command 含 `/cct hook ` 或 `cct hook ` | atomic rewrite 为 `<current_exe>/ccteam hook ...`(`current_exe()` 是 ccteam 真实路径);保留所有其他 JSON 字段 |
+
+`ccteam doctor`(裸调用)+ `ccteam doctor --install-skill` / `--install-meta-agent`
+都会触发,跟 F39 forward 模式一致。
+
+### 11.4 不做(per F39 §8.3 已保留,F44 继续保留)
+
+- **MCP server name**:`mcpServers.ccteam` 不动 — F39 没改,F44 也不改
+- **`~/.config/ccteam/` XDG / `~/.ccteam/` 项目根**:不改
+- **Cargo workspace / crate 名**:`crates/ccteam-{cli,core,hooks}` 不改
+- **git repo / cargo workspace 名**:不改
+
+### 11.5 测试影响
+
+F39 加了 13 个 forward migration 测试。F44 把它们 in-place 反向(fixtures 从
+`ccteam-*` flip 成 `cct-*`,assertions 反向)— test 总数稳定。新增 2 个
+反向迁移专属测试(`migrate_legacy_skill_dirs_handles_project_creator` /
+`migrate_legacy_skill_dirs_idempotent_after_first_run`)。
+
+`cargo test --workspace` baseline:F39 ship 后 628 → F44 ship 631(+2 净增)。
+
+---
+
+## 12. 不在范围 / V0.3 deferred
 
 - **slug rename**:state.json / `~/.claude/rules/` paths regex / tmux session 全条线迁移
 - **MCP 工具 `mcp__ccteam__interrupt(slug)`**:V0.3 跟 channel layer 一起评估 ergonomics
@@ -1229,7 +1290,7 @@ PR #3 / #4 / #5 跟 #1 解耦,可平行起 worktree;merge 顺序仍按 PR # 推�
 
 ---
 
-## 12. Workspace version bump
+## 13. Workspace version bump
 
 `Cargo.toml::workspace.package.version` `"0.0.1"` → `"0.2.2"`。retroactive 修正
 (V0.1 / V0.2 ship 时未 sync,V0.2.1 PR 也未 sync)。新政策:每个 minor / patch
@@ -1240,7 +1301,7 @@ release **必须 bump** + 在 commit message subject 一致(`v0.2.2: ...`)。
 
 ---
 
-## 13. CLAUDE.md dev-flow 追加段(草案)
+## 14. CLAUDE.md dev-flow 追加段(草案)
 
 落到 `CLAUDE.md` §五 PR / 实现纪律 末尾,新增小节:
 
@@ -1262,6 +1323,12 @@ release **必须 bump** + 在 commit message subject 一致(`v0.2.2: ...`)。
 
 ## Changelog
 
+- 2026-05-10:**F44 反向 F39** — 用户 2026-05-10 反馈:`/usr/bin/cct` 已被
+  Ubuntu `proj-bin` 包(PROJ Coordinate Conversion / GIS 工具)占用,F39 选
+  `cct` 名字时未检查此 namespace。`~/.local/bin/cct` 在标准 PATH 上前置会静默
+  shadow 系统 PROJ 工具 — silent-substitute footgun。决策:**整体反向 F39**,
+  保留 V0.2.2 umbrella(继续 `0.2.2`,不 bump version),作为单 PR #8。F44
+  PRD 写为 §11(本节);F39 §8 全文不动,作为历史记录。
 - 2026-05-09:**F39 抽出独立 finding** — 用户连追三条:`ccteam-control` skill
   前缀改 `cct-control` → 二进制 `ccteam` → `cct` → CLAUDE.md 加 `cct` 约定。三条
   同源 = "cct 短前缀约定 sweep",归并为 F39。F39 退出 F34 scope,改成独立 PR #1

--- a/skills/ccteam-control/SKILL.md
+++ b/skills/ccteam-control/SKILL.md
@@ -1,6 +1,6 @@
 <!-- ccteam-managed:skill begin -->
 ---
-name: cct-control
+name: ccteam-control
 description: |
   Manage ccteam projects from any Claude Code session. Use when the
   user asks about ccteam status, wants to start a new ccteam project,
@@ -11,13 +11,13 @@ description: |
 allowed-tools: [Bash]
 ---
 
-# cct-control
+# ccteam-control
 
 ccteam is an autonomous project orchestrator built on Claude Code.
 This skill makes ccteam reachable from any claude session via the
-short-prefix `cct` CLI (V0.2.2 F39).
+`ccteam` CLI.
 
-**Prefer the MCP server.** Once `cct doctor --install-mcp` has
+**Prefer the MCP server.** Once `ccteam doctor --install-mcp` has
 registered the server (M2.5), every claude session sees nine
 `mcp__ccteam__*` tools — call those first. The `Bash` + `--format
 json` path below stays as a fallback for sessions where the MCP
@@ -27,31 +27,29 @@ server isn't registered yet.
 
 | What you want | MCP tool (preferred) | Bash fallback |
 |---|---|---|
-| List all projects                | `mcp__ccteam__ls`                | `cct ls --format json` |
-| One project's full state         | `mcp__ccteam__show`              | `cct show <slug> --format json` |
-| Recent progress events           | `mcp__ccteam__progress`          | `cct progress <slug>` |
-| Capture session pane content     | `mcp__ccteam__peek`              | `cct peek <slug>` |
-| Start a new dev project          | `mcp__ccteam__new`               | `cct new --team=dev "<request>"` |
-| Start a product-research project | `mcp__ccteam__new`               | `cct new --team=product-research "<idea>"` |
-| Pause project (no kill)          | `mcp__ccteam__pause`             | `cct pause <slug>` |
-| Resume project                   | `mcp__ccteam__resume`            | `cct resume <slug>` |
+| List all projects                | `mcp__ccteam__ls`                | `ccteam ls --format json` |
+| One project's full state         | `mcp__ccteam__show`              | `ccteam show <slug> --format json` |
+| Recent progress events           | `mcp__ccteam__progress`          | `ccteam progress <slug>` |
+| Capture session pane content     | `mcp__ccteam__peek`              | `ccteam peek <slug>` |
+| Start a new dev project          | `mcp__ccteam__new`               | `ccteam new --team=dev "<request>"` |
+| Start a product-research project | `mcp__ccteam__new`               | `ccteam new --team=product-research "<idea>"` |
+| Pause project (no kill)          | `mcp__ccteam__pause`             | `ccteam pause <slug>` |
+| Resume project                   | `mcp__ccteam__resume`            | `ccteam resume <slug>` |
 | Send NL to a session inbox       | `mcp__ccteam__send_to_session`   | (write `.ccteam/inbox/msg-<ts>-NNN.md`) |
 | Inject ESCALATE-style decision   | `mcp__ccteam__inject_decision`   | (compose body manually + send_to_session) |
-| Health checks                    | (Bash only)                      | `cct doctor --tool-surface` |
-| Install meta-agent               | (Bash only)                      | `cct doctor --install-meta-agent <handle>` |
+| Health checks                    | (Bash only)                      | `ccteam doctor --tool-surface` |
+| Install meta-agent               | (Bash only)                      | `ccteam doctor --install-meta-agent <handle>` |
 
-When the MCP server is registered, `cct doctor --install-mcp` (run
+When the MCP server is registered, `ccteam doctor --install-mcp` (run
 once) wires `mcpServers.ccteam` into `~/.claude.json`. Existing claude
-sessions need `/reload-mcp`; new sessions pick it up immediately. The
-MCP server name stays `ccteam` (V0.2.2 §8.3 — namespace change is
-deferred to V0.3 to avoid touching user `~/.claude.json` files).
+sessions need `/reload-mcp`; new sessions pick it up immediately.
 
 ## Typical workflows
 
 ### A) Cross-project status report
 
 ```bash
-cct ls --format json | jq '.projects[] | {slug, current_phase, phase_state, cost_used_usd, age_seconds}'
+ccteam ls --format json | jq '.projects[] | {slug, current_phase, phase_state, cost_used_usd, age_seconds}'
 ```
 
 Then narrate the table to the user — call out anything in
@@ -83,22 +81,22 @@ When the user says "make a todo cli" but the brief is ambiguous,
 Pick the single most blocking question. Only after they answer, run:
 
 ```bash
-cct new --team=dev "<refined brief>"
+ccteam new --team=dev "<refined brief>"
 # or, if the user still seems uncertain:
-cct new --team=product-research "<idea>"
+ccteam new --team=product-research "<idea>"
 ```
 
 ### D) Stuck-project triage
 
 ```bash
-cct show <slug> --format json | jq '{phase: .state.current_phase, fix_count: .state.auto_loop_cycle_count, recent: .recent_events[-5:]}'
-cct peek <slug>
+ccteam show <slug> --format json | jq '{phase: .state.current_phase, fix_count: .state.auto_loop_cycle_count, recent: .recent_events[-5:]}'
+ccteam peek <slug>
 ```
 
 Combine the two outputs and recommend exactly **one** of:
-- `cct attach <slug>` — user wants to drive
-- `cct pause <slug>` — pause and think
-- `cct resume <slug>` after fixing — back to autonomous
+- `ccteam attach <slug>` — user wants to drive
+- `ccteam pause <slug>` — pause and think
+- `ccteam resume <slug>` after fixing — back to autonomous
 
 ## Decision principles
 
@@ -117,7 +115,7 @@ Combine the two outputs and recommend exactly **one** of:
 - It cannot edit `~/projects/<slug>/.ccteam/` metadata directly. All
   control flows through the CLI (or `~/.ccteam/control/` files for
   M2+ asynchronous control).
-- It cannot start the ccteam orchestrator daemon — that's `cct
+- It cannot start the ccteam orchestrator daemon — that's `ccteam
   start --foreground` and is an ops decision, not an agent decision.
 
 ## Meta-agent specifics

--- a/skills/ccteam-project-creator/SKILL.md
+++ b/skills/ccteam-project-creator/SKILL.md
@@ -1,10 +1,10 @@
 <!-- ccteam-managed:skill begin -->
 ---
-name: cct-project-creator
+name: ccteam-project-creator
 description: |
   When the user wants to create a new ccteam project — walk a four-phase
   dialogue: clarify the brief, recommend a slug, pick a team, and dispatch
-  via `cct new`. Use when the user says "新项目" / "建一个 X" / "做个 X" /
+  via `ccteam new`. Use when the user says "新项目" / "建一个 X" / "做个 X" /
   "做一个 X" / "调研 X" / "评估 X 值不值" / "看看 X 能不能做". Primary
   consumer is the ccteam meta-agent session; the skill assumes
   `AskUserQuestion` is available (which is true inside the meta-agent
@@ -13,10 +13,10 @@ description: |
 allowed-tools: [Bash, AskUserQuestion]
 ---
 
-# cct-project-creator
+# ccteam-project-creator
 
 You are a **project-creation dialogue guide**, not a worker. After this
-skill finishes, you call `cct new --slug <slug> --team <team>
+skill finishes, you call `ccteam new --slug <slug> --team <team>
 "<refined brief>"` to dispatch the project to a fresh ccteam session.
 **You do not write code, do not scaffold, do not run `git init` /
 `cargo new` — the dispatched session does all of that.**
@@ -67,7 +67,7 @@ Compose a recommended slug from the brief + Phase A answer:
   → `hermestrade-dex`).
 - **No verb-leading**: use `todo-cli`, not `build-todo-cli`.
 - **2-4 tokens, kebab-case, `[a-z0-9-]+`, ≤ 60 chars.**
-- **Do not include the team prefix** — `cct new` adds it automatically
+- **Do not include the team prefix** — `ccteam new` adds it automatically
   (B2 prefix semantics, PRD §3.2.1).
 
 Confirm with `AskUserQuestion`:
@@ -130,12 +130,12 @@ alias,canonical 名是 `research`;新派单一律用 `research`。)
 Run the CLI:
 
 ```bash
-cct new --slug <slug> --team <team> "<refined brief>"
+ccteam new --slug <slug> --team <team> "<refined brief>"
 ```
 
 Use the brief from Phase A (incorporating the user's clarification) as
 the request body. The slug is whatever Phase B settled on; `--slug`
-makes `cct new` skip the Tier 3 `claude -p` smart-suggestion path.
+makes `ccteam new` skip the Tier 3 `claude -p` smart-suggestion path.
 
 After dispatch, write an outbox `event_kind: reply` (per
 `meta_agent_role.md` §8) telling the user:
@@ -146,10 +146,10 @@ After dispatch, write an outbox `event_kind: reply` (per
     questions you'll see in the decisions queue.
   - **research** → `kickoff` runs first and may immediately
     reverse-interview before doing any research.
-- Follow-up commands: `cct show <slug>` for state, `cct attach <slug>`
+- Follow-up commands: `ccteam show <slug>` for state, `ccteam attach <slug>`
   for live tmux.
 
-Do **not** announce the dispatch before `cct new` returns successfully —
+Do **not** announce the dispatch before `ccteam new` returns successfully —
 if the CLI errors out (eg unknown team), surface the error to the user
 and re-run Phase C with the corrected team.
 
@@ -160,7 +160,7 @@ and re-run Phase C with the corrected team.
 - ❌ Never runs `git clone`, `cargo new`, `npm init` itself.
 - ❌ Never dispatches more than one project per invocation.
 - ❌ Never asks the user > 1 clarifying question per phase.
-- ❌ Never bypasses `cct new` — even if the user says "just do it" the
+- ❌ Never bypasses `ccteam new` — even if the user says "just do it" the
   ccteam pipeline is the only path that gets progress / cost / context
   / Seed Gate / Critic guarantees.
 

--- a/skills/ccteam-team-author/SKILL.md
+++ b/skills/ccteam-team-author/SKILL.md
@@ -1,18 +1,18 @@
 <!-- ccteam-managed:skill begin -->
 ---
-name: cct-team-author
+name: ccteam-team-author
 description: |
   Author a new ccteam team plugin via dialogue with the user. Use when
   the user asks to create / design / scaffold a team, or wants to package
   a custom phase pipeline as a Claude Code plugin. Primary consumer is
   the ccteam meta-agent session — it walks the user through phase list,
   tools, golden rules, retro schema, verdict schema, and plugin metadata,
-  then invokes `cct team init` / `cct team publish` to materialize
+  then invokes `ccteam team init` / `ccteam team publish` to materialize
   and share the result.
 allowed-tools: [Bash, Read, Write, Edit]
 ---
 
-# cct-team-author
+# ccteam-team-author
 
 ccteam ships two teams out of the box (`dev`, `product-research`). When
 the user wants a different workflow — code review only, market research
@@ -25,10 +25,10 @@ Claude Code runs.
 
 | What you want | Bash command |
 |---|---|
-| Scaffold a team from interview answers | `cct team init <name> --description "…"` |
-| Validate a staged team | `cct doctor --validate-team <name>` |
-| Publish to local marketplace        | `cct team publish <name> --target local` |
-| Publish to GitHub                   | `cct team publish <name> --target github --repo <owner>/<name>` |
+| Scaffold a team from interview answers | `ccteam team init <name> --description "…"` |
+| Validate a staged team | `ccteam doctor --validate-team <name>` |
+| Publish to local marketplace        | `ccteam team publish <name> --target local` |
+| Publish to GitHub                   | `ccteam team publish <name> --target github --repo <owner>/<name>` |
 | Inspect what was generated          | `ls ~/.config/ccteam/teams/<name>/` |
 
 Staging path: `~/.config/ccteam/teams/<name>/`. Layout mirrors a Claude
@@ -38,14 +38,14 @@ optional `agents/` `commands/` `hooks/hooks.json` `.mcp.json`).
 ## Typical workflow — interview the user, then scaffold
 
 The factory expects answers to a small set of questions before
-`cct team init` can produce a useful skeleton. Walk the user through
+`ccteam team init` can produce a useful skeleton. Walk the user through
 them one at a time — do **not** dump every question in a single turn.
 
 ### A) Plugin metadata
 
 1. Plugin / team `name` — must be ascii lowercase + `-` + digits.
    Doubles as `team.yaml.name`.
-2. One-line `description` (shown in `cct ls --teams`,
+2. One-line `description` (shown in `ccteam ls --teams`,
    `marketplace.json`).
 3. `author.name` (and optionally `author.email`).
 
@@ -68,7 +68,7 @@ them one at a time — do **not** dump every question in a single turn.
 Per phase, ask: which subagents / skills / MCP servers does this phase
 invoke? (Common subagents: `code-reviewer`, `code-architect`,
 `code-explorer`, `silent-failure-hunter`.) The factory writes
-`tools_required:` for each phase; `cct doctor --validate-team` then
+`tools_required:` for each phase; `ccteam doctor --validate-team` then
 cross-checks reachability.
 
 ### D) Golden rules (team-wide)
@@ -119,7 +119,7 @@ prefixes — `REVERT_TO_PHASE` / `NEED_USER_INPUT` / `ABORT` /
   `ESCALATE: …`) into the body — those are inject-prompt territory only
   (V0.2 M0.18).
 - **Validate before publishing.** Always run
-  `cct doctor --validate-team <name>` after `init` and before
+  `ccteam doctor --validate-team <name>` after `init` and before
   `publish`. Fix any `[FAIL]`; surface `[WARN]` to the user.
 
 ## Publish targets


### PR DESCRIPTION
## Summary

- F39 (V0.2.2 PR #1) renamed the binary `ccteam` → `cct` without checking namespace. Ubuntu's `proj-bin` package owns `/usr/bin/cct` (PROJ — Coordinate Conversion / GIS tool); `~/.local/bin/cct` silently shadows it on standard PATH — silent-substitute footgun.
- F44 reverses every F39 category: binary, skill (`skills/cct-* → skills/ccteam-*` via `git mv`), Rust API (`current_cct_bin → current_ccteam_bin`, `install_cct_*_skill → install_ccteam_*_skill`, `CCT_*_SKILL_* → CCTEAM_*_SKILL_*`), placeholder (`{{CCT_BIN}} → __CCTEAM_BIN__`), and forward-looking docs.
- `ccteam doctor` ships F39 → F44 reverse migration: detect `~/.claude/skills/cct-{control,team-author,project-creator}/` (marker + frontmatter checked, only ccteam-managed installs removed, user hand-edits preserved); rewrite `cct hook` → `ccteam hook` atomically in `~/projects/<slug>/.claude/settings.json`.
- Preserved (per F39 §8.3, F44 continues): MCP server name `ccteam`, `~/.ccteam/` project root, crate names, git repo name. PRD §8 (F39) and dev-plan §2 (PR #1) untouched as historical record. `docs/v0-1/`, `docs/v0-2/`, `docs/v0-2-2/e2e-retro.md` archives untouched.

PRD: `docs/v0-2-2/prd.md §11`. Dev-plan: `docs/v0-2-2/dev-plan.md §13`.

## Test plan

- [x] `cargo build --workspace` clean — produces `target/release/ccteam`
- [x] `cargo test --workspace` — 631 passed / 0 failed (628 baseline + 2 new reverse-migration tests; 13 F39 forward-migration tests flipped in-place to reverse direction)
- [x] `cargo clippy --workspace --all-targets` — 13 warnings same as baseline (no new ones)
- [x] `git grep -nE '\bcct\b' -- ':!docs/v0-2-2/prd.md' ':!docs/v0-2-2/dev-plan.md' ':!CHANGELOG*'` — every hit is intentional (LEGACY_SKILL_NAMES detection, F39 historical refs in CLAUDE.md / dev-coupling-audit / README, e2e-retro snapshot)
- [x] `crates/ccteam-cli/Cargo.toml::[[bin]] name = "ccteam"` (binary name restored)
- [x] `skills/ccteam-{control,team-author,project-creator}/SKILL.md` shipped, frontmatter `name: ccteam-*`, body command examples use `ccteam <cmd>`
- [x] `crates/ccteam-core/src/templates/settings.json` uses `__CCTEAM_BIN__` placeholder (no `{{CCT_BIN}}` residue)
- [x] CLAUDE.md baseline updated: `628 → 631`; §三 cct red-line removed; §四 Skills row reverted to `ccteam-*`; §六 V0.2.2 (F39) → V0.2.2 (F44) reverse migration entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)