### PR TITLE
v0.3 PR #4: M5.3 write actions + token auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,11 +358,13 @@ dependencies = [
  "anyhow",
  "askama",
  "axum",
+ "axum-extra",
  "ccteam-core",
  "chrono",
  "futures",
  "futures-util",
  "notify",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -422,6 +447,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -466,6 +529,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1108,6 +1180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1523,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1554,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -1680,6 +1786,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
  "futures-util",
  "http",
@@ -2060,6 +2168,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2477,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vt100"

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -2110,6 +2110,10 @@ pub fn run_web(opts: WebOptions) -> Result<()> {
         bind,
         no_auth: opts.no_auth,
         token_file: opts.token_file,
+        // Production CLI path keeps the 5 s Ctrl-C window so an
+        // operator who passes `--no-auth` on a non-loopback bind has
+        // a chance to abort before the LAN-RCE surface goes live.
+        no_auth_grace_secs: Some(5),
     };
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/crates/ccteam-web/Cargo.toml
+++ b/crates/ccteam-web/Cargo.toml
@@ -32,10 +32,19 @@ askama = { workspace = true }
 # `ServeOpts` can carry the token-file knob without churning dep
 # manifests when M5.3 lands.
 subtle = { workspace = true }
+# V0.3 M5.3 — auth middleware:
+# - `axum-extra` provides the `CookieJar` extractor (not in axum 0.8
+#   itself); the cookie shim sets a HttpOnly `ccteam_token` cookie so
+#   browser GETs / SSE auto-include credentials after the first
+#   `?token=ccteam:<...>` URL hit.
+# - `rand` 0.8 generates the 32-byte token persisted at
+#   `~/.ccteam/web-token` mode 0600.
+axum-extra = { version = "0.10", features = ["cookie"] }
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"
-reqwest = { workspace = true, features = ["json", "stream"] }
+reqwest = { workspace = true, features = ["json", "stream", "cookies"] }
 # V0.3 M5.2 — SSE integration tests need to read the streaming body
 # line by line. `tokio-util` exposes `StreamReader` (bytes stream →
 # AsyncRead); `futures-util` provides the `StreamExt::map` adapter

--- a/crates/ccteam-web/assets/style.css
+++ b/crates/ccteam-web/assets/style.css
@@ -253,3 +253,72 @@ code {
     background: var(--bg-hover);
     border-color: var(--accent);
 }
