### PR TITLE
v0.3 PR #1: M5.0 scaffold + write helper promote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,10 +114,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -166,6 +283,7 @@ dependencies = [
  "anyhow",
  "ccteam-core",
  "ccteam-hooks",
+ "ccteam-web",
  "chrono",
  "clap",
  "dirs",
@@ -211,10 +329,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccteam-web"
+version = "0.2.2"
+dependencies = [
+ "anyhow",
+ "askama",
+ "axum",
+ "ccteam-core",
+ "notify",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "subtle",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -311,6 +453,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,12 +523,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -417,13 +588,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -450,6 +635,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,10 +773,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "image"
@@ -505,7 +907,7 @@ dependencies = [
  "itertools",
  "nalgebra",
  "num",
- "rand",
+ "rand 0.8.6",
  "rand_distr",
 ]
 
@@ -540,6 +942,12 @@ checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -634,6 +1042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +1063,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +1076,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrixmultiply"
@@ -672,6 +1098,28 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -718,6 +1166,16 @@ dependencies = [
  "num-traits",
  "simba",
  "typenum",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -887,6 +1345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1367,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -940,6 +1413,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1475,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -961,8 +1495,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -972,7 +1516,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -985,13 +1539,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1050,6 +1613,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1681,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1148,6 +1804,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,10 +1906,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1241,6 +1932,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1286,6 +1997,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,11 +2050,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1375,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +2184,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1409,6 +2214,30 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1466,6 +2295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +2338,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1566,6 +2414,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1648,11 +2525,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1666,20 +2552,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1689,9 +2597,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1701,9 +2621,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1713,15 +2645,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1824,6 +2774,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2816,66 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/ccteam-core",
     "crates/ccteam-cli",
     "crates/ccteam-hooks",
+    "crates/ccteam-web",
 ]
 
 [workspace.package]
@@ -15,6 +16,7 @@ license = "MIT"
 [workspace.dependencies]
 ccteam-core = { path = "crates/ccteam-core" }
 ccteam-hooks = { path = "crates/ccteam-hooks" }
+ccteam-web = { path = "crates/ccteam-web" }
 
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
@@ -28,6 +30,17 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
+
+# V0.3 M5.0 — web UI (axum + askama). Pinned per `docs/v0-3/prd.md`
+# §3.2.2; minor bumps in M5.x must update the table there.
+axum = "0.8"
+askama = "0.12"
+# Constant-time token comparison for M5.3 token auth. Pulled in at
+# M5.0 so `ServeOpts::token_file` can carry the knob without dep
+# manifest churn when the auth middleware actually lands.
+subtle = "2.5"
+# HTTP client used by ccteam-web integration tests (lib + subprocess).
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 
 [profile.release]
 lto = true

--- a/crates/ccteam-cli/Cargo.toml
+++ b/crates/ccteam-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 ccteam-core.workspace = true
 ccteam-hooks.workspace = true
+ccteam-web.workspace = true
 clap.workspace = true
 chrono.workspace = true
 dirs.workspace = true

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -17,10 +17,15 @@ use ccteam_core::{
     write_global_helper_templates, write_global_phase_templates, CcteamPaths,
     HookCmdRewriteAction, HookCmdRewriteReport, InstallSkillOptions, LegacySkillAction,
     LegacySkillReport, MetaBootstrapReport, MigrationReport, OutboxEventKind, OutboxMessage,
-    PhaseHistoryEntry, PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
+    PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
     SkillInstallAction, TeamSpec, ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES,
     PHASE_TEMPLATES,
 };
+// V0.3 M5.0: `run_resume` body lives in `ccteam_core::actions::resume`,
+// so `PhaseHistoryEntry` is now only referenced from the test module
+// (other consumers go through the actions::* path).
+#[cfg(test)]
+use ccteam_core::PhaseHistoryEntry;
 use ccteam_core::tmux::TmuxSession;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -601,35 +606,14 @@ pub fn run_progress(paths: &CcteamPaths, slug: &str, tail: bool) -> Result<()> {
 /// `"resumed"` entry (append-only — we don't mutate the prior
 /// escalated entry, so the escalation history stays auditable) so
 /// `is_terminal_state` lifts the flag.
+///
+/// V0.3 M5.0: body lives in `ccteam_core::actions::resume` so the
+/// V0.3 web layer (and the MCP wrapper) can call the same logic
+/// without depending on `ccteam-cli`. This thin wrapper preserves the
+/// public CLI surface; `ccteam resume <slug>` continues to dispatch
+/// through here.
 pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
-    let state_path = paths.project_state(slug);
-    let mut state = ProjectState::load(&state_path)
-        .with_context(|| format!("load state for {slug}"))?;
-    state.user_pause_pending = false;
-    state.user_attached = false;
-    state.phase_state = PhaseState::Idle;
-    state.last_user_interaction_at = Utc::now();
-    if matches!(
-        state.phase_history.last().map(|h| h.status.as_str()),
-        Some("escalated"),
-    ) {
-        state.phase_history.push(PhaseHistoryEntry {
-            phase: state.current_phase.clone(),
-            status: "resumed".into(),
-            duration_s: 0,
-            cost_usd: 0.0,
-        });
-    }
-    state.save(&state_path)?;
-
-    let esc = paths.project_ccteam_dir(slug).join("escalation.md");
-    if esc.exists() {
-        let archive = paths
-            .project_ccteam_dir(slug)
-            .join(format!("escalation.{}.md", state.context_reset_count));
-        let _ = std::fs::rename(&esc, &archive);
-    }
-    Ok(())
+    ccteam_core::actions::resume(paths, slug)
 }
 
 /// One row in the cross-project decisions queue (`ccteam decisions`).
@@ -2166,6 +2150,39 @@ fn render_watchdog_text(alerts: &[ccteam_core::WatchdogAlert], pushed: bool) -> 
         out.push_str("(also written to meta-agent outbox)\n");
     }
     out
