### PR TITLE
v0.3 docs: PRD + dev-plan + README initial draft (V0.3 web UI)

### DIFF
--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -30,7 +30,9 @@ F1/F5/F6/F7/F8/F18 由独立 PR 一波关闭;**2026-05-08 V0.2 M0.23**:加 F24 +
 P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候选;
 **2026-05-08 V0.2.1 patch**:F26-F33 全部修复;
 **2026-05-09 V0.2.2 patch**:加 F34-F40 七条用户反馈 + 命名 sweep + UX 增强,跨 7 PR 全部修复;
-**2026-05-09 V0.2.2 e2e retro patch**:4-suite 并行 e2e 验证,撞 F41 (P1) + F42 (P1) + F43 (P2),同 PR 一波修),分布:
+**2026-05-09 V0.2.2 e2e retro patch**:4-suite 并行 e2e 验证,撞 F41 (P1) + F42 (P1) + F43 (P2),同 PR 一波修;
+**2026-05-10 V0.2.2 F44 反向回滚**:`/usr/bin/cct` namespace 碰撞驱动整体反向 F39,F44 单 PR 覆盖;
+**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
@@ -735,6 +737,15 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **解耦方案**:逐一反向:binary `cct` → `ccteam`、skill `cct-*` → `ccteam-*`、Rust `current_cct_bin` → `current_ccteam_bin` / `install_cct_*_skill` → `install_ccteam_*_skill`、placeholder `{{CCT_BIN}}` → `__CCTEAM_BIN__`、docs sweep。`ccteam doctor` 加 F39 → F44 反向迁移(检测 `~/.claude/skills/cct-{control,team-author,project-creator}/` marker + frontmatter 校验,匹配则 rm -rf;rewrite `~/projects/<slug>/.claude/settings.json` 内 `cct hook` → `ccteam hook` 原子写)。**保留**(per F39 §8.3):MCP server name `ccteam`、`~/.ccteam/` 项目根、crate 名、git repo / workspace 名 — 这些 F39 本就没动。
 - **优先级**:**P0**(silent-substitute footgun)。
 - **来源**:用户 2026-05-10 反馈 + 实证 `dpkg -S /usr/bin/cct` 命中 `proj-bin`。
