### PR TITLE
chore(make): add setup/start/attach end-to-end user targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ RUNTIME_DIRS   := state progress inbox queue control log
 .DEFAULT_GOAL := help
 .PHONY: help build release clean check fmt clippy test \
         install uninstall reinstall \
+        setup start attach \
         doctor tool-surface \
         tmux-clean agents-clean state-clean wipe nuke
 
@@ -68,6 +69,10 @@ help:
 	@printf '  make install       symlink %s → %s\n' '$(RELEASE_BIN)' '$(BIN_LINK)'
 	@printf '  make uninstall     remove %s (state untouched)\n' '$(BIN_LINK)'
 	@printf '  make reinstall     uninstall + install\n\n'
+	@printf '\033[1mFirst-time setup & run (end-to-end)\033[0m\n'
+	@printf '  make setup HANDLE=<h>   one-shot: init + 4 doctor installs + tool-surface\n'
+	@printf '  make start              ccteam start --foreground (Terminal A)\n'
+	@printf '  make attach HANDLE=<h>  tmux attach -t ccteam-meta-<h> (Terminal B)\n\n'
 	@printf '\033[1mHealth check\033[0m\n'
 	@printf '  make doctor        ccteam doctor --tool-surface\n'
 	@printf '  make tool-surface  alias for doctor\n\n'
@@ -137,6 +142,43 @@ uninstall:
 	fi
 
 reinstall: uninstall install
+
+# --- First-time setup & run --------------------------------------------------
+#
+# `make setup HANDLE=rob` bundles the six idempotent first-time steps so users
+# don't have to memorize / paste-and-edit the doctor command list. `make start`
+# and `make attach` wrap the canonical Quick start two-terminal flow.
+
+HANDLE ?=
+
+setup:
+	@if [ -z "$(HANDLE)" ]; then \
+	    printf '\033[31merror:\033[0m HANDLE is required. Example: make setup HANDLE=rob\n' >&2; \
+	    exit 1; \
+	fi
+	@command -v $(BIN_NAME) >/dev/null || { printf '\033[31merror:\033[0m %s not on PATH; run `make install` first\n' '$(BIN_NAME)' >&2; exit 1; }
+	$(BIN_NAME) init
+	$(BIN_NAME) doctor --install-skill
+	$(BIN_NAME) doctor --install-mcp
+	$(BIN_NAME) doctor --install-memory-bridge
+	$(BIN_NAME) doctor --install-meta-agent $(HANDLE)
+	$(BIN_NAME) doctor --tool-surface
+	@printf '\n\033[32mready.\033[0m\n'
+	@printf 'next:\n'
+	@printf '  Terminal A: make start                 (or: ccteam start --foreground)\n'
+	@printf '  Terminal B: make attach HANDLE=%s     (or: tmux attach -t ccteam-meta-%s)\n' '$(HANDLE)' '$(HANDLE)'
+
+start:
+	@command -v $(BIN_NAME) >/dev/null || { printf '\033[31merror:\033[0m %s not on PATH; run `make install`\n' '$(BIN_NAME)' >&2; exit 1; }
+	$(BIN_NAME) start --foreground
+
+attach:
+	@if [ -z "$(HANDLE)" ]; then \
+	    printf '\033[31merror:\033[0m HANDLE is required. Example: make attach HANDLE=rob\n' >&2; \
+	    exit 1; \
+	fi
+	@command -v tmux >/dev/null || { printf '\033[31merror:\033[0m tmux not installed\n' >&2; exit 1; }
+	tmux attach -t ccteam-meta-$(HANDLE)
 
 # --- Health check ------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ ccteam --version
 One-time setup (idempotent — re-runs are no-ops):
 
 ```bash
+make setup HANDLE=<your-handle>   # init + 4 doctor installs + tool-surface health check
+```
+
+`<your-handle>` is whatever you want to call yourself — snake_case, e.g. `rob` or `alice`.
+
+<details>
+<summary>What <code>make setup</code> runs (if you want to do it by hand)</summary>
+
+```bash
 ccteam init                                       # ~/.ccteam/ skeleton
 ccteam doctor --install-skill                     # ccteam-control skill (any claude session reaches ccteam)
 ccteam doctor --install-mcp                       # 9-tool MCP server in ~/.claude.json
@@ -83,7 +92,7 @@ ccteam doctor --install-meta-agent <your-handle>  # bootstrap your meta-agent pr
 ccteam doctor --tool-surface                      # health check (must be green)
 ```
 
-`<your-handle>` is whatever you want to call yourself — snake_case, e.g. `rob` or `alice`.
+</details>
 
 > **Upgrading from a pre-2026-05 ccteam?** Run `ccteam doctor --migrate-recommended-agents` once after the upgrade. Spawned project sessions now resolve plugin agents through Claude Code's plugin pipeline, so the legacy `~/.claude/agents/<name>.md` symlinks ccteam used to create are obsolete; this command removes them. User-authored agents are preserved.
 
@@ -91,10 +100,10 @@ ccteam doctor --tool-surface                      # health check (must be green)
 
 ```bash
 # Terminal A — start the orchestrator (foreground; keep this open)
-ccteam start --foreground
+make start                              # or: ccteam start --foreground
 
 # Terminal B — talk to the meta-agent
-tmux attach -t ccteam-meta-<your-handle>
+make attach HANDLE=<your-handle>        # or: tmux attach -t ccteam-meta-<your-handle>
 # Then type in natural language:
 #   "Make a markdown editor, web-based, single HTML file, no build step."
 # Or for fuzzy ideas:


### PR DESCRIPTION
## Summary

- `make setup HANDLE=<h>` — bundles `init` + 4 `doctor --install-*` + `--tool-surface` into one idempotent command; prints next-step instructions on success
- `make start` — wraps `ccteam start --foreground`
- `make attach HANDLE=<h>` — wraps `tmux attach -t ccteam-meta-<h>`
- README §Install + §Quick start updated to use the new targets; hand-rolled command list preserved in a `<details>` block for power users

## Why

The pre-existing 6-line copy-paste-and-edit block for first-time setup is unfriendly. New users have to remember to substitute their handle in line 5, run them in order, and check the last one is green. One Make target replaces that ritual.

## Test plan

- [x] `make help` renders new "First-time setup & run" section
- [x] `make setup` without HANDLE errors out with friendly message
- [x] `make -n setup HANDLE=testhandle` dry-run prints the expected 6-command sequence
- [x] `make attach` without HANDLE errors out with friendly message
- [x] No code or test changes; baseline 631 unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)