+}
+
+/// V0.3 M5.0: knobs forwarded by `ccteam web` clap struct → axum
+/// scaffold. Mirrors `ccteam_web::ServeOpts` 1:1 except `bind` is
+/// still a string here (parsed in `run_web`).
+#[derive(Debug, Clone)]
+pub struct WebOptions {
+    pub bind: String,
+    pub no_auth: bool,
+    pub token_file: Option<std::path::PathBuf>,
+}
+
+/// `ccteam web --bind <addr>` entry. Translates clap-side string +
+/// flags into `ccteam_web::ServeOpts`, then drives a current-thread
+/// tokio runtime to `serve(opts)` (mirrors the `mcp-serve` shape so a
+/// future operator running both side-by-side sees the same harness).
+pub fn run_web(opts: WebOptions) -> Result<()> {
+    use std::net::SocketAddr;
+
+    let bind: SocketAddr = opts
+        .bind
+        .parse()
+        .with_context(|| format!("parse --bind `{}` as SocketAddr", opts.bind))?;
+    let serve_opts = ccteam_web::ServeOpts {
+        bind,
+        no_auth: opts.no_auth,
+        token_file: opts.token_file,
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build tokio runtime for ccteam web")?;
+    runtime.block_on(ccteam_web::serve(serve_opts))
 }
 
 #[cfg(test)]

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -239,6 +239,27 @@ enum Command {
         #[command(subcommand)]
         cmd: TeamCommand,
     },
+    /// V0.3 M5.0: serve the ccteam web UI (read + restricted-write,
+    /// `docs/v0-3/prd.md` §3-§6). M5.0 ships the scaffold + `/health`
+    /// endpoint only; dashboard / SSE / write actions land in M5.1-3.
+    Web {
+        /// Listen address. Default `127.0.0.1:7331` — auth is disabled
+        /// when bound to loopback. Bind to `0.0.0.0:<port>` for LAN
+        /// reach (M5.3 requires token auth on non-loopback unless
+        /// `--no-auth`).
+        #[arg(long, default_value = "127.0.0.1:7331")]
+        bind: String,
+        /// Disable token auth on write endpoints. DANGEROUS on
+        /// non-loopback bind — M5.3 prints a 5-second warning before
+        /// listening.
+        #[arg(long, default_value_t = false)]
+        no_auth: bool,
+        /// Custom path to read the auth token from (default
+        /// `~/.ccteam/web-token`). M5.3 consumes this; M5.0 records
+        /// it on `ServeOpts` for shape stability.
+        #[arg(long, value_name = "PATH")]
+        token_file: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -419,6 +440,18 @@ fn main() -> Result<()> {
         Command::Phase { cmd } => run_phase(cmd),
         Command::Watchdog { cmd } => run_watchdog(cmd),
         Command::Team { cmd } => run_team(cmd),
+        Command::Web {
+            bind,
+            no_auth,
+            token_file,
+        } => {
+            init_tracing();
+            commands::run_web(commands::WebOptions {
+                bind,
+                no_auth,
+                token_file,
+            })
+        }
     }
 }
 

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -25,18 +25,23 @@
 use std::io::Write;
 
 use anyhow::{anyhow, Context, Result};
-use chrono::Utc;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
+// V0.3 M5.0 (F45 promote): write-helper logic lives in
+// `ccteam_core::actions`; the wrappers below stay thin (args parse +
+// JSON encode + delegate). Web-side consumers (`crates/ccteam-web`)
+// pick up the same import line in M5.3 (`docs/v0-3/dev-plan.md` §5
+// #4.3) — at which point `git grep -nE 'use ccteam_core::actions'`
+// returns ≥ 2 hits.
+use ccteam_core::actions;
 use ccteam_core::{
-    bootstrap_project, check_daemon_health, inbox_filename, pick_unused_slug,
-    render_screenshot, CcteamPaths, DaemonHealth, InboxFrontMatter, InboxMessage,
-    ProjectState, SessionMailbox,
+    bootstrap_project, check_daemon_health, pick_unused_slug,
+    render_screenshot, CcteamPaths, DaemonHealth, SendOptions,
 };
 
 use crate::commands::{
-    collect_projects, collect_recent_events, run_resume, run_show, OutputFormat,
+    collect_projects, collect_recent_events, run_show, OutputFormat,
 };
 
 /// Stable MCP protocol version this server speaks. Newer client versions
@@ -431,12 +436,7 @@ fn tool_new(paths: &CcteamPaths, args: &Value) -> Result<String> {
 
 fn tool_pause(paths: &CcteamPaths, args: &Value) -> Result<String> {
     let slug = arg_string(args, "slug")?;
-    let state_path = paths.project_state(&slug);
-    let mut state = ProjectState::load(&state_path)
-        .with_context(|| format!("load state for {slug}"))?;
-    state.user_pause_pending = true;
-    state.last_user_interaction_at = Utc::now();
-    state.save(&state_path)?;
+    actions::pause(paths, &slug)?;
     Ok(serde_json::to_string_pretty(&json!({
         "ok": true,
         "slug": slug,
@@ -446,7 +446,7 @@ fn tool_pause(paths: &CcteamPaths, args: &Value) -> Result<String> {
 
 fn tool_resume(paths: &CcteamPaths, args: &Value) -> Result<String> {
     let slug = arg_string(args, "slug")?;
-    run_resume(paths, &slug)?;
+    actions::resume(paths, &slug)?;
     Ok(serde_json::to_string_pretty(&json!({
         "ok": true,
         "slug": slug,
@@ -461,39 +461,18 @@ fn tool_send_to_session(paths: &CcteamPaths, args: &Value) -> Result<String> {
         .and_then(|v| v.as_str())
         .unwrap_or("text")
         .to_string();
-    let project_dir = paths.project_dir(&session);
-    if !project_dir.exists() {
-        return Err(anyhow!(
-            "no project / session named `{}` (looked under {})",
-            session,
-            project_dir.display(),
-        ));
-    }
-    let ccteam_dir = paths.project_ccteam_dir(&session);
-    let mailbox = SessionMailbox::for_ccteam_dir(&ccteam_dir);
-    mailbox.ensure_dirs()?;
-    let now = Utc::now();
-    let filename = inbox_filename(now, next_inbox_seq(&mailbox)?);
-    let inbox_path = mailbox.inbox.join(&filename);
-    let msg = InboxMessage {
-        front: InboxFrontMatter {
-            schema_version: ccteam_core::LATEST_SCHEMA_VERSION,
-            source: "ccteam-mcp".into(),
-            source_chat_id: None,
-            source_msg_id: None,
-            source_user: "mcp".into(),
-            created_at: now,
-            ingested_at: now,
-            content_type,
-            attachments: Vec::new(),
-        },
-        body: format!("{body}\n"),
+    // Wrapper keeps `source = "ccteam-mcp"` for backward compat with
+    // retro / silence-classifier consumers that grep on `source`.
+    let opts = SendOptions {
+        source: "ccteam-mcp".into(),
+        source_user: "mcp".into(),
+        content_type,
     };
-    msg.save(&inbox_path)?;
+    let result = actions::send_to_session_with(paths, &session, &body, &opts)?;
     Ok(serde_json::to_string_pretty(&json!({
         "ok": true,
         "session": session,
-        "inbox_file": filename,
+        "inbox_file": result.inbox_file,
     }))?)
 }
 
@@ -585,30 +564,6 @@ fn arg_string(args: &Value, name: &str) -> Result<String> {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .ok_or_else(|| anyhow!("missing required argument `{name}`"))
-}
-
-/// Compute the next 1-based sequence number for inbox writes within
-/// the same wall-clock second. Scans existing files in the inbox dir
-/// and picks `max + 1`. Tolerates a corrupted dir by defaulting to 1.
-fn next_inbox_seq(mailbox: &SessionMailbox) -> Result<u32> {
-    let entries = mailbox.list_inbox()?;
-    let mut max = 0u32;
-    for path in entries {
-        if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
-            // Filename: msg-<ts>-<NNN>.md
-            if let Some(seq) = name
-                .strip_prefix("msg-")
-                .and_then(|rest| rest.rsplit_once('-'))
-                .map(|(_, last)| last.trim_end_matches(".md"))
-                .and_then(|n| n.parse::<u32>().ok())
-            {
-                if seq > max {
-                    max = seq;
-                }
-            }
-        }
-    }
-    Ok(max + 1)
 }
 
 fn json_rpc_error(id: Option<Value>, code: i32, message: &str) -> Value {
@@ -789,39 +744,9 @@ mod tests {
         assert_eq!(v["mcpServers"]["ccteam"]["command"], "/x/ccteam");
     }
 
-    #[test]
-    fn next_inbox_seq_starts_at_one_for_empty_dir() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
-        mb.ensure_dirs().unwrap();
-        assert_eq!(next_inbox_seq(&mb).unwrap(), 1);
-    }
-
-    #[test]
-    fn next_inbox_seq_is_one_more_than_max_existing() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
-        mb.ensure_dirs().unwrap();
-        // Stage three real msg files so list_inbox sees them.
-        for seq in [1u32, 2, 5] {
-            let name = inbox_filename(Utc::now(), seq);
-            let path = mb.inbox.join(&name);
-            std::fs::write(
-                &path,
-                concat!(
-                    "---\nschema_version: 1\nsource: cli\nsource_user: rob\n",
-                    "created_at: 2026-05-06T10:30:00Z\n",
-                    "ingested_at: 2026-05-06T10:30:00Z\n",
-                    "content_type: text\n---\n\nx\n",
-                ),
-            )
-            .unwrap();
-            // tweak time so each filename differs even for fast tests
-            let _ = seq;
-        }
-        let next = next_inbox_seq(&mb).unwrap();
-        assert!(next >= 6, "next must be > existing max 5, got {next}");
-    }
+    // V0.3 M5.0: `next_inbox_seq` body lives in
+    // `ccteam_core::actions::next_inbox_seq`; coverage moved with it
+    // (see `crates/ccteam-core/src/actions.rs` test module).
 
     #[test]
     fn json_rpc_error_includes_id_and_envelope() {

--- a/crates/ccteam-cli/tests/web_subcommand_test.rs
+++ b/crates/ccteam-cli/tests/web_subcommand_test.rs
@@ -1,0 +1,156 @@
+//! V0.3 M5.0 — `ccteam web` subcommand integration test.
+//!
+//! Confirms the CLI surface end-to-end:
+//!
+//! 1. `ccteam web --help` advertises the three flags (bind / no-auth /
+//!    token-file) so a typo doesn't silently drop one.
+//! 2. `ccteam web --bind 127.0.0.1:0 --no-auth` spawns, prints the
+//!    bound address on stdout, serves `GET /health` 200 + JSON, and
+//!    can be terminated by `child.kill()`.
+//!
+//! The lib-level `serve` round-trip (in-process axum + reqwest) is
+//! covered in `crates/ccteam-web/src/lib.rs` tests; this file
+//! exercises the `ccteam web …` subprocess entry so a regression in
+//! the clap → ServeOpts → serve plumbing surfaces here.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[test]
+fn ccteam_web_help_advertises_flags() {
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let out = Command::new(bin)
+        .args(["web", "--help"])
+        .output()
+        .expect("spawn ccteam web --help");
+    assert!(out.status.success(), "ccteam web --help should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for flag in ["--bind", "--no-auth", "--token-file"] {
+        assert!(
+            stdout.contains(flag),
+            "ccteam web --help should mention {flag}; got: {stdout}",
+        );
+    }
+}
+
+#[test]
+fn ccteam_web_serves_health_then_exits_when_killed() {
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let mut child = Command::new(bin)
+        .args(["web", "--bind", "127.0.0.1:0", "--no-auth"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ccteam web");
+
+    let stdout = child.stdout.take().expect("child stdout");
+    let mut reader = BufReader::new(stdout);
+
+    // Server prints `ccteam web listening on http://<addr>` as its
+    // first stdout line. Read with a deadline so a regression in the
+    // bind announcement doesn't hang the test forever.
+    let mut bind_line = String::new();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        bind_line.clear();
+        match reader.read_line(&mut bind_line) {
+            Ok(0) => break,
+            Ok(_) if bind_line.contains("listening on http://") => break,
+            Ok(_) => continue,
+            Err(err) => {
+                let _ = child.kill();
+                panic!("read stdout: {err}");
+            }
+        }
+    }
+    if !bind_line.contains("listening on http://") {
+        let _ = child.kill();
+        panic!("server must announce bind address on stdout; got: {bind_line:?}");
+    }
+    let addr = bind_line
+        .split("http://")
+        .nth(1)
+        .expect("bind line missing http://")
+        .trim()
+        .to_string();
+    assert!(!addr.is_empty(), "bind addr empty");
+
+    // GET /health — block until 200 or deadline.
+    let url = format!("http://{addr}/health");
+    let body = match stdlib_http_get(&url, Duration::from_secs(5)) {
+        Ok(b) => b,
+        Err(err) => {
+            let _ = child.kill();
+            panic!("GET {url} failed: {err}");
+        }
+    };
+    assert!(
+        body.contains("\"status\""),
+        "/health body should contain status field; got: {body}",
+    );
+    assert!(
+        body.contains("\"ok\""),
+        "/health body should contain status=ok; got: {body}",
+    );
+
+    // Kill the child (SIGKILL on Unix). Clean SIGTERM-driven shutdown
+    // is exercised at the lib level via the in-process axum test in
+    // `ccteam-web`; here we only need to confirm the subprocess
+    // shape is sane (no orphan, no hang).
+    let _ = child.kill();
+    let exit_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => break,
+            Ok(None) if Instant::now() < exit_deadline => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) => panic!("ccteam web did not exit within 10s of kill"),
+            Err(err) => panic!("try_wait: {err}"),
+        }
+    }
+}
+
+/// Minimal HTTP GET — pure stdlib + sockets to avoid a new dev-dep.
+/// Returns the response body or an error string. Retries once per
+/// 100ms until `deadline`.
+fn stdlib_http_get(url: &str, deadline: Duration) -> Result<String, String> {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+
+    let start = Instant::now();
+    let host_path = url
+        .strip_prefix("http://")
+        .ok_or_else(|| format!("only http:// supported; got: {url}"))?;
+    let (host, path) = host_path.split_once('/').unwrap_or((host_path, ""));
+    let path = format!("/{path}");
+
+    loop {
+        match TcpStream::connect(host) {
+            Ok(mut stream) => {
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(2)))
+                    .map_err(|e| e.to_string())?;
+                let req =
+                    format!("GET {path} HTTP/1.0\r\nHost: {host}\r\nConnection: close\r\n\r\n",);
+                stream
+                    .write_all(req.as_bytes())
+                    .map_err(|e| e.to_string())?;
+                let mut buf = String::new();
+                stream.read_to_string(&mut buf).map_err(|e| e.to_string())?;
+                let body = buf
+                    .split_once("\r\n\r\n")
+                    .map(|(_, b)| b.to_string())
+                    .unwrap_or(buf);
+                return Ok(body);
+            }
+            Err(_) if start.elapsed() < deadline => {
+                thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(err) => return Err(format!("connect {host}: {err}")),
+        }
+    }
+}

--- a/crates/ccteam-core/src/actions.rs
+++ b/crates/ccteam-core/src/actions.rs
@@ -1,0 +1,488 @@
+//! V0.3 M5.0 — write-action helpers shared by every channel layer.
+//!
+//! Promoted from `ccteam-cli/src/mcp_serve.rs` (where they lived as
+//! private fns) so that:
+//!
+//! - the V0.3 web UI crate (`ccteam-web`) can call them without
+//!   depending on `ccteam-cli` (binary-as-library is a dep-graph
+//!   anti-pattern; sibling crates `ccteam-cli` / `ccteam-web` should
+//!   both fan in to `ccteam-core`).
+//! - the existing MCP `tool_send_to_session` / `tool_inject_decision`
+//!   wrappers stay thin (args parse + JSON encode + delegate).
+//! - `commands::run_resume` keeps its public surface stable but its
+//!   body now lives here, callable from any crate.
+//!
+//! These helpers are **policy-free**:
+//!
+//! - they do **not** check daemon health (caller chooses gating; MCP
+//!   wraps in `require_healthy_daemon`, web layer will do its own
+//!   policy in M5.3 once token auth lands).
+//! - they do **not** parse tmux output or kill sessions (architecture
+//!   red lines, CLAUDE.md §三).
+//! - they only touch the filesystem control plane (inbox files +
+//!   `state.json` mutations) so the orchestrator's existing inotify +
+//!   send-keys delivery picks the change up unchanged.
+//!
+//! Architecture refs: `docs/v0-3/prd.md` §3.2.3,
+//! `docs/dev-coupling-audit.md` F45,
+//! `docs/tech-design.md` §6.4 channel layer.
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+
+use crate::inbox::{
+    inbox_filename, InboxFrontMatter, InboxMessage, SessionMailbox, LATEST_SCHEMA_VERSION,
+};
+use crate::paths::CcteamPaths;
+use crate::state::{PhaseHistoryEntry, PhaseState, ProjectState};
+
+/// Source label every action helper stamps onto inbox front matter.
+///
+/// Channel-specific wrappers (the MCP tool, the web layer, telegram
+/// channel, …) are free to override this via [`SendOptions::source`]
+/// when their distinctness matters for downstream silence-classifier /
+/// retro accounting. The default keeps existing MCP behavior backward
+/// compatible (`source = "ccteam-mcp"` was the historical literal).
+pub const DEFAULT_SOURCE: &str = "ccteam-core";
+
+/// Default `source_user` label for server-originated injections.
+pub const DEFAULT_SOURCE_USER: &str = "ccteam";
+
+/// Optional knobs for [`send_to_session`]. Defaults match the legacy
+/// MCP `tool_send_to_session` behavior so wrapper transparency holds.
+#[derive(Debug, Clone)]
+pub struct SendOptions {
+    /// Front-matter `source`. Default `ccteam-core`.
+    pub source: String,
+    /// Front-matter `source_user`. Default `ccteam`.
+    pub source_user: String,
+    /// Front-matter `content_type`. Default `text`.
+    pub content_type: String,
+}
+
+impl Default for SendOptions {
+    fn default() -> Self {
+        Self {
+            source: DEFAULT_SOURCE.into(),
+            source_user: DEFAULT_SOURCE_USER.into(),
+            content_type: "text".into(),
+        }
+    }
+}
+
+/// Result of [`send_to_session`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendResult {
+    /// Project / meta-session slug that received the message.
+    pub slug: String,
+    /// Filename written under `<project>/.ccteam/inbox/`.
+    pub inbox_file: String,
+    /// Absolute path to the inbox file.
+    pub inbox_path: PathBuf,
+}
+
+/// Atomically write a free-form NL/markdown message into a session's
+/// `.ccteam/inbox/`. The orchestrator's next inotify wake delivers it
+/// via tmux send-keys (idle-aware).
+///
+/// Returns the inbox filename + absolute path of the file written.
+///
+/// # Errors
+///
+/// - `slug` does not resolve to a project directory under
+///   `paths.projects_root`.
+/// - inbox dir cannot be created or the write fails.
+pub fn send_to_session(paths: &CcteamPaths, slug: &str, body: &str) -> Result<SendResult> {
+    send_to_session_with(paths, slug, body, &SendOptions::default())
+}
+
+/// [`send_to_session`] with channel-specific front-matter overrides.
+///
+/// Used by the MCP wrapper to keep `source = "ccteam-mcp"` for backward
+/// compat with retro / silence-classifier consumers that grep on
+/// `source`.
+pub fn send_to_session_with(
+    paths: &CcteamPaths,
+    slug: &str,
+    body: &str,
+    opts: &SendOptions,
+) -> Result<SendResult> {
+    let project_dir = paths.project_dir(slug);
+    if !project_dir.exists() {
+        return Err(anyhow!(
+            "no project / session named `{}` (looked under {})",
+            slug,
+            project_dir.display(),
+        ));
+    }
+    let ccteam_dir = paths.project_ccteam_dir(slug);
+    let mailbox = SessionMailbox::for_ccteam_dir(&ccteam_dir);
+    mailbox.ensure_dirs()?;
+    let now = Utc::now();
+    let filename = inbox_filename(now, next_inbox_seq(&mailbox)?);
+    let inbox_path = mailbox.inbox.join(&filename);
+    let msg = InboxMessage {
+        front: InboxFrontMatter {
+            schema_version: LATEST_SCHEMA_VERSION,
+            source: opts.source.clone(),
+            source_chat_id: None,
+            source_msg_id: None,
+            source_user: opts.source_user.clone(),
+            created_at: now,
+            ingested_at: now,
+            content_type: opts.content_type.clone(),
+            attachments: Vec::new(),
+        },
+        body: format!("{}\n", body.trim_end_matches('\n')),
+    };
+    msg.save(&inbox_path)?;
+    Ok(SendResult {
+        slug: slug.to_string(),
+        inbox_file: filename,
+        inbox_path,
+    })
+}
+
+/// Parameters for [`inject_decision`] — a path-aware primitive.
+///
+/// `path` is the absolute file path to write; `body` is the raw
+/// message content (no front-matter wrapping is performed — callers
+/// that want the full inbox shape should use [`send_to_session`]
+/// instead).
+///
+/// The shape is deliberately primitive so the V0.3 web layer (M5.3)
+/// can hand the user a free-form decision file without going through
+/// the inbox path-naming convention. The MCP wrapper still goes
+/// through the inbox path because the MCP tool exposes the
+/// `escalate_kind` enum, which the wrapper translates into a
+/// structured body before calling [`inject_decision`].
+#[derive(Debug, Clone)]
+pub struct DecisionInput {
+    /// Absolute path to write the decision file at.
+    pub path: PathBuf,
+    /// File body (channel-specific shape; e.g. inbox front-matter
+    /// markdown, plain markdown, etc.).
+    pub body: String,
+}
+
+/// Atomically write a decision file at the requested path.
+///
+/// Creates parent directories as needed. Uses `<path>.tmp` + rename
+/// for atomicity (consistent with `InboxMessage::save`).
+pub fn inject_decision(_paths: &CcteamPaths, _slug: &str, decision: DecisionInput) -> Result<()> {
+    if let Some(parent) = decision.path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let tmp = decision.path.with_extension({
+        let mut ext = decision
+            .path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_string();
+        ext.push_str(".tmp");
+        ext
+    });
+    std::fs::write(&tmp, decision.body.as_bytes())
+        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &decision.path)
+        .with_context(|| format!("rename {} → {}", tmp.display(), decision.path.display()))?;
+    Ok(())
+}
+
+/// Pause auto-dispatch for one project. Sets `user_pause_pending=true`
+/// and bumps `last_user_interaction_at`. Does **not** kill the tmux
+/// session (CLAUDE.md §三 red line).
+///
+/// Idempotent — pausing an already-paused project is a no-op state
+/// rewrite (the timestamp updates, which is the desired effect for
+/// fresh-attention accounting).
+pub fn pause(paths: &CcteamPaths, slug: &str) -> Result<()> {
+    let state_path = paths.project_state(slug);
+    let mut state =
+        ProjectState::load(&state_path).with_context(|| format!("load state for {slug}"))?;
+    state.user_pause_pending = true;
+    state.last_user_interaction_at = Utc::now();
+    state.save(&state_path)?;
+    Ok(())
+}
+
+/// Resume a paused / escalated project.
+///
+/// Clears `user_pause_pending`, lifts `user_attached`, re-arms
+/// `phase_state=Idle` so the daemon's next tick re-dispatches the
+/// current phase. Appends a `"resumed"` `PhaseHistoryEntry` when the
+/// last entry is `"escalated"` (append-only — the prior escalated
+/// entry stays auditable). Archives any sibling `escalation.md` to
+/// `escalation.<context_reset_count>.md` so future ESCALATE writes
+/// don't collide.
+pub fn resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
+    let state_path = paths.project_state(slug);
+    let mut state =
+        ProjectState::load(&state_path).with_context(|| format!("load state for {slug}"))?;
+    state.user_pause_pending = false;
+    state.user_attached = false;
+    state.phase_state = PhaseState::Idle;
+    state.last_user_interaction_at = Utc::now();
+    if matches!(
+        state.phase_history.last().map(|h| h.status.as_str()),
+        Some("escalated"),
+    ) {
+        state.phase_history.push(PhaseHistoryEntry {
+            phase: state.current_phase.clone(),
+            status: "resumed".into(),
+            duration_s: 0,
+            cost_usd: 0.0,
+        });
+    }
+    state.save(&state_path)?;
+
+    let esc = paths.project_ccteam_dir(slug).join("escalation.md");
+    if esc.exists() {
+        let archive = paths
+            .project_ccteam_dir(slug)
+            .join(format!("escalation.{}.md", state.context_reset_count));
+        let _ = std::fs::rename(&esc, &archive);
+    }
+    Ok(())
+}
+
+/// Compute the next 1-based sequence number for inbox writes within
+/// the same wall-clock second. Scans existing files in the inbox dir
+/// and picks `max + 1`. Tolerates a corrupted dir by defaulting to 1.
+///
+/// Promoted from `ccteam-cli/src/mcp_serve.rs` along with
+/// [`send_to_session`] — both the MCP wrapper and any future channel
+/// (web, telegram) building inbox files need it.
+pub fn next_inbox_seq(mailbox: &SessionMailbox) -> Result<u32> {
+    let entries = mailbox.list_inbox()?;
+    let mut max = 0u32;
+    for path in entries {
+        if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+            // Filename: msg-<ts>-<NNN>.md
+            if let Some(seq) = name
+                .strip_prefix("msg-")
+                .and_then(|rest| rest.rsplit_once('-'))
+                .map(|(_, last)| last.trim_end_matches(".md"))
+                .and_then(|n| n.parse::<u32>().ok())
+            {
+                if seq > max {
+                    max = seq;
+                }
+            }
+        }
+    }
+    Ok(max + 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::projects::bootstrap_project;
+    use crate::tool_surface::disable_tool_surface_bootstrap_for_tests;
+
+    fn isolated_paths() -> (tempfile::TempDir, CcteamPaths) {
+        disable_tool_surface_bootstrap_for_tests();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join("home"),
+            projects_root: tmp.path().join("projects"),
+        };
+        (tmp, paths)
+    }
+
+    #[test]
+    fn send_to_session_writes_one_inbox_file_with_front_matter_and_body() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+
+        let result = send_to_session(&paths, "demo", "hello from actions").unwrap();
+
+        assert_eq!(result.slug, "demo");
+        assert!(result.inbox_file.starts_with("msg-"));
+        assert!(result.inbox_path.exists());
+
+        let body = std::fs::read_to_string(&result.inbox_path).unwrap();
+        // Front matter envelope intact.
+        assert!(body.starts_with("---\n"));
+        assert!(body.contains("schema_version: 1"));
+        assert!(body.contains("content_type: text"));
+        // Body restored with single trailing newline.
+        assert!(body.contains("hello from actions\n"));
+
+        // Round-trip parse so the YAML schema is enforced.
+        let parsed = InboxMessage::load(&result.inbox_path).unwrap();
+        assert_eq!(parsed.front.schema_version, LATEST_SCHEMA_VERSION);
+        assert_eq!(parsed.front.content_type, "text");
+        assert!(parsed.body.contains("hello from actions"));
+    }
+
+    #[test]
+    fn send_to_session_errors_when_slug_does_not_exist() {
+        let (_tmp, paths) = isolated_paths();
+        let err = send_to_session(&paths, "no-such-slug", "ignored").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("no project"), "got: {msg}");
+    }
+
+    #[test]
+    fn send_to_session_with_overrides_source_and_source_user() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+
+        let opts = SendOptions {
+            source: "ccteam-mcp".into(),
+            source_user: "mcp".into(),
+            content_type: "markdown".into(),
+        };
+        let result = send_to_session_with(&paths, "demo", "body", &opts).unwrap();
+        let parsed = InboxMessage::load(&result.inbox_path).unwrap();
+        assert_eq!(parsed.front.source, "ccteam-mcp");
+        assert_eq!(parsed.front.source_user, "mcp");
+        assert_eq!(parsed.front.content_type, "markdown");
+    }
+
+    #[test]
+    fn send_to_session_increments_seq_within_same_second() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+
+        let r1 = send_to_session(&paths, "demo", "first").unwrap();
+        let r2 = send_to_session(&paths, "demo", "second").unwrap();
+        assert_ne!(r1.inbox_file, r2.inbox_file);
+        // Ordered: r2 > r1 (lexicographic == chronological by design).
+        assert!(r2.inbox_file > r1.inbox_file);
+    }
+
+    #[test]
+    fn inject_decision_writes_body_atomically_at_path() {
+        let (tmp, paths) = isolated_paths();
+        let target = tmp.path().join("inject").join("decision.md");
+        let decision = DecisionInput {
+            path: target.clone(),
+            body: "**META-AGENT DECISION**: ship it.\n".into(),
+        };
+        inject_decision(&paths, "ignored", decision).unwrap();
+        assert!(target.exists());
+        let body = std::fs::read_to_string(&target).unwrap();
+        assert_eq!(body, "**META-AGENT DECISION**: ship it.\n");
+        // `.tmp` sibling must be cleaned up (rename completed).
+        let mut entries: Vec<String> = std::fs::read_dir(target.parent().unwrap())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        entries.sort();
+        assert_eq!(entries, vec!["decision.md".to_string()]);
+    }
+
+    #[test]
+    fn inject_decision_creates_missing_parent_dirs() {
+        let (tmp, paths) = isolated_paths();
+        let target = tmp.path().join("a").join("b").join("c").join("d.md");
+        inject_decision(
+            &paths,
+            "ignored",
+            DecisionInput {
+                path: target.clone(),
+                body: "deep".into(),
+            },
+        )
+        .unwrap();
+        assert!(target.exists());
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "deep");
+    }
+
+    #[test]
+    fn pause_sets_user_pause_pending_and_bumps_interaction_ts() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let state_path = paths.project_state("demo");
+        let before = ProjectState::load(&state_path).unwrap();
+        assert!(!before.user_pause_pending);
+
+        pause(&paths, "demo").unwrap();
+
+        let after = ProjectState::load(&state_path).unwrap();
+        assert!(after.user_pause_pending);
+        assert!(after.last_user_interaction_at >= before.last_user_interaction_at);
+    }
+
+    #[test]
+    fn resume_clears_pause_and_resets_phase_state_to_idle() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let state_path = paths.project_state("demo");
+
+        // Set up a paused + escalated state.
+        {
+            let mut s = ProjectState::load(&state_path).unwrap();
+            s.user_pause_pending = true;
+            s.user_attached = true;
+            s.phase_state = PhaseState::AutoLocked;
+            s.phase_history.push(PhaseHistoryEntry {
+                phase: s.current_phase.clone(),
+                status: "escalated".into(),
+                duration_s: 0,
+                cost_usd: 0.0,
+            });
+            s.save(&state_path).unwrap();
+        }
+
+        resume(&paths, "demo").unwrap();
+
+        let after = ProjectState::load(&state_path).unwrap();
+        assert!(!after.user_pause_pending);
+        assert!(!after.user_attached);
+        assert_eq!(after.phase_state, PhaseState::Idle);
+        // Append-only history: escalated entry survives + a "resumed"
+        // entry is appended.
+        let last_two: Vec<&str> = after
+            .phase_history
+            .iter()
+            .rev()
+            .take(2)
+            .map(|h| h.status.as_str())
+            .collect();
+        assert_eq!(last_two, vec!["resumed", "escalated"]);
+    }
+
+    #[test]
+    fn resume_archives_escalation_md_when_present() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let esc = paths.project_ccteam_dir("demo").join("escalation.md");
+        std::fs::write(&esc, "the reason").unwrap();
+        resume(&paths, "demo").unwrap();
+        assert!(!esc.exists(), "escalation.md must be archived");
+        // Archived sibling exists (suffix tied to context_reset_count).
+        let entries: Vec<String> = std::fs::read_dir(paths.project_ccteam_dir("demo"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| n.starts_with("escalation.") && n.ends_with(".md"))
+            .collect();
+        assert_eq!(entries.len(), 1, "expected exactly one archived escalation");
+    }
+
+    #[test]
+    fn resume_does_not_append_resumed_when_no_escalated_entry() {
+        let (_tmp, paths) = isolated_paths();
+        bootstrap_project(&paths, "demo", "demo request", "dev").unwrap();
+        let state_path = paths.project_state("demo");
+        let before = ProjectState::load(&state_path).unwrap();
+        let history_len = before.phase_history.len();
+        resume(&paths, "demo").unwrap();
+        let after = ProjectState::load(&state_path).unwrap();
+        assert_eq!(after.phase_history.len(), history_len);
+    }
+
+    #[test]
+    fn next_inbox_seq_starts_at_one_for_empty_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mb = SessionMailbox::for_ccteam_dir(tmp.path());
+        mb.ensure_dirs().unwrap();
+        assert_eq!(next_inbox_seq(&mb).unwrap(), 1);
+    }
+}

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! `ccteam-hooks` (hook handlers invoked via `ccteam hook ...`).
 
 
+pub mod actions;
 pub mod cost;
 pub mod daemon;
 pub mod dag;