+
+### F45 — write 动作 helper 锁在 ccteam-cli::mcp_serve 私有 fn,V0.3 web crate 无法复用(2026-05-10 加;**待修复:V0.3 M5.0 PR #1 promote + V0.3 M5.3 PR #4 close**)
+
+- **文件:行号**:`crates/ccteam-cli/src/mcp_serve.rs::tool_send_to_session`(line 456,`fn` 非 `pub fn`)+ `tool_inject_decision`(line 500,同)+ pause / resume 在 mcp_serve 内 inline logic 无独立 fn。
+- **现状**:V0.2.2 ship 时,写动作 helper 全部位于 `ccteam-cli::mcp_serve.rs` 私有 fn,只供 MCP tool dispatch 内部消费;V0.3 web UI(新 crate `crates/ccteam-web`)需要复用同一逻辑写 inbox / control,但 `ccteam-web` 不能 depend on `ccteam-cli`(binary-as-library 反模式 + dep 图倒挂 — `ccteam-cli` 是 binary entry,`ccteam-web` 是新 crate,sibling 关系应共下沉 `ccteam-core`)。读侧 helper 已 public(`collect_projects` / `collect_recent_events` / `run_resume` / `run_show`,以及 `ccteam_core::ProjectState` / `CcteamPaths` / `render_screenshot` / `tmux::capture_pane_*` / `check_daemon_health` / `SessionMailbox` / `inbox_filename` / `pick_unused_slug` / `bootstrap_project`),写侧未 promote。
+- **是否真 dev-specific**:**否——dep 图整理 + 跨消费者复用**。
+- **解耦方案**:V0.3 M5.0(PR #1)新建 `crates/ccteam-core/src/actions.rs`,提 4 个 pub fn:`send_to_session(paths, slug, text)` / `inject_decision(paths, slug, DecisionInput)` / `pause(paths, slug)` / `resume(paths, slug)`;`mcp_serve.rs::tool_*` 内部 logic 全提到 `actions::*`,wrapper 留 args 拆 + JSON encode;`ccteam-web::routes::actions::*` 直调 `ccteam_core::actions::*`,`ccteam-web` 只 depend on `ccteam-core`(`cargo tree -p ccteam-web` 验证不出现 `ccteam-cli`)。M5.3(PR #4)写动作 endpoint 落地后 close。
+- **优先级**:**P1**(V0.3 M5.0 启动门槛;`ccteam-web` 没这个 promote 就走不通)。
+- **来源**:V0.3 M5.0 audit(`docs/v0-3/prd.md §3`)。
 
 ### F40 — `product-research` team 名冗长 + 领域名缺位(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #6 alias 软迁移)**)
 

--- a/docs/v0-2/README.md
+++ b/docs/v0-2/README.md
@@ -3,6 +3,10 @@
 V0.2 已 ship(`origin/main = 503269a`,8 个 milestone M0.16-M0.23,497/0 测试)。
 本目录收纳 V0.2 全部相关文档。
 
+> **V0.3 起始**(drafting,2026-05-10):web UI(读 + 受限写)— 详
+> [`docs/v0-3/`](../v0-3/)。下方 "V0.3 deferred 项" 仍 deferred(web UI 是
+> 新增主线,不替代列出的 deferred 项)。
+
 ## 文档清单
 
 | 文件 | 内容 | 何时读 |

--- a/docs/v0-3/README.md
+++ b/docs/v0-3/README.md
@@ -1,0 +1,79 @@
+# V0.3 文档索引
+
+V0.3 是首个开「对外可视层」的 ccteam 主线版本 — 一个本地 / 局域网 web UI,
+展示全局项目 / agent / subagent 状态(progress.jsonl 事件流 + 项目详情 +
+F38 截图),并提供有限的写动作(`/btw` / inject_decision / pause / resume)。
+新 crate `crates/ccteam-web`,axum + askama + htmx + SSE 单 binary,无 npm /
+无 build toolchain。
+
+**状态**:**drafting**(2026-05-10 doc-only kickoff PR;实施跨 5 PR M5.0-M5.4
+未启动)。
+
+base = `origin/main` `2988de6`(V0.2.2 F44 ship 终点);测试 baseline 起点
+631/0;workspace.version 起点 `0.2.2`,V0.3 ship gate 前 bump `0.3.0`。
+
+## 文档清单
+
+| 文件 | 内容 | 何时读 |
+|---|---|---|
+| [`prd.md`](prd.md) | V0.3 PRD — 12 节,5 milestone(M5.0-M5.4)设计 + 技术决策 + 威胁模型 + PR sequencing | V0.3 设计意图源头 |
+| [`dev-plan.md`](dev-plan.md) | 5 PR milestone 拆解 + worktree 分支 + subagent briefing 模板 + 红线 grep 矩阵 | V0.3 实施 |
+
+## Milestones 速查
+
+| M | 范围 | 优先级 | PR # | 独立可 ship |
+|---|---|---|---|---|
+| M5.0 scaffold + write helper promote | crate 基础设施 + 解耦 | P0(立 dep 图) | 1 | 否(基础) |
+| M5.1 read-only dashboard | 项目列表 + 详情页 | P0(用户首批 dogfood)| 2 | **是** |
+| M5.2 SSE event push + 按需截图 | 实时流 + F38 reuse | P0 | 3 | **是** |
+| M5.3 写动作 + token 鉴权 | /btw / inject_decision / pause / resume + 默认 token | P0 + 安全 critical | 4 | 否(依赖 #2 模板)|
+| M5.4 e2e + retro + ship gate | workspace.version 0.2.2 → 0.3.0 + retro | P0 | 5 | 否(ship gate)|
+
+## 关键设计决策
+
+详 `prd.md §8` 技术决策汇总:
+
+- **新 crate `crates/ccteam-web`**:依赖 ccteam-core only,**不依赖 ccteam-cli**
+  (避免 binary-as-library dep 倒挂)
+- **写动作 helper promote**:`send_to_session` / `inject_decision` / `pause` /
+  `resume` 从 `ccteam-cli::mcp_serve` 私有 fn 提到 `ccteam-core::actions`
+  pub fn(M5.0 关键解耦)
+- **SSE 拓扑**:两个端点(`/sse/all` 全局 + `/sse/project/<slug>` per-slug),
+  不在一条连接 multiplex
+- **截图按需 GET**,**不 polling**(F38 单次渲染百 ms 级,polling 烧 CPU)
+- **默认 token 鉴权**(非 loopback bind 自动开;loopback 不强 token);
+  `--no-auth` 显式 opt-out + 大字 stderr 警告 + 5s 倒计时
+- **CSRF 防御 = `Authorization` header 本身**(浏览器跨域 form-submit 不自动加)
+
+## 安全:V0.3 主要风险
+
+详 `prd.md §9` 威胁模型:
+
+- ccteam 项目 session 跑 `--dangerously-skip-permissions` claude
+- web 写动作(`/btw` / `inject_decision`)是 unsanitized prompt-injection 向量
+- 组合「非 loopback bind + 无鉴权 + 写动作」= **LAN-wide remote code execution**
+- 缓解:**默认开 token 鉴权**,用户可 `--no-auth` 显式 opt-out(stderr 大字警告)
+- 用户原偏好「暂不考虑安全」改为 `--no-auth` 显式选项;PRD review 时是用户
+  显式决策点(接受默认 / 推翻成无鉴权默认)
+
+V0.4 deferred:OAuth / TLS / per-project ACL / 多用户 / 隧道集成。
+
+## 跟其他文档关系
+
+- 主仓 `CLAUDE.md` §一(baseline)/ §三 红线(ccteam-web 不 dep ccteam-cli;
+  progress.jsonl SoT;不解析 tmux 输出)/ §六(易踩坑)— 实施 M5.0 / M5.4 落
+- `docs/tech-design.md` §3.8 用户接口层(加 web layer)+ §6.4 channel layer
+  (web 是新 channel)— PR #2-#5 增量补
+- `docs/interfaces.md` §13(新章节 web routes + SSE wire + token 协议)— PR
+  #2-#5 增量补
+- `docs/dev-coupling-audit.md` F45(M5.0 write helper promote)— PR #1 加,
+  PR #4 / #5 close
+- `docs/v0-2/README.md` 加 V0.3 起始 pointer(本 doc-only PR 落)
+- `docs/requirements.md` 痛点 7「进度永远不透明」+ 痛点 9「AI 团队需要人来主持」
+  (部分)— PRD §1.1 映射
+
+## 配套(M5.4 落)
+
+- Cargo workspace.package.version `"0.2.2"` → `"0.3.0"`
+- CLAUDE.md §一 baseline 表格回填(V0.3 milestone 行 + 测试数实测)
+- `docs/v0-3/e2e-retro.md` 落档(M5.4 后,V0.2.2 e2e-retro 模板)

--- a/docs/v0-3/dev-plan.md
+++ b/docs/v0-3/dev-plan.md
@@ -1,0 +1,873 @@
+# V0.3 开发计划
+
+> V0.3 主线版本实施计划。按依赖顺序拆 5 个 PR(每 PR 对一 milestone M5.x)+
+> 一 chore ship gate。worktree-per-PR;每 PR 一份 subagent briefing 让派工拿到
+> 模板 + 进 worktree 即可开干。
+>
+> 配套文档:
+> - 需求决策:`docs/v0-3/prd.md`(12 节,~880 行)
+> - 文档索引:`docs/v0-3/README.md`
+>
+> base = `origin/main` `2988de6`(V0.2.2 F44 ship);测试 baseline = **631/0**。
+>
+> 跟 V0.2.2 dev-plan 不同点:V0.3 是**主线版本**,milestone 而非 finding 编号
+> (M5.0-M5.4);单一 feature(web UI)分阶段 ship,M5.1 / M5.2 各自独立可
+> ship — 用户可在 dashboard / SSE 落地后即 dogfood,不必等 M5.3 写动作 + 鉴权
+> 一并出。
+
+---
+
+## 1. PR 总览
+
+| # | milestone | branch | 工程量估 | 主要前置依赖 |
+|---|---|---|---|---|
+| **PR #1** | M5.0 scaffold + write helper promote | `v0-3-scaffold` | ~400 LoC + ~10 测试,~3 天 | 无(立 dep 图) |
+| **PR #2** | M5.1 read-only dashboard | `v0-3-dashboard` | ~500 LoC + 模板 + ~10 测试,~3 天 | **PR #1**(消费 ccteam-web crate scaffold)|
+| **PR #3** | M5.2 SSE + 按需截图 | `v0-3-sse-screenshot` | ~600 LoC + ~12 测试,~4 天 | PR #1;软依赖 PR #2(模板) |
+| **PR #4** | M5.3 写动作 + 鉴权 | `v0-3-write-actions` | ~600 LoC + ~15 测试,~4 天 | PR #1(actions helper);PR #2(project.html forms)|
+| **PR #5** | M5.4 e2e + retro + workspace.version | `v0-3-ship-gate` | ~150 LoC + 文档,~2 天 | PR #1-#4 全部 merge,V0.3 ship gate |
+
+**总计**:~2.25 kLOC + ~55 测试,~16 天(单人 5 天/周即 3 周;PR #3 / #4
+并行可压到 ~12 天)。
+
+### 依赖图
+
+```
+PR #1 (M5.0 scaffold + actions promote) ── 必先 merge
+   ↓
+PR #2 (M5.1 dashboard) ── 独立 ship,后续 PR 在其模板上加
+   ↓ (软依赖,模板上 SSE / form 增量)
+PR #3 (M5.2 SSE + screenshot) ───┐
+                                  ├──► PR #5 (M5.4 ship gate)
+PR #4 (M5.3 write + token auth) ─┘
+```
+
+并行机会:**PR #3 / #4 同时起 2 个 worktree**(SSE routes vs actions routes
+冲突面只在 project.html 模板);PR #1 / #2 是 critical path 串行。
+
+---
+
+## 2. PR #1 — M5.0 scaffold + write helper promote
+
+> **目标**:新 crate `crates/ccteam-web` 立起 + axum/askama/notify 依赖 pin +
+> `ccteam web` 子命令 + 写动作 helper 从 `ccteam-cli::mcp_serve` 提到
+> `ccteam-core::actions`。机械 + 解耦,先 merge 立基础。
+
+**关联 PRD**:§3(M5.0 全文)+ §8.1(crate 组织)+ §11(workspace.version V0.3
+不 bump,留 PR #5 落)
+
+### 任务
+
+- [ ] **#1.1** 新 crate `crates/ccteam-web/`
+  - `Cargo.toml`:depends `ccteam-core` + axum 0.8 + askama 0.12 + tokio
+    workspace + notify workspace + serde / serde_json workspace + tracing
+    workspace
+  - `src/lib.rs`:`pub async fn serve(opts: ServeOpts)` 占位,bind +
+    health endpoint 启动
+  - `src/routes/{mod,health}.rs`:`GET /health` 返 200 JSON
+  - 单元测试:`tokio::test` 起 server + reqwest hit `/health`
+- [ ] **#1.2** workspace `Cargo.toml` 把 `ccteam-web` 加入 `members`,把 axum +
+  askama pin minor 版本到 `[workspace.dependencies]`
+- [ ] **#1.3** `ccteam web` CLI 子命令
+  - `crates/ccteam-cli/src/main.rs`:`Commands::Web { bind, no_auth, token_file }`
+  - `crates/ccteam-cli/src/commands.rs::run_web(opts)`:翻 clap struct → `ServeOpts`,
+    `tokio::runtime` block on `ccteam_web::serve(opts)`
+- [ ] **#1.4** 写动作 helper promote
+  - 新 `crates/ccteam-core/src/actions.rs`,4 个 pub fn:
+    `send_to_session(paths, slug, text)`、
+    `inject_decision(paths, slug, DecisionInput)`、
+    `pause(paths, slug)`、`resume(paths, slug)`
+  - 现有 `ccteam-cli/src/mcp_serve.rs::tool_send_to_session`(line 456)+
+    `tool_inject_decision`(line 500)内部 logic 提到 `actions::*`;mcp_serve
+    fn 留 wrapper 拆 args + JSON encode
+  - pause / resume 在 mcp_serve 内 inline 的 logic 同步抽
+  - **dep graph 守恒**:验证 `ccteam-web` 不依赖 `ccteam-cli`(`cargo tree`
+    检查)
+- [ ] **#1.5** lib.rs re-export
+  - `crates/ccteam-core/src/lib.rs`:`pub use actions::{send_to_session,
+    inject_decision, pause, resume, DecisionInput};`
+- [ ] **#1.6** doctor 集成(可选,本 PR 不强求)
+  - `commands.rs::run_doctor` 加 web 检查段:检测 `~/.ccteam/web-token`
+    存在 + mode 0600 → warn / OK 输出
+- [ ] **#1.7** 测试
+  - `actions.rs` 单元:`send_to_session` 写 inbox 文件 + 拼 InboxMessage 字段
+    verify
+  - `mcp_serve.rs` 现有 13 个测试不动(回归保证 wrapper 透传)
+  - `ccteam-web` 端 health 200 e2e
+  - `ccteam-cli/tests/web_subcommand_test.rs`:`ccteam web --bind 127.0.0.1:0`
+    spawn,发 `/health` 200,SIGTERM 干净退出
+
+### 验收(摘 PRD §3.4)
+
+- [ ] `crates/ccteam-web/` workspace member,Cargo.toml 列依赖 + pin minor
+- [ ] `cargo build --workspace` 全绿
+- [ ] `crates/ccteam-core/src/actions.rs` 4 个 pub fn 落地 + 单元测试
+- [ ] `mcp_serve.rs` 内 `tool_*` delegate 到 `ccteam_core::actions::*`;MCP
+  测试套件全绿
+- [ ] `ccteam web --bind 127.0.0.1:7331` 启动,`curl http://127.0.0.1:7331/health`
+  返 200 JSON
+- [ ] `cargo tree -p ccteam-web` 不出现 `ccteam-cli`
+- [ ] `cargo test --workspace` ≥ 631 baseline + ≥ 4 new
+
+### 文档同步
+
+- `docs/interfaces.md` §10.6 维护命令加 `ccteam web` 行(基本 schema:bind /
+  no-auth flag)
+- `docs/dev-coupling-audit.md` F45 加(详 §10):"V0.3 M5.0 promote send_to_session
+  / inject_decision / pause / resume from ccteam-cli::mcp_serve(private fn)
+  to ccteam-core::actions(public)"
+- `docs/tech-design.md` §6 扩展点表加 web layer 行(简短 placeholder,M5.4
+  补全)
+
+---
+
+## 3. PR #2 — M5.1 read-only dashboard
+
+> **目标**:`/` dashboard 项目列表 + `/project/<slug>` 详情页(state + recent
+> events + outbox);askama HTML templates;htmx + 自包含 CSS / JS;无实时,
+> 静态渲染。**独立可 ship**。
+
+**关联 PRD**:§4(M5.1 全文)+ §8.7(前端 stack)
+
+**前置**:**PR #1 必须先 merge**(消费 ccteam-web crate scaffold)。
+
+### 任务
+
+- [ ] **#2.1** routes
+  - `routes/dashboard.rs::handle_index`:`GET /` 调
+    `ccteam_cli::commands::collect_projects(paths)` → askama render
+  - `routes/project.rs::handle_project`:`GET /project/<slug>`:调
+    `collect_recent_events(paths, slug, 200)` + `ProjectState::load(slug)` +
+    扫 outbox → askama render
+  - `routes/assets.rs::handle_asset`:`GET /assets/{file}` static 路由,
+    `include_bytes!` 编译期载入 htmx + CSS
+- [ ] **#2.2** 模板
+  - `templates/base.html`:HTML5 boilerplate + `<script src="/assets/htmx.min.js">`
+    + `<link rel="stylesheet" href="/assets/style.css">` + nav
+  - `templates/dashboard.html`:extends base,table 列(slug / team / phase /
+    last event ts / status badge / cost)
+  - `templates/project.html`:extends base,sections(state JSON / recent
+    events / outbox messages / screenshot panel placeholder)
+- [ ] **#2.3** Status badge 计算
+  - 复用 V0.2.2 F35 silence_classifier **只读**分类;`Healthy` / `Terminal` /
+    `SubagentBusy` / `MidToolHung` / `PostStopLimbo` 之一 → 渲染颜色 badge
+  - 不在 web 层 trigger 任何 escalate(只读,即使分类是 Limbo)
+- [ ] **#2.4** Outbox parsing
+  - 复用 `ccteam_core::SessionMailbox` 已 public API 扫
+    `~/projects/<slug>/.ccteam/outbox/`
+  - 文件名 sort newest first,展示前 20 条;每条 frontmatter `kind` /
+    `created_at` + body 头 200 char 摘要
+- [ ] **#2.5** 静态资源
+  - `crates/ccteam-web/assets/htmx.min.js`(vendored ~14 KB,从
+    `https://unpkg.com/htmx.org@2.x` snapshot)
+  - `crates/ccteam-web/assets/style.css`(~3 KB,monospace + dark-mode-friendly)
+  - `include_bytes!` 编译期打包(模仿 F38 vendored TTF 模式)
+- [ ] **#2.6** 测试
+  - askama 模板编译期类型检查 — failing template 即编译 fail
+  - `tests/dashboard_test.rs`:reqwest 起 server + `GET /` 200 + HTML body
+    contains slug name
+  - `tests/project_test.rs`:fixture state.json + progress.jsonl,`GET
+    /project/<slug>` 200 + body contains "current_phase" + outbox markers
+  - `GET /project/nonexistent` → 404
+  - `GET /assets/htmx.min.js` 200 + Content-Type `application/javascript`
+
+### 验收(摘 PRD §4.4)
+
+- [ ] `GET /` 返 200 + valid HTML + 列出 `~/.ccteam/projects/` 全 slug
+- [ ] `GET /project/<slug>` 返 200 + state + events + outbox 段
+- [ ] 不存在 slug → 404
+- [ ] askama template 编译期类型检查
+- [ ] 新增 ≥ 6 e2e 测试(reqwest hit + HTML assertion)
+- [ ] **独立可 ship** — M5.1 merge 后用户可 dogfood dashboard,M5.2 / M5.3 不 block
+
+### 文档同步
+
+- `docs/interfaces.md` §13(新章节):web routes 表(M5.1 阶段 read-only)
+- `docs/tech-design.md` §3.8 加 dashboard 描述
+
+---
+
+## 4. PR #3 — M5.2 SSE event push + 按需截图
+
+> **目标**:`notify` 文件 watcher 监 `~/.ccteam/progress/` 全目录 → broadcast
+> channel → 两个 SSE 端点(`/sse/all` / `/sse/project/<slug>`);F38
+> `render_screenshot` 在 `/screenshot/<slug>.png` 端点同步调用,Cache-Control
+> no-cache + htmx button 手刷。**独立可 ship**(read-only + live)。
+
+**关联 PRD**:§5(M5.2 全文)+ §8.2-§8.4(技术决策)
+
+**前置**:PR #1(crate scaffold);软依赖 PR #2(模板加 SSE swap markup)。
+
+### 任务
+
+- [ ] **#3.1** Watcher 后台 task
+  - `src/watcher.rs::{EventBus, EventMsg, spawn_watcher}`
+  - `notify::recommended_watcher` + `RecursiveMode::Recursive` 监
+    `<paths.progress_dir()>` + `<paths.state_dir()>`
+  - `Event::Modify(Path)` callback → 计算文件 last-read offset → tail 新增 lines
+    → parse slug from filename → broadcast `EventMsg { slug, event_json }`
+  - `tokio::sync::broadcast::channel(1024)`;laggy receiver drop on overflow
+  - file offset 维护用 `HashMap<PathBuf, u64>`(单 Mutex)
+- [ ] **#3.2** SSE endpoints
+  - `routes/sse.rs::handle_sse_all`:`GET /sse/all` → axum SSE response,subscribe
+    `EventBus`,每条 msg 转 `Event::default().event("progress").data(json)`
+  - `routes/sse.rs::handle_sse_project`:`GET /sse/project/<slug>` 同上,
+    server-side filter `msg.slug == <slug>`
+  - keepalive:`tokio::time::interval(Duration::from_secs(15))` 发 `: keepalive\n\n`
+- [ ] **#3.3** 模板加 SSE markup(rebase 到 PR #2 后)
+  - `dashboard.html`:`<table id="events" hx-ext="sse" sse-connect="/sse/all"
+    sse-swap="progress">`
+  - `project.html`:`<table id="events" hx-ext="sse"
+    sse-connect="/sse/project/{{slug}}" sse-swap="progress">`
+- [ ] **#3.4** 截图 endpoint
+  - `routes/screenshot.rs::handle_screenshot`:`GET /screenshot/<slug>.png` →
+    `ccteam_core::render_screenshot(slug, default opts)` → 返 PNG bytes,
+    Content-Type `image/png`,Cache-Control `no-cache, must-revalidate`
+  - F38 失败(Ok(None) / Err)→ 504 Gateway Timeout + plain-text reason
+- [ ] **#3.5** 模板加截图 panel(rebase 到 PR #2 后)
+  - `project.html`:
+    ```html
+    <button hx-get="/screenshot/{{slug}}.png" hx-target="#screenshot-img"
+            hx-swap="outerHTML">Refresh</button>
+    <img id="screenshot-img" src="/screenshot/{{slug}}.png" alt="pane">
+    ```
+- [ ] **#3.6** 测试
+  - `tests/watcher_test.rs`:tempdir + manual append progress.jsonl line + 等
+    `EventBus` 收到 + 字段 verify
+  - `tests/sse_test.rs`:reqwest stream `/sse/all`,另一线程 append progress.jsonl,
+    断 ≥ 1 event 收到
+  - per-slug filter:`/sse/project/<slug>` 只收对应 slug
+  - keepalive:监连接 16s 看到 `: keepalive` line
+  - `tests/screenshot_test.rs`:fixture project + tmux mock(失败优先,因为
+    CI 无 tmux)→ 504 + reason;若有 tmux,200 + PNG magic byte verify
+
+### 验收(摘 PRD §5.4)
+
+- [ ] watcher 单 instance dispatch 多 receiver 不 starve
+- [ ] `GET /sse/all` 实时推送,append progress.jsonl 后 1s 内浏览器收到
+- [ ] `GET /sse/project/<slug>` 只收对应 slug 事件
+- [ ] keepalive 注释行 15s 周期发出
+- [ ] `GET /screenshot/<slug>.png` 200 PNG / 504 plain-text
+- [ ] 新增 ≥ 8 测试
+- [ ] **独立可 ship**
+
+### 文档同步
+
+- `docs/interfaces.md` §13(扩):SSE wire format(`event: progress` + `data:
+  one-line-JSON` + slug 注入语义)
+- `docs/interfaces.md` §13:`GET /screenshot/<slug>.png` schema
+- `docs/tech-design.md` §6.4 channel layer:加 web SSE 描述
+
+---
+
+## 5. PR #4 — M5.3 写动作 + token 鉴权
+
+> **目标**:四个 POST endpoint(`/api/<slug>/{btw,inject_decision,pause,resume}`)
+> 调 `ccteam-core::actions::*`;auth middleware 默认开 token(非 loopback bind),
+> `--no-auth` 显式 opt-out。CSRF 防御 = `Authorization` header。
+
+**关联 PRD**:§6(M5.3 全文)+ §8.5-§8.6 + §9 威胁模型
+
+**前置**:PR #1(actions helper public);PR #2(project.html forms 加在
+template 内)。
+
+### 任务
+
+- [ ] **#4.1** auth middleware
+  - `src/auth.rs::{AuthLayer, AuthState, validate_token}`
+  - bind heuristic(`serve` 内决定 enabled):
+    - loopback → enabled = false,不生成 token
+    - 非 loopback + `!no_auth` → enabled = true,token 加载或生成
+    - 非 loopback + `no_auth` → enabled = false,stderr warn
+  - `subtle::ConstantTimeEq` 比对 token,4xx 不泄漏耗时
+- [ ] **#4.2** token 文件管理
+  - `~/.ccteam/web-token` 不存在 → `rand::random::<[u8; 32]>()` → hex →
+    `OpenOptions::mode(0o600).create_new`
+  - 已存在 → `metadata::permissions::mode()` 校验 0600,否则 stderr warn
+  - console echo:
+    ```
+    ccteam web listening on http://0.0.0.0:7331
+    Auth token (write actions): ccteam:<token>
+    Reset with: rm ~/.ccteam/web-token && restart
+    ```
+- [ ] **#4.3** 写动作 routes
+  - `routes/actions.rs`:四个 POST handler:
+    - `POST /api/<slug>/btw`(form-encoded `text=...`)→ `actions::send_to_session`
+    - `POST /api/<slug>/inject_decision`(form-encoded `path=...&body=...`)→
+      `actions::inject_decision`
+    - `POST /api/<slug>/pause` →`actions::pause`
+    - `POST /api/<slug>/resume` → `actions::resume`
+  - 成功 → 303 See Other 回 `/project/<slug>`(htmx 跟 swap)
+  - 失败 → 4xx + plain-text error
+  - axum extractor `Form<BtwForm>` validation `text.len() in 1..=4000`
+- [ ] **#4.4** 模板加 forms(rebase 到 PR #2 后)
+  - `project.html` 加 sidebar:
+    - `/btw` 自由文本 textarea form
+    - `inject_decision` select(decision candidates)+ textarea form
+    - pause / resume button-form
+  - `<div id="flash"></div>` 占位接 swap 反馈
+- [ ] **#4.5** Decision candidates 扫
+  - `routes/project.rs` 加 helper 扫 `~/projects/<slug>/.ccteam/decision-*.md` →
+    pass `Vec<PathBuf>` 给模板
+- [ ] **#4.6** stderr 警告(--no-auth + 非 loopback 时)
+  - `serve` 启动 banner 加大字 `WARNING: --no-auth on non-loopback bind = LAN-wide
+    RCE on bypassPermissions sessions. Press Ctrl-C within 5s to abort.`
+  - 5s 倒计时(`tokio::time::sleep`)再正式 listen — 给用户最后机会
+- [ ] **#4.7** 测试
+  - `tests/auth_test.rs`:
+    - loopback bind 默认 → 无 Authorization header 也通
+    - 非 loopback bind 默认 → 无 header → 401;带 `Authorization: Bearer
+      ccteam:<token>` → 200/303
+    - `--no-auth` 非 loopback → stderr 含 "LAN-wide RCE";server 仍服务
+    - constant-time:不同长度 token 比对耗时差 < 10us(`std::time::Instant`
+      多 round 取 max,绝对值 sanity check)
+  - `tests/actions_test.rs`:
+    - `POST /api/<slug>/btw text=hello` → 303 + inbox 文件落地;`InboxMessage`
+      字段含 `text=hello`
+    - `POST /api/<slug>/inject_decision path=...&body=...` → 303 + decision 写入
+    - `POST /api/<slug>/pause` → state.json `paused: true`
+    - `POST /api/<slug>/resume` 反向
+  - `tests/csrf_test.rs`:模拟跨域 form POST `Origin: https://evil.com` 无
+    Authorization → 401(并断 axum 不上 logic;路径短 circuit)
+  - `tests/web_token_file_test.rs`:首次启动生成 token + mode 0600;再次启动复用
+  - `~/.ccteam/web-token` 删除后重启重新生成
+
+### 验收(摘 PRD §6.4)
+
+- [ ] 四个 POST endpoint 各自走 actions::* 调 + 写文件 verify
+- [ ] 默认非 loopback bind 强 token;loopback 不强 token
+- [ ] `--no-auth` 大字警告 + 5s 倒计时
+- [ ] constant-time 比对(单元 + 文档化)
+- [ ] mode 0600 token 文件
+- [ ] 新增 ≥ 12 测试
+
+### 文档同步
+
+- `docs/interfaces.md` §13(扩):POST endpoints schema + Authorization header +
+  token file 协议
+- `docs/tech-design.md` §3.8:加 web channel 写动作描述
+- `docs/dev-coupling-audit.md` F45 close 标记
+
+---
+
+## 6. PR #5 — M5.4 e2e + retro + ship gate
+
+> **目标**:V0.3 ship gate。e2e 测试 + retro 文档 + workspace.version bump
+> 0.2.2 → 0.3.0 + CLAUDE.md baseline + docs sweep。
+
+**关联 PRD**:§7(M5.4 全文)+ §11(version bump)
+
+**前置**:PR #1-#4 全部 merge。
+
+### 任务
+
+- [ ] **#5.1** e2e_test.rs
+  - `crates/ccteam-web/tests/e2e_test.rs`:tempdir `CCTEAM_HOME`,fixture
+    state.json + progress.jsonl + outbox,spin server `127.0.0.1:0`,reqwest
+    跑 happy path:GET / → GET /project/<slug> → SSE 收 1 event → POST
+    /api/<slug>/btw → 等 1s 看 inbox 文件落
+- [ ] **#5.2** workspace.version bump
+  - `Cargo.toml::workspace.package.version` `"0.2.2"` → `"0.3.0"`
+  - commit subject `v0.3.0:` 前缀
+- [ ] **#5.3** CLAUDE.md baseline 回填
+  - §一表格:`Workspace version 0.3.0`;`测试 baseline <实测>`;V0.3 milestone
+    行加
+  - §一 onboarding 30s tip 不动
+  - **本 PR 是 V0.3 ship 唯一改 CLAUDE.md 的 PR**;PR #1-#4 都不改 CLAUDE.md
+- [ ] **#5.4** retro 文档
+  - `docs/v0-3/e2e-retro.md`:模仿 V0.2.2 e2e-retro 模板,4-suite 跨 multi-session
+    项目验证 dashboard / SSE / write action / 截图 / 鉴权
+  - 跨浏览器 spot-check(Chrome / Firefox / Safari macOS)
+- [ ] **#5.5** docs sweep
+  - `docs/v0-2/README.md`:V0.3 起始 pointer 改为 "已 ship V0.3:web UI"
+  - `docs/dev-coupling-audit.md` F45 close
+  - `docs/tech-design.md` §3.8 / §6.4 web 段终稿
+  - `docs/interfaces.md` §13 web routes 终稿
+- [ ] **#5.6** 红线 grep 矩阵全跑过(详 §8 矩阵)
+- [ ] **#5.7** 测试 + clippy
+  - `cargo test --workspace` 全绿
+  - `cargo clippy --workspace --no-deps` 不新增 warning(4 pre-existing 不算)
+
+### 验收
+
+- [ ] e2e_test.rs 端到端 happy path 通过
+- [ ] `Cargo.toml::workspace.package.version = "0.3.0"`
+- [ ] CLAUDE.md §一 baseline 表格更新
+- [ ] `docs/v0-3/e2e-retro.md` 落档
+- [ ] `cargo test --workspace` 全绿,baseline ≥ 631 + V0.3 累计新增
+- [ ] clippy 不新增 warning
+
+---
+
+## 7. Worktree subagent briefing 模板
+
+每 PR 起 worktree 时,主 session 用 Agent 工具派,briefing 套以下模板:
+
+### 7.1 通用前置(每 PR briefing 都加)
+
+```markdown
+## 起始
+
+```
+git fetch origin
+git worktree add -b <branch> /tmp/ccteam-<topic> origin/main
+cd /tmp/ccteam-<topic>
+cargo test --workspace 2>&1 | tail -3   # confirm 631 baseline
+```
+
+## 必读(全 PR 通用)
+
+- `CLAUDE.md` §一(状态)+ §三 红线 + §五 PR 纪律
+- `docs/v0-3/prd.md` §<N>(本 PR 对应 milestone 全文)
+- `docs/v0-3/dev-plan.md` §<N>(本 PR 任务 / 验收)
+- `docs/tech-design.md` §6.4 channel layer + §5.5 progress.jsonl SoT
+- `docs/interfaces.md` §1 文件系统布局 + §4 progress.jsonl 事件流
+
+## 全 PR 红线
+
+- progress.jsonl 是 SoT,**不解析 tmux 终端输出**
+- 永不主动 kill 长 session
+- ccteam-web **不 depend on ccteam-cli**(`cargo tree -p ccteam-web` 验证)
+- 测试不退步(baseline 631);clippy 不新增 warning
+- 文档同步(对应 dev-plan 段)
+
+## PR 命令(完整 HEREDOC,见下)
+```
+
+### 7.2 PR #1 briefing(M5.0 scaffold)
+
+```markdown
+## 任务
+
+V0.3 PR #1 — 新 crate `crates/ccteam-web` 立起 + axum 0.8 / askama 0.12 /
+notify(workspace pin)依赖 + `ccteam web` 子命令 + 写动作 helper 从
+`ccteam-cli::mcp_serve` 提到 `ccteam-core::actions`(关键解耦)。
+
+## 触点代码
+
+- `Cargo.toml`(workspace members 加 `ccteam-web`;workspace.dependencies pin
+  axum / askama)
+- `crates/ccteam-web/`(新建)
+- `crates/ccteam-core/src/actions.rs`(新模块)
+- `crates/ccteam-core/src/lib.rs`(re-export)
+- `crates/ccteam-cli/src/mcp_serve.rs::tool_send_to_session`(line 456)+
+  `tool_inject_decision`(line 500)— 内部 logic 提到 actions
+- `crates/ccteam-cli/src/main.rs`(`Commands::Web`)
+- `crates/ccteam-cli/src/commands.rs`(`run_web`)
+
+## 实施步骤(详 dev-plan §2)
+
+1. 新 crate scaffold(#1.1)
+2. workspace deps pin(#1.2)
+3. ccteam web 子命令(#1.3)
+4. actions promote(#1.4)
+5. lib re-export(#1.5)
+6. doctor(#1.6,可选)
+7. 测试(#1.7)
+
+## 红线 grep
+
+```bash
+# ccteam-web 不依赖 ccteam-cli
+cargo tree -p ccteam-web | grep -E 'ccteam-cli'
+# 期望:0 命中
+
+# actions 是 ccteam-core 模块,被 mcp_serve + ccteam-web 共消费
+git grep -nE 'use ccteam_core::actions' crates/
+# 期望:命中 ≥ 2(mcp_serve + ccteam-web)
+
+# mcp_serve wrapper logic 不重复 actions 内部
+git grep -nE 'fn tool_(send_to_session|inject_decision)' crates/ccteam-cli/src/mcp_serve.rs
+# 期望:命中 2(wrapper);wrapper 内只 args 拆 + JSON encode + 调 actions::*
+```
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-3-scaffold --title "v0.3 PR #1: M5.0 scaffold + write helper promote" --body "$(cat <<'EOF'
+## Closes
+- M5.0(`docs/v0-3/prd.md` §3)
+- F45 部分(write helper promote;`docs/dev-coupling-audit.md`)
+
+## 改动
+- 新 crate `crates/ccteam-web`(axum 0.8 / askama 0.12 / notify workspace)
+- `ccteam web --bind <addr> --no-auth` CLI 子命令
+- `GET /health` 200 JSON
+- `crates/ccteam-core/src/actions.rs` 模块,4 pub fn(send_to_session /
+  inject_decision / pause / resume)从 mcp_serve.rs 私有 fn promote
+- mcp_serve.rs 内 tool_* delegate 到 actions::*
+
+## 测试
+- 新增 ~10(actions 单元 / health e2e / web subcommand spawn)
+- mcp_serve 现有测试套件全绿(回归保证)
+
+## 关联
+- Closes V0.3 M5.0
+- 痛点 7(`docs/requirements.md`)+ tech-design §6 扩展点
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 7.3 PR #2 briefing(M5.1 dashboard)
+
+```markdown
+## 任务
+
+V0.3 PR #2 — read-only dashboard:`/` 项目列表 + `/project/<slug>` 详情页;
+askama 模板;htmx + minimal CSS vendored;outbox 段;screenshot panel
+placeholder(M5.2 加)。
+
+## 前置
+
+PR #1 必须 merge(消费 ccteam-web crate scaffold)。
+
+## 触点代码
+
+- `crates/ccteam-web/src/routes/{dashboard,project,assets}.rs`(新建)
+- `crates/ccteam-web/templates/{base,dashboard,project}.html`(新建)
+- `crates/ccteam-web/assets/{htmx.min.js,style.css}`(vendored)
+- `crates/ccteam-web/src/lib.rs`(router 注册)
+
+## 实施步骤(详 dev-plan §3)
+
+1. routes(#2.1)
+2. 模板(#2.2)
+3. status badge(#2.3)
+4. outbox parsing(#2.4)
+5. 静态资源(#2.5)
+6. 测试(#2.6)
+
+## 红线 grep
+
+```bash
+# 模板用 askama,编译期类型检查
+git grep -nE 'use askama' crates/ccteam-web/src/
+# 期望:命中 ≥ 1
+
+# 不解析 tmux 终端输出
+git grep -nE 'capture_pane|tmux capture' crates/ccteam-web/src/
+# 期望:0 命中(M5.2 截图通过 ccteam_core::render_screenshot,M5.1 不接)
+
+# 状态 badge 用 silence_classifier 的 read-only 分类,不 trigger escalate
+git grep -nE 'silence_classifier' crates/ccteam-web/src/
+# 期望:命中只在 read-only path,不调 re-inject / escalate fn
+```
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-3-dashboard --title "v0.3 PR #2: M5.1 read-only dashboard" --body "$(cat <<'EOF'
+## Closes
+- M5.1(`docs/v0-3/prd.md` §4)
+
+## 改动
+- `GET /` dashboard:项目列表表格(slug / team / phase / last event / status
+  badge / cost)
+- `GET /project/<slug>` 详情:state JSON / recent events 200 条 / outbox 20 条
+- `GET /assets/{htmx.min.js,style.css}` static handler
+- askama 模板:base / dashboard / project
+- 静态 + 自包含,无 npm / 无 build toolchain
+
+## 测试
+- 新增 ~10(dashboard 200 + slug list / project state body / 404 / assets)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 7.4 PR #3 briefing(M5.2 SSE + screenshot)
+
+```markdown
+## 任务
+
+V0.3 PR #3 — `notify` 文件 watcher 监 `~/.ccteam/progress/` 全目录 →
+`tokio::sync::broadcast` channel → 两个 SSE endpoint(/sse/all 全局,
+/sse/project/<slug> per-slug filter);F38 `render_screenshot` 在
+`/screenshot/<slug>.png` 同步调用,Cache-Control no-cache + htmx 手动刷 button。
+
+## 前置
+
+PR #1(crate scaffold);软依赖 PR #2(模板加 SSE swap markup)。
+
+## 触点代码
+
+- `crates/ccteam-web/src/watcher.rs`(新)
+- `crates/ccteam-web/src/routes/{sse,screenshot}.rs`(新)
+- `crates/ccteam-web/templates/{dashboard,project}.html`(rebase #2 后,加
+  SSE markup + screenshot panel)
+- `crates/ccteam-core/src/screenshot.rs`(F38 已 ship,只 reuse)
+
+## 实施步骤(详 dev-plan §4)
+
+1. watcher(#3.1)
+2. SSE endpoints(#3.2)
+3. 模板 SSE markup(#3.3)
+4. screenshot endpoint(#3.4)
+5. 模板 screenshot panel(#3.5)
+6. 测试(#3.6)
+
+## 红线 grep
+
+```bash
+# watcher 单 instance,不每文件起独立
+git grep -nE 'watch\(' crates/ccteam-web/src/watcher.rs
+# 期望:命中 1-2(progress dir + state dir)
+
+# broadcast bound 防 OOM
+git grep -nE 'broadcast::channel' crates/ccteam-web/src/
+# 期望:命中含 bound 字面 1024
+
+# 不 polling 截图
+git grep -nE 'interval\(.*screenshot\|render_screenshot.*loop' crates/ccteam-web/src/
+# 期望:0 命中(只在 GET handler 同步调)
+
+# screenshot 失败不 panic
+git grep -nE 'unwrap\(\)|expect\(' crates/ccteam-web/src/routes/screenshot.rs
+# 期望:0 命中(全 ? + match)
+```
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-3-sse-screenshot --title "v0.3 PR #3: M5.2 SSE + on-demand screenshot" --body "$(cat <<'EOF'
+## Closes
+- M5.2(`docs/v0-3/prd.md` §5)
+
+## 改动
+- `GET /sse/all` 全局 SSE 流;`GET /sse/project/<slug>` per-slug filter
+- 单 notify recursive watcher 监 ~/.ccteam/progress/ + state/
+- broadcast(1024)channel,laggy receiver drop
+- keepalive 注释行 15s 周期
+- `GET /screenshot/<slug>.png` on-demand,F38 reuse,Cache-Control no-cache
+- 模板 SSE swap markup + screenshot panel button
+
+## 测试
+- 新增 ~12(watcher dispatch / per-slug filter / SSE wire / keepalive /
+  screenshot 200 + 504)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 7.5 PR #4 briefing(M5.3 write actions + auth)
+
+```markdown
+## 任务
+
+V0.3 PR #4 — 四个 POST 写动作 endpoint(/api/<slug>/{btw,inject_decision,
+pause,resume})调 ccteam-core::actions;auth middleware 默认 token 鉴权(非
+loopback bind);--no-auth 显式 opt-out + 大字 stderr 警告 + 5s 倒计时;CSRF
+防御 = Authorization header 本身。
+
+## 前置
+
+PR #1(actions helper public);PR #2(project.html 模板,加 form sidebar)。
+
+## 触点代码
+
+- `crates/ccteam-web/src/auth.rs`(新)
+- `crates/ccteam-web/src/routes/actions.rs`(新)
+- `crates/ccteam-web/templates/project.html`(rebase #2 后加 forms)
+- `crates/ccteam-web/Cargo.toml`(加 subtle = "2")
+- `~/.ccteam/web-token` 文件协议
+
+## 实施步骤(详 dev-plan §5)
+
+1. auth middleware(#4.1)
+2. token 文件管理(#4.2)
+3. actions routes(#4.3)
+4. 模板 forms(#4.4)
+5. decision candidates 扫(#4.5)
+6. stderr 警告 + 倒计时(#4.6)
+7. 测试(#4.7)
+
+## 红线 grep
+
+```bash
+# constant-time token 比对
+git grep -nE 'subtle::|ConstantTimeEq' crates/ccteam-web/src/auth.rs
+# 期望:命中 ≥ 1
+
+# token 文件 mode 0600
+git grep -nE '0o600|mode\(0o6' crates/ccteam-web/src/auth.rs
+# 期望:命中 ≥ 1
+
+# 写 endpoint 全经 actions module,不重复 mcp_serve fn
+git grep -nE 'send_to_session|inject_decision' crates/ccteam-web/src/routes/actions.rs
+# 期望:全部 `ccteam_core::actions::*` 调用,无 inline 写 inbox 文件 logic
+
+# 大字警告 + 倒计时
+git grep -nE 'LAN-wide RCE|bypassPermissions' crates/ccteam-web/src/
+# 期望:命中 ≥ 1(stderr 警告 fmt)
+```
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-3-write-actions --title "v0.3 PR #4: M5.3 write actions + token auth" --body "$(cat <<'EOF'
+## Closes
+- M5.3(`docs/v0-3/prd.md` §6)
+- F45 close(`docs/dev-coupling-audit.md`,搭 PR #1 actions promote)
+
+## 改动
+- POST /api/<slug>/{btw,inject_decision,pause,resume} 调 ccteam-core::actions
+- auth.rs middleware:bind heuristic(loopback 免 token / 非 loopback 默认开
+  token),--no-auth 显式 opt-out
+- ~/.ccteam/web-token mode 0600 32-byte hex,首启自动生成 + console echo
+- subtle::ConstantTimeEq 比对 token
+- --no-auth + 非 loopback 启动时 stderr 大字警告 + 5s 倒计时
+- project.html 加 forms sidebar(自由文本 textarea / 结构化 inject_decision /
+  pause+resume button)
+- CSRF 防御 = Authorization header 本身(浏览器跨域 form-submit 不自动加)
+
+## 测试
+- 新增 ~15(auth middleware 4 路径 / token 文件 / actions 4 endpoint / CSRF /
+  constant-time)
+
+## 安全说明
+本 PR 引入写动作面;详 PRD §9 威胁模型。默认开 token 鉴权,用户可
+--no-auth opt-out(stderr 大字警告 + 5s 倒计时)。
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 7.6 PR #5 briefing(M5.4 ship gate)
+
+```markdown
+## 任务
+
+V0.3 PR #5 — ship gate。e2e_test.rs 端到端 / retro 文档 / workspace.version
+0.2.2 → 0.3.0 / CLAUDE.md baseline / docs sweep。
+
+## 前置
+
+PR #1-#4 全部 merge。
+
+## 触点代码
+
+- `crates/ccteam-web/tests/e2e_test.rs`(新)
+- `Cargo.toml`(workspace.package.version)
+- `CLAUDE.md` §一 baseline 表格
+- `docs/v0-3/e2e-retro.md`(新)
+- `docs/v0-2/README.md`(V0.3 pointer 改 ship)
+- `docs/dev-coupling-audit.md`(F45 close)
+- `docs/tech-design.md` §3.8 / §6.4
+- `docs/interfaces.md` §13
+
+## 实施步骤(详 dev-plan §6)
+
+1. e2e_test.rs(#5.1)
+2. workspace.version(#5.2)
+3. CLAUDE.md baseline(#5.3)
+4. retro(#5.4)
+5. docs sweep(#5.5)
+6. 红线 grep 矩阵(#5.6)
+7. 测试 + clippy(#5.7)
+
+## 红线 grep 矩阵(详 §8)
+
+详 dev-plan §8 全 PR 跨维度 grep 矩阵。本 PR 是最后 gate,**全部跑一遍**。
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-3-ship-gate --title "v0.3.0: workspace.version bump + V0.3 ship gate" --body "$(cat <<'EOF'
+## Closes
+- V0.3 ship gate
+- M5.4(`docs/v0-3/prd.md` §7)
+- `docs/dev-coupling-audit.md` F45 close
+
+## 改动
+- `Cargo.toml::workspace.package.version` "0.2.2" → "0.3.0"
+- CLAUDE.md §一 baseline 回填(测试数 / V0.3 milestone 行)
+- docs/v0-3/e2e-retro.md 落档
+- docs sweep:v0-2/README V0.3 pointer / dev-coupling-audit F45 close /
+  tech-design §3.8 + §6.4 / interfaces §13
+
+## 测试
+- e2e_test.rs 端到端 happy path
+- baseline 大于等于 631 + V0.3 累计新增,全绿
+- clippy 不新增 warning
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+---
+
+## 8. 红线 grep 矩阵
+
+每 PR commit 前必查;PR #5 ship gate 全跑一遍。
+
+| 红线维度 | grep | 期望 | 跨 PR |
+|---|---|---|---|
+| **progress.jsonl 是 SoT** | `git grep -nE 'capture_pane\|tmux capture' crates/ccteam-web/src/` | 0 命中(M5.2 截图通过 `ccteam_core::render_screenshot` 调,内部已 vt100 化)| 全 PR |
+| **永不主动 kill** | `git grep -nE '\bkill\b' crates/ccteam-web/src/` | 0 命中 | 全 PR |
+| **ccteam-web 不依赖 ccteam-cli** | `cargo tree -p ccteam-web \| grep -E 'ccteam-cli'` | 0 命中 | PR #1 起守 |
+| **actions module 共消费** | `git grep -nE 'use ccteam_core::actions' crates/` | ≥ 2 命中(mcp_serve + ccteam-web) | PR #1 / 全 PR ship gate |
+| **token constant-time** | `git grep -nE 'subtle::\|ConstantTimeEq' crates/ccteam-web/src/auth.rs` | ≥ 1 命中 | PR #4 |
+| **token mode 0600** | `git grep -nE '0o600\|mode\(0o6' crates/ccteam-web/src/auth.rs` | ≥ 1 命中 | PR #4 |
+| **--no-auth 大字警告** | `git grep -nE 'LAN-wide RCE\|bypassPermissions' crates/ccteam-web/src/` | ≥ 1 命中 | PR #4 |
+| **不 polling 截图** | `git grep -nE 'interval\(.*screenshot\|render_screenshot.*loop' crates/ccteam-web/src/` | 0 命中(只 GET handler 同步调) | PR #3 |
+| **broadcast bound 防 OOM** | `git grep -nE 'broadcast::channel' crates/ccteam-web/src/` | bound 显式 1024 字面 | PR #3 |
+| **status badge 不 trigger 副作用** | `git grep -nE 'silence_classifier' crates/ccteam-web/src/` | 命中只在 read-only 分类,不调 re-inject / escalate fn | PR #2 |
+
+---
+
+## 9. 文档同步矩阵
+
+每 PR merge 时同步;PR #5 ship gate 校验完成。
+
+| PR | docs/tech-design.md | docs/interfaces.md | docs/dev-coupling-audit.md | CLAUDE.md / 其他 |
+|---|---|---|---|---|
+| **#1 M5.0** | §6 扩展点表 placeholder | §10.6 `ccteam web` 命令 | F45 加 | — |
+| **#2 M5.1** | §3.8 dashboard 描述 | §13 web routes(M5.1 read-only)| — | — |
+| **#3 M5.2** | §6.4 channel layer | §13 SSE wire format / screenshot endpoint | — | — |
+| **#4 M5.3** | §3.8 写动作 + token auth | §13 POST endpoints / Authorization / token 文件 | F45 close | — |
+| **#5 M5.4** | §3.8 / §6.4 终稿 | §13 终稿 | F45 close 校验 | CLAUDE.md §一 baseline;v0-2/README V0.3 ship pointer;v0-3/e2e-retro.md 落档 |
+
+跨版本 SoT 不动:`docs/v0-1/` `docs/v0-2/` `docs/v0-2-2/` 历史归档。
+
+---
+
+## 10. 测试 baseline
+
+| PR | base | 增量 | 累计 |
+|---|---|---|---|
+| #1 M5.0 | 631 | +~10(actions promote 单元 / health e2e) | ~641 |
+| #2 M5.1 | 641 | +~10(dashboard / project / 404 / assets) | ~651 |
+| #3 M5.2 | 651 | +~12(watcher / SSE / per-slug filter / screenshot) | ~663 |
+| #4 M5.3 | 663 | +~15(actions endpoints / auth middleware / token file / CSRF) | ~678 |
+| #5 M5.4 | 678 | +~5(e2e happy path) | **~683** |
+
+clippy 不新增 warning(4 pre-existing 不算)。
+
+---
+
+## Changelog
+
+- 2026-05-10:初稿。基于 `docs/v0-3/prd.md` + V0.2.2 dev-plan 风格参考拆 5 PR
+  (M5.0-M5.4),~2.25 kLOC + ~50 测试,~3 周。每 PR worktree subagent
+  briefing 模板就位,subagent 拿到模板 + 进 worktree 即可开干。

--- a/docs/v0-3/prd.md
+++ b/docs/v0-3/prd.md
@@ -554,23 +554,21 @@ token 生成路径:
   hex 编码 → 写文件 `mode 0600` → stdout echo:
   ```
   ccteam web listening on http://0.0.0.0:7331
-  Auth token (write actions): ccteam:<token>
+  Auth token: ccteam:<token>
   Reset with: rm ~/.ccteam/web-token && restart
   ```
 - 已存在 → 校验 mode 0600(否则 warn)+ 加载
 
-middleware 行为:
+middleware 行为(**整体权限,不区分读写** — 用户 2026-05-10 决策,不留 `--read-public` 后门):
 
 - enabled = false → pass through
-- enabled = true 且 path matches `^/api/` → check `Authorization: Bearer ccteam:<token>`,
-  constant-time 对比(`subtle::ConstantTimeEq`);不匹配 → 401 plain-text "auth required"
-- 其他路径(GET dashboard / SSE / screenshot)— V0.3 默认 **也 require token**
-  (token cookie + bearer 二选一);用户嫌烦走 `--no-auth`(loopback 开发态)
-  或 V0.4 加 `--read-public` flag(`docs/v0-3/` deferred)
-
-注:本 PRD 第一版**所有 endpoint** 都受 token 保护(包括 read);M5.3 实施时
-比较成本与 UX 后,允许 PR 内细调(eg 只 gate `/api/`,read 端 cookie-based)。
-最终方案 `interfaces.md` 落档时定。
+- enabled = true → **所有路径**(GET dashboard / SSE / screenshot / POST `/api/...`)
+  统一 check `Authorization: Bearer ccteam:<token>`,constant-time 对比
+  (`subtle::ConstantTimeEq`);不匹配 → 401 plain-text "auth required"
+- 浏览器 GET 通过 token cookie 注入:首次访问带 query string `?token=ccteam:<...>`,
+  middleware set HttpOnly cookie + 302 redirect 去掉 query;后续 GET / SSE 走 cookie。
+  POST `/api/...` 仍要 `Authorization: Bearer` header(同时也是 CSRF 防御 — §6.2.5)
+- 用户嫌烦走 `--no-auth`(loopback 开发态默认无 auth,非 loopback 显式 opt-out + stderr warn)
 
 #### 6.2.5 CSRF 防御
 

--- a/docs/v0-3/prd.md
+++ b/docs/v0-3/prd.md
@@ -1,0 +1,885 @@
+# PRD V0.3 — Web UI(读 + 受限写)
+
+> 范围:V0.3 主线 = 一个本地 / 局域网 web UI,展示 ccteam 全局项目 / agent /
+> subagent 状态,并提供有限的写动作(`/btw` 派单、注入决策、pause/resume)。
+> 新 crate `crates/ccteam-web` 暴露 `ccteam web` 子命令,内嵌 HTTP server。
+>
+> base = `origin/main` `2988de6`(V0.2.2 ship 终点,F44 反向回滚已 merge);
+> 测试 baseline 631/0;workspace.version 起点 `0.2.2`,V0.3 ship gate 前 bump
+> `0.3.0`。
+>
+> V0.3 是首个开"对外可视层"的版本,跟 V0.1 / V0.2 主架构红线兼容(progress.jsonl
+> 仍是 SoT,session 仍 tmux 长跑,控制面板仍数据驱动)。本 PR 是 docs-only
+> kickoff;实施跨 5 milestone(M5.0-M5.4)走 worktree-per-PR 派工。
+
+---
+
+## 1. 背景
+
+### 1.1 痛点映射
+
+V0.3 主修 `requirements.md` 两条痛点:
+
+- **痛点 7「进度永远不透明」**:V0.2 之前用户唯一观测面是 tmux attach + outbox
+  目录手翻,跨多项目并发(M3+ team factory ship 后用户实际跑 ≥ 3 项目)难一目了然
+  全局态。痛点 7 用户原话「我不在的时候它自己跑,我在的时候用一句话就能知道
+  '现在怎么样了'。所有进度都看得到、可追溯,但不需要我主动去查」。终端 UI 满足
+  「自己跑」,但「一句话就知道」需要可视化聚合。Web UI 是直接答案。
+- **痛点 9「AI 团队需要人来主持」**(部分):web UI 不是新主持人,但把「现在哪
+  个项目卡了 / 谁在 idle / 谁要决策」聚合到一屏,把用户从 attach 多 session 解放,
+  跟 V0.2 watchdog + V0.2.2 enriched outbox 形成「自检 → 用户一屏看 → 一键 nudge」
+  闭环。
+
+不修痛点(V0.3 显式排除 — 详 §10):跨项目记忆 / 长 session 守护 / 多 session
+fan-out 之类已 V0.1-V0.2 ship 项,web UI 只「展示 + 受限写」,不替代任何已 ship
+机制。
+
+### 1.2 架构定位
+
+参考 `tech-design.md` §6 扩展点表,V0.3 web UI 走以下接入面:
+
+- **§6.4 channel layer**:web UI 是新 channel(继 telegram channel 后第二个;
+  方向上是「桌面侧」channel,不上 cloud);消费 progress.jsonl 事件、写 inbox /
+  control 文件,**不绕开 orchestrator 状态机**
+- **§5.5 progress.jsonl SoT**:所有读端数据来源 = progress.jsonl + state.json,
+  **绝不解析 tmux 终端输出**(F38 截图是显式 vt100 状态机渲染,不是文本解析)
+- **§6.9 idle-aware 注入**:web UI 写 `/btw` 走跟 telegram channel + MCP
+  `send_to_session` 完全相同的 inbox + idle dispatch 路径,不开新通路
+- **§3.7 跨项目记忆零检索**:web UI 不读 `~/.claude/rules/`,不解析 memory
+  文件;用户要看 lessons 走 Claude session 内 `/memory` 命令,不归 web UI
+
+### 1.3 用户接入面增量
+
+V0.2 / V0.2.2 用户接入面三层:
+
+| 层 | M3 起 | V0.2 / V0.2.2 |
+|---|---|---|
+| 终端 attach | tmux attach session | + cct-control skill in meta-agent + cct snapshot(F38)|
+| MCP `mcp__ccteam__*` | M2 ship | + watchdog + enriched outbox + screenshot(F38)|
+| 文件系统 / `progress.jsonl` | M0+ | + outbox 富字段(F35)|
+
+V0.3 加第四层:
+
+| 层 | V0.3 |
+|---|---|
+| **本地 / 局域网 web UI** | dashboard 全项目状态 + 项目详情页(progress 事件流 / outbox / pane 截图)+ 写动作表单(/btw / inject_decision / pause / resume)|
+
+四层并存,各有强项 — terminal 给 power user 全控,MCP 给 meta-agent 自动化,
+filesystem 给 hooks / 调试,web UI 给「一屏看全局」。
+
+---
+
+## 2. 范围
+
+5 milestone:
+
+- **M5.0**:`ccteam-web` crate scaffold + `ccteam web` 子命令 + write helper
+  promote 到 `ccteam-core::actions`(关键解耦,详 §3 / §8.1)
+- **M5.1**:read-only dashboard(项目列表 + 项目详情)— **独立可 ship**
+- **M5.2**:SSE 实时事件流 + 按需 PNG 截图(F38 reuse)— **独立可 ship**
+- **M5.3**:写动作(/btw / inject_decision / pause / resume)+ 默认 token 鉴权
+- **M5.4**:E2E + retro + workspace.version bump 0.2.2 → 0.3.0 + V0.3 ship gate
+
+总规模估:~2.5 kLOC(新 crate + 模板 + handler + 测试)+ 端到端 ~3-4 周
+(单人,5 PR 串行;M5.1 / M5.2 可独立 ship 让用户提前 dogfood)。
+
+---
+
+## 3. M5.0 — Scaffold + write helper promote
+
+### 3.1 问题
+
+新 crate 的 stand-up 工作 + 一个**关键解耦决策**:web UI 不能 depend on
+`ccteam-cli`(CLI binary 是 library 是反模式 — 把可执行 entry 当 lib 再被 lib
+crate 反向依赖,dep 图倒挂)。web UI 必须 depend on `ccteam-core`,所以写动作
+helper 必须从 `ccteam-cli::commands` / `ccteam-cli::mcp_serve` 提到
+`ccteam-core::actions`。
+
+dispatcher 已审计当前 surface:
+
+- **读侧 helper(已 public)**:`ccteam_core::ProjectState` /
+  `ccteam_core::CcteamPaths` / `ccteam_core::render_screenshot`(F38)/
+  `ccteam_core::tmux::{capture_pane_tail, capture_pane_with_ansi}` /
+  `ccteam_core::check_daemon_health` + `DaemonHealth` /
+  `ccteam_core::{InboxFrontMatter, InboxMessage, SessionMailbox}` /
+  `inbox_filename` / `pick_unused_slug` / `bootstrap_project` /
+  `ccteam_cli::commands::{collect_projects, collect_recent_events,
+  run_resume, run_show, run_new}`(`run_resume` 是 pub fn,`run_new` /
+  `run_show` 已被 `mcp_serve.rs` 跨模块调用,事实上算 pub)
+- **写侧 helper(目前内部 fn,不 public)**:`tool_send_to_session` /
+  `tool_inject_decision`(`crates/ccteam-cli/src/mcp_serve.rs::456`、`::500`,
+  `fn` 非 `pub fn`)/ pause / resume 逻辑(MCP 只在 mcp_serve 内 inline 实现,
+  没单独 pub fn)
+
+### 3.2 设计
+
+#### 3.2.1 新 crate `crates/ccteam-web`
+
+- workspace member,sibling 于 `ccteam-cli` / `ccteam-core` / `ccteam-hooks`
+- 依赖:`ccteam-core` only(**不 dep `ccteam-cli`**;dep 图保持 cli + web 都
+  下沉到 core)
+- 入口:`pub async fn serve(opts: ServeOpts) -> Result<()>` —
+  `ccteam-cli::commands::run_web(opts)` 调用
+- 不是独立 binary。`ccteam web` 是 ccteam-cli 子命令,run_web 内 `tokio::runtime`
+  block on `ccteam_web::serve(opts)`
+
+#### 3.2.2 Tech stack(pin minor 版本)
+
+| 用途 | crate | 版本 |
+|---|---|---|
+| HTTP server | `axum` | `0.8`(latest stable) |
+| async runtime | `tokio` | workspace `1.x`(已 pin) |
+| HTML templating | `askama` | `0.12` |
+| File watching | `notify` | workspace `8`(已 pin) |
+| Tracing | `tracing` / `tracing-subscriber` | workspace |
+| Serde / JSON | `serde` / `serde_json` | workspace |
+| HTTP client(测试用)| `reqwest` | `0.12`,dev-deps |
+
+**前端**:`htmx`(~14 KB minified,vendored 进 `assets/`,通过 `include_bytes!`
+编译期打包)+ minimal CSS(<5 KB,inline 模板)。无 npm / 无 Vite / 无 build
+toolchain。
+
+模板树:
+
+```
+crates/ccteam-web/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs            # serve(opts) entry
+│   ├── routes/           # axum router
+│   │   ├── mod.rs
+│   │   ├── dashboard.rs  # GET /
+│   │   ├── project.rs    # GET /project/<slug>
+│   │   ├── sse.rs        # GET /sse/all, /sse/project/<slug>
+│   │   ├── screenshot.rs # GET /screenshot/<slug>.png
+│   │   └── actions.rs    # POST /api/<slug>/{btw,inject_decision,pause,resume}
+│   ├── auth.rs           # token middleware
+│   ├── watcher.rs        # notify recursive watcher → broadcast channel
+│   └── templates.rs      # askama template structs
+├── templates/
+│   ├── base.html
+│   ├── dashboard.html
+│   └── project.html
+└── assets/
+    ├── htmx.min.js       # vendored ~14 KB
+    └── style.css
+```
+
+#### 3.2.3 Write helper promote(M5.0 关键解耦)
+
+新建 `crates/ccteam-core/src/actions.rs` 模块,提 4 个函数 public:
+
+```rust
+// 全部按 M2 mcp_serve.rs 现有内部 fn 等价语义提
+pub fn send_to_session(paths: &CcteamPaths, slug: &str, text: &str) -> Result<SendResult>;
+pub fn inject_decision(paths: &CcteamPaths, slug: &str, decision: DecisionInput) -> Result<InjectResult>;
+pub fn pause(paths: &CcteamPaths, slug: &str) -> Result<()>;
+pub fn resume(paths: &CcteamPaths, slug: &str) -> Result<()>;
+```
+
+callsite 重写:
+
+| 文件 | 改动 |
+|---|---|
+| `ccteam-cli/src/mcp_serve.rs` | `tool_send_to_session` / `tool_inject_decision` 内部 logic 全提到 `ccteam_core::actions::*`;mcp_serve 内 fn 留 wrapper 拆 args + JSON encode 输出 |
+| `ccteam-web/src/routes/actions.rs` | 直接调 `ccteam_core::actions::*`,无中间层 |
+
+**Dep 图**(M5.0 ship 后):
+
+```
+ccteam-hooks ──► ccteam-core ◄── ccteam-cli
+                     ▲
+                     └────────── ccteam-web   (新)
+```
+
+干净;`ccteam-web` 不依赖 `ccteam-cli`。
+
+#### 3.2.4 `ccteam web` CLI 入口
+
+`crates/ccteam-cli/src/main.rs` 加子命令(clap):
+
+```rust
+Commands::Web {
+    /// Listen address. Default 127.0.0.1:7331 — auth disabled. 0.0.0.0:7331 enables
+    /// token auth on write endpoints unless --no-auth.
+    #[arg(long, default_value = "127.0.0.1:7331")]
+    bind: String,
+
+    /// Disable token auth (DANGEROUS on non-loopback bind).
+    #[arg(long)]
+    no_auth: bool,
+
+    /// Custom path to read auth token from (default: ~/.ccteam/web-token).
+    #[arg(long)]
+    token_file: Option<PathBuf>,
+}
+```
+
+`commands.rs::run_web(opts: WebOpts)` 把 clap struct 翻成 `ServeOpts`,
+delegate 到 `ccteam_web::serve`。
+
+#### 3.2.5 Health endpoint
+
+`GET /health` → 200 JSON `{"status":"ok","version":"<pkg>","bind":"<addr>"}`。
+M5.0 验收脚本调它确认 server up。
+
+#### 3.2.6 Doctor 集成
+
+`ccteam doctor` 加 web 检查段:
+
+- 检测 `~/.ccteam/web-token` 存在 + mode 0600(若不是 warn)
+- 检测最近 `ccteam web` 启动日志(可选 — V0.3 暂不做,V0.4 deferred)
+
+### 3.3 不做(M5.0)
+
+- 任何 dashboard / project view / SSE / screenshot endpoint(M5.1 / M5.2)
+- 任何写动作 endpoint(M5.3)
+- token 生成 logic(M5.3 一并 ship 鉴权时落)
+- WebSocket(永久 deferred,SSE 足够)
+
+### 3.4 验收
+
+- [ ] `crates/ccteam-web/` workspace member,`Cargo.toml` 列依赖 + pin 版本
+- [ ] `cargo build --workspace` 全绿(新 crate 编译过,dep 图无 cycle)
+- [ ] `crates/ccteam-core/src/actions.rs` 新模块,4 个 pub fn 落地 + 单元测试
+- [ ] `mcp_serve.rs` 内 `tool_send_to_session` / `tool_inject_decision`
+  delegate 到 `ccteam_core::actions::*`;MCP 测试套件全绿(回归保证)
+- [ ] `ccteam web --bind 127.0.0.1:7331` 启动,`curl http://127.0.0.1:7331/health`
+  返 200 + JSON
+- [ ] `ccteam doctor` 不退步;web 段 detection 不失败
+- [ ] `cargo test --workspace` ≥ 631 baseline + ≥ 4 new(actions promote 单元)
+
+---
+
+## 4. M5.1 — Read-only dashboard
+
+### 4.1 问题
+
+用户要「一屏看全局」。M5.1 落最小可 dogfood 的 read-only 面 — 项目列表 +
+项目详情页,模板渲染,无实时更新(M5.2 加 SSE 才有)。
+
+### 4.2 设计
+
+#### 4.2.1 路由
+
+| Path | Handler | 说明 |
+|---|---|---|
+| `GET /` | `dashboard.rs::handle_index` | 项目列表(table)+ 顶部 nav |
+| `GET /project/<slug>` | `project.rs::handle_project` | 项目详情(state + recent events + outbox + screenshot button)|
+| `GET /assets/htmx.min.js` | static handler | vendored htmx |
+| `GET /assets/style.css` | static handler | minimal inline-able CSS |
+| `GET /health` | M5.0 已落 | health JSON |
+
+#### 4.2.2 Dashboard view(`/`)
+
+调 `ccteam_cli::commands::collect_projects(paths)` 返 `Vec<ProjectSummary>`;
+askama 渲染 table 列:
+
+| 列 | 来源 |
+|---|---|
+| Slug | `ProjectSummary::slug` |
+| Team | `ProjectSummary::team` |
+| Phase | `state.json::current_phase` |
+| Last event | progress.jsonl 末事件 timestamp |
+| Status badge | `daemon_health` + 静默时长(`Healthy` / `Idle 5m` / `Stalled 30m+`)|
+| Cost | accumulated `cost_usd` |
+
+**status badge 计算口径**:不重新发明,直接复用 V0.2.2 F35 silence_classifier
+**只读**地分类(M5.1 不写)— `Healthy` / `Terminal` / `SubagentBusy` / `MidToolHung` /
+`PostStopLimbo` 之一,渲染成颜色 badge。
+
+#### 4.2.3 Project detail view(`/project/<slug>`)
+
+调 `collect_recent_events(paths, slug, limit=200)` 返事件列表 + `state.json`
+完整状态。模板渲染:
+
+- **Header**:slug / team / phase / cost / created_at
+- **Tabs / sections**:
+  1. State(`state.json` JSON pretty-print,折叠)
+  2. Recent events table(progress.jsonl tail 200)
+  3. Outbox messages(`~/projects/<slug>/.ccteam/outbox/*.md` parse 前置)
+  4. Screenshot panel(M5.2 加 button)
+- **Sidebar**(M5.3 加 write actions form);M5.1 留占位 placeholder
+
+#### 4.2.4 Outbox parsing
+
+复用 `ccteam_core::{InboxFrontMatter, InboxMessage, SessionMailbox}` 已 public
+接口扫 outbox。文件名 sort newest first,展示前 20 条。
+
+#### 4.2.5 模板与样式
+
+- `templates/base.html`:HTML5 boilerplate + nav + htmx script tag
+- `templates/dashboard.html`:extends base,table 列
+- `templates/project.html`:extends base,sections
+- `style.css`:无 framework,~3 KB(monospace + dark-mode-friendly contrast)
+
+无 JS framework;无 React / Vue / Svelte;htmx 引入只为 M5.2 / M5.3 的 SSE +
+form swap,M5.1 阶段静态渲染足够。
+
+### 4.3 不做(M5.1)
+
+- 实时更新(M5.2)
+- screenshot rendering(M5.2)
+- 任何写动作(M5.3)
+- 项目创建 / 删除 UI(永久 deferred — 走 meta-agent + cct-project-creator skill)
+- 配置 UI(永久 deferred)
+- 用户管理(永久 deferred)
+
+### 4.4 验收
+
+- [ ] `GET /` 返 200 + valid HTML + 列出 `~/.ccteam/projects/` 全 slug
+- [ ] `GET /project/<slug>` 返 200 + state + events + outbox 段
+- [ ] 不存在 slug → `GET /project/nonexistent` 返 404
+- [ ] CSS / htmx assets `GET /assets/*` 返 200
+- [ ] askama template 编译期类型检查
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 6 e2e(`reqwest` 起 server,断
+  state code + HTML contains expected slug)
+- [ ] **独立可 ship** — M5.1 merge 后用户已能看 dashboard,M5.2 / M5.3 不 block
+
+---
+
+## 5. M5.2 — SSE event push + 按需截图
+
+### 5.1 问题
+
+M5.1 是静态渲染,用户刷页才看到新事件。M5.2 加实时推送 — progress.jsonl 写入
+→ 浏览器表格行新增,无需刷页。截图按 click 渲染,不自动 polling(F38 渲染百
+ms 级,polling 浪费 CPU)。
+
+### 5.2 设计
+
+#### 5.2.1 文件 watcher 架构
+
+- 单个 recursive `notify` watcher 监 `~/.ccteam/progress/`(目录,非 per-file)
+- watcher 用 `notify::recommended_watcher(handler)` + `RecursiveMode::Recursive`
+- 文件名约定:`<slug>.jsonl`(M0 起协议)— 新文件出现自动覆盖,不需要 re-arm
+- 同样监 `~/.ccteam/state/`(项目元数据变更触发 dashboard refresh)
+
+#### 5.2.2 事件 dispatch
+
+```rust
+// crates/ccteam-web/src/watcher.rs
+pub struct EventBus {
+    tx: tokio::sync::broadcast::Sender<EventMsg>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct EventMsg {
+    pub slug: String,        // server-side injected (parsed from filename)
+    pub event_json: String,  // raw progress.jsonl line
+}
+```
+
+Watcher 后台 task:
+
+- `notify` callback 收到 `Event::Modify(Path)` → 计算 path 末次 read offset,
+  read 新增 lines,parse 出 slug from filename,广播到 broadcast channel
+- broadcast `bound = 1024`(broadcast 满 → laggy receiver 被 drop,客户端 SSE
+  reconnect 续上;不为 backlog 占内存)
+
+#### 5.2.3 SSE endpoints
+
+**两个端点,不复用一条连接**(advisor 确认设计;复用易丢追踪):
+
+| Path | Filter | 用途 |
+|---|---|---|
+| `GET /sse/all` | 无 | dashboard 全局 view |
+| `GET /sse/project/<slug>` | server-side filter `msg.slug == <slug>` | 详情页 view |
+
+**wire format**:每条 SSE event payload = 单行 JSON(progress.jsonl 一行 +
+server 注入 `slug` 字段):
+
+```
+event: progress
+data: {"slug":"dev-foo","ts":"2026-05-10T12:34:56Z","kind":"phase_done","phase":"plan-eng",...}
+
+```
+
+- `event:` 字段固定 `progress`(future-proof,新 event type 加新 `event:` 名)
+- `data:` 必须单行(SSE protocol 限制);progress.jsonl 本就是 JSON-Lines,
+  每行一 event 已天然兼容
+- keep-alive:server 每 15s 发 `: keepalive\n\n` 注释行,防代理超时(对应
+  反代 / nginx 默认 60s timeout)
+
+#### 5.2.4 htmx hookup
+
+dashboard.html / project.html 加:
+
+```html
+<div hx-ext="sse" sse-connect="/sse/project/{{slug}}" sse-swap="progress">
+  <table id="events-table">{{...初始 200 条 server-render...}}</table>
+</div>
+```
+
+新事件到 → htmx swap into `#events-table` first row。不需 JS,htmx ext 自带。
+
+#### 5.2.5 Screenshot endpoint
+
+| Path | 行为 |
+|---|---|
+| `GET /screenshot/<slug>.png` | 同步调 `ccteam_core::render_screenshot(slug, opts)`(F38)→ 返 PNG bytes,Content-Type `image/png`,Cache-Control `no-cache, must-revalidate` |
+
+**触发**:project.html 加 button:
+
+```html
+<button hx-get="/screenshot/{{slug}}.png" hx-target="#screenshot-img" hx-swap="outerHTML">
+  Refresh screenshot
+</button>
+<img id="screenshot-img" src="/screenshot/{{slug}}.png" alt="pane snapshot">
+```
+
+页面加载时一次自动渲染(`<img src>`),后续靠 button 手动刷。**不 polling**
+(F38 单次渲染 ~200-500ms,polling 烧 CPU 且 png 大不必要)。
+
+graceful degrade:F38 已 spec'd `render_screenshot` 失败返 `Ok(None)` /
+`Err`;handler 包成 504 + plain-text reason,前端 alt text 显示 "screenshot
+unavailable"。
+
+### 5.3 不做(M5.2)
+
+- 自动 polling 截图(永远不做)
+- WebSocket(SSE 足够)
+- per-project SSE 端点之外的 multiplexed channel
+- 历史截图 archive view(V0.4 channel layer 评估)
+- mobile-responsive(V0.4)
+
+### 5.4 验收
+
+- [ ] `GET /sse/all` 返 SSE stream;`curl -N http://127.0.0.1:7331/sse/all`
+  在另一 shell 写 progress.jsonl event 后 1s 内收到
+- [ ] `GET /sse/project/<slug>` 同上,只收对应 slug 事件
+- [ ] notify watcher 多 receiver 不 starve(`broadcast` channel)
+- [ ] `GET /screenshot/<slug>.png` 返 PNG bytes;F38 unavailable 时返 504
+  text(不 panic)
+- [ ] htmx SSE swap dashboard 实时刷新表格(浏览器手测;e2e 用 reqwest stream
+  断 ≥ 1 event 收到)
+- [ ] keepalive `: keepalive` 注释行 15s 周期发出
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 8 测试(watcher dispatch /
+  per-slug filter / SSE wire format / screenshot 200 + 504 / keepalive)
+- [ ] **独立可 ship** — M5.2 merge 后 dashboard 实时刷,M5.3 写动作可单独 ship
+
+---
+
+## 6. M5.3 — 写动作 + token 鉴权
+
+### 6.1 问题
+
+read-only dashboard 不够 — 用户经常需要在看到 stalled 项目后立刻 `/btw 改成 X`
+或 inject decision,现状要切 terminal。M5.3 落写动作。
+
+**关键安全决策**:用户原话「暂不考虑安全问题」+ 选 0.0.0.0 bind + 写动作。
+组合 `--dangerously-skip-permissions` claude session = LAN-wide RCE。本 PRD
+**默认开 token 鉴权**,用户可 `--no-auth` 显式 opt-out(详 §6.4 + §9 威胁模型)。
+
+### 6.2 设计
+
+#### 6.2.1 路由
+
+四个 POST endpoint,**全部走** `ccteam-core::actions::*`(M5.0 promote):
+
+| Path | Body | Action |
+|---|---|---|
+| `POST /api/<slug>/btw` | `text=<urlencoded>` | `actions::send_to_session(paths, slug, text)` |
+| `POST /api/<slug>/inject_decision` | `path=<rel-path>&body=<urlencoded>` | `actions::inject_decision(paths, slug, DecisionInput { path, body })` |
+| `POST /api/<slug>/pause` | (空)| `actions::pause(paths, slug)` |
+| `POST /api/<slug>/resume` | (空)| `actions::resume(paths, slug)` |
+
+成功 → 303 See Other 回 `/project/<slug>`(htmx 自动跟 swap);失败 → 4xx +
+plain-text error。
+
+#### 6.2.2 表单(显式分两个,不 conflate)
+
+`/btw` 自由文本表单:
+
+```html
+<form hx-post="/api/{{slug}}/btw" hx-target="#flash">
+  <textarea name="text" required minlength="1" maxlength="4000"></textarea>
+  <button type="submit">Send /btw</button>
+</form>
+```
+
+`inject_decision` 结构化表单:
+
+```html
+<form hx-post="/api/{{slug}}/inject_decision" hx-target="#flash">
+  <select name="path" required>
+    {{#each decision_candidates}}
+    <option>{{this}}</option>
+    {{/each}}
+  </select>
+  <textarea name="body" required minlength="1" maxlength="8000"></textarea>
+  <button type="submit">Inject decision</button>
+</form>
+```
+
+`decision_candidates` 来自扫 `~/projects/<slug>/.ccteam/decision-*.md`(读侧 fn,
+不 promote 到 actions,本身就是只读)。
+
+`pause` / `resume` 单 button:
+
+```html
+<form hx-post="/api/{{slug}}/{{action}}" hx-target="#flash">
+  <button type="submit">{{action_label}}</button>
+</form>
+```
+
+#### 6.2.3 Outbox view(read-only)
+
+project.html 加 outbox section,渲染 `~/projects/<slug>/.ccteam/outbox/*.md`
+parse 前置(`InboxFrontMatter`)+ body 头 200 char 摘要 + click 展开。无写动作。
+
+#### 6.2.4 Auth middleware
+
+新建 `crates/ccteam-web/src/auth.rs`,axum `tower::Layer`:
+
+```rust
+pub struct AuthLayer {
+    enabled: bool,
+    token: Option<String>,  // None = no-auth path
+}
+```
+
+bind heuristic(`serve` 内决定):
+
+| bind | --no-auth | enabled | token gen |
+|---|---|---|---|
+| `127.0.0.1:*` / `[::1]:*` | false | false(loopback 信任)| 不生成 |
+| `127.0.0.1:*` / `[::1]:*` | true | false | 不生成 |
+| 非 loopback | false | **true**(默认 enable)| 生成或读 `~/.ccteam/web-token` |
+| 非 loopback | true | false(显式 opt-out) | 不生成 |
+
+token 生成路径:
+
+- 首次启动检测 `~/.ccteam/web-token` 不存在 → 生成 32-byte `rand::random` →
+  hex 编码 → 写文件 `mode 0600` → stdout echo:
+  ```
+  ccteam web listening on http://0.0.0.0:7331
+  Auth token (write actions): ccteam:<token>
+  Reset with: rm ~/.ccteam/web-token && restart
+  ```
+- 已存在 → 校验 mode 0600(否则 warn)+ 加载
+
+middleware 行为:
+
+- enabled = false → pass through
+- enabled = true 且 path matches `^/api/` → check `Authorization: Bearer ccteam:<token>`,
+  constant-time 对比(`subtle::ConstantTimeEq`);不匹配 → 401 plain-text "auth required"
+- 其他路径(GET dashboard / SSE / screenshot)— V0.3 默认 **也 require token**
+  (token cookie + bearer 二选一);用户嫌烦走 `--no-auth`(loopback 开发态)
+  或 V0.4 加 `--read-public` flag(`docs/v0-3/` deferred)
+
+注:本 PRD 第一版**所有 endpoint** 都受 token 保护(包括 read);M5.3 实施时
+比较成本与 UX 后,允许 PR 内细调(eg 只 gate `/api/`,read 端 cookie-based)。
+最终方案 `interfaces.md` 落档时定。
+
+#### 6.2.5 CSRF 防御
+
+写动作用 htmx `hx-post` 发的是 form-encoded POST,但 **要求** `Authorization:
+Bearer` header(浏览器跨域 form-submit 不会自动加 Authorization 头),所以
+`Authorization` header 本身就是 CSRF token — 攻击者跨域 form 无法注入这个
+header,fetch / XHR 跨域要 CORS preflight,默认拒绝。
+
+不需要单独 CSRF token 字段。
+
+#### 6.2.6 反馈 UI
+
+post-submit:
+
+- 200/303 → flash banner "Sent" + 2s 自动 fade
+- 4xx/5xx → flash banner red + error text
+
+htmx `hx-target="#flash"` swap into `<div id="flash"></div>` 占位。
+
+### 6.3 不做(M5.3)
+
+- OAuth(Google / GitHub)— V0.4
+- HTTPS / TLS termination — V0.4(假设反代;loopback 不需要)
+- per-project ACL — V0.4
+- session-based auth — V0.4(token 足够 V0.3)
+- write 速率限制 / rate-limit — V0.4
+- 多用户 — 永久(ccteam 是单用户工具)
+
+### 6.4 验收
+
+- [ ] `POST /api/<slug>/btw text=hello` 返 303 + `~/projects/<slug>/.ccteam/inbox/`
+  落消息文件
+- [ ] `POST /api/<slug>/inject_decision path=...&body=...` 返 303 + decision
+  写入
+- [ ] `POST /api/<slug>/pause` 返 303 + state.json `paused: true`
+- [ ] `POST /api/<slug>/resume` 同 pause 反向
+- [ ] 非 loopback bind + 默认 → token 生成 + console echo;`POST /api/.../btw`
+  无 token → 401;带 `Authorization: Bearer ccteam:<token>` → 200/303
+- [ ] loopback bind 默认 → 无 token,无 Authorization 也通
+- [ ] `--no-auth` flag + 非 loopback → stderr warn "WARNING: no-auth on
+  non-loopback bind = LAN-wide RCE on bypassPermissions sessions",但仍服务
+- [ ] constant-time 比对 token(单元测试 mock 不同长度 token 不泄漏耗时)
+- [ ] `~/.ccteam/web-token` 文件 mode 0600(`stat -c %a` = 600)
+- [ ] CSRF e2e:模拟跨域 form POST 无 Authorization → 401(浏览器 fetch CORS
+  preflight 也拒)
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 12 测试
+
+---
+
+## 7. M5.4 — E2E + retro + ship gate
+
+### 7.1 问题
+
+V0.3 ship 前需要端到端验证 + retro 文档 + workspace.version bump。
+
+### 7.2 设计
+
+#### 7.2.1 E2E 测试
+
+新建 `crates/ccteam-web/tests/e2e_test.rs`:
+
+- spin up `ccteam-web` server in test(rand port,`127.0.0.1:0`)
+- fixture project at temp `~/.ccteam/`(用 `CCTEAM_HOME` env)
+- reqwest 跑端到端:`GET /` 200 → `GET /project/<slug>` 200 → SSE stream 收 1
+  event → `POST /api/<slug>/btw` 200 → 等 1s 看 inbox 文件落
+- 不依赖真 tmux session;mock daemon 用 fixture
+
+#### 7.2.2 Retro 文档
+
+`docs/v0-3/e2e-retro.md` —— 模仿 V0.2.2 retro 模板:
+
+- 4-suite 跑 dev / research smoke 跨 multi-session 项目
+- M5.0-M5.3 撞坑回顾 + dust patches(若有)
+- 截图 / SSE / write action 跨浏览器(Chrome / Firefox / Safari)兼容性 spot-check
+
+#### 7.2.3 workspace.version bump
+
+`Cargo.toml::workspace.package.version` `"0.2.2"` → `"0.3.0"`。
+
+#### 7.2.4 CLAUDE.md baseline 回填
+
+`CLAUDE.md` §一 表格更新:
+
+| 项 | V0.3 后 |
+|---|---|
+| Workspace version | `0.3.0` |
+| 测试 baseline | 实测后填 |
+| 已 ship 里程碑 | 加 V0.3 行 |
+
+#### 7.2.5 docs 同步
+
+- `docs/v0-2/README.md`:已在 doc-only kickoff PR 加 V0.3 起始 pointer;ship
+  时不再改
+- `docs/dev-coupling-audit.md`:F45(M5.0 write helper promote)close 标记
+- `docs/tech-design.md` §3.8 用户接口层 + §6.4 channel layer:加 web UI 段
+- `docs/interfaces.md`:加 §13 / §14 web UI route + SSE + token schema
+
+### 7.3 不做(M5.4)
+
+- 性能 benchmark(V0.4)
+- 跨平台 binary release(已经 `cargo install` ship,无新载体)
+- 翻译 / i18n(永久 deferred;ccteam 中英混用文档标准)
+
+### 7.4 验收
+
+- [ ] `cargo test --workspace` 全绿,baseline 大于等于 631 + V0.3 累计新增
+- [ ] e2e_test.rs spin-up + reqwest 端到端 happy path 通过
+- [ ] `docs/v0-3/e2e-retro.md` 落档
+- [ ] `Cargo.toml::workspace.package.version = "0.3.0"`
+- [ ] `CLAUDE.md` §一 baseline 表格更新
+- [ ] clippy 不新增 warning(4 pre-existing 不算)
+- [ ] `docs/v0-2/README.md` V0.3 pointer 改为 "已 ship"
+
+---
+
+## 8. 技术决策汇总
+
+### 8.1 Crate 组织
+
+- 新 crate `crates/ccteam-web`,workspace member,sibling 于
+  ccteam-{cli,core,hooks}
+- 依赖 `ccteam-core` only(**不依赖 ccteam-cli**)
+- 入口 `pub async fn serve(opts: ServeOpts)`;`ccteam-cli::commands::run_web`
+  通过 `ccteam web` 子命令调用
+- write helper(`send_to_session` / `inject_decision` / `pause` / `resume`)
+  从 `ccteam-cli::mcp_serve.rs` 私有 fn 提到 `ccteam-core::actions` 模块;
+  mcp_serve 内 wrapper 留 JSON encoding/decoding,核心 logic 共享
+
+### 8.2 文件 watching
+
+- 单个 `notify` recursive watcher 监 `~/.ccteam/progress/`(目录,非 per-file)
+- `tokio::sync::broadcast` channel 多 SSE consumer fan-out
+- 文件名 → slug 解析(`<slug>.jsonl` 约定)
+- 新文件出现自动覆盖,不需 re-arm
+
+### 8.3 SSE 拓扑
+
+- 两个端点 `/sse/all` + `/sse/project/<slug>`,不在一条连接 multiplex
+- wire format:`event: progress` + `data: <one-line-JSON>`(progress.jsonl 直发,
+  server 注入 `slug` 字段)
+- `: keepalive` 注释行 15s 周期防代理超时
+
+### 8.4 截图
+
+- `GET /screenshot/<slug>.png` on-demand,**不 polling**
+- 调 `ccteam_core::render_screenshot`(F38 ship);Cache-Control no-cache
+- htmx button 手动刷 + 页面加载一次 `<img src>` 自动渲染
+- F38 graceful degrade 由 handler 翻译 504 + plain-text reason
+
+### 8.5 写动作 UI
+
+- 4 endpoint:`/btw` / `/inject_decision` / `/pause` / `/resume`,全 POST
+- form 显式分开(`/btw` 自由文本 textarea;`/inject_decision` 结构化 select +
+  textarea),不 conflate
+- htmx `hx-post` + `hx-target="#flash"` swap 反馈 banner
+
+### 8.6 鉴权
+
+- 默认 token 鉴权 + bind heuristic(loopback → 不需 token;非 loopback →
+  自动生成 + console echo)
+- token 文件 `~/.ccteam/web-token` mode 0600,32-byte hex
+- `Authorization: Bearer ccteam:<token>` header(constant-time 比对,
+  `subtle` crate)
+- CSRF 防御 = `Authorization` header 本身(浏览器跨域 form-submit 不会自动加)
+- `--no-auth` flag 显式 opt-out + stderr 警告
+
+### 8.7 前端
+
+- `htmx` ~14 KB vendored,无 JS framework
+- `askama` HTML templates,编译期类型检查
+- minimal CSS ~3 KB,无 framework
+- 编译期 `include_bytes!` 把 htmx + CSS 打进 binary,`ccteam-web` 自包含,无
+  separate static-files install step(模仿 F38 vendored TTF 模式)
+
+---
+
+## 9. 已知风险 / 威胁模型
+
+### 9.1 LAN-wide RCE — V0.3 主要风险
+
+ccteam 项目 session 跑 `--dangerously-skip-permissions` claude(tech-design
+§6.1)。写动作(`/btw` / `inject_decision`)是 unsanitized prompt-injection
+向量:任何能 POST 到 `/api/<slug>/btw` 的客户端能让 claude session 执行任意
+shell 命令(因为 bypassPermissions),包括但不限于:
+
+- `rm -rf ~`
+- exfiltrate `~/.ssh/`
+- crypto miner
+- 横向移动到同 LAN 其他 ccteam 实例
+
+组合「非 loopback bind(0.0.0.0)+ 无鉴权 + 写动作」= **LAN-wide remote code
+execution on user's dev machine**。
+
+**与 V0.2.2 F44 silent-shadow 对比**:F44 是命名碰撞,后果是用户跑 GIS 工具
+跑到 ccteam binary,confusion 重于损失;V0.3 无鉴权 0.0.0.0 部署是真正的 RCE,
+**威胁模型材料级别更高**。
+
+#### 9.1.1 缓解 — token 鉴权默认开
+
+PRD §6.2.4 设计:
+
+- loopback bind(127.0.0.1 / ::1)→ 默认无 token(信任 loopback)
+- 非 loopback bind(0.0.0.0 等)→ **默认 token 鉴权**,首次启动自动生成 32-byte
+  hex token,console echo,文件 mode 0600
+- `--no-auth` 显式 opt-out + stderr 大字警告
+
+#### 9.1.2 用户决策点
+
+用户原话「暂不考虑安全问题」+ 选 0.0.0.0 + 写动作。本 PRD 推翻这个默认,
+**默认开 token 鉴权**。用户 review 本 PRD 时可:
+
+- (A)接受默认(token 鉴权)— 本 PRD 不变
+- (B)推翻默认(`--no-auth` 改成默认行为)— 需要在本节加用户显式签字
+  「acknowledge LAN-wide RCE risk」
+
+#### 9.1.3 deferred 安全增强(V0.4)
+
+- HTTPS / TLS(假设反代;V0.3 纯 HTTP)
+- OAuth(Google / GitHub)
+- per-project ACL
+- 隧道集成(ngrok / Cloudflare Tunnel)
+- 多用户 / 团队权限模型
+
+### 9.2 其他风险
+
+- **新 crate 编译时长**:axum + askama + tower 加 ~30s cold build。可接受,
+  不阻塞;`cargo check` 已分钟级。
+- **askama 模板编译错误**:模板失败编译期报错,不会 runtime 翻车;反而比
+  template engine + fallback string 更稳。
+- **notify 跨平台**:Linux inotify / macOS FSEvents 已 spec'd;不开 Windows
+  支持(ccteam tmux 假设 Unix)。
+- **broadcast 满 / receiver lag**:`bound = 1024`,lag 客户端 SSE reconnect
+  续上 — 不为 backlog 占内存。
+- **F38 不可用 / 崩溃**:V0.2.2 已 ship 了 graceful degrade,handler 包成
+  504 + plain-text 显示给用户。
+- **web UI bug 让 dashboard 挂掉**:不影响 CLI / MCP / tmux;CLI / MCP / 文件
+  系统三层都还在,web UI 是第四层,可降级到前三层。
+
+---
+
+## 10. 不在范围 / V0.4 deferred
+
+- **认证升级**:OAuth / per-project ACL / multi-user
+- **HTTPS / TLS terminate**:V0.4(假设反代)
+- **WebSocket**:SSE 足够;若未来双向写需求 ≥ N 才上
+- **mobile-responsive layout**:V0.4 channel layer 评估
+- **项目创建 UI**:永久 — 走 meta-agent + cct-project-creator skill
+- **配置 / 用户偏好持久化**:V0.4
+- **截图历史 archive view**:V0.4 channel layer
+- **隧道集成**(ngrok / Cloudflare Tunnel):V0.4
+- **远程协作 / 团队共享**:永久 — ccteam 单用户工具
+- **多语言 UI(i18n)**:永久 deferred
+- **性能 benchmark / 大量项目压测**(>20 project simul)— V0.4
+- **写动作 rate-limit**:V0.4
+- **session-based 鉴权(cookie 替代 bearer)**:V0.4 UX 评估
+
+---
+
+## 11. Workspace version bump
+
+`Cargo.toml::workspace.package.version` `"0.2.2"` → `"0.3.0"` 在 M5.4 chore PR
+落地。
+
+V0.2.2 起立的政策:每 minor/patch release 必须 bump + commit subject
+`vX.Y.Z:` 前缀。
+
+---
+
+## 12. PR sequencing
+
+| # | milestone | branch | 工程量估 | 主要前置 |
+|---|---|---|---|---|
+| **PR #1** | M5.0 scaffold + write helper promote | `v0-3-scaffold` | ~400 LoC + ~10 测试,~3 天 | 无 |
+| **PR #2** | M5.1 read-only dashboard | `v0-3-dashboard` | ~500 LoC + 模板 + ~10 测试,~3 天 | PR #1 |
+| **PR #3** | M5.2 SSE + 截图 | `v0-3-sse-screenshot` | ~600 LoC + ~12 测试,~4 天 | PR #1(软依赖 PR #2 模板)|
+| **PR #4** | M5.3 写动作 + 鉴权 | `v0-3-write-actions` | ~600 LoC + ~15 测试,~4 天 | PR #1(写 helper);PR #2(模板;forms 加在 project.html)|
+| **PR #5** | M5.4 e2e + retro + ship gate | `v0-3-ship-gate` | ~150 LoC + 文档,~2 天 | 全部 PR merge |
+
+**总计**:~2.25 kLOC + ~50 测试,~16 天(单人 5 天/周即 3 周)。
+
+依赖图:
+
+```
+PR #1 (M5.0 scaffold) — 必先 merge,立 deps + dep 图
+   ↓
+PR #2 (M5.1 dashboard) — read-only,可独立 ship
+   ↓ (软依赖,PR #3 / #4 模板加在 #2 基础上)
+PR #3 (M5.2 SSE + screenshot) ─┐
+                                ├──► PR #5 (M5.4 ship gate)
+PR #4 (M5.3 write + auth) ──────┘
+```
+
+并行机会:**PR #3 / #4 可并行**(SSE 改 sse routes,写动作改 actions routes,
+冲突点只在 project.html 模板)。
+
+worktree 用法(详 dev-plan §7 briefing 模板):
+
+```
+git worktree add -b v0-3-<topic> /tmp/ccteam-v03-<topic> origin/main
+```
+
+跟 V0.2.2 一致,subagent 派工 briefing 含 PRD 章节 + 验收条目。
+
+---
+
+## Changelog
+
+- 2026-05-10:初稿。基于 dispatcher Telegram 对话用户决策(read+write / SSE +
+  PNG / 0.0.0.0 / Rust embedded);advisor 审查通过;backing API 现状 audit
+  完毕(读端 helper public,写端需 promote 到 ccteam-core::actions);威胁模型
+  默认开 token 鉴权,用户原偏好「暂不考虑安全」改为 `--no-auth` 显式 opt-out。
+  base = `origin/main` `2988de6`(V0.2.2 ship 终点)。


### PR DESCRIPTION
## Summary

- **V0.3 主线** = 一个本地 / 局域网 web UI,展示 ccteam 全局项目 / agent / subagent 状态(progress.jsonl 事件流 + 项目详情 + F38 截图),并提供有限写动作(/btw / inject_decision / pause / resume);新 crate crates/ccteam-web,axum + askama + htmx + SSE 单 binary,无 npm / 无 build toolchain
- **5 milestone**(M5.0-M5.4)拆 5 PR + 1 ship gate:scaffold + write helper promote / read-only dashboard / SSE + 按需截图 / 写动作 + token 鉴权 / e2e + retro + workspace.version 0.2.2 → 0.3.0 — M5.1 / M5.2 各自独立可 ship 让用户提前 dogfood
- **关键解耦**(F45,新):写动作 helper 从 ccteam-cli::mcp_serve 私有 fn 提到 ccteam-core::actions pub fn,确保 ccteam-web 只 dep ccteam-core(不 dep ccteam-cli,避免 binary-as-library 反模式)

## Threat model summary

ccteam 项目 session 跑 ``--dangerously-skip-permissions`` claude;web 写动作(/btw / inject_decision)是 unsanitized prompt-injection 向量。组合「非 loopback bind + 无鉴权 + 写动作」= **LAN-wide RCE on user's dev machine**。比 V0.2.2 F44 silent-shadow 风险材料级别更高。

**缓解**:**默认开 token 鉴权**(非 loopback bind 自动生成 32-byte hex token,文件 mode 0600,console echo;loopback bind 信任不需 token)。用户可 ``--no-auth`` 显式 opt-out + 大字 stderr 警告 + 5s 倒计时。

**用户决策点**:用户原偏好「暂不考虑安全问题」改为 ``--no-auth`` 显式选项。PRD review 时用户可:(A)接受默认(token 鉴权);(B)推翻默认(签字 acknowledge LAN-wide RCE risk)。详 ``docs/v0-3/prd.md`` §9 威胁模型。

## 文档

- [PRD](docs/v0-3/prd.md)(~880 行)
- [Dev plan](docs/v0-3/dev-plan.md)(~870 行,5 PR briefing 模板就位)
- [README](docs/v0-3/README.md)
- F45 加在 [dev-coupling-audit.md](docs/dev-coupling-audit.md)
- V0.3 起始 pointer 加在 [docs/v0-2/README.md](docs/v0-2/README.md)

## 映射

- ``docs/requirements.md`` 痛点 7「进度永远不透明」+ 痛点 9「AI 团队需要人来主持」(部分)
- ``docs/tech-design.md`` §3.8 用户接口层 + §6.4 channel layer + §6 扩展点
- ``docs/dev-coupling-audit.md`` F45(新,M5.0 write helper promote)

## Test plan

- [x] N/A — docs-only PR
- [x] sanity: ``cargo build --workspace`` 在 worktree 内全绿(本 PR 仅改 docs/ 不动代码,验证未误添 stray 文件)

## PR sequencing

本 PR merge 后,subagent 派 V0.3 PR #1-#5 跨 5 worktree(详 dev-plan §7 briefing 模板)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>