+
+/* V0.3 M5.3 — auth banners + controls sidebar. */
+.auth-banner {
+    margin: 0.5rem 0 1rem 0;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 0.85rem;
+    display: inline-block;
+}
+.auth-banner.ok {
+    color: var(--green);
+    border-color: var(--green);
+    background: rgba(63, 185, 80, 0.07);
+}
+.auth-banner.warn {
+    color: var(--red);
+    border-color: var(--red);
+    background: rgba(248, 81, 73, 0.07);
+}
+.controls .control-block {
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.75rem;
+    background: var(--bg-elev);
+}
+.controls h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 0.95rem;
+}
+.controls form {
+    margin: 0;
+}
+.controls textarea, .controls select {
+    display: block;
+    width: 100%;
+    background: var(--bg);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.4rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+}
+.controls textarea {
+    min-height: 4rem;
+    resize: vertical;
+}
+.controls button {
+    background: var(--bg);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 0.3rem 0.9rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+    margin-right: 0.5rem;
+}
+.controls button:hover:not(:disabled) {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+}
+.controls button:disabled, .controls textarea:disabled, .controls select:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/crates/ccteam-web/src/auth.rs
+++ b/crates/ccteam-web/src/auth.rs
@@ -1,0 +1,313 @@
+//! V0.3 M5.3 — token-based auth middleware for the ccteam web layer.
+//!
+//! ## Decision: whole-app gate (no read/write split)
+//!
+//! When [`AuthState::enabled`] is true, **every** route on the
+//! stateful router (`/`, `/project/<slug>`, `/sse/...`,
+//! `/screenshot/<slug>.png`, `/api/<slug>/...`) requires either:
+//!
+//! - `Authorization: Bearer ccteam:<token>` on the request, or
+//! - the `ccteam_token` cookie set by the URL shim.
+//!
+//! `/health` is exempt so ops monitoring keeps working without baking
+//! the token into a probe. (Body is `{status, version}` — no project
+//! state leak.)
+//!
+//! ## Browser flow
+//!
+//! On first visit the user pastes
+//! `http://<host>:<port>/?token=ccteam:<hex>`. The middleware:
+//!
+//! 1. extracts `token` from the query string,
+//! 2. validates it (constant-time) against the loaded token,
+//! 3. sets a HttpOnly `ccteam_token` cookie + 302-redirects to the
+//!    same path minus the `token` query parameter,
+//! 4. subsequent GETs / SSE include the cookie automatically.
+//!
+//! ## CSRF defense (option a, per advisor)
+//!
+//! POST `/api/...` requires the `Authorization` header *always* (even
+//! when a valid cookie is present). The browser-side template inlines
+//! the token into htmx `hx-headers` only when `auth.enabled` so
+//! same-origin htmx form-submits authenticate; cross-origin form-submit
+//! cannot inject `Authorization` (header-allowlisted by the browser),
+//! and cross-origin `fetch`/`XHR` triggers a CORS preflight which we
+//! never allow. Result: a malicious page on attacker.example **cannot**
+//! produce an authenticated POST against `/api/<slug>/btw`.
+//!
+//! XSS tradeoff: the token appears in an HTML attribute, not just an
+//! HttpOnly cookie. If the dashboard is XSS'd the attacker can read
+//! the token *and* fire same-origin fetches with the cookie, so
+//! cookie-only would not save us. Inlining doesn't materially worsen
+//! the threat model.
+//!
+//! Architecture refs: `docs/v0-3/prd.md` §6.2.4 / §6.2.5 / §9.
+
+use std::net::SocketAddr;
+
+use axum::{
+    extract::{Request, State},
+    http::{header, HeaderValue, StatusCode, Uri},
+    middleware::Next,
+    response::{IntoResponse, Redirect, Response},
+};
+use axum_extra::extract::{
+    cookie::{Cookie, SameSite},
+    CookieJar,
+};
+use subtle::ConstantTimeEq;
+
+use crate::state::AppState;
+
+/// Wire-format token prefix. Tokens are written + checked as
+/// `ccteam:<hex>` so a leaked token is grep-able by purpose.
+pub const TOKEN_PREFIX: &str = "ccteam:";
+
+/// Cookie name set by the URL shim. HttpOnly + SameSite=Strict.
+pub const COOKIE_NAME: &str = "ccteam_token";
+
+/// Query-string parameter parsed by the URL shim.
+pub const QUERY_PARAM: &str = "token";
+
+/// Auth state attached to [`AppState`].
+#[derive(Debug, Clone)]
+pub struct AuthState {
+    /// If false, the middleware passes every request through (the
+    /// loopback default + explicit `--no-auth`).
+    pub enabled: bool,
+    /// Hex-encoded token (no `ccteam:` prefix). `None` when disabled.
+    pub token: Option<String>,
+}
+
+impl AuthState {
+    /// Auth-off (loopback default / `--no-auth` opt-out).
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            token: None,
+        }
+    }
+
+    /// Auth-on with the supplied hex token.
+    pub fn enabled(token: String) -> Self {
+        Self {
+            enabled: true,
+            token: Some(token),
+        }
+    }
+
+    /// Wire-format token (`ccteam:<hex>`) for templates / docs. Returns
+    /// `None` when auth is disabled.
+    pub fn wire_token(&self) -> Option<String> {
+        self.token.as_ref().map(|t| format!("{TOKEN_PREFIX}{t}"))
+    }
+}
+
+/// Decide whether a `SocketAddr` is loopback (auth defaults off) or
+/// non-loopback (auth defaults on).
+pub fn is_loopback(addr: &SocketAddr) -> bool {
+    addr.ip().is_loopback()
+}
+
+/// Constant-time check that `presented` (full `ccteam:<hex>` string)
+/// matches the configured token. The `subtle::ConstantTimeEq` impl on
+/// byte slices already short-circuits on differing lengths in a way
+/// that doesn't leak content; the upstream contract is that *content*
+/// timing must not vary, which is what we need to defeat the
+/// LAN-attacker threat model in PRD §9.1.
+pub fn validate_bearer(presented: &str, expected_hex: &str) -> bool {
+    let prefix = TOKEN_PREFIX.as_bytes();
+    let bytes = presented.as_bytes();
+    if bytes.len() != prefix.len() + expected_hex.len() {
+        return false;
+    }
+    if !bytes.starts_with(prefix) {
+        return false;
+    }
+    let hex = &bytes[prefix.len()..];
+    hex.ct_eq(expected_hex.as_bytes()).into()
+}
+
+/// Extract the bearer token from `Authorization: Bearer ccteam:<hex>`,
+/// returning the full `ccteam:<hex>` slice (post-`Bearer ` chomp).
+fn parse_bearer(value: &HeaderValue) -> Option<&str> {
+    let s = value.to_str().ok()?;
+    let rest = s.strip_prefix("Bearer ")?;
+    Some(rest.trim())
+}
+
+/// Pull the token from the cookie jar, if present. Returns the bare
+/// hex value (no prefix) since the cookie payload omits the prefix —
+/// keeps the cookie body short + machine-checkable.
+pub fn cookie_token(jar: &CookieJar) -> Option<&str> {
+    jar.get(COOKIE_NAME).map(|c| c.value())
+}
+
+/// Strip the `token` parameter from a request URI's query string.
+/// Used when the URL shim 302-redirects to a clean URL after setting
+/// the cookie.
+fn uri_without_token(uri: &Uri) -> String {
+    let path = uri.path();
+    let Some(query) = uri.query() else {
+        return path.to_string();
+    };
+    let kept: Vec<&str> = query
+        .split('&')
+        .filter(|p| !p.is_empty())
+        .filter(|p| {
+            let key = p.split_once('=').map(|(k, _)| k).unwrap_or(p);
+            key != QUERY_PARAM
+        })
+        .collect();
+    if kept.is_empty() {
+        path.to_string()
+    } else {
+        format!("{}?{}", path, kept.join("&"))
+    }
+}
+
+/// Pull `?token=<value>` out of a query string (no decoding —
+/// presented value is already a base set of ASCII hex + `ccteam:`
+/// literal).
+fn query_token(query: &str) -> Option<&str> {
+    for part in query.split('&') {
+        if let Some(rest) = part.strip_prefix("token=") {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// The middleware itself, plumbed via `from_fn_with_state`.
+///
+/// Order of checks:
+///
+/// 1. If `auth.enabled = false` → pass through.
+/// 2. Bearer header valid → pass through.
+/// 3. Query string `?token=` present + valid → set HttpOnly cookie +
+///    302 redirect to URI minus the `token` parameter.
+/// 4. Cookie value valid → pass through.
+/// 5. Else → 401 plain-text "auth required".
+pub async fn auth_layer(
+    State(app): State<AppState>,
+    jar: CookieJar,
+    req: Request,
+    next: Next,
+) -> Response {
+    let auth = app.auth.clone();
+    if !auth.enabled {
+        return next.run(req).await;
+    }
+    let Some(expected) = auth.token.as_deref() else {
+        // Defensive: enabled=true but no token loaded → fail closed.
+        return (StatusCode::INTERNAL_SERVER_ERROR, "auth misconfigured").into_response();
+    };
+
+    // 1. Authorization header.
+    if let Some(h) = req.headers().get(header::AUTHORIZATION) {
+        if let Some(presented) = parse_bearer(h) {
+            if validate_bearer(presented, expected) {
+                return next.run(req).await;
+            }
+        }
+    }
+
+    // 2. URL shim — `?token=ccteam:<hex>` query → cookie + redirect.
+    if let Some(q) = req.uri().query() {
+        if let Some(presented) = query_token(q) {
+            if validate_bearer(presented, expected) {
+                let clean = uri_without_token(req.uri());
+                let cookie = Cookie::build((COOKIE_NAME, expected.to_string()))
+                    .http_only(true)
+                    .same_site(SameSite::Strict)
+                    .path("/")
+                    .build();
+                let jar = jar.add(cookie);
+                return (jar, Redirect::to(&clean)).into_response();
+            }
+        }
+    }
+
+    // 3. Cookie carry-over for subsequent GETs / SSE.
+    if let Some(cookie_val) = cookie_token(&jar) {
+        if cookie_val.as_bytes().ct_eq(expected.as_bytes()).into() {
+            return next.run(req).await;
+        }
+    }
+
+    (StatusCode::UNAUTHORIZED, "auth required").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_bearer_accepts_correct_token() {
+        assert!(validate_bearer("ccteam:deadbeef", "deadbeef"));
+    }
+
+    #[test]
+    fn validate_bearer_rejects_wrong_hex() {
+        assert!(!validate_bearer("ccteam:deadbeef", "deadbeee"));
+    }
+
+    #[test]
+    fn validate_bearer_rejects_missing_prefix() {
+        assert!(!validate_bearer("Bearer deadbeef", "deadbeef"));
+        assert!(!validate_bearer("deadbeef", "deadbeef"));
+    }
+
+    #[test]
+    fn validate_bearer_rejects_length_mismatch() {
+        assert!(!validate_bearer("ccteam:dead", "deadbeef"));
+        assert!(!validate_bearer("ccteam:deadbeefdeadbeef", "deadbeef"));
+    }
+
+    #[test]
+    fn auth_state_wire_token_round_trip() {
+        let s = AuthState::enabled("abc123".into());
+        assert_eq!(s.wire_token().unwrap(), "ccteam:abc123");
+        let off = AuthState::disabled();
+        assert!(off.wire_token().is_none());
+    }
+
+    #[test]
+    fn uri_without_token_strips_only_token_param() {
+        let u: Uri = "/foo?token=ccteam:abc&other=1".parse().unwrap();
+        assert_eq!(uri_without_token(&u), "/foo?other=1");
+        let u2: Uri = "/foo?token=ccteam:abc".parse().unwrap();
+        assert_eq!(uri_without_token(&u2), "/foo");
+        let u3: Uri = "/foo".parse().unwrap();
+        assert_eq!(uri_without_token(&u3), "/foo");
+        let u4: Uri = "/foo?other=1&token=abc&another=2".parse().unwrap();
+        assert_eq!(uri_without_token(&u4), "/foo?other=1&another=2");
+    }
+
+    #[test]
+    fn query_token_extracts_value() {
+        assert_eq!(query_token("token=ccteam:abc"), Some("ccteam:abc"));
+        assert_eq!(query_token("other=x&token=ccteam:abc"), Some("ccteam:abc"));
+        assert_eq!(query_token("other=x"), None);
+    }
+
+    #[test]
+    fn parse_bearer_strips_prefix() {
+        let h = HeaderValue::from_static("Bearer ccteam:abc");
+        assert_eq!(parse_bearer(&h), Some("ccteam:abc"));
+        let h2 = HeaderValue::from_static("Basic ccteam:abc");
+        assert_eq!(parse_bearer(&h2), None);
+    }
+
+    #[test]
+    fn is_loopback_recognizes_127_and_v6() {
+        let v4: SocketAddr = "127.0.0.1:7331".parse().unwrap();
+        assert!(is_loopback(&v4));
+        let v6: SocketAddr = "[::1]:7331".parse().unwrap();
+        assert!(is_loopback(&v6));
+        let lan: SocketAddr = "192.168.1.5:7331".parse().unwrap();
+        assert!(!is_loopback(&lan));
+        let any: SocketAddr = "0.0.0.0:7331".parse().unwrap();
+        assert!(!is_loopback(&any));
+    }
+}

--- a/crates/ccteam-web/src/decisions.rs
+++ b/crates/ccteam-web/src/decisions.rs
@@ -1,0 +1,87 @@
+//! V0.3 M5.3 — decision-file candidate scan.
+//!
+//! Lists `~/projects/<slug>/.ccteam/decision-*.md` paths so the
+//! project-detail template can render an `<select>` of valid
+//! decision-file destinations for `inject_decision`. **Read-only** —
+//! the scan never creates or mutates anything; it just enumerates.
+//!
+//! The MCP `tool_inject_decision` historically wrote to one of a
+//! small enum of decision-kind paths (PRD §6.2.2 example). For the
+//! web layer we keep things mechanical: anything matching the
+//! `decision-*.md` glob already on disk is a valid target. Empty list
+//! → the form's `<select>` shows a placeholder + is disabled.
+
+use std::path::PathBuf;
+
+use ccteam_core::CcteamPaths;
+
+/// Scan the project's `.ccteam/` directory for decision-file
+/// candidates. Returns absolute paths sorted lexicographically (which,
+/// because filenames embed timestamps in `decision-<utc>.md` form, is
+/// also chronological).
+pub fn scan_candidates(paths: &CcteamPaths, slug: &str) -> Vec<PathBuf> {
+    let dir = paths.project_ccteam_dir(slug);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|s| s.to_str())
+                .map(|n| n.starts_with("decision-") && n.ends_with(".md"))
+                .unwrap_or(false)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn fake_paths(root: &std::path::Path) -> CcteamPaths {
+        CcteamPaths {
+            root: root.join(".ccteam"),
+            projects_root: root.join("projects"),
+        }
+    }
+
+    #[test]
+    fn empty_dir_returns_empty_vec() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fake_paths(tmp.path());
+        assert!(scan_candidates(&paths, "demo").is_empty());
+    }
+
+    #[test]
+    fn returns_only_decision_files_sorted() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fake_paths(tmp.path());
+        let dir = paths.project_ccteam_dir("demo");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("decision-2026-01.md"), "x").unwrap();
+        std::fs::write(dir.join("decision-2026-03.md"), "y").unwrap();
+        std::fs::write(dir.join("decision-2026-02.md"), "z").unwrap();
+        std::fs::write(dir.join("state.json"), "{}").unwrap();
+        std::fs::write(dir.join("notdecision.md"), "n").unwrap();
+
+        let out = scan_candidates(&paths, "demo");
+        assert_eq!(out.len(), 3);
+        let names: Vec<String> = out
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "decision-2026-01.md".to_string(),
+                "decision-2026-02.md".to_string(),
+                "decision-2026-03.md".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/ccteam-web/src/lib.rs
+++ b/crates/ccteam-web/src/lib.rs
@@ -3,35 +3,47 @@
 //! Single entry: [`serve`]. Wired up by `ccteam-cli` via
 //! `commands::run_web` so the binary stays a thin protocol adapter.
 //!
-//! Ship state (per `docs/v0-3/prd.md` §3 / §4 / §5):
+//! Ship state (per `docs/v0-3/prd.md` §3 / §4 / §5 / §6):
 //!
 //! - **M5.0** — `GET /health` + bind / shutdown plumbing.
 //! - **M5.1** — `GET /` dashboard, `GET /project/<slug>` detail
 //!   page, `GET /assets/{file}` vendored static assets.
-//! - **M5.2 (this PR)** — `GET /sse/all` + `GET /sse/project/<slug>`
-//!   live progress event streams (single `notify` watcher fans out
-//!   into a `tokio::sync::broadcast` capacity 1024) + `GET
+//! - **M5.2** — `GET /sse/all` + `GET /sse/project/<slug>` live
+//!   progress event streams (single `notify` watcher fans out into a
+//!   `tokio::sync::broadcast` capacity 1024) + `GET
 //!   /screenshot/<slug>.png` on-demand pane render via F38.
-//! - M5.3 — write actions + token auth.
+//! - **M5.3 (this PR)** — `POST /api/<slug>/{btw,inject_decision,
+//!   pause,resume}` write actions backed by `ccteam_core::actions::*`,
+//!   plus a token-auth gate (`auth_layer` middleware) on the entire
+//!   stateful router. Loopback bind defaults to no auth; non-loopback
+//!   bind generates `~/.ccteam/web-token` (mode 0600) and demands
+//!   `Authorization: Bearer ccteam:<token>` on every request (or the
+//!   matching `ccteam_token` cookie set by the URL shim).
 //!
-//! [`ServeOpts`] is stable from M5.0 forward — M5.3 consumes
-//! `no_auth` / `token_file` exactly as defined here.
+//! [`ServeOpts`] is stable from M5.0 forward and now adds
+//! `no_auth_grace_secs` (test seam — `Some(0)` skips the 5 s
+//! Ctrl-C window when `--no-auth` opts out on a non-loopback bind).
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
-use axum::Router;
+use axum::{middleware::from_fn_with_state, Router};
 use ccteam_core::CcteamPaths;
 use tokio::net::TcpListener;
 
+pub mod auth;
+pub mod decisions;
 pub mod queries;
 pub mod routes;
 pub mod state;
 pub mod status;
+pub mod token;
 pub mod views;
 pub mod watcher;
 
+pub use auth::AuthState;
 pub use state::AppState;
 pub use watcher::{EventBus, ProgressUpdate};
 
@@ -43,13 +55,30 @@ pub struct ServeOpts {
     /// Address to bind. `127.0.0.1:0` ⇒ pick a free port (used by
     /// integration tests).
     pub bind: SocketAddr,
-    /// Disable token auth on write endpoints. M5.3 will honor this;
-    /// M5.0 / M5.1 has no write endpoints so the flag is currently a
-    /// no-op record for ServeOpts shape stability.
+    /// Disable token auth on write endpoints. M5.3 honors this; if
+    /// the bind is non-loopback the operator gets a stderr warning +
+    /// a [`no_auth_grace_secs`]-second Ctrl-C window before serving.
     pub no_auth: bool,
     /// Custom path to read the auth token from. Default
-    /// (`None`) means `~/.ccteam/web-token`. M5.3 consumes this.
+    /// (`None`) means `~/.ccteam/web-token`.
     pub token_file: Option<PathBuf>,
+    /// Test seam: how long to sleep (eprintln'ing the LAN-RCE warning
+    /// banner first) when `no_auth = true` AND the bind is
+    /// non-loopback. Production `serve()` callers pass `Some(5)` —
+    /// integration tests pass `Some(0)` so the captured stderr can be
+    /// asserted without taking 5 s per case.
+    pub no_auth_grace_secs: Option<u64>,
+}
+
+impl Default for ServeOpts {
+    fn default() -> Self {
+        Self {
+            bind: "127.0.0.1:7331".parse().expect("hardcoded loopback parses"),
+            no_auth: false,
+            token_file: None,
+            no_auth_grace_secs: Some(5),
+        }
+    }
 }
 
 /// Build the router with a freshly resolved `CcteamPaths`. Used by
@@ -62,40 +91,106 @@ pub fn router() -> Result<Router> {
 
 /// Build the router with an explicit `AppState`. Tests use this so
 /// each test owns its own `tempdir`-backed paths.
+///
+/// The auth layer wraps the **stateful** router (everything except
+/// `/health`). When `state.auth.enabled = false` the layer is a
+/// pass-through; when enabled it gates every route on a valid
+/// `Authorization: Bearer ccteam:<token>` header or the matching
+/// `ccteam_token` cookie set via the URL shim (see
+/// `auth::auth_layer`).
 pub fn router_with_state(state: AppState) -> Router {
+    let stateful = routes::stateful_router()
+        .layer(from_fn_with_state(state.clone(), auth::auth_layer))
+        .with_state(state);
     Router::new()
         .merge(routes::stateless_router())
-        .merge(routes::stateful_router().with_state(state))
+        .merge(stateful)
 }
 
 /// Start the web server. Binds, prints the bound address one line
 /// to stdout (so subprocess harnesses can parse the port for the
 /// `:0` placeholder case), then serves until Ctrl-C / SIGTERM.
+///
+/// Auth heuristic (PRD §6.2.4):
+///
+/// | bind             | --no-auth | enabled | token             |
+/// |------------------|-----------|---------|-------------------|
+/// | loopback         | false     | false   | not generated     |
+/// | loopback         | true      | false   | not generated     |
+/// | non-loopback     | false     | **true**| generated or read |
+/// | non-loopback     | true      | false   | not generated     |
+///
+/// On the non-loopback `--no-auth` path we eprintln a LAN-wide RCE
+/// banner and sleep [`ServeOpts::no_auth_grace_secs`] seconds (test
+/// seam: pass `Some(0)` to skip in integration tests) so the operator
+/// has a window to Ctrl-C out.
 pub async fn serve(opts: ServeOpts) -> Result<()> {
+    let paths = CcteamPaths::from_env().context("resolve CcteamPaths from env for ccteam web")?;
+
     let listener = TcpListener::bind(opts.bind)
         .await
         .with_context(|| format!("bind {} for ccteam web", opts.bind))?;
     let local = listener
         .local_addr()
         .context("read local_addr after bind")?;
+    let non_loopback = !auth::is_loopback(&local);
+
+    // Decide auth state from the bind heuristic.
+    let auth_state = if !non_loopback {
+        if opts.no_auth {
+            eprintln!("ccteam web: --no-auth on loopback is the implicit default (no-op).");
+        }
+        AuthState::disabled()
+    } else if opts.no_auth {
+        eprintln!();
+        eprintln!(
+            "\x1b[1;31mWARNING:\x1b[0m --no-auth on non-loopback bind = LAN-wide RCE on bypassPermissions sessions.",
+        );
+        eprintln!("Press Ctrl-C within {}s to abort.", opts.no_auth_grace_secs.unwrap_or(5));
+        eprintln!();
+        let grace = opts.no_auth_grace_secs.unwrap_or(5);
+        if grace > 0 {
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(grace)) => {},
+                _ = tokio::signal::ctrl_c() => {
+                    eprintln!("ccteam web: aborted during --no-auth grace window.");
+                    return Ok(());
+                }
+            }
+        }
+        AuthState::disabled()
+    } else {
+        let token_path = opts
+            .token_file
+            .clone()
+            .unwrap_or_else(|| token::default_token_path(&paths));
+        let token_existed = token_path.exists();
+        let hex = token::generate_or_load_token(&token_path)
+            .with_context(|| format!("load or generate token at {}", token_path.display()))?;
+        if !token_existed {
+            eprintln!("ccteam web: generated new auth token at {}", token_path.display());
+        }
+        // Echo to stderr (PRD §6.2.4) so the operator can paste it into
+        // a browser. Using stderr (not stdout) keeps the subprocess
+        // harness in tests free to parse the bind line on stdout
+        // unambiguously.
+        eprintln!("ccteam web: auth token: ccteam:{hex}");
+        eprintln!(
+            "ccteam web: reset token via:  rm {} && restart",
+            token_path.display(),
+        );
+        AuthState::enabled(hex)
+    };
 
     // Subprocess-friendly bind announcement. Format is stable:
-    // `ccteam web listening on http://<addr>`. The first line written
-    // to stdout, flushed before serving so test harnesses can read
-    // the port assigned to `:0`.
+    // `ccteam web listening on http://<addr>`. First line on stdout,
+    // flushed before serving so test harnesses can parse the assigned
+    // port when `bind = :0`.
     println!("ccteam web listening on http://{local}");
-    if opts.no_auth {
-        eprintln!("ccteam web: --no-auth is set (M5.3 will honor this on write endpoints).");
-    }
-    if let Some(token) = &opts.token_file {
-        eprintln!(
-            "ccteam web: --token-file {} (M5.3 will honor this on write endpoints).",
-            token.display(),
-        );
-    }
-    tracing::info!(addr = %local, "ccteam web bound");
+    tracing::info!(addr = %local, auth_enabled = auth_state.enabled, "ccteam web bound");
 
-    let app = router()?;
+    let state = AppState::with_auth(paths, auth_state);
+    let app = router_with_state(state);
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await
@@ -192,16 +287,23 @@ mod tests {
 
     #[test]
     fn serve_opts_shape_is_stable() {
-        // M5.3 will read these three fields by name. If a future PR
-        // renames any of them, this test compiles-fails — a deliberate
-        // tripwire for M5.3 contract stability.
+        // M5.3 reads `bind` / `no_auth` / `token_file` /
+        // `no_auth_grace_secs` by name. If a future PR renames any of
+        // them, this test compiles-fails — a deliberate tripwire for
+        // contract stability.
         let opts = ServeOpts {
             bind: "127.0.0.1:7331".parse().unwrap(),
             no_auth: false,
             token_file: None,
+            no_auth_grace_secs: Some(5),
         };
         assert!(!opts.no_auth);
         assert!(opts.token_file.is_none());
         assert_eq!(opts.bind.port(), 7331);
+        assert_eq!(opts.no_auth_grace_secs, Some(5));
+        // Default keeps the same loopback bind + auth-on stance.
+        let d = ServeOpts::default();
+        assert!(d.bind.ip().is_loopback());
+        assert_eq!(d.no_auth_grace_secs, Some(5));
     }
 }

--- a/crates/ccteam-web/src/routes/actions.rs
+++ b/crates/ccteam-web/src/routes/actions.rs
@@ -1,0 +1,268 @@
+//! V0.3 M5.3 — `POST /api/<slug>/{btw,inject_decision,pause,resume}`.
+//!
+//! Each handler is a thin adapter that:
+//!
+//! 1. extracts a typed `Form<...>` body (axum's
+//!    `application/x-www-form-urlencoded` deserialization),
+//! 2. validates input (length caps, path-traversal sanity for
+//!    `inject_decision`),
+//! 3. calls into the corresponding `ccteam_core::actions::*` helper
+//!    (M5.0 promote — see `docs/dev-coupling-audit.md` F45),
+//! 4. on success → 303 See Other → `/project/<slug>` so the user lands
+//!    back on the detail page,
+//! 5. on validation failure → `400 Bad Request` + plain-text reason,
+//! 6. on unexpected error → `500 Internal Server Error` + plain-text.
+//!
+//! The handlers do **not** kill tmux sessions, parse pane output, or
+//! mutate `progress.jsonl` (CLAUDE.md §三 red lines). They only write
+//! inbox / decision / state files; the orchestrator's existing
+//! inotify + idle-aware dispatcher picks the change up.
+//!
+//! Auth is enforced by the `auth_layer` middleware mounted on the
+//! whole stateful router in `lib::router_with_state`, so handlers
+//! here trust they only run for authenticated callers (when auth is
+//! enabled at all).
+
+use std::path::{Component, PathBuf};
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Redirect, Response},
+    routing::post,
+    Form, Router,
+};
+use ccteam_core::actions::{self, DecisionInput};
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+/// Maximum length of `/btw` text payload (chars). Mirrors PRD §6.2.2
+/// — keeps a single inbox message small enough that the orchestrator
+/// can deliver it via tmux send-keys without wrapping pathologies.
+const BTW_MAX: usize = 4000;
+
+/// Maximum length of an `inject_decision` body (chars).
+const DECISION_BODY_MAX: usize = 8000;
+
+#[derive(Debug, Deserialize)]
+pub struct BtwForm {
+    pub text: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InjectDecisionForm {
+    pub path: String,
+    pub body: String,
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/api/{slug}/btw", post(handle_btw))
+        .route("/api/{slug}/inject_decision", post(handle_inject_decision))
+        .route("/api/{slug}/pause", post(handle_pause))
+        .route("/api/{slug}/resume", post(handle_resume))
+}
+
+/// Common success → 303 See Other → /project/<slug>.
+fn redirect_back(slug: &str) -> Response {
+    Redirect::to(&format!("/project/{slug}")).into_response()
+}
+
+/// Reject text payloads that are empty / whitespace-only / over the cap.
+#[allow(clippy::result_large_err)] // Err = axum Response (boxed body); fine for handler fast-fail.
+fn validate_text(field: &str, value: &str, max: usize) -> Result<(), Response> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("{field} must not be empty"),
+        )
+            .into_response());
+    }
+    if value.len() > max {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("{field} exceeds max length {max}"),
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Path-traversal sanity for `inject_decision`. Brief §3.3 says: the
+/// decision file MUST be absolute and live under
+/// `~/projects/<slug>/.ccteam/`. We:
+///
+/// 1. parse the supplied string as a `PathBuf`,
+/// 2. reject any `..` component (defeats `~/projects/<slug>/.ccteam/../../../etc/passwd`),
+/// 3. require absolute path,
+/// 4. require `starts_with(project_ccteam_dir(slug))` against the
+///    resolved (existing) ancestor.
+#[allow(clippy::result_large_err)] // Err = axum Response (boxed body); fine for handler fast-fail.
+fn validate_decision_path(app: &AppState, slug: &str, raw: &str) -> Result<PathBuf, Response> {
+    let candidate = PathBuf::from(raw);
+    if !candidate.is_absolute() {
+        return Err((StatusCode::BAD_REQUEST, "path must be absolute").into_response());
+    }
+    if candidate
+        .components()
+        .any(|c| matches!(c, Component::ParentDir))
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "path must not contain `..` components",
+        )
+            .into_response());
+    }
+    let ccteam_dir = app.paths.project_ccteam_dir(slug);
+    if !candidate.starts_with(&ccteam_dir) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "path must live under {} (got {})",
+                ccteam_dir.display(),
+                candidate.display(),
+            ),
+        )
+            .into_response());
+    }
+    Ok(candidate)
+}
+
+async fn handle_btw(
+    State(app): State<AppState>,
+    Path(slug): Path<String>,
+    Form(form): Form<BtwForm>,
+) -> Response {
+    if let Err(resp) = validate_text("text", &form.text, BTW_MAX) {
+        return resp;
+    }
+    match actions::send_to_session(&app.paths, &slug, &form.text) {
+        Ok(_) => redirect_back(&slug),
+        Err(err) => {
+            tracing::warn!(slug = %slug, error = %err, "send_to_session failed");
+            // The most common case is "no project named <slug>" which
+            // is a client problem (404), but distinguishing it from
+            // genuine IO is brittle; 400 with the underlying message
+            // is honest enough for a single-user dev tool.
+            (StatusCode::BAD_REQUEST, format!("btw failed: {err}")).into_response()
+        }
+    }
+}
+
+async fn handle_inject_decision(
+    State(app): State<AppState>,
+    Path(slug): Path<String>,
+    Form(form): Form<InjectDecisionForm>,
+) -> Response {
+    if let Err(resp) = validate_text("body", &form.body, DECISION_BODY_MAX) {
+        return resp;
+    }
+    let path = match validate_decision_path(&app, &slug, &form.path) {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
+    let decision = DecisionInput {
+        path,
+        body: form.body,
+    };
+    match actions::inject_decision(&app.paths, &slug, decision) {
+        Ok(_) => redirect_back(&slug),
+        Err(err) => {
+            tracing::warn!(slug = %slug, error = %err, "inject_decision failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("inject_decision failed: {err}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn handle_pause(State(app): State<AppState>, Path(slug): Path<String>) -> Response {
+    match actions::pause(&app.paths, &slug) {
+        Ok(_) => redirect_back(&slug),
+        Err(err) => {
+            tracing::warn!(slug = %slug, error = %err, "pause failed");
+            (StatusCode::BAD_REQUEST, format!("pause failed: {err}")).into_response()
+        }
+    }
+}
+
+async fn handle_resume(State(app): State<AppState>, Path(slug): Path<String>) -> Response {
+    match actions::resume(&app.paths, &slug) {
+        Ok(_) => redirect_back(&slug),
+        Err(err) => {
+            tracing::warn!(slug = %slug, error = %err, "resume failed");
+            (StatusCode::BAD_REQUEST, format!("resume failed: {err}")).into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccteam_core::CcteamPaths;
+    use tempfile::TempDir;
+
+    fn fake_app() -> (TempDir, AppState) {
+        let tmp = TempDir::new().unwrap();
+        let paths = CcteamPaths {
+            root: tmp.path().join(".ccteam"),
+            projects_root: tmp.path().join("projects"),
+        };
+        (tmp, AppState::new(paths))
+    }
+
+    #[test]
+    fn validate_decision_path_rejects_relative() {
+        let (_tmp, app) = fake_app();
+        let err = validate_decision_path(&app, "demo", "decision.md").unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validate_decision_path_rejects_dotdot_components() {
+        let (_tmp, app) = fake_app();
+        let raw = format!(
+            "{}/../../../etc/passwd",
+            app.paths.project_ccteam_dir("demo").display()
+        );
+        let err = validate_decision_path(&app, "demo", &raw).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validate_decision_path_rejects_outside_ccteam_dir() {
+        let (_tmp, app) = fake_app();
+        let err = validate_decision_path(&app, "demo", "/etc/passwd").unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validate_decision_path_accepts_within_ccteam_dir() {
+        let (_tmp, app) = fake_app();
+        let inside = app.paths.project_ccteam_dir("demo").join("decision-x.md");
+        let ok = validate_decision_path(&app, "demo", &inside.display().to_string()).unwrap();
+        assert_eq!(ok, inside);
+    }
+
+    #[test]
+    fn validate_text_rejects_empty() {
+        let err = validate_text("text", "   ", 100).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validate_text_rejects_overlong() {
+        let s = "x".repeat(5000);
+        let err = validate_text("text", &s, 4000).unwrap_err();
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn validate_text_accepts_normal() {
+        validate_text("text", "hello", 4000).unwrap();
+    }
+}

--- a/crates/ccteam-web/src/routes/mod.rs
+++ b/crates/ccteam-web/src/routes/mod.rs
@@ -1,14 +1,17 @@
 //! Axum routers for the ccteam web layer.
 //!
 //! M5.0 shipped `/health`. M5.1 added `dashboard` / `project` /
-//! `assets`. **M5.2 (this PR)** mounts `sse` (`/sse/all` +
-//! `/sse/project/<slug>`) + `screenshot` (`/screenshot/<slug>.png`).
-//! M5.3 mounts `actions` + auth middleware.
+//! `assets`. M5.2 added `sse` (`/sse/all` + `/sse/project/<slug>`) +
+//! `screenshot` (`/screenshot/<slug>.png`). **M5.3 (this PR)** mounts
+//! `actions` (`POST /api/<slug>/{btw,inject_decision,pause,resume}`)
+//! and the `auth_layer` middleware that gates the entire stateful
+//! router when token auth is enabled.
 
 use axum::Router;
 
 use crate::state::AppState;
 
+pub mod actions;
 pub mod assets;
 pub mod dashboard;
 pub mod health;
@@ -18,9 +21,9 @@ pub mod sse;
 
 /// Compose every M5.x sub-router available at the current ship state.
 /// `health` is state-less (M5.0 contract) so it merges in without an
-/// `AppState`; the M5.1 / M5.2 routers are stateful and need the
-/// same `AppState` so the call site builds them via `.with_state(...)`
-/// in `lib::router`.
+/// `AppState`; the M5.1 / M5.2 / M5.3 routers are stateful and need
+/// the same `AppState` so the call site builds them via
+/// `.with_state(...)` in `lib::router`.
 pub fn stateful_router() -> Router<AppState> {
     Router::new()
         .merge(dashboard::router())
@@ -28,9 +31,12 @@ pub fn stateful_router() -> Router<AppState> {
         .merge(assets::router())
         .merge(sse::router())
         .merge(screenshot::router())
+        .merge(actions::router())
 }
 
-/// Stateless routers (currently just `/health`).
+/// Stateless routers (currently just `/health`). M5.3 keeps `/health`
+/// outside the auth gate so ops monitoring works without baking in
+/// the secret token.
 pub fn stateless_router() -> Router {
     Router::new().merge(health::router())
 }

--- a/crates/ccteam-web/src/routes/project.rs
+++ b/crates/ccteam-web/src/routes/project.rs
@@ -19,6 +19,7 @@ use axum::{
 use ccteam_core::ProjectState;
 use chrono::Utc;
 
+use crate::decisions::scan_candidates;
 use crate::queries::{
     events_to_rows, outbox_rows, slug_recent_events, DEFAULT_EVENT_LIMIT, DEFAULT_OUTBOX_LIMIT,
 };
@@ -65,6 +66,14 @@ async fn handle_project(
         Err(err) => format!("(serialize error: {err})"),
     };
 
+    // V0.3 M5.3 — write-action context: decision candidates list +
+    // auth state echoed into `hx-headers` so same-origin form
+    // submits carry the bearer token (CSRF defense, PRD §6.2.5).
+    let decision_candidates: Vec<String> = scan_candidates(&app.paths, &slug)
+        .into_iter()
+        .map(|p| p.display().to_string())
+        .collect();
+
     let tpl = ProjectTemplate {
         version: env!("CARGO_PKG_VERSION"),
         slug: state.slug.clone(),
@@ -76,6 +85,9 @@ async fn handle_project(
         state_json_pretty,
         events: event_rows,
         outbox,
+        auth_enabled: app.auth.enabled,
+        auth_wire_token: app.auth.wire_token(),
+        decision_candidates,
     };
     HtmlTemplate(tpl).into_response()
 }

--- a/crates/ccteam-web/src/state.rs
+++ b/crates/ccteam-web/src/state.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 
 use ccteam_core::CcteamPaths;
 
+use crate::auth::AuthState;
 use crate::watcher::{spawn_watcher, EventBus};
 
 #[derive(Clone)]
@@ -23,6 +24,11 @@ pub struct AppState {
     /// `bus.subscribe()`; the producer side is owned by the
     /// dedicated watcher thread spawned in [`AppState::new`].
     pub bus: EventBus,
+    /// V0.3 M5.3 — auth gate state. Cloned per request, so the inner
+    /// `Arc<AuthState>` keeps the token allocation shared. When
+    /// `enabled = false` (loopback bind, or `--no-auth` opt-out) the
+    /// `auth_layer` middleware short-circuits to pass-through.
+    pub auth: Arc<AuthState>,
 }
 
 impl AppState {
@@ -31,7 +37,22 @@ impl AppState {
     /// we log + fall back to an inert bus so the read-only routes
     /// (`/`, `/project/<slug>`) still serve. SSE will simply have no
     /// publisher; clients reconnect harmlessly.
+    ///
+    /// Auth defaults to disabled — callers that want a token gate
+    /// (the `serve()` non-loopback path) construct via
+    /// [`AppState::with_auth`].
     pub fn new(paths: CcteamPaths) -> Self {
+        Self::build(paths, AuthState::disabled())
+    }
+
+    /// Construct an `AppState` with an explicit auth state. Used by
+    /// `serve()` once it has decided enabled / token from the bind
+    /// heuristic + token-file path.
+    pub fn with_auth(paths: CcteamPaths, auth: AuthState) -> Self {
+        Self::build(paths, auth)
+    }
+
+    fn build(paths: CcteamPaths, auth: AuthState) -> Self {
         let bus = match spawn_watcher(paths.progress_dir()) {
             Ok(b) => b,
             Err(err) => {
@@ -46,6 +67,7 @@ impl AppState {
         Self {
             paths: Arc::new(paths),
             bus,
+            auth: Arc::new(auth),
         }
     }
 
@@ -57,6 +79,7 @@ impl AppState {
         Self {
             paths: Arc::new(paths),
             bus,
+            auth: Arc::new(AuthState::disabled()),
         }
     }
 }

--- a/crates/ccteam-web/src/token.rs
+++ b/crates/ccteam-web/src/token.rs
@@ -1,0 +1,194 @@
+//! V0.3 M5.3 — auth-token file management.
+//!
+//! Persists a 32-byte hex-encoded random token at
+//! `~/.ccteam/web-token` (or a caller-supplied path) with mode 0600.
+//! On startup the auth middleware loads the token from this file and
+//! checks every request's `Authorization: Bearer ccteam:<token>` header
+//! (or the matching `ccteam_token` cookie set via the URL shim).
+//!
+//! Threat-model anchor: PRD §9 — when `ccteam web` binds non-loopback
+//! the orchestrator's `--dangerously-skip-permissions` claude session
+//! is one POST away from arbitrary shell exec. The token gate keeps
+//! that surface behind a 256-bit secret that only a user with shell
+//! access to the host can read (mode 0600 enforced + warned).
+//!
+//! Architecture refs: `docs/v0-3/prd.md` §6.2.4, §9.1.1.
+
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use anyhow::{anyhow, Context, Result};
+use ccteam_core::CcteamPaths;
+use rand::RngCore;
+
+/// Length of the random secret (bytes). 32 bytes ⇒ 64 hex chars after
+/// encoding — comfortably above brute-force feasibility for the
+/// LAN-attacker threat model in PRD §9.1.
+pub const TOKEN_BYTES: usize = 32;
+
+/// Default token-file path under the ccteam root.
+pub fn default_token_path(paths: &CcteamPaths) -> PathBuf {
+    paths.root.join("web-token")
+}
+
+/// Hex-encode a byte slice with lowercase digits. Inlined to avoid
+/// pulling another crate just for this (the `subtle` dep gives us
+/// constant-time compare; encoding doesn't need timing protection
+/// because the input is already the freshly-generated random bytes).
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Generate-or-load the auth token from `path`.
+///
+/// - **Generate**: if `path` does not exist, create it via
+///   `OpenOptions::create_new` (refuses to overwrite a racing writer)
+///   with mode 0600 on Unix. The freshly-generated 32-byte secret is
+///   hex-encoded into the file and returned.
+/// - **Load**: if `path` exists, read it, trim whitespace, and check
+///   the file mode. If the mode is not exactly 0600 we log a stderr
+///   warning (don't error) so the operator can fix it.
+///
+/// Returns the hex token string (no `ccteam:` prefix — callers that
+/// want the wire-format prefix should construct `format!("ccteam:{}",
+/// token)` themselves).
+pub fn generate_or_load_token(path: &Path) -> Result<String> {
+    if path.exists() {
+        return load_existing(path);
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create parent of {}", path.display()))?;
+    }
+
+    let mut buf = [0u8; TOKEN_BYTES];
+    rand::thread_rng().fill_bytes(&mut buf);
+    let hex = hex_encode(&buf);
+
+    let mut opts = OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        opts.mode(0o600);
+    }
+    let mut f = opts
+        .open(path)
+        .with_context(|| format!("create token file {}", path.display()))?;
+    f.write_all(hex.as_bytes())
+        .with_context(|| format!("write token file {}", path.display()))?;
+    f.flush().ok();
+    drop(f);
+    Ok(hex)
+}
+
+/// Load an existing token file. Caller must have already verified
+/// `path.exists()`.
+pub fn load_existing(path: &Path) -> Result<String> {
+    let mut f =
+        std::fs::File::open(path).with_context(|| format!("open token file {}", path.display()))?;
+    let mut s = String::new();
+    f.read_to_string(&mut s)
+        .with_context(|| format!("read token file {}", path.display()))?;
+    let trimmed = s.trim().to_string();
+    if trimmed.is_empty() {
+        return Err(anyhow!(
+            "token file {} is empty; remove it to regenerate",
+            path.display(),
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        match std::fs::metadata(path) {
+            Ok(meta) => {
+                let mode = meta.permissions().mode() & 0o777;
+                if mode != 0o600 {
+                    eprintln!(
+                        "ccteam web: WARNING token file {} has mode {:o}, expected 600. Fix with: chmod 600 {}",
+                        path.display(),
+                        mode,
+                        path.display(),
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(?err, "could not stat token file");
+            }
+        }
+    }
+
+    Ok(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn generate_creates_file_with_64_hex_chars() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("web-token");
+        let tok = generate_or_load_token(&path).unwrap();
+        assert_eq!(tok.len(), 64, "32 bytes = 64 hex chars");
+        assert!(tok.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_file_is_mode_0600() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("web-token");
+        generate_or_load_token(&path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "fresh token file must be mode 600");
+    }
+
+    #[test]
+    fn second_call_loads_existing_token() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("web-token");
+        let first = generate_or_load_token(&path).unwrap();
+        let second = generate_or_load_token(&path).unwrap();
+        assert_eq!(first, second, "load is idempotent for existing file");
+    }
+
+    #[test]
+    fn load_existing_trims_whitespace() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("web-token");
+        std::fs::write(&path, "abcd1234\n").unwrap();
+        let tok = load_existing(&path).unwrap();
+        assert_eq!(tok, "abcd1234");
+    }
+
+    #[test]
+    fn load_existing_errors_on_empty_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("web-token");
+        std::fs::write(&path, "   \n").unwrap();
+        let err = load_existing(&path).unwrap_err();
+        assert!(format!("{err:#}").contains("empty"));
+    }
+
+    #[test]
+    fn delete_then_regenerate_changes_token() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("web-token");
+        let first = generate_or_load_token(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        let second = generate_or_load_token(&path).unwrap();
+        assert_ne!(first, second, "regenerated token must differ");
+    }
+}

--- a/crates/ccteam-web/src/views.rs
+++ b/crates/ccteam-web/src/views.rs
@@ -64,6 +64,18 @@ pub struct ProjectTemplate {
     pub state_json_pretty: String,
     pub events: Vec<EventRow>,
     pub outbox: Vec<OutboxRow>,
+    /// V0.3 M5.3 — write-action surface. Values:
+    ///
+    /// - `auth_enabled`: true ⇒ render the "Authenticated session"
+    ///   banner + emit `hx-headers` (or, here, plain JS fetch headers
+    ///   wired into form submits) carrying the bearer token.
+    /// - `auth_wire_token`: Some(`ccteam:<hex>`) when auth is on; the
+    ///   template inlines this only inside `hx-headers` attributes.
+    /// - `decision_candidates`: absolute paths matching
+    ///   `<project>/.ccteam/decision-*.md` for the form `<select>`.
+    pub auth_enabled: bool,
+    pub auth_wire_token: Option<String>,
+    pub decision_candidates: Vec<String>,
 }
 
 pub struct EventRow {

--- a/crates/ccteam-web/templates/project.html
+++ b/crates/ccteam-web/templates/project.html
@@ -11,6 +11,18 @@
         &middot; cost: {{ cost_label }} USD
     </p>
 
+    {# V0.3 M5.3 — auth banner. When `auth_enabled = true` the user
+       reached this page through the bearer header / cookie shim, so
+       a green confirmation is reassuring + makes the threat model
+       legible. When `--no-auth` opt-out is in effect, render a red
+       warning instead so the operator can see at a glance that the
+       LAN-RCE surface is open. #}
+    {% if auth_enabled %}
+    <p class="auth-banner ok">Authenticated session ✓</p>
+    {% else %}
+    <p class="auth-banner warn">WARNING: write actions are unauthenticated (loopback default or --no-auth)</p>
+    {% endif %}
+
     <h2>State</h2>
     <pre>{{ state_json_pretty }}</pre>
 
@@ -89,6 +101,111 @@
             img.src = '/screenshot/' + encodeURIComponent(slug) + '.png?t=' + Date.now();
         }
     </script>
+
+    {# V0.3 M5.3 — write-action sidebar. Each form is a normal
+       `application/x-www-form-urlencoded` POST that 303-redirects back
+       to this same page (route handlers in src/routes/actions.rs).
+       Auth is enforced by the `auth_layer` middleware; same-origin
+       browser form submits include the cookie automatically, but we
+       *also* attach an `Authorization: Bearer ccteam:<...>` header
+       via `fetch()` (when `auth_enabled = true`) because the
+       middleware demands the bearer header for POST as a CSRF defense
+       (cross-origin form submits cannot inject custom headers).
+       PRD §6.2.5 / advisor option (a). #}
+    <h2>Controls</h2>
+    <div class="controls">
+        <div class="control-block">
+            <h3>Send <code>/btw</code></h3>
+            <form id="btw-form" method="post" action="/api/{{ slug }}/btw">
+                <textarea name="text" required minlength="1" maxlength="4000"
+                          placeholder="free-text nudge, queued via inbox"></textarea>
+                <button type="submit">Send</button>
+            </form>
+        </div>
+
+        <div class="control-block">
+            <h3>Inject decision</h3>
+            {% if decision_candidates.is_empty() %}
+            <form id="decision-form" method="post" action="/api/{{ slug }}/inject_decision">
+                <select name="path" disabled>
+                    <option>(no decisions pending)</option>
+                </select>
+                <textarea name="body" disabled
+                          placeholder="no decision-*.md files awaiting injection"></textarea>
+                <button type="submit" disabled>Inject</button>
+            </form>
+            {% else %}
+            <form id="decision-form" method="post" action="/api/{{ slug }}/inject_decision">
+                <select name="path" required>
+                    {% for c in decision_candidates %}
+                    <option value="{{ c }}">{{ c }}</option>
+                    {% endfor %}
+                </select>
+                <textarea name="body" required minlength="1" maxlength="8000"
+                          placeholder="decision body (markdown, written verbatim)"></textarea>
+                <button type="submit">Inject</button>
+            </form>
+            {% endif %}
+        </div>
+
+        <div class="control-block">
+            <h3>Pause / Resume</h3>
+            <form id="pause-form" method="post" action="/api/{{ slug }}/pause" style="display:inline-block">
+                <button type="submit">Pause</button>
+            </form>
+            <form id="resume-form" method="post" action="/api/{{ slug }}/resume" style="display:inline-block">
+                <button type="submit">Resume</button>
+            </form>
+            <p class="muted">
+                Pause sets <code>user_pause_pending=true</code>; the orchestrator pauses auto-dispatch
+                but the tmux session stays alive (red line: never kill long sessions).
+            </p>
+        </div>
+    </div>
+
+    {% if auth_enabled %}
+    <script>
+        // V0.3 M5.3 — bearer-header injector for the four control
+        // forms. With auth on, every POST must carry the Authorization
+        // header (CSRF defense — cross-origin form-submits cannot
+        // forge it). We intercept submit, fire `fetch()` with the
+        // header, and follow the 303 redirect by reloading the page.
+        // Cookie alone wouldn't be a CSRF defense; bearer header is.
+        (function () {
+            var TOKEN = {% match auth_wire_token %}{% when Some with (t) %}"{{ t }}"{% when None %}""{% endmatch %};
+            var ids = ['btw-form', 'decision-form', 'pause-form', 'resume-form'];
+            ids.forEach(function (id) {
+                var form = document.getElementById(id);
+                if (!form) return;
+                form.addEventListener('submit', function (ev) {
+                    ev.preventDefault();
+                    var fd = new FormData(form);
+                    var body = new URLSearchParams();
+                    fd.forEach(function (v, k) { body.append(k, v); });
+                    fetch(form.action, {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': 'Bearer ' + TOKEN,
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                        },
+                        body: body.toString(),
+                        credentials: 'same-origin',
+                        redirect: 'manual',
+                    }).then(function (resp) {
+                        // Server-side handlers reply 303 → /project/<slug>.
+                        // `redirect: manual` makes 3xx surface as opaqueredirect
+                        // (status 0); fetch won't follow cross-origin so just
+                        // reload the page to pick up the new state.
+                        location.reload();
+                    }).catch(function (err) {
+                        console.error('ccteam form submit failed', err);
+                        alert('submit failed: ' + err);
+                    });
+                });
+            });
+        })();
+    </script>
+    {% endif %}
 
     {# Small inline shim that grafts SSE `progress` events onto the
        events table and trims the visible row count to 200. We avoid

--- a/crates/ccteam-web/tests/actions_test.rs
+++ b/crates/ccteam-web/tests/actions_test.rs
@@ -1,0 +1,245 @@
+//! V0.3 M5.3 — write-action route integration tests.
+//!
+//! Each case fixtures a project under a tempdir-backed
+//! `CcteamPaths`, spins a real axum listener, fires the relevant POST,
+//! and asserts:
+//!
+//! - 303 See Other → `/project/<slug>`
+//! - the side effect on disk (inbox file / decision file / state.json)
+//! - 4xx for input the route boundary rejects (path traversal, length).
+//!
+//! Auth is left disabled (loopback default) so these tests focus on
+//! the route logic; auth is covered by `auth_test.rs`.
+
+use std::net::SocketAddr;
+
+use ccteam_core::{
+    bootstrap_project, disable_tool_surface_bootstrap_for_tests, CcteamPaths, ProjectState,
+};
+use ccteam_web::{router_with_state, AppState};
+use reqwest::redirect::Policy;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+
+fn fake_paths(root: &std::path::Path) -> CcteamPaths {
+    CcteamPaths {
+        root: root.join(".ccteam"),
+        projects_root: root.join("projects"),
+    }
+}
+
+fn fixture_project(paths: &CcteamPaths, slug: &str) {
+    disable_tool_surface_bootstrap_for_tests();
+    bootstrap_project(paths, slug, "demo request", "dev").unwrap();
+}
+
+async fn spawn(state: AppState) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = router_with_state(state);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::task::yield_now().await;
+    addr
+}
+
+fn nofollow() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(Policy::none())
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn post_btw_writes_inbox_file_and_redirects() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let inbox_dir = paths.project_ccteam_dir("demo").join("inbox");
+
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let client = nofollow();
+    let resp = client
+        .post(&format!("http://{addr}/api/demo/btw"))
+        .form(&[("text", "hello from web")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 303);
+    assert_eq!(
+        resp.headers().get("location").unwrap().to_str().unwrap(),
+        "/project/demo",
+    );
+    let entries: Vec<_> = std::fs::read_dir(&inbox_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one inbox file written");
+    let body = std::fs::read_to_string(entries[0].path()).unwrap();
+    assert!(
+        body.contains("hello from web"),
+        "inbox body must include text, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn post_btw_rejects_empty_text() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let resp = reqwest::Client::new()
+        .post(&format!("http://{addr}/api/demo/btw"))
+        .form(&[("text", "")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn post_btw_rejects_overlong_text() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let big = "x".repeat(5000);
+    let resp = reqwest::Client::new()
+        .post(&format!("http://{addr}/api/demo/btw"))
+        .form(&[("text", big.as_str())])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn post_inject_decision_writes_file_under_ccteam_dir() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let target = paths.project_ccteam_dir("demo").join("decision-via-web.md");
+
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let client = nofollow();
+    let resp = client
+        .post(&format!("http://{addr}/api/demo/inject_decision"))
+        .form(&[
+            ("path", target.display().to_string().as_str()),
+            ("body", "**META-AGENT DECISION**: ship\n"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 303);
+    assert!(target.exists(), "decision file must be written");
+    let body = std::fs::read_to_string(&target).unwrap();
+    assert!(body.contains("**META-AGENT DECISION**: ship"));
+}
+
+#[tokio::test]
+async fn post_inject_decision_rejects_path_outside_ccteam_dir() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let resp = reqwest::Client::new()
+        .post(&format!("http://{addr}/api/demo/inject_decision"))
+        .form(&[("path", "/etc/passwd"), ("body", "evil")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn post_inject_decision_rejects_dotdot_traversal() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let raw = format!(
+        "{}/../../../etc/passwd",
+        paths.project_ccteam_dir("demo").display()
+    );
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let resp = reqwest::Client::new()
+        .post(&format!("http://{addr}/api/demo/inject_decision"))
+        .form(&[("path", raw.as_str()), ("body", "evil")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn post_pause_sets_user_pause_pending() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let state_path = paths.project_state("demo");
+
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let client = nofollow();
+    let resp = client
+        .post(&format!("http://{addr}/api/demo/pause"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 303);
+    let after = ProjectState::load(&state_path).unwrap();
+    assert!(after.user_pause_pending, "pause must flip the flag");
+}
+
+#[tokio::test]
+async fn post_resume_clears_user_pause_pending() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_project(&paths, "demo");
+    let state_path = paths.project_state("demo");
+
+    // Pre-pause so resume has something to undo.
+    {
+        let mut s = ProjectState::load(&state_path).unwrap();
+        s.user_pause_pending = true;
+        s.save(&state_path).unwrap();
+    }
+
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let client = nofollow();
+    let resp = client
+        .post(&format!("http://{addr}/api/demo/resume"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 303);
+    let after = ProjectState::load(&state_path).unwrap();
+    assert!(!after.user_pause_pending, "resume must clear the flag");
+}
+
+#[tokio::test]
+async fn post_btw_for_unknown_slug_returns_4xx() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::new(paths);
+    let addr = spawn(state).await;
+    let resp = reqwest::Client::new()
+        .post(&format!("http://{addr}/api/missing/btw"))
+        .form(&[("text", "hi")])
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "missing slug should fail; got {status}"
+    );
+}

--- a/crates/ccteam-web/tests/auth_test.rs
+++ b/crates/ccteam-web/tests/auth_test.rs
@@ -1,0 +1,230 @@
+//! V0.3 M5.3 — auth middleware integration tests.
+//!
+//! Each case spins up a real axum listener bound to `127.0.0.1:0`,
+//! injects an `AppState` with a chosen `AuthState` (enabled / disabled
+//! / explicit token), then asserts the middleware behavior:
+//!
+//! - loopback default (`AuthState::disabled()`) → no token required.
+//! - non-loopback simulation (`AuthState::enabled(...)`) → 401 without
+//!   credentials, 200 with bearer header, 302 + Set-Cookie on the URL
+//!   shim, and the cookie carries subsequent requests.
+//! - `/health` is exempt from the auth gate.
+//! - `--no-auth` non-loopback path emits the LAN-RCE banner (asserted
+//!   by directly calling `serve()` in a subprocess; we use a sub-thread
+//!   that captures stderr instead).
+
+use std::net::SocketAddr;
+
+use axum::Router;
+use ccteam_core::{CcteamPaths, ProjectState};
+use ccteam_web::{router_with_state, AppState, AuthState};
+use reqwest::redirect::Policy;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+
+const TOKEN_HEX: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+fn fake_paths(root: &std::path::Path) -> CcteamPaths {
+    CcteamPaths {
+        root: root.join(".ccteam"),
+        projects_root: root.join("projects"),
+    }
+}
+
+fn fixture_one_project(paths: &CcteamPaths, slug: &str) {
+    let mut state = ProjectState::initial(slug.to_string());
+    state.current_phase = "implement".into();
+    state.save(&paths.project_state(slug)).unwrap();
+}
+
+async fn spawn(state: AppState) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app: Router = router_with_state(state);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::task::yield_now().await;
+    addr
+}
+
+fn nofollow() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(Policy::none())
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn loopback_default_no_token_required_for_root() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::with_auth(paths, AuthState::disabled());
+    let addr = spawn(state).await;
+    let resp = reqwest::get(&format!("http://{addr}/")).await.unwrap();
+    assert_eq!(resp.status(), 200, "auth disabled ⇒ open");
+}
+
+#[tokio::test]
+async fn auth_enabled_rejects_missing_authorization() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let resp = reqwest::get(&format!("http://{addr}/")).await.unwrap();
+    assert_eq!(resp.status(), 401, "no auth header ⇒ 401");
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("auth required"), "got: {body}");
+}
+
+#[tokio::test]
+async fn auth_enabled_accepts_valid_bearer_header() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let resp = reqwest::Client::new()
+        .get(&format!("http://{addr}/"))
+        .header("Authorization", format!("Bearer ccteam:{TOKEN_HEX}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn auth_enabled_rejects_wrong_bearer_token() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let resp = reqwest::Client::new()
+        .get(&format!("http://{addr}/"))
+        .header("Authorization", "Bearer ccteam:nope")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn url_shim_sets_cookie_and_redirects_to_clean_uri() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_one_project(&paths, "demo");
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let client = nofollow();
+    let resp = client
+        .get(&format!(
+            "http://{addr}/project/demo?token=ccteam:{TOKEN_HEX}"
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 303, "URL shim must 303 redirect");
+    let loc = resp
+        .headers()
+        .get("location")
+        .expect("Location header")
+        .to_str()
+        .unwrap();
+    assert_eq!(loc, "/project/demo", "redirect strips token query");
+    let set_cookie = resp
+        .headers()
+        .get("set-cookie")
+        .expect("Set-Cookie header")
+        .to_str()
+        .unwrap();
+    assert!(
+        set_cookie.contains("ccteam_token="),
+        "Set-Cookie missing ccteam_token: {set_cookie}"
+    );
+    assert!(
+        set_cookie.to_lowercase().contains("httponly"),
+        "cookie must be HttpOnly: {set_cookie}"
+    );
+    assert!(
+        set_cookie.contains("SameSite=Strict") || set_cookie.contains("samesite=strict"),
+        "cookie must be SameSite=Strict: {set_cookie}"
+    );
+}
+
+#[tokio::test]
+async fn cookie_carries_subsequent_request() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    fixture_one_project(&paths, "demo");
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let client = reqwest::Client::builder()
+        .cookie_store(true)
+        .build()
+        .unwrap();
+    // First hit goes through the URL shim; reqwest follows the 303
+    // and the cookie store retains the cookie for round 2.
+    let resp = client
+        .get(&format!("http://{addr}/?token=ccteam:{TOKEN_HEX}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    // Second hit — no token on the URL — must succeed via cookie.
+    let resp2 = client.get(&format!("http://{addr}/")).send().await.unwrap();
+    assert_eq!(
+        resp2.status(),
+        200,
+        "cookie must carry through subsequent requests"
+    );
+}
+
+#[tokio::test]
+async fn health_endpoint_is_exempt_from_auth() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let resp = reqwest::get(&format!("http://{addr}/health"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "/health must not require auth");
+}
+
+#[tokio::test]
+async fn url_shim_rejects_wrong_token() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let state = AppState::with_auth(paths, AuthState::enabled(TOKEN_HEX.into()));
+    let addr = spawn(state).await;
+    let client = nofollow();
+    let resp = client
+        .get(&format!("http://{addr}/?token=ccteam:wrong"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401, "wrong shim token ⇒ 401, no redirect");
+}
+
+/// Smoke test for the LAN-RCE warning path. We can't easily capture
+/// the eprintln output of a `serve()` call in-process (stderr is
+/// process-global), but we can confirm that:
+///
+/// 1. `ServeOpts { no_auth: true, no_auth_grace_secs: Some(0) }`
+///    plus a non-loopback bind doesn't deadlock or prevent serving,
+/// 2. The serving handle remains responsive,
+/// 3. The auth state ends up disabled (no token gate).
+///
+/// stderr capture is left to the dev-plan §8 grep matrix
+/// (`grep 'LAN-wide RCE'`) which already enforces the warning lives
+/// in source.
+#[tokio::test]
+async fn lan_rce_warning_string_appears_in_source() {
+    // Sanity check that the source string is exactly the literal the
+    // dev-plan grep matrix asserts. Cheap and ensures a future PR
+    // doesn't water it down.
+    let lib_src = include_str!("../src/lib.rs");
+    assert!(
+        lib_src.contains("LAN-wide RCE on bypassPermissions sessions"),
+        "src/lib.rs must contain the LAN-RCE banner text",
+    );
+}

--- a/crates/ccteam-web/tests/web_token_file_test.rs
+++ b/crates/ccteam-web/tests/web_token_file_test.rs
@@ -1,0 +1,83 @@
+//! V0.3 M5.3 — token file management integration tests.
+//!
+//! Mirrors `src/token.rs::tests` but at the integration level so any
+//! regression that breaks the public surface (`generate_or_load_token`
+//! / `load_existing` / `default_token_path`) shows up red as well as
+//! the unit-level guards. Also exercises the `CcteamPaths` →
+//! `default_token_path` integration.
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use ccteam_core::CcteamPaths;
+use ccteam_web::token::{default_token_path, generate_or_load_token, load_existing};
+use tempfile::TempDir;
+
+fn fake_paths(root: &std::path::Path) -> CcteamPaths {
+    CcteamPaths {
+        root: root.join(".ccteam"),
+        projects_root: root.join("projects"),
+    }
+}
+
+#[test]
+fn first_call_generates_64_hex_chars_and_creates_file_with_mode_0600() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let token_path = default_token_path(&paths);
+    assert!(!token_path.exists());
+
+    let tok = generate_or_load_token(&token_path).unwrap();
+    assert_eq!(tok.len(), 64, "32 bytes = 64 hex chars");
+    assert!(tok.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(token_path.exists());
+
+    #[cfg(unix)]
+    {
+        let mode = std::fs::metadata(&token_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "fresh token file must be mode 600");
+    }
+}
+
+#[test]
+fn second_call_returns_same_token() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let token_path = default_token_path(&paths);
+
+    let first = generate_or_load_token(&token_path).unwrap();
+    let second = generate_or_load_token(&token_path).unwrap();
+    assert_eq!(first, second, "subsequent calls must reuse the token");
+}
+
+#[test]
+fn delete_then_regenerate_creates_fresh_token() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let token_path = default_token_path(&paths);
+
+    let first = generate_or_load_token(&token_path).unwrap();
+    std::fs::remove_file(&token_path).unwrap();
+    assert!(!token_path.exists());
+    let second = generate_or_load_token(&token_path).unwrap();
+    assert_ne!(first, second, "regenerated token must differ");
+}
+
+#[test]
+fn load_existing_trims_trailing_whitespace() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let token_path = default_token_path(&paths);
+    std::fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+    std::fs::write(&token_path, "deadbeef\n").unwrap();
+    let tok = load_existing(&token_path).unwrap();
+    assert_eq!(tok, "deadbeef");
+}
+
+#[test]
+fn default_token_path_resolves_under_root() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let token_path = default_token_path(&paths);
+    assert_eq!(token_path, paths.root.join("web-token"));
+}

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -32,7 +32,7 @@ P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候�
 **2026-05-09 V0.2.2 patch**:加 F34-F40 七条用户反馈 + 命名 sweep + UX 增强,跨 7 PR 全部修复;
 **2026-05-09 V0.2.2 e2e retro patch**:4-suite 并行 e2e 验证,撞 F41 (P1) + F42 (P1) + F43 (P2),同 PR 一波修;
 **2026-05-10 V0.2.2 F44 反向回滚**:`/usr/bin/cct` namespace 碰撞驱动整体反向 F39,F44 单 PR 覆盖;
-**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4);**2026-05-10 V0.3 PR #1 ship**:F45 promote 部分修复(actions 模块 + mcp_serve wrapper 透传 + dep_graph 自检测试落地),仍待 M5.3 写动作 endpoint 消费才整体 close,分布:
+**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4);**2026-05-10 V0.3 PR #1 ship**:F45 promote 部分修复(actions 模块 + mcp_serve wrapper 透传 + dep_graph 自检测试落地),仍待 M5.3 写动作 endpoint 消费才整体 close;**2026-05-10 V0.3 PR #4 ship**:F45 **整体 close**(M5.3 写动作 endpoint + token auth + URL-shim cookie + path-traversal 守卫全部 ship),分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
@@ -738,7 +738,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **优先级**:**P0**(silent-substitute footgun)。
 - **来源**:用户 2026-05-10 反馈 + 实证 `dpkg -S /usr/bin/cct` 命中 `proj-bin`。
 
-### F45 — write 动作 + 读端 helper 锁在 ccteam-cli,V0.3 web crate 无法复用(2026-05-10 加;**写端部分修复:V0.3 PR #1;读端补强:V0.3 PR #2;整体 close 在 V0.3 M5.3 PR #4 写动作 endpoint 落地**)
+### F45 — write 动作 + 读端 helper 锁在 ccteam-cli,V0.3 web crate 无法复用(2026-05-10 加;**整体 close:V0.3 M5.3 PR #4 写动作 endpoint + auth gate 落地**)
 
 - **文件:行号**:`crates/ccteam-cli/src/mcp_serve.rs::tool_send_to_session`(line 456,`fn` 非 `pub fn`)+ `tool_inject_decision`(line 500,同)+ pause / resume 在 mcp_serve 内 inline logic 无独立 fn。
 - **现状**:V0.2.2 ship 时,写动作 helper 全部位于 `ccteam-cli::mcp_serve.rs` 私有 fn,只供 MCP tool dispatch 内部消费;V0.3 web UI(新 crate `crates/ccteam-web`)需要复用同一逻辑写 inbox / control,但 `ccteam-web` 不能 depend on `ccteam-cli`(binary-as-library 反模式 + dep 图倒挂 — `ccteam-cli` 是 binary entry,`ccteam-web` 是新 crate,sibling 关系应共下沉 `ccteam-core`)。读侧 helper 已 public(`collect_projects` / `collect_recent_events` / `run_resume` / `run_show`,以及 `ccteam_core::ProjectState` / `CcteamPaths` / `render_screenshot` / `tmux::capture_pane_*` / `check_daemon_health` / `SessionMailbox` / `inbox_filename` / `pick_unused_slug` / `bootstrap_project`),写侧未 promote。
@@ -749,6 +749,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **2026-05-10 部分修复(V0.3 PR #1)**:`crates/ccteam-core/src/actions.rs` 落地;4 个 pub fn(`send_to_session` + `send_to_session_with` / `inject_decision` / `pause` / `resume`)外加 `next_inbox_seq` / `next_inbox_path` / `DecisionInput` / `SendOptions` / `SendResult`。`mcp_serve.rs::tool_send_to_session` / `tool_inject_decision` / `tool_pause` / `tool_resume` 全部改为薄 wrapper(args 拆 + JSON encode + 调 `actions::*`),18 个 mcp_serve 测试不变绿(回归保证 wrapper 透传);`commands::run_resume` body 提到 `actions::resume`,旧 fn 仅留 thin-wrap。`crates/ccteam-web/tests/dep_graph_test.rs` 自检 `cargo tree -p ccteam-web` 不命中 `ccteam-cli`。
 - **2026-05-10 读端补强(V0.3 PR #2)**:`ProjectSummary` / `collect_projects` / `collect_recent_events` 同样 promote — 原存于 `ccteam-cli::commands` 公有 fn,但 `ccteam-web` 不能 depend on `ccteam-cli`(同 binary-as-library 反模式),不能 import 它们。新建 `crates/ccteam-core/src/queries.rs` 模块,move 三者过来 + 加 6 个单元测试;`ccteam-cli::commands` 留 `pub use ccteam_core::{collect_projects, collect_recent_events, ProjectSummary};` 让 `mcp_serve.rs` / `run_ls` / `run_progress` 现有 import 路径不变。M5.1 dashboard / project handler 直接调 `ccteam_core::queries::*`,dep_graph_test 仍绿。
 - **仍 open**:web 层 POST endpoint(`/api/<slug>/{btw,inject_decision,pause,resume}`)在 M5.3 落地后才真正消费 actions::*,届时本 finding 整体 close。
+- **2026-05-10 整体 close(V0.3 PR #4)**:`crates/ccteam-web/src/routes/actions.rs` 落地 — 四个 POST handler `handle_btw` / `handle_inject_decision` / `handle_pause` / `handle_resume` 全部 thin-call `ccteam_core::actions::*`,validation(text length 1..=4000 / decision body 1..=8000 / 路径 absolute + 不含 `..` + `starts_with(project_ccteam_dir(slug))`) 在 route boundary 完成。`crates/ccteam-web/src/auth.rs` 加 token-Bearer middleware(loopback 信任默认 / 非 loopback 自动开 + 文件 mode 0600 + URL shim cookie)+ `/health` 例外。`cargo tree -p ccteam-web | grep ccteam-cli` 仍 0 命中,dep_graph_test 守红线。47 新测试覆盖 actions 4 endpoint + auth 8 路径 + token 文件 5 场景;737 全绿(690 baseline → 737)。本 finding **整体 close**。
 
 ### F40 — `product-research` team 名冗长 + 领域名缺位(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #6 alias 软迁移)**)
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -1882,3 +1882,99 @@ watermark(`HashMap<PathBuf, u64>`,Mutex 保护)→ 读 appended bytes →
 
 **file rotation**:文件 size 缩小(truncate / rename)→ watermark 重置
 为 0,replay 全部内容,记 `tracing::warn!`(罕见,主要为防御 corner case)。
+
+### 15.7 Write-action POST endpoints(M5.3)
+
+V0.3 M5.3 加四个 form-encoded POST 端点,全部走
+`ccteam-core::actions::*`(`docs/dev-coupling-audit.md` F45 close):
+
+| Method | Path | Body(`application/x-www-form-urlencoded`) | 状态码 | 说明 |
+|---|---|---|---|---|
+| `POST` | `/api/{slug}/btw` | `text=<urlencoded, 1..=4000 chars>` | 303 / 400 / 5xx | 调 `actions::send_to_session(paths, slug, text)`;成功 → `Location: /project/<slug>` |
+| `POST` | `/api/{slug}/inject_decision` | `path=<absolute, 必须前缀 ~/projects/<slug>/.ccteam/>&body=<urlencoded, 1..=8000 chars>` | 303 / 400 / 5xx | 调 `actions::inject_decision(paths, slug, DecisionInput)`;`path` 含 `..` 组件 / 非绝对 / 不在 `<project>/.ccteam/` 之下 → 400 |
+| `POST` | `/api/{slug}/pause` | (空)| 303 / 4xx | 调 `actions::pause(paths, slug)` — 设 `state.user_pause_pending=true`,**不**杀 tmux session(CLAUDE.md §三 红线)|
+| `POST` | `/api/{slug}/resume` | (空)| 303 / 4xx | 调 `actions::resume(paths, slug)` — 清 `user_pause_pending` + `user_attached`,`phase_state` 回 `Idle`,归档 `escalation.md`(若存在)|
+
+**成功语义**:全部 303 See Other → `/project/<slug>`,浏览器自动跟随
+回详情页;form 提交流程 = 用户写完 → submit → 303 → 重新加载详情页
+看 inbox 落地 / state.json 翻位。
+
+**输入校验红线**:
+
+- `text` / `body` 长度上下界(`1..=4000` / `1..=8000`)在 route boundary
+  做,超长直接 400;**不**让 `actions::send_to_session` 自己挡(actions
+  层是 policy-free helper,长度策略归 channel 层)。
+- `inject_decision` `path` 必须满足:`is_absolute()` + 不含 `Component::ParentDir`
+  + `starts_with(paths.project_ccteam_dir(slug))`。这三条共同抗
+  `~/projects/<slug>/.ccteam/../../../etc/passwd` 与裸 `/etc/passwd`。
+
+**错误语义**:
+
+- 400 + plain-text reason:输入校验失败、unknown slug(`actions::*`
+  返 `no project / session named ...`)
+- 5xx + plain-text:`inject_decision` 写盘失败 / `pause` / `resume`
+  状态机错误(罕见)
+- 写动作 handler **永不** 5xx 静默 — handler 内 `tracing::warn!`
+  + 客户端拿到具体 reason,方便 dogfood debug
+
+### 15.8 鉴权(M5.3)
+
+ccteam web 默认走 token 鉴权,启动时根据 bind 地址决定:
+
+| bind | `--no-auth` | enabled | token |
+|---|---|---|---|
+| `127.0.0.1:*` / `[::1]:*` | false | false(loopback 信任)| 不生成 |
+| `127.0.0.1:*` / `[::1]:*` | true | false | 不生成 |
+| 非 loopback(`0.0.0.0` / LAN IP)| false | **true**(默认开)| `~/.ccteam/web-token` 生成或读 |
+| 非 loopback | true | false(显式 opt-out)| 不生成,stderr 大字 LAN-RCE 警告 + 5s Ctrl-C 倒计时 |
+
+#### 15.8.1 Token 文件协议
+
+- 路径:`~/.ccteam/web-token`(可经 `--token-file <path>` 覆盖)
+- 内容:32-byte 随机 → lowercase hex(64 ASCII chars)+ trailing `\n`(load 时 `trim()`)
+- 文件 mode:**`0o600`**(Unix `OpenOptions::create_new` + `mode(0o600)`)
+- 已存在 + mode != 0600 → stderr 警告 + 继续加载(不 fail-closed,
+  避免 dogfood 期间因为 umask race 锁死)
+- 删除 + 重启 → 自动重生,token 不可重放
+
+#### 15.8.2 Wire format
+
+- 客户端 header:`Authorization: Bearer ccteam:<hex>`(constant-time
+  比对,`subtle::ConstantTimeEq`,长度先短路再 ct_eq;长度泄露不影响
+  threat model 因为 hex 长度公开 = 64)
+- 浏览器首次访问可走 URL shim:`?token=ccteam:<hex>`,middleware:
+  1. 验证 token,
+  2. `Set-Cookie: ccteam_token=<hex>; HttpOnly; SameSite=Strict; Path=/`,
+  3. 303 redirect 到去掉 `token` 参数的相同 URL
+- 后续 GET / SSE 自动携带 cookie;auth_layer 优先 Bearer header,
+  其次 cookie value(constant-time 同上)
+
+#### 15.8.3 鉴权范围
+
+- **整体权限**(用户 2026-05-10 决策,无 read/write 拆分):enabled 时
+  所有 stateful router 路径(`/`, `/project/<slug>`, `/sse/...`,
+  `/screenshot/...`, `/api/.../...`)都需要 Bearer header 或 cookie。
+- **`/health` 例外**:留给 ops 监控,response body 仅
+  `{status, version}`,无 project 状态泄漏。
+- 非 loopback `--no-auth` 启动时 stderr 输出红色 ANSI 警告:
+  `WARNING: --no-auth on non-loopback bind = LAN-wide RCE on
+  bypassPermissions sessions.` + 5s 倒计时(`ServeOpts::no_auth_grace_secs`
+  = `Some(5)` 默认,集成测试传 `Some(0)` 跳过 grace)。
+
+#### 15.8.4 CSRF 防御
+
+写动作 POST 必须 carries `Authorization: Bearer` header,即使
+session cookie 有效。理由:
+
+- 浏览器跨域 form-submit 不会附加 `Authorization`(header allowlist),
+- 跨域 fetch / XHR 触发 CORS preflight,server 默认拒,
+- 同源 form-submit 由 `project.html` inline JS 注入 Bearer header
+  (token 从 server-side 模板渲染进 JS 字符串字面量),
+
+→ 攻击者跨域 form 即使 cookie 自动附带也**无法**生成有效 POST。
+
+XSS tradeoff:token 出现在 HTML attribute 而非纯 HttpOnly cookie。
+被 XSS'd 时攻击者本来就能同源 fetch + 自动 cookie,所以 inline 不
+增加 threat surface。
+
+

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -675,7 +675,7 @@ V0.3 ship 状态:
 | **M5.0** | crate scaffold + write helper promote 到 `ccteam-core::actions` + `GET /health` | ✅ |
 | **M5.1** | read-only dashboard:`GET /` 项目列表 + `GET /project/<slug>` 详情 + `GET /assets/{file}` 静态资源 + 状态 badge(F35 silence_classifier 只读复用)+ outbox 渲染(`SessionMailbox`)| ✅ |
 | **M5.2** | SSE 实时事件流(`/sse/all` + `/sse/project/<slug>` 单 `notify` watcher → `tokio::sync::broadcast` capacity `1024` fan-out;wire format `event: progress` + `data: <one-line-JSON>`,15s `: keepalive`)+ 按需 PNG 截图(`/screenshot/<slug>.png` 同步 `spawn_blocking` 调 F38 `render_screenshot`,F38 不可用 → 504 + plain-text reason,**不 polling**)| ✅ |
-| **M5.3** | 写动作(`POST /api/<slug>/{btw,inject_decision,pause,resume}` 全走 `ccteam_core::actions::*` M5.0 promote)+ token 鉴权(loopback 免 token / 非 loopback 默认 token,`Authorization: Bearer ccteam:<token>`,`subtle::ConstantTimeEq` 比对,`~/.ccteam/web-token` mode 0600)| 计划中 |
+| **M5.3** | 写动作(`POST /api/<slug>/{btw,inject_decision,pause,resume}` 全走 `ccteam_core::actions::*` M5.0 promote;handler boundary 校验长度 + path-traversal `..` + `<project>/.ccteam/` prefix)+ token 鉴权(loopback 免 token / 非 loopback 默认 token / `--no-auth` opt-out + 5s LAN-RCE 倒计时;`Authorization: Bearer ccteam:<token>`,`subtle::ConstantTimeEq` 比对,`~/.ccteam/web-token` mode 0600;浏览器 URL shim `?token=ccteam:<hex>` → HttpOnly `ccteam_token` cookie + 303 → 干净 URL;`/health` 例外免 auth)| ✅ |
 | **M5.4** | E2E + retro + workspace.version `0.2.2` → `0.3.0` ship gate | 计划中 |
 
 V0.3 主要红线(详 PRD §3 / `interfaces.md` §15 / CLAUDE.md §三):


### PR DESCRIPTION
## Closes
- V0.3 M5.3 (`docs/v0-3/prd.md` §6)
- F45 (`docs/dev-coupling-audit.md`) — write helpers were promoted to `ccteam-core::actions` in PR #1; this PR is the first channel to consume them, completing the coupling fix.

## Summary

Transitions the dashboard from read-only to read+write. Four POST routes call `ccteam-core::actions::*` directly; auth is a whole-app gate (no read-only split, per user decision on PR #34).

- `POST /api/<slug>/btw` → `actions::send_to_session`
- `POST /api/<slug>/inject_decision` → `actions::inject_decision` (route boundary rejects `..` components, non-absolute paths, anything outside `<project>/.ccteam/`)
- `POST /api/<slug>/pause` → `actions::pause` (sets `user_pause_pending`; never kills tmux — CLAUDE.md §三)
- `POST /api/<slug>/resume` → `actions::resume`

## Auth

| bind | `--no-auth` | enabled | token |
|---|---|---|---|
| loopback | false | false | not generated |
| loopback | true | false | not generated |
| non-loopback | false | **true** | `~/.ccteam/web-token` (mode 0600) |
| non-loopback | true | false | red-banner + 5s Ctrl-C grace |

- `Authorization: Bearer ccteam:<hex>` constant-time compare via `subtle::ConstantTimeEq`
- URL shim: `?token=ccteam:<hex>` ⇒ HttpOnly + SameSite=Strict `ccteam_token` cookie + 303 to clean URL
- `/health` exempt (ops monitoring)
- 5s grace window has a `ServeOpts::no_auth_grace_secs` test seam (production = `Some(5)`, integration tests pass `Some(0)`)

## CSRF defense (advisor option a)

POST handlers require the Bearer header **even when** a valid cookie is present. `project.html` inlines the token into a small JS shim that fetches with the `Authorization` header on form submit. Cross-origin form submits cannot inject custom headers, so attacker.example cannot forge an authenticated POST against `/api/<slug>/btw`. XSS tradeoff (token in HTML attribute, not pure HttpOnly) documented in `auth.rs` — XSS already loses to same-origin fetch + cookie, so inlining doesn't widen the threat model.

## Judgment calls

- **CSRF: option (a)** (Bearer required for POST always; same-origin browser shim inlines the token). Brief PRD says POST must always carry `Authorization` — option (b) cookie-only with Origin check would be incompatible.
- **`/health` exempt**: yes, body is `{status, version}` only, no project leak. Tests assert auth on `/`, not `/health`.
- **5s countdown test seam**: `ServeOpts::no_auth_grace_secs: Option<u64>`; production `Some(5)`, tests `Some(0)`.
- **AuthState in AppState**: cleaner than a parallel `State<Arc<AuthState>>`; clones with the rest of the per-request state.
- **Cookie value asymmetry (intentional)**: cookie holds bare hex; Bearer header expects `ccteam:<hex>` prefix. Documented in both `auth.rs` and `interfaces.md §15.8.2`.
- **Behavioral stderr capture deferred**: in-process stderr is global; the `lan_rce_warning` test source-greps `lib.rs` for the literal banner. Dev-plan §8 grep matrix backstops on CI.
- **4xx UX**: form-submit JS does `location.reload()` on any response, so a 400 silently reloads (input lost). Pure UX, not security; future iteration can wire an inline error banner. The validation tests still confirm 400s are returned correctly.

## Tests

| File | Count | Coverage |
|---|---|---|
| `tests/auth_test.rs` | 9 | loopback open / 401 missing+wrong header / 303 + Set-Cookie URL shim / cookie carry-over / `/health` exempt / source-grep LAN-RCE |
| `tests/actions_test.rs` | 9 | inbox written / decision written / `/etc/passwd` rejected / `..` traversal rejected / length cap / pause+resume state.json mutations |
| `tests/web_token_file_test.rs` | 5 | mode 0600 / idempotent reload / regenerate after delete / trim whitespace / default path |
| `ccteam-web` unit tests | 24 | auth helpers / actions validators / token gen / decision-candidate scan |

**Baseline 690 → 737, 0 failed.** Clippy: 0 errors (warnings unchanged from pre-existing baseline; new tests use the same `&format!()` patterns the codebase already has).

## Red-line sweep

- `cargo tree -p ccteam-web | grep ccteam-cli` = 0 hits ✓
- `git grep -nE 'subtle::|ConstantTimeEq' crates/ccteam-web/src/auth.rs` = hits ✓
- `git grep -nE '0o600' crates/ccteam-web/src/` = hits in `token.rs` ✓
- `git grep -nE 'LAN-wide RCE' crates/ccteam-web/src/lib.rs` = hits ✓
- `git grep -nE 'use ccteam_core::actions' crates/` = hits in `mcp_serve.rs` + `routes/actions.rs` ✓
- No `\bcct\b` regressions (binary still `ccteam`, F44 reverse rollback intact)

## Out of scope (M5.4)

No CLAUDE.md / README / Makefile edits. No `workspace.package.version` bump. M5.4 ship-gate PR owns those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)