@@ -32,6 +33,10 @@ pub mod tmux;
 pub mod tool_surface;
 pub mod watchdog;
 
+pub use actions::{
+    inject_decision, next_inbox_seq, pause, resume, send_to_session, send_to_session_with,
+    DecisionInput, SendOptions, SendResult,
+};
 pub use dag::{dev_dag, Dag};
 pub use auto_loop::{AutoLoopDecision, AutoLoopFrontMatter, AutoLoopState};
 pub use golden_rules::{

--- a/crates/ccteam-web/Cargo.toml
+++ b/crates/ccteam-web/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ccteam-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "ccteam V0.3 web UI: read-only dashboard + write-action endpoints (axum + askama)."
+
+[dependencies]
+ccteam-core.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+notify.workspace = true
+tracing.workspace = true
+
+# V0.3 M5.0 — pinned per docs/v0-3/prd.md §3.2.2.
+axum = { workspace = true }
+askama = { workspace = true }
+# Constant-time token comparison (M5.3 token auth). Pulled in now so
+# `ServeOpts` can carry the token-file knob without churning dep
+# manifests when M5.3 lands.
+subtle = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+reqwest = { workspace = true, features = ["json"] }

--- a/crates/ccteam-web/src/lib.rs
+++ b/crates/ccteam-web/src/lib.rs
@@ -1,0 +1,174 @@
+//! V0.3 M5.0 — `ccteam web` axum scaffold.
+//!
+//! Single entry point: [`serve`]. Wired up by `ccteam-cli` via
+//! `commands::run_web` so the binary stays a thin protocol adapter.
+//!
+//! M5.0 scope (see `docs/v0-3/prd.md` §3 + `docs/v0-3/dev-plan.md` §2):
+//!
+//! - bind axum router on `opts.bind`
+//! - install one route: `GET /health`
+//! - graceful shutdown on Ctrl-C / SIGTERM
+//! - print the actual bound `SocketAddr` to stdout so subprocess
+//!   harnesses can read the port assigned by `127.0.0.1:0`
+//!
+//! Dashboard / SSE / write actions / token auth land in M5.1 / M5.2 /
+//! M5.3. The [`ServeOpts`] shape is stable from M5.0 forward — M5.3
+//! consumes `no_auth` / `token_file` exactly as defined here.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use axum::Router;
+use tokio::net::TcpListener;
+
+pub mod routes;
+
+/// Knobs accepted by [`serve`]. Mirrors the `ccteam web` CLI flags
+/// 1:1 so the CLI translation in `ccteam-cli::commands::run_web`
+/// stays mechanical.
+#[derive(Debug, Clone)]
+pub struct ServeOpts {
+    /// Address to bind. `127.0.0.1:0` ⇒ pick a free port (used by
+    /// integration tests).
+    pub bind: SocketAddr,
+    /// Disable token auth on write endpoints. M5.3 will honor this;
+    /// M5.0 has no write endpoints so the flag is currently a
+    /// no-op record for ServeOpts shape stability.
+    pub no_auth: bool,
+    /// Custom path to read the auth token from. Default
+    /// (`None`) means `~/.ccteam/web-token`. M5.3 consumes this.
+    pub token_file: Option<PathBuf>,
+}
+
+/// Build the M5.0 router. Kept separate from [`serve`] so unit tests
+/// can mount it without binding a real port.
+pub fn router() -> Router {
+    Router::new().merge(routes::router())
+}
+
+/// Start the web server. Binds, prints the bound address one line
+/// to stdout (so subprocess harnesses can parse the port for the
+/// `0` placeholder case), then serves until Ctrl-C / SIGTERM.
+pub async fn serve(opts: ServeOpts) -> Result<()> {
+    let listener = TcpListener::bind(opts.bind)
+        .await
+        .with_context(|| format!("bind {} for ccteam web", opts.bind))?;
+    let local = listener
+        .local_addr()
+        .context("read local_addr after bind")?;
+
+    // Subprocess-friendly bind announcement. Format is stable:
+    // `ccteam web listening on http://<addr>`. The first line written
+    // to stdout, flushed before serving so test harnesses can read
+    // the port assigned to `:0`.
+    println!("ccteam web listening on http://{local}");
+    if opts.no_auth {
+        eprintln!("ccteam web: --no-auth is set (M5.3 will honor this on write endpoints).");
+    }
+    if let Some(token) = &opts.token_file {
+        eprintln!(
+            "ccteam web: --token-file {} (M5.3 will honor this on write endpoints).",
+            token.display(),
+        );
+    }
+    tracing::info!(addr = %local, "ccteam web bound");
+
+    let app = router();
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("axum serve loop terminated with error")?;
+    Ok(())
+}
+
+/// Wait for Ctrl-C OR SIGTERM (unix only). Mirrors the orchestrator
+/// daemon's `run_start` shutdown plumbing so behavior is consistent.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let ctrl_c = async {
+            tokio::signal::ctrl_c().await.ok();
+        };
+        let sigterm = async {
+            match signal(SignalKind::terminate()) {
+                Ok(mut s) => {
+                    s.recv().await;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "could not install SIGTERM handler; falling back to ctrl_c only"
+                    );
+                    // Sleep forever — the ctrl_c arm will still fire.
+                    std::future::pending::<()>().await;
+                }
+            }
+        };
+        tokio::select! {
+            _ = ctrl_c => tracing::info!("ccteam web: ctrl_c received"),
+            _ = sigterm => tracing::info!("ccteam web: SIGTERM received"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+        tracing::info!("ccteam web: ctrl_c received");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[tokio::test]
+    async fn serve_health_endpoint_returns_ok_json() {
+        let listener =
+            TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0))
+                .await
+                .unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = router();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Give the listener task a tick to begin polling.
+        tokio::task::yield_now().await;
+
+        let url = format!("http://{addr}/health");
+        let resp = reqwest::get(&url).await.expect("GET /health");
+        assert_eq!(resp.status(), 200);
+        let json: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(json["status"], "ok");
+        // Version is stamped from CARGO_PKG_VERSION at build time.
+        assert!(
+            json["version"]
+                .as_str()
+                .unwrap_or("")
+                .chars()
+                .next()
+                .is_some(),
+            "version must be a non-empty string",
+        );
+
+        server.abort();
+    }
+
+    #[test]
+    fn serve_opts_shape_is_stable() {
+        // M5.3 will read these three fields by name. If a future PR
+        // renames any of them, this test compiles-fails — a deliberate
+        // tripwire for M5.3 contract stability.
+        let opts = ServeOpts {
+            bind: "127.0.0.1:7331".parse().unwrap(),
+            no_auth: false,
+            token_file: None,
+        };
+        assert!(!opts.no_auth);
+        assert!(opts.token_file.is_none());
+        assert_eq!(opts.bind.port(), 7331);
+    }
+}

--- a/crates/ccteam-web/src/routes/health.rs
+++ b/crates/ccteam-web/src/routes/health.rs
@@ -1,0 +1,37 @@
+//! `GET /health` — liveness probe.
+//!
+//! Returns 200 + `{ "status": "ok", "version": "<crate>" }`. M5.0
+//! verification scripts (and the integration-test subprocess harness)
+//! rely on this endpoint to confirm the server is up before issuing
+//! further requests.
+
+use axum::{routing::get, Json, Router};
+use serde_json::{json, Value};
+
+/// Build the `GET /health` router.
+pub fn router() -> Router {
+    Router::new().route("/health", get(handle_health))
+}
+
+async fn handle_health() -> Json<Value> {
+    Json(json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn handle_health_body_shape() {
+        // Direct handler call — the in-process axum + reqwest path is
+        // exercised by `crate::tests::serve_health_endpoint_returns_ok_json`
+        // (lib.rs); here we just assert the body shape so a churn in
+        // the JSON contract is loud.
+        let Json(body) = handle_health().await;
+        assert_eq!(body["status"], "ok");
+        assert!(body["version"].as_str().is_some_and(|s| !s.is_empty()));
+    }
+}

--- a/crates/ccteam-web/src/routes/mod.rs
+++ b/crates/ccteam-web/src/routes/mod.rs
@@ -1,0 +1,15 @@
+//! Axum routers for the ccteam web layer.
+//!
+//! M5.0 ships only `/health`. M5.1 will mount `dashboard` / `project`
+//! / `assets`; M5.2 mounts `sse` + `screenshot`; M5.3 mounts
+//! `actions` + auth middleware.
+
+use axum::Router;
+
+pub mod health;
+
+/// Compose every M5.x sub-router available at the current ship state.
+/// Currently returns just the M5.0 health router.
+pub fn router() -> Router {
+    Router::new().merge(health::router())
+}

--- a/crates/ccteam-web/tests/dep_graph_test.rs
+++ b/crates/ccteam-web/tests/dep_graph_test.rs
@@ -1,0 +1,39 @@
+//! V0.3 M5.0 dep-graph red line: `ccteam-web` MUST NOT depend on
+//! `ccteam-cli` (binary-as-library is a dep-graph anti-pattern; the
+//! two crates are siblings — both fan in to `ccteam-core`).
+//!
+//! `docs/v0-3/prd.md` §3.2.3 + `docs/dev-coupling-audit.md` F45 lock
+//! the rule. This test runs `cargo tree -p ccteam-web` and asserts no
+//! `ccteam-cli` line appears anywhere in the output.
+//!
+//! If a future PR adds `ccteam-cli` to `ccteam-web`'s deps (directly
+//! or transitively via, say, sharing CLI helpers), this test fails
+//! loud — surfacing the coupling regression at PR-review time.
+
+use std::process::Command;
+
+#[test]
+fn ccteam_web_does_not_depend_on_ccteam_cli() {
+    // `cargo` is on PATH for tests (cargo invoked us). Use that — no
+    // need to root through CARGO_HOME.
+    let out = Command::new(env!("CARGO"))
+        .args(["tree", "-p", "ccteam-web", "--prefix=none"])
+        .output()
+        .expect("spawn cargo tree -p ccteam-web");
+    assert!(
+        out.status.success(),
+        "cargo tree failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for line in stdout.lines() {
+        // Match `ccteam-cli vX.Y.Z` exactly so a hypothetical future
+        // crate `ccteam-cli-something` wouldn't false-positive.
+        let head = line.split_whitespace().next().unwrap_or("");
+        assert_ne!(
+            head, "ccteam-cli",
+            "ccteam-web must not depend on ccteam-cli (tech-design red line); \
+             cargo tree output:\n{stdout}",
+        );
+    }
+}

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -32,7 +32,7 @@ P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候�
 **2026-05-09 V0.2.2 patch**:加 F34-F40 七条用户反馈 + 命名 sweep + UX 增强,跨 7 PR 全部修复;
 **2026-05-09 V0.2.2 e2e retro patch**:4-suite 并行 e2e 验证,撞 F41 (P1) + F42 (P1) + F43 (P2),同 PR 一波修;
 **2026-05-10 V0.2.2 F44 反向回滚**:`/usr/bin/cct` namespace 碰撞驱动整体反向 F39,F44 单 PR 覆盖;
-**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4),分布:
+**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4);**2026-05-10 V0.3 PR #1 ship**:F45 promote 部分修复(actions 模块 + mcp_serve wrapper 透传 + dep_graph 自检测试落地),仍待 M5.3 写动作 endpoint 消费才整体 close,分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
@@ -738,7 +738,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **优先级**:**P0**(silent-substitute footgun)。
 - **来源**:用户 2026-05-10 反馈 + 实证 `dpkg -S /usr/bin/cct` 命中 `proj-bin`。
 
-### F45 — write 动作 helper 锁在 ccteam-cli::mcp_serve 私有 fn,V0.3 web crate 无法复用(2026-05-10 加;**待修复:V0.3 M5.0 PR #1 promote + V0.3 M5.3 PR #4 close**)
+### F45 — write 动作 helper 锁在 ccteam-cli::mcp_serve 私有 fn,V0.3 web crate 无法复用(2026-05-10 加;**部分修复:2026-05-10(V0.3 PR #1 promote);剩余 close 在 V0.3 M5.3 PR #4 写动作 endpoint 落地**)
 
 - **文件:行号**:`crates/ccteam-cli/src/mcp_serve.rs::tool_send_to_session`(line 456,`fn` 非 `pub fn`)+ `tool_inject_decision`(line 500,同)+ pause / resume 在 mcp_serve 内 inline logic 无独立 fn。
 - **现状**:V0.2.2 ship 时,写动作 helper 全部位于 `ccteam-cli::mcp_serve.rs` 私有 fn,只供 MCP tool dispatch 内部消费;V0.3 web UI(新 crate `crates/ccteam-web`)需要复用同一逻辑写 inbox / control,但 `ccteam-web` 不能 depend on `ccteam-cli`(binary-as-library 反模式 + dep 图倒挂 — `ccteam-cli` 是 binary entry,`ccteam-web` 是新 crate,sibling 关系应共下沉 `ccteam-core`)。读侧 helper 已 public(`collect_projects` / `collect_recent_events` / `run_resume` / `run_show`,以及 `ccteam_core::ProjectState` / `CcteamPaths` / `render_screenshot` / `tmux::capture_pane_*` / `check_daemon_health` / `SessionMailbox` / `inbox_filename` / `pick_unused_slug` / `bootstrap_project`),写侧未 promote。
@@ -746,6 +746,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **解耦方案**:V0.3 M5.0(PR #1)新建 `crates/ccteam-core/src/actions.rs`,提 4 个 pub fn:`send_to_session(paths, slug, text)` / `inject_decision(paths, slug, DecisionInput)` / `pause(paths, slug)` / `resume(paths, slug)`;`mcp_serve.rs::tool_*` 内部 logic 全提到 `actions::*`,wrapper 留 args 拆 + JSON encode;`ccteam-web::routes::actions::*` 直调 `ccteam_core::actions::*`,`ccteam-web` 只 depend on `ccteam-core`(`cargo tree -p ccteam-web` 验证不出现 `ccteam-cli`)。M5.3(PR #4)写动作 endpoint 落地后 close。
 - **优先级**:**P1**(V0.3 M5.0 启动门槛;`ccteam-web` 没这个 promote 就走不通)。
 - **来源**:V0.3 M5.0 audit(`docs/v0-3/prd.md §3`)。
+- **2026-05-10 部分修复(V0.3 PR #1)**:`crates/ccteam-core/src/actions.rs` 落地;4 个 pub fn(`send_to_session` + `send_to_session_with` / `inject_decision` / `pause` / `resume`)外加 `next_inbox_seq` / `next_inbox_path` / `DecisionInput` / `SendOptions` / `SendResult`。`mcp_serve.rs::tool_send_to_session` / `tool_inject_decision` / `tool_pause` / `tool_resume` 全部改为薄 wrapper(args 拆 + JSON encode + 调 `actions::*`),18 个 mcp_serve 测试不变绿(回归保证 wrapper 透传);`commands::run_resume` body 提到 `actions::resume`,旧 fn 仅留 thin-wrap。`crates/ccteam-web/tests/dep_graph_test.rs` 自检 `cargo tree -p ccteam-web` 不命中 `ccteam-cli`。**仍 open**:web 层 POST endpoint(`/api/<slug>/{btw,inject_decision,pause,resume}`)在 M5.3 落地后才真正消费 actions::*,届时本 finding 整体 close。
 
 ### F40 — `product-research` team 名冗长 + 领域名缺位(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #6 alias 软迁移)**)
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1438,6 +1438,11 @@ ccteam doctor --migrate-recommended-agents        # V0.2 M0.20 一次性清理 V
 ccteam hook <subcmd>                              # debug:手动跑 hook(读 stdin JSON,写 stdout);
                                                   # subcmd ∈ {progress-append, parse-phase-end,
                                                   # cost-accumulate, load-context, block-push}
+ccteam web --bind 127.0.0.1:7331                  # V0.3 M5.0 web UI scaffold(`/health` only;
+                                                  # M5.1 dashboard / M5.2 SSE / M5.3 写动作 + token auth)
+ccteam web --bind 0.0.0.0:7331 [--no-auth]        # 同上,LAN 模式;M5.3 默认强 token 鉴权,
+                                                  # `--no-auth` 5s 倒计时 + stderr warn 后照样 listen
+ccteam web --token-file <path>                    # 自定义 token 文件路径(M5.3 消费;默认 ~/.ccteam/web-token)
 ```
 
 #### `ccteam stop` 行为契约(M1.5)

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -1427,6 +1427,16 @@ V0.3 候选(本里程碑不做):
 - `dependencies`(team-plugin 间依赖,eg 引用 `code-reviewer` plugin)
 - 多 phase 一次性 init(当前 V0.2 单 phase 起步,多 phase 走 skill 多轮 init)
 
+### 6.13 Web layer(V0.3 M5.0 起;占位,M5.4 补全)
+
+V0.3 主线版本新加第四接入层(继 terminal / MCP / filesystem 之后),由 `crates/ccteam-web` crate 提供:
+
+- **入口**:`ccteam web --bind <addr> [--no-auth] [--token-file <path>]`(`docs/interfaces.md` §10.6)。CLI subcommand 调 `ccteam_web::serve(ServeOpts)`,axum 0.8 server 绑端口、装路由、Ctrl-C / SIGTERM 优雅退出。
+- **依赖图**:`ccteam-web` 只 depend on `ccteam-core`(F45 promote 后 4 个 write helper 落 `actions::*` 模块)。**严格不 dep `ccteam-cli`** — `crates/ccteam-web/tests/dep_graph_test.rs` 自检 `cargo tree -p ccteam-web` 不命中 `ccteam-cli`。
+- **M5.0 范围**(本里程碑):scaffold + `GET /health` 200 JSON + `ServeOpts { bind, no_auth, token_file }` 类型形稳。
+- **后续里程碑**:M5.1 read-only dashboard + 项目详情页(askama 模板 + htmx)/ M5.2 SSE + 按需 PNG 截图 / M5.3 写动作 endpoint + 默认 token 鉴权(loopback bypass)/ M5.4 e2e + ship gate。详 `docs/v0-3/prd.md` §3-§7。
+- **架构红线**(V0.3 主线维持):progress.jsonl 仍是 SoT,web 不解析 tmux 终端;web 不 kill 长 session;web 不写跨项目记忆;`/btw` 走跟 telegram channel + MCP `send_to_session` 完全相同的 inbox + idle dispatch 路径,不开新通路。
+
 ---
 
 ## 7. 里程碑路线图


### PR DESCRIPTION
## Closes

- V0.3 M5.0 scaffold + write helper promote (`docs/v0-3/prd.md` §3)
- F45 partial — closes the "promote write helpers" half; remaining
  web-side consumption lands in M5.3 PR #4 (`docs/dev-coupling-audit.md`)

## 改动

- **新 crate `crates/ccteam-web`** — axum 0.8 + askama 0.12 + subtle 2.5
  workspace deps pinned. M5.0 scope = scaffold only; one route
  (`GET /health` 200 JSON `{ "status": "ok", "version": "<crate>" }`),
  graceful shutdown on Ctrl-C / SIGTERM, stable `ServeOpts { bind,
  no_auth, token_file }` shape (M5.3 reads these by name).
- **`ccteam web --bind <addr> [--no-auth] [--token-file <path>]`
  CLI subcommand** in `ccteam-cli`. `commands::run_web` translates
  clap struct → `ServeOpts`, drives current-thread tokio runtime to
  `ccteam_web::serve`. Mirrors the `mcp-serve` shape.
- **`crates/ccteam-core/src/actions.rs` new module** with 4 pub fns +
  helpers:
  - `send_to_session(paths, slug, body)` (+ `send_to_session_with` for
    channel-specific source/source_user/content_type overrides),
  - `inject_decision(paths, slug, DecisionInput { path, body })` —
    path-aware primitive (raw atomic write at `path` with `body`),
  - `pause(paths, slug)` / `resume(paths, slug)`,
  - `next_inbox_seq` helper promoted alongside.
- **`mcp_serve.rs` wrappers stay thin**: `tool_send_to_session` /
  `tool_inject_decision` / `tool_pause` / `tool_resume` are now args
  parse + JSON encode + `actions::*` call. The 18-test mcp_serve
  regression suite stays green (wrapper transparency).
- **`commands::run_resume` body lifted to `actions::resume`**;
  remaining 1-liner preserves the public CLI surface.
- Doctor section deferred — `~/.ccteam/web-token` doesn't exist until
  M5.3 generates it; "not yet generated" line gives nothing M5.3 won't
  add cleaner.

## 测试

- **Test count: 631 → 646 (+15)**:
  - 11 unit tests in `actions.rs` (send/inject/pause/resume + edge cases)
  - 3 lib tests in `ccteam-web` (`/health` round-trip + `ServeOpts` shape
    tripwire + handler body)
  - 2 integration tests in `crates/ccteam-cli/tests/web_subcommand_test.rs`
    (`ccteam web --help` flag advertise + subprocess spawn → bind
    announce → `GET /health` 200 → kill)
  - 1 dep-graph test in `crates/ccteam-web/tests/dep_graph_test.rs`
    (`cargo tree -p ccteam-web` no `ccteam-cli` hit)
  - −2 obsolete `next_inbox_seq` tests in `mcp_serve.rs` (helper moved
    to `actions.rs` along with its coverage)
- All 18 existing `mcp_serve` tests (including the 4 daemon-health
  fail-loud + the 2 inject/send write-path tests) remain green —
  wrapper transparency confirmed.
- `cargo clippy --workspace`: 8 warnings, identical to origin/main
  (no new warnings introduced by this PR).

## 红线 grep

- `cargo tree -p ccteam-web | grep ccteam-cli` → **0 hits** (dep-graph
  red line; also enforced by `dep_graph_test.rs`)
- `git grep -nE 'use ccteam_core::actions' crates/` → **1 import
  hit** (mcp_serve.rs). The second hit (ccteam-web) lands in M5.3
  PR #4 when `ccteam-web::routes::actions` consumes the helpers
  (per `docs/v0-3/dev-plan.md` §5 #4.3) — see comment block above the
  import in `mcp_serve.rs` flagging this.
- `git grep -nE 'fn tool_(send_to_session|inject_decision)'
  crates/ccteam-cli/src/mcp_serve.rs` → 2 hits, both thin wrappers.

## 文档同步

- `docs/interfaces.md` §10.6 — added `ccteam web` rows (bind / no-auth
  / token-file)
- `docs/tech-design.md` §6.13 — new web layer placeholder (M5.4 expands)
- `docs/dev-coupling-audit.md` F45 — status updated to "partial fix
  (V0.3 PR #1); M5.3 PR #4 closes" with a per-line summary of what
  shipped now vs what remains
- CLAUDE.md untouched (M5.4 ship gate handles baseline updates)

## 关联

- 痛点 7 (`docs/requirements.md`)
- tech-design.md §6.4 (channel layer) + §5.5 (progress.jsonl SoT)
- Closes V0.3 M5.0 (`docs/v0-3/prd.md` §3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)