### PR TITLE
v0.3.1 docs: PRD + dev-plan + README initial draft

### DIFF
--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -32,13 +32,14 @@ P0 + 同 PR 关闭;**2026-05-08 V0.2 e2e retro**:加 F26-F33 八条 V0.2.1 候�
 **2026-05-09 V0.2.2 patch**:加 F34-F40 七条用户反馈 + 命名 sweep + UX 增强,跨 7 PR 全部修复;
 **2026-05-09 V0.2.2 e2e retro patch**:4-suite 并行 e2e 验证,撞 F41 (P1) + F42 (P1) + F43 (P2),同 PR 一波修;
 **2026-05-10 V0.2.2 F44 反向回滚**:`/usr/bin/cct` namespace 碰撞驱动整体反向 F39,F44 单 PR 覆盖;
-**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4);**2026-05-10 V0.3 PR #1 ship**:F45 promote 部分修复(actions 模块 + mcp_serve wrapper 透传 + dep_graph 自检测试落地),仍待 M5.3 写动作 endpoint 消费才整体 close;**2026-05-10 V0.3 PR #4 ship**:F45 **整体 close**(M5.3 写动作 endpoint + token auth + URL-shim cookie + path-traversal 守卫全部 ship),分布:
+**2026-05-10 V0.3 doc-only kickoff**:加 F45 P1(write helper promote ccteam-cli → ccteam-core::actions,M5.0 关键解耦),实施在 V0.3 PR #1 / #4);**2026-05-10 V0.3 PR #1 ship**:F45 promote 部分修复(actions 模块 + mcp_serve wrapper 透传 + dep_graph 自检测试落地),仍待 M5.3 写动作 endpoint 消费才整体 close;**2026-05-10 V0.3 PR #4 ship**:F45 **整体 close**(M5.3 写动作 endpoint + token auth + URL-shim cookie + path-traversal 守卫全部 ship);**2026-05-10 V0.3.1 doc-only kickoff**:加 F46-F51 六条(战略 pivot:flex team kind + adhoc multi-session + HarnessAdapter trait + CodexAdapter stub + web flex 适配 + ship gate),待 V0.3.1 ship 后填 close 状态;分布:
 
 | 优先级 | 数量 | 编号 |
 |---|---|---|
 | **P0 阻塞泛化(剩余)** | 0 | — |
 | **P1 该做但可后置(剩余)** | 2 | F15(M1+ block-push 时做)、F23(conditional;待 spike 重跑) |
 | **P2 边角(剩余)** | 1 | F17 |
+| **V0.3.1 待 ship**(2026-05-10 加) | 6 | F46(P0)、F47(P1)、F48(P0)、F49(P0)、F50(P1)、F51(P0)|
 | **N/A 已是领域无关** | 2 | F14, F19(M3 docs sweep 后)|
 | **已修复** | 38 | F1 / F5 / F6 / F7 / F18(2026-05-07 rename PR;F1 触发逻辑实际早 M3.1 已切到 template.auto_loop,本 PR 完成命名层 sweep)、F2 / F3 / F4(M3.1 dag.rs)、F8(2026-05-07 directory scan)、F9 / F10 / F11(M3.4 team-aware bootstrap;F11 dev 仍裸 `phases/` 但非阻塞)、F12 / F13(M3.3 `--team` CLI + `state.team`)、F16(M3.4 phase 模板 team 化)、F20(M3.1+M3.4 retro_schema 数据形式 + product-research 填字段 + M4.1 phase 消费)、F21(@a5fb21d)、F22(PR #12)、**F24 / F25(2026-05-08 M0.23 PR)**、**F26 / F27 / F28 / F29 / F30 / F31 / F32 / F33(2026-05-08 V0.2.1 patch)**、**F34 / F35 / F36 / F37 / F38 / F39 / F40(2026-05-09 V0.2.2 patch — 7 finding 跨 7 PR)**、**F41 / F42 / F43(2026-05-09 V0.2.2 e2e retro patch)** |
 
@@ -750,6 +751,60 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **2026-05-10 读端补强(V0.3 PR #2)**:`ProjectSummary` / `collect_projects` / `collect_recent_events` 同样 promote — 原存于 `ccteam-cli::commands` 公有 fn,但 `ccteam-web` 不能 depend on `ccteam-cli`(同 binary-as-library 反模式),不能 import 它们。新建 `crates/ccteam-core/src/queries.rs` 模块,move 三者过来 + 加 6 个单元测试;`ccteam-cli::commands` 留 `pub use ccteam_core::{collect_projects, collect_recent_events, ProjectSummary};` 让 `mcp_serve.rs` / `run_ls` / `run_progress` 现有 import 路径不变。M5.1 dashboard / project handler 直接调 `ccteam_core::queries::*`,dep_graph_test 仍绿。
 - **仍 open**:web 层 POST endpoint(`/api/<slug>/{btw,inject_decision,pause,resume}`)在 M5.3 落地后才真正消费 actions::*,届时本 finding 整体 close。
 - **2026-05-10 整体 close(V0.3 PR #4)**:`crates/ccteam-web/src/routes/actions.rs` 落地 — 四个 POST handler `handle_btw` / `handle_inject_decision` / `handle_pause` / `handle_resume` 全部 thin-call `ccteam_core::actions::*`,validation(text length 1..=4000 / decision body 1..=8000 / 路径 absolute + 不含 `..` + `starts_with(project_ccteam_dir(slug))`) 在 route boundary 完成。`crates/ccteam-web/src/auth.rs` 加 token-Bearer middleware(loopback 信任默认 / 非 loopback 自动开 + 文件 mode 0600 + URL shim cookie)+ `/health` 例外。`cargo tree -p ccteam-web | grep ccteam-cli` 仍 0 命中,dep_graph_test 守红线。47 新测试覆盖 actions 4 endpoint + auth 8 路径 + token 文件 5 场景;737 全绿(690 baseline → 737)。本 finding **整体 close**。
+
+### F46 — HarnessAdapter trait 缺位,Claude Code statusline 结构化数据丢失(2026-05-10 加;**待 V0.3.1 PR #1 ship**)
+
+- **文件:行号**:`crates/ccteam-core/src/harness.rs`(新建);`crates/ccteam-web/src/routes/sse.rs`(扩 harness SSE);`~/.claude/statusline-command.sh` wrapper 落 `~/.ccteam/harness/<slug>-<sid>.json`。
+- **现状**:V0.3 web UI dashboard 的数据源 = `progress.jsonl` + tmux pane 截图(F38);Claude Code statusline + subagent 面板里**有大量结构化数据**(模型名 / context% / token / cost / rate-limit / subagent),V0.3 dashboard 拿不到结构化版本(只截图视觉版),F35 enriched outbox 也只 ASCII pane_tail。V0.3.1 引入 Codex 后,session 也不再只有一种 harness — 需要 trait 抽象统一。
+- **是否真 dev-specific**:**否——presentation 信息抽象层。** 跟 phase / team 无关,所有 harness 都需要(claude / codex / 未来 cline / aider / 等)。
+- **解耦方案**:`crates/ccteam-core/src/harness.rs` 加 `HarnessAdapter` trait + `HarnessSnapshot` / `SubagentState` / `SpawnOpts` / `SessionHandle` / `HarnessError` 数据结构;`ClaudeCodeAdapter` 完整实现 trait 全部方法;`ccteam doctor --install-statusline-adapter` 安装 wrapper(marker `# ccteam-managed:statusline begin/end` 保护用户手改 + 原文件 backup .bak-<utc-ts>);`~/.ccteam/harness/<slug>-<sid>.json` 协议(stdin JSON 全覆盖,delta archive V0.4 deferred);web SSE `GET /sse/harness/<slug>` + `/sse/harness/<slug>/<sid>`。**红线**:harness snapshot 只是 presentation,**不参与 orchestrator 状态决策**(progress.jsonl 仍 SoT)。
+- **优先级**:**P0**(V0.3.1 foundation;F47/F49/F50 都依赖 trait shape)。
+- **来源**:`docs/v0-3-1/prd.md §3`;研究 doc `docs/research/v0-3-1-harness-adapter-plan.md`(V0.3 ship 前临时记录,本 finding 是其正式版);用户 Telegram 2026-05-10 message 311。
+
+### F47 — Codex CLI 缺前向兼容 trait stub,V0.3.2 实现无地方接入(2026-05-10 加;**待 V0.3.1 PR #2 ship**)
+
+- **文件:行号**:`crates/ccteam-core/src/harness.rs`(F46 后扩 `CodexAdapter`);`crates/ccteam-core/src/team.rs::TeamSpec`(加 `sessions: Vec<DefaultSessionSpec>` 字段);`crates/ccteam-cli/src/commands.rs::run_session_*`(`--harness=codex` flag);`run_doctor` 加 codex 检测段。
+- **现状**:V0.3.1 不实现 Codex 完整支持(`docs/research/ccteam-codex-integration.md` M2-M5 路线 ~月级工程量),但 CLI 与 schema 需要现在就接受 `harness: codex` 让用户提前声明意图,V0.3.2 落 `CodexAdapter` 实现时不破已 ship 代码。
+- **是否真 dev-specific**:**否——前向兼容 stub。**
+- **解耦方案**:`CodexAdapter` 全 stub 实现 trait,`spawn_session` / `ingest_snapshot` / `shutdown_session` 全返 `Err(HarnessError::NotImplemented { harness: "codex", reason: "Codex adapter is trait-stub in V0.3.1; full implementation tracked in docs/v0-3-1/prd.md §F47, deferred to V0.3.2+. Use --harness=claude or wait." })`(reason 是 `&'static str`,无 alloc);`team.yaml::sessions[]` schema(`harness: claude | codex`,serde 默认 `claude`);`ccteam session add --harness codex` 接受 flag,执行返友好 error + exit 1;`ccteam doctor` 检测 `which codex` 输出 informational(不 fail)。
+- **优先级**:**P1**(forward-compat 接口,本 PR 不阻塞用户跑 claude harness)。
+- **来源**:`docs/v0-3-1/prd.md §4` + `docs/research/ccteam-codex-integration.md` M0-M1 路线 + 用户 Telegram 2026-05-10 message 313 决策"V0.3.1 落 stub,V0.3.2 落 impl"。
+
+### F48 — `kind: flex` team kind 缺位,phase 编排是 ccteam 唯一工作姿态(2026-05-10 加;**待 V0.3.1 PR #3 ship**)
+
+- **文件:行号**:`crates/ccteam-core/src/team.rs::TeamSpec`(加 `kind: TeamKind` 字段);`crates/ccteam-core/src/orchestrator.rs::TeamRuntime`(加 `should_run_auto_loop` / `should_inject_phase` / `should_check_golden_rules` helpers);`crates/ccteam-core/src/team_factory.rs::init_team_staging`(`--kind=flex` 跳过 phase scaffold)。
+- **现状**:V0.1/V0.2/V0.3 ccteam 团队都是 phase-driven(workflow 暗含),没有"空 phase / 用户原生姿态驱动 session" 这种姿态。V0.3.1 战略 pivot 把 ccteam 扩展为 session farm,需要支持用户在 session 里自由跑(无 phase 注入 / 无 auto_loop / 无 golden_rules),ccteam 只观测 + 记录 + 提供控制面。
+- **是否真 dev-specific**:**否——team kind 抽象。**
+- **解耦方案**:`team.yaml::kind` 字段,`TeamKind { Workflow, MultiWorkflow, Flex }`,`#[serde(default)]` 保 V0.1/V0.2/V0.3 yaml parse 不变(默认 `Workflow`)。`kind: flex` 与 `parallelism`(phase 级字段)正交 — flex 团队无 phase 所以 `parallelism` 不适用。`TeamSpec::validate` 拒绝非法组合(flex + golden_rules / escalate_grammar_extensions / 非空 phase_dir)。orchestrator behavior gating 三个 helper(`should_run_auto_loop` 等)按 kind 返 bool;**flex 团队 silence_classifier / cost watcher / hooks / progress.jsonl / 跨项目 memory bridge 仍跑**(observability 全保留)。team factory `--kind=flex` scaffold 跳过 phase markdown。
+- **优先级**:**P0**(V0.3.1 战略 pivot 核心;F49 multi-session 在此基础上)。
+- **来源**:`docs/v0-3-1/prd.md §5`;用户 Telegram 2026-05-10 message 311 原话:"team 工厂创建出空的 phases 团队...用户原始用 claude code 方式来完成"。
+
+### F49 — Adhoc multi-session 缺位,单项目无法托管 N 个不同 harness session(2026-05-10 加;**待 V0.3.1 PR #4 ship**)
+
+- **文件:行号**:`crates/ccteam-cli/src/commands.rs::run_session_{add,ls,attach,rm}`(新建);`crates/ccteam-core/src/state.rs::ProjectState`(扩 `sessions: BTreeMap<sid, SessionRecord>` + `next_sid_seq: BTreeMap<harness, u64>` 字段);`crates/ccteam-hooks/src/progress.rs`(`progress.jsonl` 路径解析按 `state::team_kind` 分流到 `<slug>/<sid>.jsonl` 子目录 vs flat `<slug>.jsonl`)。
+- **现状**:V0.3 ccteam 项目 = 单 tmux session(except `parallelism: multi_session` 的 phase 级 fan-out 拓扑)。flex 团队需要 adhoc:用户起项目后任意时刻 `ccteam session add` 起新 session,删 session,attach 任一 session,混合 Claude+Codex(支持 cross-review pattern)。multi_session 的 master + 预定义 sub-module 是 phase 级、代码维度,**不**适合 adhoc + 进程维度。
+- **是否真 dev-specific**:**否——session 维度并行机制。**
+- **解耦方案**:**新轻量 session 注册**(不复用 multi_session 拓扑)— `~/projects/<team>-<slug>/.ccteam/sessions/<sid>/` 子目录,master `state.json::sessions{sid: {harness, tmux_session, started_at, pid}}` + `next_sid_seq{harness: u64}` 字段(serde default 空 BTreeMap 保 V0.3 单 session 项目兼容);sid 格式 `<harness>-<n>`,n 单调递增**删后不复用**;tmux 命名 `ccteam-<slug>-<sid>`(workflow / multi_workflow 项目仍 `ccteam-<slug>` 不变);`progress.jsonl` flex 项目走 `~/.ccteam/progress/<slug>/<sid>.jsonl`,workflow 项目仍 `<slug>.jsonl` flat;`ccteam session {add,ls,attach,rm}` CLI;**`rm` 是唯一显式用户授权 kill 路径**(CLAUDE.md §三 红线)。master state.json atomic write + retry-on-conflict 应对并发 add race。
+- **优先级**:**P0**(V0.3.1 战略 pivot 核心 — flex 团队的实际用法)。
+- **来源**:`docs/v0-3-1/prd.md §6`;用户 Telegram 2026-05-10 message 312"多 session 拉前 V0.3.1"决策。
+
+### F50 — Web 层假设单 session 项目,flex 团队无展示路径(2026-05-10 加;**待 V0.3.1 PR #5 ship**)
+
+- **文件:行号**:`crates/ccteam-web/templates/dashboard.html`(加 `Kind` 列);`crates/ccteam-web/templates/project.html`(flex 项目走 N session cards 模板分支);新模板 `templates/session.html` + handler `routes/session.rs`;`crates/ccteam-web/src/routes/sse.rs`(扩 `/sse/project/<slug>/<sid>` server-side filter);`crates/ccteam-core/src/screenshot.rs::render_screenshot`(签名加 `sid: Option<&str>`)。
+- **现状**:V0.3 web UI(M5.0-M5.4 ship)假设单 session 项目;V0.3.1 引入 flex + adhoc multi-session 后,dashboard 需要 `Kind` 列,project 详情页对 flex 走 N session cards,需要新页 `/session/<slug>/<sid>`,SSE 需要 sid filter,screenshot 需要扩 `<slug>-<sid>.png`。
+- **是否真 dev-specific**:**否——展示层适配。**
+- **解耦方案**:dashboard 加 `Kind` 列(workflow / multi_workflow / flex);`Phase` 列对 flex 项目渲染 `—`;flex 项目 detail 页走 N session cards 分支(harness badge 蓝/绿,缩略截图,Detail link);workflow / multi_workflow 项目 detail 完全不变(回归保证);新页 `/session/<slug>/<sid>` 渲染 header + per-session events / harness panel / write actions sidebar;`/sse/project/<slug>/<sid>` server-side `msg.sid == <sid>` 过滤(`EventMsg` 加 `sid: Option<String>`);`/sse/harness/<slug>/<sid>` 推 harness_snapshot;`/screenshot/<slug>-<sid>.png` 路由 — `render_screenshot(slug, Some(sid), opts)`;`/screenshot/<slug>.png` workflow 项目保留(V0.3 兼容)。
+- **优先级**:**P1**(展示层 — 用户首屏看到的 V0.3.1 价值,但不阻塞 backend ship)。
+- **来源**:`docs/v0-3-1/prd.md §7`;用户 Telegram 2026-05-10 message 315 dashboard 决策。
+
+### F51 — V0.3.1 ship gate(2026-05-10 加;**待 V0.3.1 PR #6 ship**)
+
+- **文件:行号**:`Cargo.toml`(workspace.package.version 0.3.0 → 0.3.1);`CLAUDE.md` §一 baseline 表格 + §六 易踩坑;`docs/v0-3-1/e2e-retro.md`(新建);`docs/v0-2/README.md`(V0.3 pointer 更新);`docs/dev-coupling-audit.md` F46-F51 close 标记;`crates/ccteam-web/tests/flex_e2e_test.rs`(新建)。
+- **现状**:V0.3.1 patch round(F46-F50)ship 后需要正式 ship gate。V0.2.2 政策:每 minor / patch release 必须 bump workspace.version + commit subject `vX.Y.Z:` 前缀。
+- **是否真 dev-specific**:**否——chore + ship gate。**
+- **解耦方案**:flex_e2e_test.rs 跑端到端(reqwest server happy path + codex error path);`Cargo.toml::workspace.package.version` `"0.3.0"` → `"0.3.1"`;CLAUDE.md §一 baseline 回填(workspace.version + 实测测试数 + V0.3.1 milestone 行);CLAUDE.md §六 加 V0.3 → V0.3.1 升级注;`docs/v0-3-1/e2e-retro.md` 4-suite 跨 flex 多 session / harness adapter / web UI / codex stub;`docs/v0-2/README.md` 更新 V0.3 起始 pointer 为 "已 ship V0.3 + V0.3.1";dev-coupling-audit.md F46-F51 close 标记;tech-design.md / interfaces.md 增量段终稿。
+- **优先级**:**P0**(ship gate)。
+- **来源**:`docs/v0-3-1/prd.md §8` / §12 / §13。
 
 ### F40 — `product-research` team 名冗长 + 领域名缺位(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #6 alias 软迁移)**)
 

--- a/docs/v0-2/README.md
+++ b/docs/v0-2/README.md
@@ -5,9 +5,13 @@ V0.2 已 ship(`origin/main = 503269a`,8 个 milestone M0.16-M0.23,497/0 测试)�
 
 > **已 ship V0.3**(2026-05-10,`docs/v0-3/`):web UI dashboard + SSE +
 > 写动作 + token auth(5 milestone M5.0-M5.4,新 crate `ccteam-web`,
-> workspace.version 0.3.0,738 测试)。下方 "V0.3 deferred 项" 仍 deferred
-> (web UI 是新增主线,不替代列出的 deferred 项;V0.4 候选见
-> [`docs/v0-3/prd.md §10`](../v0-3/prd.md))。
+> workspace.version 0.3.0,738 测试)。**+ V0.3.1 起始(drafting,
+> `docs/v0-3-1/`)**:战略 pivot — flex team kind + adhoc multi-session +
+> HarnessAdapter trait + CodexAdapter stub(F46-F51,6 finding 跨 6 PR,
+> workspace.version 目标 0.3.1)。下方 "V0.3 deferred 项" 仍 deferred(V0.3
+> web UI / V0.3.1 session farm 都是新增主线,不替代列出的 deferred 项;
+> V0.4 候选见 [`docs/v0-3/prd.md §10`](../v0-3/prd.md) +
+> [`docs/v0-3-1/prd.md §10`](../v0-3-1/prd.md))。
 
 ## 文档清单
 

--- a/docs/v0-3-1/README.md
+++ b/docs/v0-3-1/README.md
@@ -1,0 +1,108 @@
+# V0.3.1 文档索引
+
+V0.3.1 是 V0.3 主线 ship 后的**首个 patch round**(F-numbered findings under
+one umbrella),也是 ccteam 的**战略支点版本**:从"phase-driven workflow
+orchestrator"扩展为"session-layer farm + observability + cross-project
+memory bridge",同时支持 Claude Code 与 OpenAI Codex CLI。phase 编排演进
+**暂停**(无新 phase / Fat Skills 演进机制),改起一支新 team kind `flex`
+(空 phase,用户原生方式驱动多 session,ccteam 观测 + 记录 + 提供控制面)。
+
+**状态**:**drafting**(2026-05-10,docs-only PR;F46-F51 实施待 docs merge
+后并行派工)。
+
+base = `origin/main` `f9baf3f`(V0.3 ship 终点,workspace.version `0.3.0`,
+测试 baseline `738/0`)。F51 PR 会 bump 到 `0.3.1` 并回填 CLAUDE.md baseline。
+
+## 文档清单
+
+| 文件 | 内容 | 何时读 |
+|---|---|---|
+| [`prd.md`](prd.md) | V0.3.1 PRD — 战略 pivot 背景 + 6 finding(F46-F51)设计 + 已知风险 + V0.4 deferred + PR sequencing | V0.3.1 设计意图源头 |
+| [`dev-plan.md`](dev-plan.md) | 6 PR 拆解 + 依赖图 + 红线 grep 矩阵 + worktree subagent briefing 模板(F46 完整,F47-F51 增量化基) | V0.3.1 实施 |
+
+## Findings 速查
+
+| F | 范围 | 优先级 | PR # | 独立可 ship |
+|---|---|---|---|---|
+| **F46** `HarnessAdapter` trait + `ClaudeCodeAdapter` | trait + statusline dual-write + web SSE harness snapshot stream | P0(立 trait,后续都基于它) | 1 | 是(doctor 装 wrapper 即可,不需 flex team) |
+| **F47** `CodexAdapter` trait stub + `harness` 字段 | trait shape 完整、方法 `Err(NotImplemented)`、`team.yaml::sessions[].harness` 字段 + CLI flag | P1(forward-compat) | 2 | 是(独立 stub,不阻塞 F48/F49) |
+| **F48** `kind: flex` team kind | team factory `--kind=flex`、orchestrator behavior gating(`auto_loop` / `golden_rules` / `phase_inject` off,silence/cost/hooks/progress/memory on)、`team.yaml::kind` schema | P0(基础) | 3 | 是(flex bootstrap 单 claude session) |
+| **F49** Adhoc multi-session primitives | `ccteam session {add,ls,attach,rm}` CLI、per-session subdir layout、tmux `<slug>-<sid>` 命名、混合 harness 共存、progress 子路径 | P0 | 4 | 是 |
+| **F50** Web 层更新 | dashboard `kind` 列、flex 详情页 per-session 卡片(harness badge)、`/session/<slug>/<sid>` 详情、SSE filter by sid | P1 | 5 | 是(前端) |
+| **F51** Chore + ship gate | workspace.version 0.3.0 → 0.3.1、CLAUDE.md baseline 回填、e2e for flex multi-session、`docs/v0-3-1/e2e-retro.md`、`docs/v0-2/README.md` 更新 | P0 | 6 | 否(ship gate)|
+
+## 关键设计决策
+
+详 `prd.md §1` 战略背景 / §2 范围 / §10 不在范围:
+
+- **三 team kind 并存**(prd §3 F48):`workflow`(默认,V0.1+)/ `multi_workflow`
+  (V0.2 起 `parallelism: multi_session` 团队;数据驱动,无需新名)/ `flex`
+  (V0.3.1 新增,空 phase,用户驱动 session)。`team.yaml::kind` 字段缺省
+  `workflow` 保 V0.1/V0.2/V0.3 yaml 解析不变。
+- **`kind` 与 `parallelism` 正交**:`kind` 是**team 级**字段,`parallelism`
+  仍是**phase 级**字段。`flex` 团队无 phase 所以 `parallelism` 不适用。
+- **HarnessAdapter trait**(prd §3 F46):`ccteam-core::harness` 模块,
+  `ClaudeCodeAdapter` 全实现,`CodexAdapter` 全 stub(spawn / ingest 返
+  `Err(NotImplemented { harness, reason })`,reason 指向 PRD §F47)。
+- **adhoc session 协议正交于 multi_session**:flex 用**新轻量 session 注册**
+  (`~/projects/<team>-<slug>/sessions/<sid>/` 子目录 + master `state.json::sessions`
+  字段记 sid → harness 映射),**不复用** `parallelism: multi_session` 的
+  master + 预定义 sub-module 拓扑。
+- **sid 格式**:`<harness>-<n>`(`claude-1` / `codex-2` ...);全项目内单调
+  递增,删后不复用。
+- **tmux 命名**:`ccteam-<slug>-<sid>`(单 session 项目仍 `ccteam-<slug>`
+  无 sid 后缀,V0.3 兼容)。
+- **progress.jsonl scoping**:flex 项目走 `~/.ccteam/progress/<slug>/<sid>.jsonl`
+  子目录(单文件每 session);非 flex 项目继续 `~/.ccteam/progress/<slug>.jsonl`
+  flat 命名(M0 协议保持)。
+- **flex 团队 orchestrator 行为**:`auto_loop` / `phase prompt inject` /
+  `golden_rules` 三条 **off**(无 phase 可触发);`silence_classifier` / cost
+  watcher / hooks(progress_append / cost_accumulate / parse_phase_end)/
+  cross-project memory bridge **on**。
+- **永不主动 kill**:`ccteam session rm <slug> <sid>` 是**唯一**显式用户授权
+  kill 路径;cost / silence / stale 不触发 kill(CLAUDE.md §三 红线)。
+
+## V0.4 deferred 项
+
+详 `prd.md §10`:
+
+- **CodexAdapter 完整实现**(spawn / ingest / hook surface)— V0.3.2
+- **flex workflow promotion / demotion UX**(把累积事件提升为冻结 phase /
+  随时拆掉)— V0.3.2 / V0.4(Fat Skills evolution path,详
+  [`docs/research/thin-harness-fat-skills-architecture-improvement.md`](../research/thin-harness-fat-skills-architecture-improvement.md) §6.1)
+- **flex_workflows.yaml 持久化 schema** — V0.3.2 / V0.4
+- **CC → Codex review 自动派单 pipeline**(implement phase_done 自动起 codex
+  exec sidecar)— `docs/research/ccteam-codex-integration.md` M2 路线
+- **harness snapshot 历史 archive**(retro 用)— V0.4
+- **subagent live progress**(Claude Code 上游 API 出来后) — V0.4
+
+## 跟其他文档关系
+
+- 主仓 `CLAUDE.md` §一 baseline 待 F51 PR 回填(0.3.0 → 0.3.1,V0.3.1 milestone
+  行,738 → 新数);§三 红线 V0.3.1 不动(progress.jsonl SoT / 永不主动 kill /
+  ccteam-core 无 team 名字面量);§六 易踩坑由 F51 加一条 V0.3 → V0.3.1 升级注
+- `docs/tech-design.md` §3.3 / §6.3 / §6.11 — F48 / F49 ship 后增补 flex /
+  HarnessAdapter / 多 session 段
+- `docs/interfaces.md` §1.3(扩 flex layout)/ §2.1(state.json `sessions` 字段)/
+  §5.5(team.yaml `kind` + `harnesses` 字段)/ §15(web routes harness SSE +
+  session detail)— F46-F50 每 PR 增量补
+- `docs/dev-coupling-audit.md` F46-F51 — 本 PR 加初始条目,各 PR 实施后填
+  close 状态
+- `docs/v0-2/README.md` "已 ship V0.3" 段更新为 "已 ship V0.3 + V0.3.1
+  起始(drafting)"(本 doc-only PR 落)
+- `docs/research/v0-3-1-harness-adapter-plan.md` — V0.3 ship 期临时记录,
+  本 PRD §1 / §3 F46 是其正式版,临时文件留 git history
+- `docs/research/ccteam-codex-integration.md` — V0.3.1 F47 trait stub
+  setup;V0.4 codex M2 routes 走该研究 doc 的 M1-M5 路线
+- `docs/research/thin-harness-fat-skills-architecture-improvement.md` —
+  战略论证;V0.3.1 是 Fat Skills evolution 的**起点**(空 flex 是 phase
+  fat-skill 的 fat-skill 演进起点)
+- `docs/requirements.md` 痛点 1(久不写代码)+ 痛点 11(探索性 idea)—
+  V0.3.1 主映射;新增"手动 + 渐进固化"工作姿态作 V0.3.1 自带
+
+## 配套(F51 PR 落)
+
+- `Cargo.toml::workspace.package.version` `"0.3.0"` → `"0.3.1"`
+- `CLAUDE.md` §一 baseline 表格回填(workspace.version + 实测测试数 +
+  V0.3.1 milestone 行)
+- `docs/v0-3-1/e2e-retro.md`(F51 ship gate 后落档)

--- a/docs/v0-3-1/dev-plan.md
+++ b/docs/v0-3-1/dev-plan.md
@@ -1,0 +1,599 @@
+# V0.3.1 开发计划
+
+> V0.3.1 patch round 实施计划。按依赖顺序拆 6 个 PR(F46-F51,每 finding 一
+> PR,最后 F51 是 ship gate chore)。worktree-per-PR;每 PR 一份 subagent
+> briefing。
+>
+> 配套文档:
+> - 需求决策:`docs/v0-3-1/prd.md`(13 节)
+> - 文档索引:`docs/v0-3-1/README.md`
+>
+> base = `origin/main` `f9baf3f`(V0.3 ship);测试 baseline `738/0`;
+> workspace.version 起点 `0.3.0`。
+>
+> 跟 V0.3 dev-plan 不同点:V0.3.1 是 patch round 用 F-编号(V0.2.2 模式),
+> 不 bump main version,只 patch(0.3.0 → 0.3.1)。本文档**只完整给出 F46
+> 的 subagent briefing**(立 trait + statusline wrapper 是基础),后续 PR 的
+> briefing 各自由派工 dispatcher 在 F46 模板基础上增量化(参考 PRD 对应章节
+> + 本文档 §3-§7 任务清单)。
+
+---
+
+## 1. PR 总览
+
+| # | finding | branch | 工程量估 | 主要前置依赖 |
+|---|---|---|---|---|
+| **PR #1** | **F46** HarnessAdapter trait + ClaudeCodeAdapter | `v0-3-1-harness-adapter` | ~400 LoC + ~12 测试,~3-4 天 | 无(立 trait,后续都基于) |
+| **PR #2** | **F47** CodexAdapter stub + harness 字段 | `v0-3-1-codex-stub` | ~150 LoC + ~5 测试,~1-2 天 | PR #1(消费 trait)|
+| **PR #3** | **F48** kind: flex team kind | `v0-3-1-flex-kind` | ~250 LoC + ~10 测试,~2-3 天 | 无(独立 schema 加;推荐 #2 后做 sessions[] 字段定下) |
+| **PR #4** | **F49** Adhoc multi-session primitives | `v0-3-1-multi-session` | ~400 LoC + ~15 测试,~3-4 天 | PR #1(spawn_session)+ PR #3(kind: flex 项目才能 add) |
+| **PR #5** | **F50** Web 层更新 | `v0-3-1-web-flex` | ~300 LoC + ~8 测试,~2-3 天 | PR #1(harness SSE)+ PR #4(per-session) |
+| **PR #6** | **F51** chore + ship gate | `v0-3-1-ship-gate` | ~150 LoC + 文档,~1-2 天 | PR #1-#5 全部 merge |
+
+**总计**:~1.65 kLOC + ~50 测试,~12-15 天(单人 5 天/周即 2.5-3 周;
+PR #2/#3 + PR #4/#5 并行可压到 ~10 天)。
+
+### 1.1 依赖图
+
+```
+PR #1 (F46 HarnessAdapter)  ── trait + ClaudeCodeAdapter,foundation
+   ↓
+PR #2 (F47 CodexAdapter stub)            (并行起点;只依 trait)
+   ↓
+PR #3 (F48 kind: flex)                   (不强依 #1/#2;推荐 #2 后定 sessions[])
+   ↓
+PR #4 (F49 multi-session) ───┐
+   ↓                          │
+PR #5 (F50 web flex) ────────┴──► PR #6 (F51 ship gate)
+```
+
+并行机会:**PR #2 vs #3** 同时起 worktree(touch 不同模块);**PR #4
+backend vs PR #5 frontend** 同时起 worktree(冲突点只在 askama template +
+SSE 路由)。
+
+---
+
+## 2. PR #1 — F46 HarnessAdapter trait + ClaudeCodeAdapter
+
+> **目标**:立 `crates/ccteam-core/src/harness.rs` 模块,trait + 数据结构 +
+> 错误类型 + `ClaudeCodeAdapter` 完整实现 + statusline wrapper 安装入口
+> + web SSE harness endpoint。**Foundation PR — 必先 merge**。
+
+**关联 PRD**:§3(F46 全文)+ §1.3 战略论证(thin-harness research doc)
+
+**前置**:无。
+
+### 2.1 任务
+
+- [ ] **#1.1** 新模块 `crates/ccteam-core/src/harness.rs`
+  - `HarnessAdapter` trait(`name` / `ingest_snapshot` / `subagent_states` /
+    `spawn_session` / `shutdown_session`)
+  - `HarnessSnapshot` / `SubagentState` / `SpawnOpts` / `SessionHandle`
+    数据结构(详 PRD §3.2.2)
+  - `HarnessError` enum(`thiserror::Error` 派生);`NotImplemented` 变体的
+    `harness` 与 `reason` 都是 `&'static str`(让 `CodexAdapter` 用 const
+    string 不必 alloc)
+  - `lib.rs` re-export:`pub use harness::{HarnessAdapter, HarnessSnapshot,
+    SubagentState, HarnessError, ClaudeCodeAdapter};`
+- [ ] **#1.2** `ClaudeCodeAdapter` 实现
+  - `name() -> "claude-code"`
+  - `ingest_snapshot(raw)`:解析 statusline stdin JSON;解析失败返
+    `IngestFailed(detail)`;成功返 `HarnessSnapshot { harness: "claude-code",
+    model_display_name, context_used_pct, cost_usd_total, rate_limit_pct,
+    cwd, raw, captured_at }`
+  - `spawn_session(opts)`:tmux new-session 启动 claude `--dangerously-skip-permissions`
+    + cwd 切到 `~/projects/<team>-<slug>/`(F49 落地后改 `<sid>` subdir);
+    返 `SessionHandle { tmux_session, harness, sid, pid, started_at }`
+  - `shutdown_session(handle)`:tmux kill-session(graceful — 先 send-keys
+    `/exit\n` 等 5s,再 kill);只在用户 `ccteam session rm` 时调
+- [ ] **#1.3** statusline wrapper 安装(doctor flag)
+  - `crates/ccteam-cli/src/commands.rs::run_doctor` 加 `--install-statusline-adapter`
+    flag(可选,doctor 默认调用时也跑一次幂等)
+  - 写 `~/.claude/statusline-command.sh` wrapper:
+    - 检测原文件;有 → backup 到 `.bak-<utc-ts>`,写入 wrapper(包含 marker
+      section + 透传到 `/path/to/orig.bak-<ts>`)
+    - 无 → 直接写 wrapper 不透传
+  - marker section:`# ccteam-managed:statusline begin` / `... end`
+  - wrapper body:`tee` stdin 到 `~/.ccteam/harness/<slug>-<sid>.json`(slug/sid
+    从 cwd 推导;推不到则 `_meta-<handle>.json`)+ 透传 stdin 到 stdout
+- [ ] **#1.4** harness JSON dual-write 路径推导
+  - 新 helper `crates/ccteam-core/src/harness/path.rs::derive_harness_path(cwd, paths) -> PathBuf`
+  - cwd 匹配 `~/projects/<team>-<slug>/sessions/<sid>/...` → `<harness-dir>/<slug>-<sid>.json`
+  - cwd 匹配 `~/projects/<team>-<slug>/...`(无 sessions/ 子层)→
+    `<harness-dir>/<slug>-claude-1.json`(单 session 项目默认)
+  - cwd 匹配 `~/projects/<handle>-meta/...` → `<harness-dir>/_meta-<handle>.json`
+  - 其他 → 丢弃(返 None,wrapper 检测 None 不写)
+- [ ] **#1.5** web SSE harness endpoints
+  - `crates/ccteam-web/src/routes/harness_sse.rs` 新建:
+    - `GET /sse/harness/<slug>`:推该 slug 下所有 session harness_snapshot
+    - `GET /sse/harness/<slug>/<sid>`:单 session
+  - watcher 后台 task 监 `~/.ccteam/harness/`(notify recursive)→ broadcast
+    channel(`tokio::sync::broadcast`,bound 1024,同 V0.3 progress watcher
+    模式 — 可考虑独立 channel 也可复用 EventBus 加 `EventKind`)
+  - SSE wire format:`event: harness_snapshot` + `data: <one-line-JSON>`(同
+    V0.3 progress wire format,加 `slug` + `sid` server 字段)
+- [ ] **#1.6** 测试
+  - `harness.rs` 单元:`HarnessSnapshot` round-trip serialize / deserialize;
+    `derive_harness_path` 5 种 cwd 形态(单 session / multi-session /
+    meta / mismatch);`ClaudeCodeAdapter::ingest_snapshot` 解析 5 种 stdin
+    JSON shape(官方 + 用户魔改)
+  - `crates/ccteam-cli/tests/statusline_install_test.rs`:
+    - 无原 statusline 文件 → wrapper 直接写;marker 包裹 dual-write
+    - 有原 statusline 文件 → backup + 透传 callsite 写入
+    - 重跑 doctor → marker section 覆盖,backup 不重复
+  - `crates/ccteam-web/tests/harness_sse_test.rs`:reqwest stream
+    `/sse/harness/<slug>`,另一 thread append `~/.ccteam/harness/<slug>-claude-1.json`
+    after,断 ≥ 1 event 收到 + 字段 verify
+
+### 2.2 验收(摘 PRD §3.4)
+
+- [ ] `crates/ccteam-core/src/harness.rs` 模块落地,trait + 数据结构 + 错误
+  类型 + `ClaudeCodeAdapter` 实现完整
+- [ ] `ccteam doctor --install-statusline-adapter` 安装 wrapper(marker 保护
+  + 原文件 backup)
+- [ ] `~/.ccteam/harness/<slug>-<sid>.json` 文件 dual-write happy path
+- [ ] `/sse/harness/<slug>` + `/sse/harness/<slug>/<sid>` SSE 推送
+  harness_snapshot 事件
+- [ ] 用户已有自定义 statusline 脚本时,wrapper tee + 透传不破坏原 footer
+- [ ] 路径匹配不到 slug 时,fallback 不 panic
+- [ ] `cargo test --workspace` baseline 738 不退步;新增 ≥ 12 测试
+
+### 2.3 文档同步
+
+- `docs/interfaces.md` §15(web routes,V0.3 已写)加 `/sse/harness/<slug>` /
+  `/sse/harness/<slug>/<sid>` schema
+- `docs/interfaces.md` §1.1 全局目录加 `~/.ccteam/harness/<slug>-<sid>.json`
+- `docs/dev-coupling-audit.md` F46 加(详 §9):"V0.3.1 HarnessAdapter trait
+  抽象 + ClaudeCodeAdapter 实现"
+- `docs/tech-design.md` §6 扩展点表加 harness layer 行(简短 placeholder,
+  F51 补全)
+
+---
+
+## 3. PR #2 — F47 CodexAdapter stub + harness 字段
+
+> **目标**:`CodexAdapter` 全 stub(所有方法返 `NotImplemented`,reason
+> 指向 PRD §F47);`team.yaml::sessions[]` schema(`harness: claude | codex`);
+> `ccteam session add --harness codex` CLI 接受;doctor codex 检测。
+
+**关联 PRD**:§4(F47 全文)+ §3.2.2 trait shape
+
+**前置**:PR #1(消费 trait)。
+
+### 3.1 任务
+
+- [ ] **#2.1** `CodexAdapter` 实现 — `harness.rs` 加空 struct + impl trait
+  全部方法返 `NotImplemented`(详 PRD §4.2.1)
+- [ ] **#2.2** `team.yaml::sessions[]` schema —
+  `crates/ccteam-core/src/team.rs::TeamSpec` 加 `pub sessions:
+  Vec<DefaultSessionSpec>` + `DefaultSessionSpec { sid, harness:
+  HarnessKind }` + `HarnessKind { Claude, Codex }`(详 PRD §5.2.1
+  Rust 字段定义)。**注**:F48 PR #3 才加 `kind` 字段;F47 PR 只加
+  `sessions[]` 与 `HarnessKind`(独立可并行,不撞 #3)
+- [ ] **#2.3** `ccteam session` CLI 子命令 stub
+  - **F49 PR 才完整实现** `add/ls/attach/rm`,本 PR(F47)只立 CLI parser
+    + `--harness` flag schema(`clap::ValueEnum` 派生)+ `add` 调
+    `CodexAdapter::spawn_session` 时返 friendly error(实测 stub error path)
+  - 注意:F47 PR ship 时 `ccteam session add --harness claude` 会走
+    `ClaudeCodeAdapter::spawn_session` — F46 已实现,但因 `state.json::sessions{}`
+    schema 在 F49 才落,本 PR 不真正写 master state(只能 dry-run / smoke
+    test on `--harness=codex` error path)。建议 F47 PR 实测 codex error
+    branch 即可,claude branch 在 F49 PR 完整 happy path
+- [ ] **#2.4** `ccteam doctor` codex 检测段
+  - `which codex` → 输出 `[ccteam] codex CLI: present @ <path>` /
+    `[ccteam] codex CLI: not found (V0.3.1 trait-stub only; install codex
+    CLI for V0.3.2+ — see docs/research/ccteam-codex-integration.md)`
+  - 不 fail 任何条件
+- [ ] **#2.5** 测试
+  - `harness.rs::CodexAdapter::spawn_session` 返 `NotImplemented` + 错误
+    消息含 "V0.3.1" / "deferred to V0.3.2" / "docs/v0-3-1/prd.md §F47"
+  - `team.yaml` parse `sessions: [{sid: claude-1, harness: claude}]` 成功
+    + round-trip
+  - `team.yaml` parse `sessions: [{sid: codex-1, harness: codex}]` 成功
+    (schema 接受 codex 不 fail)
+  - `ccteam session add <slug> --harness codex` exit 1 + stderr 含 stub
+    错误消息
+
+### 3.2 验收(摘 PRD §4.4)
+
+- [ ] `CodexAdapter` 全 stub,error 消息含 V0.3.2 引用
+- [ ] `team.yaml::sessions[]` schema 解析 ≥ 5 fixture
+- [ ] `ccteam session add --harness codex` 友好 error path
+- [ ] doctor codex 检测段输出 informational
+- [ ] interfaces.md §5.5 schema 同步加 `sessions[]` 字段
+- [ ] 新增 ≥ 5 测试
+
+### 3.3 文档同步
+
+- `docs/interfaces.md` §5.5 加 `sessions[]` 字段
+- `docs/dev-coupling-audit.md` F47 加
+
+---
+
+## 4. PR #3 — F48 kind: flex team kind
+
+> **目标**:`team.yaml::kind` 字段(默认 `workflow`,V0.1/V0.2/V0.3 yaml
+> 不动);orchestrator behavior gating helpers;team factory `--kind=flex`
+> scaffold(无 phases/);claude_md_template seed for flex 团队。
+
+**关联 PRD**:§5(F48 全文)
+
+**前置**:无强依赖(独立 schema 加);**推荐**在 PR #2 之后 — 让
+`sessions[]` 字段在 PR #2 已定,这里只加 `kind` + 验证组合。
+
+### 4.1 任务
+
+- [ ] **#3.1** `team.rs::TeamSpec` 加 `kind: TeamKind` 字段(详 PRD §5.2.1);
+  `TeamKind` enum(`Workflow` / `MultiWorkflow` / `Flex`);`#[serde(default)]`
+  保 V0.1/V0.2/V0.3 yaml parse 不变
+- [ ] **#3.2** `TeamSpec::validate` 加 flex 团队约束:
+  - `kind: flex` + 非空 `golden_rules` → fail-loud + msg 指向 PRD §5.2.1
+  - `kind: flex` + 非空 `escalate_grammar_extensions` → 同上
+  - `kind: flex` + 存在 `phase_dir` 对应非空目录 → 同上(team factory
+    publish 时校验)
+  - `kind: workflow / multi_workflow` + 非空 `sessions[]` → warn(不 fail;
+    用户该字段只对 flex 有意义)
+- [ ] **#3.3** orchestrator behavior gating(详 PRD §5.2.3)
+  - `crates/ccteam-core/src/orchestrator.rs::TeamRuntime` 加三个 helper
+    fn:`should_run_auto_loop` / `should_inject_phase` /
+    `should_check_golden_rules`,按 `self.spec.kind` 返 bool
+  - tick 循环里所有 `if state.team == ...` 字面字符串(若仍存在)替换
+    为 helper 调用(grep 验证 — strategic doc §3 红线)
+- [ ] **#3.4** team factory `--kind=flex`
+  - `ccteam team init <name> --kind <kind>` clap 加 `--kind` flag(默认 workflow)
+  - `team_factory.rs::init_team_staging` 检测 kind=flex 跳过 phase scaffold;
+    生成 staging tree(plugin.json + team.yaml + README.md,**无** phases/)
+  - team.yaml 默认 `kind: flex` + `description` 占位 + `sessions: [{sid: claude-1, harness: claude}]` 默认 +
+    `claude_md_template` 写 flex 团队默认指令(详 PRD §5.2.4 模板要求)
+- [ ] **#3.5** `ccteam team publish <name>` flex 团队成功 publish 到
+  `~/.ccteam/teams/<name>/`;`doctor --validate-team <name>` 跳过 phase 引用
+  校验(对 flex)
+- [ ] **#3.6** seed flex team(可选 — 提一支 demo)
+  - `teams/flex/`(repo 内 seed)— 不强求,但能让 e2e fixture 有可用 spec;
+    若不 ship seed,F51 e2e 用 staging dir fixture 起也行
+- [ ] **#3.7** 测试
+  - `TeamSpec` round-trip serialize / deserialize 含 `kind`
+  - `validate` 拒绝 flex + golden_rules / escalate_grammar_extensions / 非空
+    phase_dir 的非法组合
+  - V0.3 dev / research / meta-agent yaml 在 V0.3.1 升级后 parse 不变(回归
+    fixture,5 个 spec round-trip 不破)
+  - team factory `--kind=flex` 生成 staging tree(snapshot 测试)
+  - orchestrator helpers 返值 unit:workflow → true/true/true,flex →
+    false/false/false
+
+### 4.2 验收(摘 PRD §5.4)
+
+- [ ] `team.yaml::kind` 字段 default `workflow` parse 不变
+- [ ] flex 团队 validate 拒绝非法组合
+- [ ] orchestrator helpers 三个,kind-aware
+- [ ] team factory `--kind=flex` scaffold 无 phases/
+- [ ] V0.3 已 ship 团队完全无变化
+- [ ] 新增 ≥ 8 测试
+
+### 4.3 文档同步
+
+- `docs/interfaces.md` §5.5 加 `kind` 字段
+- `docs/dev-coupling-audit.md` F48 加
+
+---
+
+## 5. PR #4 — F49 Adhoc multi-session primitives
+
+> **目标**:`ccteam session {add,ls,attach,rm}` CLI;per-session subdir;
+> master state.json `sessions{}` + `next_sid_seq{}` 字段;tmux `<slug>-<sid>`
+> 命名;`progress.jsonl` flex 项目子目录 scoping。
+
+**关联 PRD**:§6(F49 全文)
+
+**前置**:PR #1(spawn_session);PR #3(kind: flex 项目才能 add)。
+
+### 5.1 任务摘要
+
+- [ ] `~/projects/<team>-<slug>/.ccteam/sessions/<sid>/` 子目录创建(F49 §6.2.1)
+- [ ] master `state.json::sessions{}` + `next_sid_seq{}` 字段(F49 §6.2.2;
+  serde default 空 BTreeMap 保 V0.3 单 session 项目兼容)
+- [ ] sid 单调递增 + 删后不复用(`next_sid_seq` 计数器)
+- [ ] tmux `ccteam-<slug>-<sid>` 命名;flex 项目第一个 session 也带 `-<sid>`
+  后缀(workflow / multi_workflow 项目仍 `ccteam-<slug>` 不变,V0.3 兼容)
+- [ ] `progress.jsonl` flex 项目走 `~/.ccteam/progress/<slug>/<sid>.jsonl`
+  子目录(`hooks::progress_append` 解析 `state.json::team_kind` 自动分流;
+  workflow 项目 flat path 不变)
+- [ ] `ccteam session add <slug> [--harness X] [--sid Y]`:
+  - 检测 team kind != flex → friendly error
+  - 调 `<HarnessAdapter>::spawn_session`(F46/F47);写 master state.json
+    `sessions[]`;tmux new-session;hooks 启动
+  - sid 自动分配(`next_sid_seq[harness]++`)or 用户指定(校验唯一)
+  - master state.json atomic write + retry-on-conflict(F49 §9.4 缓解)
+- [ ] `ccteam session ls <slug>`:读 state.json `sessions{}` → 表格(sid /
+  harness / tmux / started / pid / status from per-session progress.jsonl 末事件)
+- [ ] `ccteam session attach <slug> <sid>`:tmux attach `ccteam-<slug>-<sid>`;
+  不存在 → fail-loud + 列可用
+- [ ] `ccteam session rm <slug> <sid>`:`shutdown_session`(graceful);tmux
+  kill;清 state.json `sessions[sid]`;**唯一**显式 kill 路径(CLAUDE.md
+  §三 红线)
+- [ ] CLI 在 workflow / multi_workflow 团队上调 session 子命令 → friendly
+  error("session subcommands only work on flex teams; this project is
+  team `<name>` (kind=<kind>)")
+
+### 5.2 测试(详 PRD §6.4)
+
+- per-session subdir 创建
+- state.json round-trip 含 sessions{} + next_sid_seq{};V0.3 单 session
+  项目 state.json 不含俩字段(serde default)
+- progress.jsonl flex 子目录路径 vs workflow flat 路径分流(team_kind 驱动)
+- `add` happy path(claude harness)
+- `add --harness codex` friendly error(F47 stub)
+- `ls` 表格输出 + per-session status
+- `attach` 命中 + miss 各自路径
+- `rm` graceful shutdown + state 清理
+- sid 单调递增 + 删后不复用(并发 add 单元测试,2 thread spawn)
+- workflow 团队 `session add` → friendly error
+
+### 5.3 文档同步
+
+- `docs/interfaces.md` §1.3 / §2.1 schema 同步 flex layout + state.json
+  sessions / next_sid_seq 字段
+- `docs/dev-coupling-audit.md` F49 加
+
+---
+
+## 6. PR #5 — F50 Web 层更新
+
+> **目标**:dashboard `kind` 列;flex 项目详情页 per-session cards + harness
+> badges;新页 `/session/<slug>/<sid>`;SSE filter by sid;screenshot 扩展
+> `<slug>-<sid>.png`。
+
+**关联 PRD**:§7(F50 全文)
+
+**前置**:PR #1(harness SSE);PR #4(per-session events / sid)。
+
+### 6.1 任务摘要
+
+- [ ] dashboard `dashboard.html`:加 `Kind` 列;flex 项目 `Phase` 列渲 `—`
+- [ ] project 详情 `project.html`:flex 项目走新模板分支(N session cards
+  + harness badge + 缩略截图 + Detail link);workflow / multi_workflow
+  项目仍走 V0.3 单 panel 模板(回归保证)
+- [ ] 新模板 `templates/session.html` + handler `routes/session.rs`:
+  `GET /session/<slug>/<sid>` 渲染 header / events / harness panel /
+  write actions sidebar
+- [ ] SSE handler 加 sid filter:
+  - `GET /sse/project/<slug>/<sid>` server-side `msg.sid == <sid>` 过滤
+  - `EventMsg` 加 `sid: Option<String>` 字段(workflow 项目 None)
+  - watcher tail 解析路径 `~/.ccteam/progress/<slug>/<sid>.jsonl` 时注入 sid
+- [ ] screenshot endpoint 扩展:
+  - `GET /screenshot/<slug>-<sid>.png` 路由 — `render_screenshot(slug, Some(sid), opts)`
+  - F38 `render_screenshot` 签名加 `sid: Option<&str>` 参数;`<sid>` 决定
+    tmux session name 与输出文件名;非 None 时实际 tmux session
+    `ccteam-<slug>-<sid>`
+  - `GET /screenshot/<slug>.png`(workflow 项目)路由保留 — 调
+    `render_screenshot(slug, None, opts)`,V0.3 行为完全保持
+- [ ] askama 模板编译期类型检查不破
+
+### 6.2 测试(详 PRD §7.4)
+
+- dashboard `Kind` 列 ≥ 6 fixture 项目(workflow / multi_workflow / flex
+  各 2)
+- flex 项目 `/project/<slug>` 渲 N session cards + harness badge
+- workflow / multi_workflow 项目 `/project/<slug>` 完全不变(V0.3 e2e 测试
+  不破)
+- `/session/<slug>/<sid>` 200 + content
+- SSE filter by sid:启 server,append progress 不同 sid 文件,断接收顺序
+- screenshot endpoint `<slug>-<sid>.png` 200 / 404 / 504(F38 失败)
+- screenshot endpoint `<slug>.png` workflow 项目 200(回归)
+
+### 6.3 文档同步
+
+- `docs/interfaces.md` §15(web routes)加 `/session/<slug>/<sid>` /
+  `/sse/project/<slug>/<sid>` / `/sse/harness/<slug>` 等 endpoint schema
+- `docs/dev-coupling-audit.md` F50 加
+
+---
+
+## 7. PR #6 — F51 chore + ship gate
+
+> **目标**:V0.3.1 ship gate。flex_e2e_test.rs + retro 文档 +
+> workspace.version bump 0.3.0 → 0.3.1 + CLAUDE.md baseline + docs sweep。
+
+**关联 PRD**:§8(F51 全文)+ §12 / §13
+
+**前置**:PR #1-#5 全部 merge。
+
+### 7.1 任务摘要
+
+- [ ] `crates/ccteam-web/tests/flex_e2e_test.rs`:tempdir CCTEAM_HOME,
+  fixture 1 flex project + 2 sessions + mock harness JSON,reqwest 跑 happy
+  path(详 PRD §8.2.1)
+- [ ] `Cargo.toml::workspace.package.version` `"0.3.0"` → `"0.3.1"`;commit
+  subject `v0.3.1:` 前缀
+- [ ] CLAUDE.md §一 baseline 表格更新(workspace.version + 实测测试数 +
+  V0.3.1 milestone 行;详 PRD §13)
+- [ ] CLAUDE.md §六 加 V0.3 → V0.3.1 升级注
+- [ ] `docs/v0-3-1/e2e-retro.md` 落档(模仿 V0.3 / V0.2.2 retro 模板;
+  4-suite 跨 flex 多 session / harness adapter / web UI / codex stub)
+- [ ] `docs/v0-2/README.md` V0.3 起始 pointer 更新为"已 ship V0.3 + V0.3.1"
+- [ ] `docs/dev-coupling-audit.md` F46-F51 close 标记(改 `2026-05-10 加;
+  待 V0.3.1 ship` 为 `... 2026-05-10 加;V0.3.1 PR #N ship 已修复`)
+- [ ] `docs/tech-design.md` §3.3 / §6.3 / §6.11 加 flex / HarnessAdapter /
+  多 session 段终稿
+- [ ] `docs/interfaces.md` §1.3 / §2.1 / §5.5 / §15 增量段终稿
+- [ ] 红线 grep 矩阵全跑过(详 §9 矩阵)
+- [ ] `cargo test --workspace` 全绿;`cargo clippy --workspace --no-deps`
+  不新增 warning(4 pre-existing 不算)
+
+### 7.2 验收(摘 PRD §8.4)
+
+- [ ] flex_e2e_test.rs 端到端 happy path + codex error path 通过
+- [ ] `Cargo.toml::workspace.package.version = "0.3.1"`
+- [ ] CLAUDE.md §一 / §六 更新
+- [ ] `docs/v0-3-1/e2e-retro.md` 落档
+- [ ] `cargo test --workspace` ≥ 738 + V0.3.1 累计新增
+- [ ] clippy 无新 warning
+
+---
+
+## 8. Worktree subagent briefing 模板
+
+每 PR 起 worktree 时,主 session 用 Agent 工具派,briefing 套以下模板。
+
+### 8.1 通用前置(每 PR briefing 都加)
+
+```markdown
+## 起始
+
+```
+git fetch origin
+git worktree add -b <branch> /tmp/ccteam-v031-<topic> origin/main
+cd /tmp/ccteam-v031-<topic>
+cargo test --workspace 2>&1 | tail -3   # confirm 738 baseline
+```
+
+## 必读(全 PR 通用)
+
+- `CLAUDE.md` §一(状态)+ §三 红线 + §五 PR 纪律
+- `docs/v0-3-1/prd.md` §<N>(本 PR 对应 finding 全文)+ §1 战略背景 +
+  §10 不在范围(避免 silently 拉前 V0.4 deferred)
+- `docs/v0-3-1/dev-plan.md` §<N>(本 PR 任务 / 验收)
+- `docs/tech-design.md` §6 扩展点 + §3.7 跨项目记忆 + §5.5 progress.jsonl SoT
+- `docs/interfaces.md` §1 文件系统布局 + §2 state 协议 + §5.5 team.yaml +
+  §15 web routes
+- `docs/research/v0-3-1-harness-adapter-plan.md`(临时计划记录,V0.3 ship
+  前 dispatcher 写,本 PRD §3 是正式版)
+- (PR #2):`docs/research/ccteam-codex-integration.md`(F47 stub 路线 — M0
+  只读路径)
+
+## 全 PR 红线(CLAUDE.md §三)
+
+- progress.jsonl 是 SoT,**不解析 tmux 终端输出**;harness snapshot 是
+  presentation-only,**不参与状态判定**
+- **永不主动 kill 长 session** — `session rm` 是唯一显式用户授权 kill 路径
+- ccteam-core **无 team 名字面量** — kind / harness / sid 全数据驱动
+- 测试不退步(baseline 738);clippy 不新增 warning
+- 文档同步(对应 dev-plan §文档同步段)
+
+## PR 命令(完整 HEREDOC,见下)
+```
+
+### 8.2 PR #1 briefing(F46 HarnessAdapter — 完整)
+
+```markdown
+## 任务
+
+V0.3.1 PR #1 — `crates/ccteam-core/src/harness.rs` 新模块,`HarnessAdapter`
+trait + 数据结构 + 错误类型 + `ClaudeCodeAdapter` 完整实现 + statusline
+wrapper 安装入口 + web SSE harness endpoint。Foundation PR — 后续 5 PR 都
+基于本 PR 的 trait shape。
+
+## 触点代码
+
+- `crates/ccteam-core/src/harness.rs`(新建)
+- `crates/ccteam-core/src/lib.rs`(re-export)
+- `crates/ccteam-cli/src/commands.rs`(`run_doctor` 加 `--install-statusline-adapter`)
+- `crates/ccteam-cli/src/main.rs`(`Commands::Doctor` 加 `install_statusline_adapter` flag)
+- `crates/ccteam-web/src/routes/harness_sse.rs`(新建)
+- `crates/ccteam-web/src/lib.rs`(router 注册)
+- `crates/ccteam-web/src/watcher.rs`(扩 EventBus 加 harness path 监 / 复用)
+
+## 实施步骤(详 dev-plan §2)
+
+1. trait + 数据结构 + 错误类型(#1.1)
+2. `ClaudeCodeAdapter` 实现(#1.2)
+3. statusline wrapper 安装(#1.3)
+4. harness JSON dual-write 路径推导(#1.4)
+5. web SSE harness endpoints(#1.5)
+6. 测试(#1.6)
+
+## 红线 grep
+
+```bash
+# harness module 不解析 tmux 终端输出
+git grep -nE 'capture_pane|tmux capture' crates/ccteam-core/src/harness.rs
+# 期望:0 命中(只读 statusline JSON,不解析终端)
+
+# orchestrator 不消费 harness snapshot 做状态决策
+git grep -nE 'HarnessSnapshot' crates/ccteam-core/src/orchestrator.rs
+# 期望:0 命中(orchestrator SoT 是 progress.jsonl,harness 只 presentation)
+
+# trait 命名规范
+git grep -nE 'pub trait HarnessAdapter' crates/ccteam-core/src/harness.rs
+# 期望:命中 1
+
+# CodexAdapter 不在 PR #1 出现(留 PR #2 独立 ship)
+git grep -nE 'CodexAdapter' crates/
+# 期望:0 命中
+```
+
+## PR 命令
+
+```bash
+gh pr create --base main --head v0-3-1-harness-adapter --title "v0.3.1 PR #1: F46 HarnessAdapter trait + ClaudeCodeAdapter" --body "$(cat <<'EOF'
+## Closes
+- F46 部分(`docs/dev-coupling-audit.md`):trait + ClaudeCodeAdapter 落地;
+  CodexAdapter stub 在 PR #2 follow-up
+
+## 关联
+- 战略 pivot(`docs/v0-3-1/prd.md §1`):V0.3 ship 后,V0.3.1 把 ccteam 从
+  "phase orchestrator" 扩展为"session farm + observability layer";本 PR
+  立 HarnessAdapter trait 作 foundation
+- 痛点 7 进度透明(`docs/requirements.md`)— harness snapshot 增加结构化
+  数据维度
+- tech-design §6 扩展点 — harness 是新扩展点
+
+## 改动
+- 新模块 `crates/ccteam-core/src/harness.rs`:trait + 数据结构 + 错误类型 +
+  ClaudeCodeAdapter 实现
+- `ccteam doctor --install-statusline-adapter` 安装 wrapper(marker 保护用户
+  手改 + 原文件 backup .bak-<utc-ts>)
+- `~/.ccteam/harness/<slug>-<sid>.json` 协议落地(stdin JSON 全覆盖,无
+  delta archive — V0.4 deferred)
+- web SSE `GET /sse/harness/<slug>` + `/sse/harness/<slug>/<sid>` 推
+  harness_snapshot 事件
+
+## 测试
+- 新增 ~12(harness 单元 / wrapper 安装 / SSE wire / dual-write fallback)
+- V0.3 现有测试不破(738 → 750)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+```
+
+### 8.3 后续 PR briefing(增量化基)
+
+PR #2-#6 的 briefing 在 dispatcher 派工时基于 §8.2 模板**增量化**生成,
+关键修改点:
+
+- **任务段**:替换为对应 finding 的核心范围(详本 dev-plan §3-§7);引用
+  PRD 对应章节(§4 / §5 / §6 / §7 / §8)
+- **触点代码**:列具体改动文件(本 dev-plan §3-§7 任务摘要列出)
+- **红线 grep**:每 PR 自己的 grep 矩阵 — 见 §9
+- **PR 命令 body**:Closes 段对应 finding;改动段对应任务;测试段对应新增
+  测试数
+
+完整模板复用 §8.1 通用前置 + §8.2 形态;dispatcher 派工时 inline 替换。
+
+---
+
+## 9. 红线 grep 矩阵(每 PR ship 前跑过)
+
+| 红线 | grep 命令 | 期望 |
+|---|---|---|
+| harness 不解析 tmux 输出 | `git grep -nE 'capture_pane' crates/ccteam-core/src/harness.rs` | 0 命中 |
+| orchestrator 不消费 harness snapshot 做状态决策 | `git grep -nE 'HarnessSnapshot' crates/ccteam-core/src/orchestrator.rs` | 0 命中 |
+| ccteam-core 不出现 team 名字面量 | `git grep -nE '"flex"\|"workflow"\|"multi_workflow"' crates/ccteam-core/src/{orchestrator,team_resolver}.rs` | 仅在 enum derive / 测试 fixture 出现,业务路径 0 命中 |
+| ccteam-web 不依赖 ccteam-cli | `cargo tree -p ccteam-web \| grep ccteam-cli` | 0 命中(V0.3 PR #1 已建测试,F50 PR 不破) |
+| `session rm` 是唯一显式 kill 路径 | `git grep -nE 'shutdown_session\|tmux kill-session\|kill_session' crates/ccteam-core/src/` | 仅在 `harness.rs::shutdown_session` 实现 + `commands.rs::run_session_rm` 调用,其他路径 0 命中 |
+| flex 团队解析仍走 TeamSpec 数据驱动 | `git grep -nE 'if state.team' crates/ccteam-core/src/orchestrator.rs` | 0 命中(strategic doc §3 红线;`should_run_auto_loop` 等 helper 替代) |
+| codex stub error 消息含追踪指针 | `git grep -nE 'docs/v0-3-1/prd.md §F47\|deferred to V0.3.2' crates/ccteam-core/src/harness.rs` | ≥ 3 命中(spawn / ingest / shutdown 都指向) |
+
+---
+
+## Changelog
+
+- 2026-05-10:**初稿**。dev-plan 跟 V0.2.2 / V0.3 模式,但**只完整给出 PR
+  #1(F46 HarnessAdapter)的 subagent briefing**(立 trait + statusline
+  wrapper 是 foundation,后续 PR 在其基础上增量),PR #2-#6 briefing 由
+  dispatcher 派工时基于 §8.2 模板增量化生成。base = `origin/main` `f9baf3f`
+  (V0.3 ship);测试 baseline 738/0;workspace.version 0.3.0 → 0.3.1(F51 PR)。

--- a/docs/v0-3-1/prd.md
+++ b/docs/v0-3-1/prd.md
@@ -1,0 +1,1254 @@
+# PRD V0.3.1 — Strategic pivot: flex team + multi-session + HarnessAdapter
+
+> 范围:V0.3.1 是 V0.3 主线 ship 后的首个 patch round(跟 V0.2.2 模式一致,
+> F-numbered findings under one umbrella),也是 ccteam 的**战略支点版本**。
+>
+> base = `origin/main` `f9baf3f`(V0.3 ship 终点);测试 baseline `738/0`;
+> workspace.version 起点 `0.3.0`,F51 PR 落地时 bump `0.3.1`。
+>
+> 跟 V0.2.2 / V0.3 不同:V0.3.1 既是命名习惯上的 patch round(F-finding,
+> 不 bump main version),又是产品意义上的**战略支点** — 把 ccteam 的
+> 自我定位从"phase-driven workflow orchestrator"扩展为"session-layer farm
+> + observability + cross-project memory bridge",同时支持 Claude Code
+> 与 OpenAI Codex CLI。phase 编排演进**暂停**(无新 phase / 无 Fat Skills
+> 演进机制),改起一支新 team kind `flex`(空 phase,用户原生方式驱动多
+> session)。
+
+---
+
+## 1. 背景 — 战略 pivot
+
+### 1.1 用户对话源(2026-05-10)
+
+V0.3 在 2026-05-10 ship 后的同一天,用户在 dispatcher session 的
+Telegram dialogue(messages 311-318)里把 V0.3.1 的方向钉死。原话节选:
+
+> "team 工厂创建出空的 phases 团队,空团队的能力是 tmux 管理多个 claude
+> code 和 codex session,工作流采用用户原始用 claude code 方式来完成...
+> 由用户做主动态调整,而不是一开始创建一套永远不变的 phases。"
+
+这条诉求实质把 ccteam 重新定位:不只是一个**预定 phase 编排器**,而是**一个
+session farm + observability layer**;用户用最原始的 Claude Code(或 Codex)
+姿态干活,ccteam 在一旁观测、记录、提供控制面;recurring pattern 出现后,
+**用户**才决定哪些 phase 值得"冻结",并做 promotion(V0.3.2/V0.4 deferred,
+非本轮范围)。
+
+### 1.2 用户已 confirm 的关键回答
+
+| Q | Answer |
+|---|---|
+| team kind 名字 | **`flex`**(暗示"flexible / mutable",CLI 上短) |
+| Codex 深度 | **trait stub only** — `CodexAdapter` 完整实现 deferred V0.3.2 |
+| 多 session | **拉前 V0.3.1** — 单项目可托管 N session,Claude+Codex 混合,支持 cross-review 模式 |
+| Orchestrator 在 flex 团队的行为 | auto_loop / phase prompt 注入 / golden_rules **off** by default;silence_classifier / cost watcher / hooks / progress.jsonl / 跨项目 memory **on** |
+| Dashboard | 加 `kind` 列,phase 列 nullable;flex 项目用 per-session cards(N 卡片),每张挂 harness badge |
+
+### 1.3 战略论证(指向 research docs)
+
+V0.3.1 的方向直接落在 ccteam 已有的两份 research doc 论证里:
+
+- **`docs/research/thin-harness-fat-skills-architecture-improvement.md`**
+  §1 结论 / §2.1 Thin Harness / §6 改进项:V0.3.1 不让 harness 做厚,反而
+  砍掉一支 phase machinery 的扩展(暂停 phase 编排演进),把复杂度全部
+  让给 user + LLM 在 session 内自由发挥;**flex 团队是 fat-skill-的-fat-skill**
+  演进起点(用户先在 session 里自己跑,recurring pattern 后再考虑 freeze
+  到 phase) — 这恰好是 thin harness 论证的极限形态。
+- **`docs/research/ccteam-codex-integration.md`** §1 一句话结论 / §6.3
+  Codex 作为 ccteam 控制端 / §7 代码改造建议:Codex 集成不应从"替换 Claude
+  Code"开始,而应从"作为独立 reviewer / 控制端 / skill 运行面"开始。
+  V0.3.1 F47 落 trait stub 是该路线的 M0(文档与手动路径)+ M1(控制面安装)
+  的前置 — 把 trait shape 立起来,让后续 V0.3.2 的 `CodexAdapter` 实现有
+  地方接入,不必动 V0.3.1 已 ship 的代码。
+
+V0.3.1 的支点性体现在两点:
+
+1. **暂停 phase 编排演进**:没有新 phase,没有新 sub_skill 协议,没有 Fat
+   Skills 第一等对象升级 — 这些都 V0.4 deferred。
+2. **新增 session-layer 视角**:flex 团队 + adhoc multi-session +
+   HarnessAdapter trait,共同把 ccteam 抽象成"多 session 元工具",Claude
+   与 Codex 都可作为 first-class harness。
+
+---
+
+## 2. 范围
+
+实现 6 finding(F46-F51)+ 配套 ship gate:
+
+- **F46**:`HarnessAdapter` trait + `ClaudeCodeAdapter`(statusline dual-write
+  到 `~/.ccteam/harness/<slug>-<sid>.json`,web SSE 消费 snapshot stream)—
+  立 trait,后续 finding 都基于它
+- **F47**:`CodexAdapter` trait stub(impl 签名完整,所有方法返
+  `Err(NotImplemented)`);`team.yaml::sessions[].harness` 字段;CLI 接受
+  `--harness=codex` 但 spawn 时返友好 error
+- **F48**:`kind: flex` team kind — `team.yaml::kind` 字段(默认 `workflow`,
+  V0.1/V0.2/V0.3 yaml 不动);team factory `ccteam team init <name> --kind=flex`;
+  orchestrator behavior gating(`should_run_auto_loop` / `should_inject_phase`
+  对 flex 返 false;silence/cost/hooks/progress/memory 不变)
+- **F49**:adhoc multi-session primitives — `ccteam session {add,ls,attach,rm}`
+  CLI;per-session 子目录布局 `~/projects/<team>-<slug>/sessions/<sid>/`;
+  tmux `ccteam-<slug>-<sid>` 命名;混合 harness 共存;`progress.jsonl`
+  scoping(`~/.ccteam/progress/<slug>/<sid>.jsonl` 子目录)
+- **F50**:web 层更新 — dashboard `kind` 列;flex `/project/<slug>` per-session
+  cards + harness badges;新 `/session/<slug>/<sid>` 详情页;SSE filter by
+  sid;screenshot endpoint 扩 `<slug>-<sid>.png`
+- **F51**:chore + ship gate — workspace.version `0.3.0` → `0.3.1`、
+  CLAUDE.md baseline 回填、e2e for flex multi-session、`docs/v0-3-1/e2e-retro.md`、
+  `docs/v0-2/README.md` 更新
+
+总规模估:~1.5 kLOC 增量(+ ~30 测试)+ 端到端 ~2-3 周(单人,6 PR 大体串行,
+F47 / F48 + F49 / F50 部分可并行)。
+
+---
+
+## 3. F46 — `HarnessAdapter` trait + `ClaudeCodeAdapter`
+
+### 3.1 问题
+
+V0.3 web UI 的 dashboard 数据源 = `progress.jsonl` 事件流 + tmux pane 截图
+(F38)。但 Claude Code 的 statusline + subagent 面板里**有大量结构化数据**
+(模型名 / context% / token 计数 / cost / rate-limit / subagent 列表 + 进度),
+V0.3 dashboard 只能拿到截图视觉版本(像素文本),不可 query;F35 enriched
+outbox 也只有 ASCII pane_tail。
+
+进一步,V0.3.1 引入 Codex 后,session 不再只有一种 harness。需要一层 trait
+抽象把"harness 元数据 + 控制面"统一,Claude Code 与 Codex 都可填,web /
+CLI / orchestrator 不需 if-by-name。
+
+### 3.2 设计
+
+#### 3.2.1 模块位置
+
+新模块 `crates/ccteam-core/src/harness.rs`(后续 sub-module 可拆 `harness/`
+目录)。trait + 数据结构 + `ClaudeCodeAdapter` 实现 + `CodexAdapter` stub
+都在这里(F47 在 F46 基础上加 stub)。
+
+#### 3.2.2 trait 形态
+
+```rust
+// crates/ccteam-core/src/harness.rs
+
+pub trait HarnessAdapter: Send + Sync {
+    /// Stable identifier, e.g. "claude-code", "codex".
+    fn name(&self) -> &'static str;
+
+    /// Ingest a fresh status snapshot from the harness's native channel
+    /// (Claude Code statusline stdin JSON; codex's equivalent TBD).
+    /// Returns a normalized HarnessSnapshot the web layer / orchestrator
+    /// can consume without knowing which harness generated it.
+    fn ingest_snapshot(&self, raw: &str) -> Result<HarnessSnapshot, HarnessError>;
+
+    /// Best-effort subagent state. Returns empty Vec when the harness
+    /// doesn't expose this surface (V0.3.1 Claude Code: empty until
+    /// upstream API; Codex stub: empty).
+    fn subagent_states(&self, snapshot: &HarnessSnapshot) -> Vec<SubagentState> {
+        vec![]
+    }
+
+    /// Spawn a new session. Returns SessionHandle (tmux session name +
+    /// pid + initial state). Codex stub: returns
+    /// Err(HarnessError::NotImplemented { ... }).
+    fn spawn_session(&self, opts: SpawnOpts) -> Result<SessionHandle, HarnessError>;
+
+    /// Graceful shutdown. The ONLY context that calls this is the user's
+    /// explicit `ccteam session rm` request — never silent kill (red line
+    /// CLAUDE.md §三).
+    fn shutdown_session(&self, handle: &SessionHandle) -> Result<(), HarnessError>;
+}
+
+pub struct HarnessSnapshot {
+    pub harness: String,                      // "claude-code" / "codex"
+    pub model_display_name: String,
+    pub context_used_pct: u8,                 // 0-100
+    pub cost_usd_total: f64,
+    pub rate_limit_pct: Option<u8>,
+    pub cwd: Option<PathBuf>,
+    pub raw: serde_json::Value,               // full JSON for forward-compat
+    pub captured_at: DateTime<Utc>,
+}
+
+pub struct SubagentState {
+    pub kind: String,                         // "main", "general-purpose", "code-reviewer"
+    pub label: Option<String>,                // human label
+    pub running_for: Option<Duration>,
+    pub tokens_in: Option<u64>,
+    pub tokens_out: Option<u64>,
+}
+
+pub struct SpawnOpts {
+    pub project_slug: String,
+    pub sid: String,                          // "claude-1" / "codex-2" / ...
+    pub cwd: PathBuf,
+    pub bypass_permissions: bool,             // CC: --dangerously-skip-permissions
+    pub extra_args: Vec<String>,              // harness-specific
+}
+
+pub struct SessionHandle {
+    pub tmux_session: String,                 // "ccteam-<slug>-<sid>"
+    pub harness: String,
+    pub sid: String,
+    pub pid: Option<u32>,
+    pub started_at: DateTime<Utc>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HarnessError {
+    #[error("harness '{harness}' not implemented in V0.3.1: {reason}")]
+    NotImplemented { harness: &'static str, reason: &'static str },
+    #[error("snapshot ingest failed: {0}")]
+    IngestFailed(String),
+    #[error("spawn failed: {0}")]
+    SpawnFailed(String),
+    #[error("shutdown failed: {0}")]
+    ShutdownFailed(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+```
+
+#### 3.2.3 ClaudeCodeAdapter — 完整实现
+
+`ClaudeCodeAdapter` 落 trait 全部方法,数据 flow:
+
+```
+Claude Code TUI
+  ↓ stdin JSON
+statusline-command.sh (wrapper, ccteam-managed)
+  ↓ original render path                  ↓ NEW dual-write
+TUI footer string                        ~/.ccteam/harness/<slug>-<sid>.json
+                                          ↓ notify watch
+                                         ccteam-web::routes::sse::handle_harness_sse
+                                          ↓ SSE (event: harness_snapshot)
+                                         dashboard / project / session detail
+```
+
+**slug + sid 推导**(关键):wrapper 从 stdin JSON 的 `.cwd` 字段匹配
+`~/projects/<team>-<slug>/sessions/<sid>/` 路径前缀(F49 落地后)或 `~/projects/<team>-<slug>/`
+(单 session 项目,V0.3 兼容,sid = `claude-1` 默认)。匹配不到的 session
+(meta-agent / random claude session)写 `~/.ccteam/harness/_meta-<handle>.json`
+或丢弃(无 panic)。
+
+**wrapper 安装**(`ccteam doctor --install-statusline-adapter`):
+
+- 检测用户原 `~/.claude/statusline-command.sh`;有 → wrapper `tee` stdin 进
+  `~/.ccteam/harness/<slug>-<sid>.json` + 透传到原脚本 stdout(保留用户
+  自定义 footer);无 → 直接写 dual-write 文件,stdout 输出最简化 footer
+- marker 保护用户手改:`# ccteam-managed:statusline begin / end`(同 V0.2.2
+  F39 / F44 marker pattern,F44 反向后实际 marker 文本是
+  `<!-- ccteam-managed:skill -->` 同款,这里是 sh comment 形式)
+- 幂等:`doctor` 重跑只覆盖 marker section,用户手改段保留
+
+**红线 reminder**:不解析 statusline 渲染输出,只解析 stdin JSON。
+`progress.jsonl` 仍是 orchestrator 的状态 SoT,harness snapshot 是
+**presentation-only 信息**,**不参与状态判定**(CLAUDE.md §三 红线)。
+
+#### 3.2.4 web SSE consumer
+
+新 SSE endpoint:
+
+| Path | 内容 |
+|---|---|
+| `GET /sse/harness/<slug>` | 推该 slug 下所有 session 的 harness_snapshot 事件 |
+| `GET /sse/harness/<slug>/<sid>` | 单 session 过滤,详情页用 |
+
+wire format 跟 V0.3 progress SSE 一致,event name `harness_snapshot`,data
+是 `HarnessSnapshot` 序列化 JSON(单行)。watcher 监 `~/.ccteam/harness/`
+目录,文件 modify → 读取 → 广播。
+
+dashboard / project / session detail 的 askama 模板加 harness panel(model
+进度条 / cost 累计 / rate-limit %)— 详 F50。
+
+### 3.3 不做(V0.3.1 内,V0.4 deferred)
+
+- **Claude Code subagent live progress**(token counts in flight)— 上游无 API
+- **statusline 数据进入 orchestrator 决策** — 破 §三 SoT 红线,永久 deferred
+- **harness snapshot 历史 archive**(retro 用)— V0.4
+- **wrapper 自动检测多用户 statusline 脚本**(systemd / launchd 风险)— V0.4
+- **CodexAdapter 实现** — 见 F47
+
+### 3.4 验收
+
+- [ ] `crates/ccteam-core/src/harness.rs` 模块落地,trait + 数据结构 + 错误类型
+- [ ] `ClaudeCodeAdapter` 实现 trait 全部方法
+- [ ] `ccteam doctor --install-statusline-adapter` 安装 wrapper(marker 保护)
+- [ ] `~/.ccteam/harness/<slug>-<sid>.json` 文件 dual-write happy path 测试
+- [ ] `/sse/harness/<slug>` SSE endpoint 推送 harness_snapshot 事件
+- [ ] 用户已有自定义 statusline 脚本时,wrapper tee + 透传不破坏原 footer
+  (回归测试 fixture)
+- [ ] 路径匹配不到 slug 时,fallback 路径不 panic(可丢弃或写
+  `~/.ccteam/harness/_meta-<handle>.json`)
+- [ ] 单元测试:`HarnessSnapshot` round-trip serialize / deserialize;
+  `ClaudeCodeAdapter::ingest_snapshot` 解析 5 种 statusline JSON shape
+  (官方 + 用户魔改)
+- [ ] `cargo test --workspace` baseline 738 不退步;新增 ≥ 8 测试
+
+---
+
+## 4. F47 — `CodexAdapter` trait stub + `harness` 字段
+
+### 4.1 问题
+
+V0.3.1 不实现 Codex 完整支持(`docs/research/ccteam-codex-integration.md`
+M2-M5 路线,~月级工程量),但需要把 trait shape **现在就立**,让 V0.3.2
+的 `CodexAdapter` 实现有地方接入,不必动 V0.3.1 已 ship 的代码;同时 CLI
+和 team.yaml schema 都需要识别 `harness: codex` 让用户提前声明意图。
+
+### 4.2 设计
+
+#### 4.2.1 `CodexAdapter` stub
+
+`crates/ccteam-core/src/harness.rs` 加 `CodexAdapter` 空 struct:
+
+```rust
+pub struct CodexAdapter;
+
+impl HarnessAdapter for CodexAdapter {
+    fn name(&self) -> &'static str { "codex" }
+
+    fn ingest_snapshot(&self, _raw: &str) -> Result<HarnessSnapshot, HarnessError> {
+        Err(HarnessError::NotImplemented {
+            harness: "codex",
+            reason: "Codex adapter is trait-stub in V0.3.1; full implementation tracked in docs/v0-3-1/prd.md §F47, deferred to V0.3.2+. Use --harness=claude or wait.",
+        })
+    }
+
+    fn spawn_session(&self, _opts: SpawnOpts) -> Result<SessionHandle, HarnessError> {
+        Err(HarnessError::NotImplemented {
+            harness: "codex",
+            reason: "Codex spawn is trait-stub in V0.3.1; full implementation tracked in docs/v0-3-1/prd.md §F47 + docs/research/ccteam-codex-integration.md M1, deferred to V0.3.2+. Use --harness=claude or wait.",
+        })
+    }
+
+    fn shutdown_session(&self, _handle: &SessionHandle) -> Result<(), HarnessError> {
+        Err(HarnessError::NotImplemented {
+            harness: "codex",
+            reason: "Codex shutdown is trait-stub in V0.3.1; deferred to V0.3.2+.",
+        })
+    }
+}
+```
+
+#### 4.2.2 `team.yaml::sessions[].harness` 字段(flex 团队用)
+
+flex 团队的 `team.yaml`(F48 引入 `kind: flex` 后)可声明默认会话:
+
+```yaml
+# teams/<flex-team>/team.yaml
+name: my-flex
+kind: flex                                   # F48 引入
+description: "My exploratory workspace"
+sessions:                                    # F47 新字段(仅 kind: flex 时有意义)
+  - sid: claude-1
+    harness: claude                          # claude | codex
+  - sid: codex-1
+    harness: codex
+```
+
+`sessions:` 是**默认初始 session 列表**(team factory bootstrap 时给项目预设;
+用户可后续 `ccteam session add/rm` 改);非 flex 团队该字段忽略(deny_unknown_fields
+不开,该字段直接是 `Option<Vec<DefaultSessionSpec>>` default `None`)。
+
+#### 4.2.3 CLI 接受 `--harness=codex`
+
+`ccteam session add <slug> --harness codex` 在 V0.3.1 接受 flag,但执行到
+`CodexAdapter::spawn_session` 时返 `Err(HarnessError::NotImplemented)`,CLI
+打印友好 error:
+
+```
+$ ccteam session add my-flex-foo --harness codex
+Error: Codex spawn is trait-stub in V0.3.1; full implementation tracked in
+docs/v0-3-1/prd.md §F47 + docs/research/ccteam-codex-integration.md M1,
+deferred to V0.3.2+. Use --harness=claude or wait.
+```
+
+(用户体感清晰指向追踪 issue;不 panic / 不无声 fallback。)
+
+#### 4.2.4 doctor 检查
+
+`ccteam doctor` 加 codex 检测段(用 `which codex` 检测 binary 是否在 PATH;
+不强 fail 任何条件,只输出 informational):
+
+```
+[ccteam] codex CLI: not found (V0.3.1 trait-stub only; install codex CLI for V0.3.2+).
+```
+
+(类比 V0.2.2 ship 的 `claude-mem` 可选检测模式。)
+
+### 4.3 不做(V0.3.1 内,V0.4 deferred)
+
+- **Codex statusline / hook 实际接入** — V0.3.2(`ccteam-codex-integration.md`
+  M1)
+- **`mcp__codex__codex` MCP peer 注册给 meta-agent** — V0.3.2 / V0.4
+- **AGENTS.md 模板生成**(同 CLAUDE.md 双栈)— V0.4
+- **Codex skill 双栈分发**(`.agents/skills/`)— V0.4(详见 codex-integration
+  doc M4)
+- **CodexExecRunner sub-skill runner** — V0.4
+- **`codex mcp-server` 注册给 Claude meta-agent** — V0.4
+
+### 4.4 验收
+
+- [ ] `CodexAdapter` struct 实现 `HarnessAdapter` trait,所有方法返
+  `Err(HarnessError::NotImplemented)` + reason 指向本 PRD 与 codex-integration
+  research doc
+- [ ] `team.yaml::sessions[]` 字段 schema 解析;`harness: claude | codex`
+  枚举(serde 默认 `claude`)
+- [ ] `ccteam session add <slug> --harness codex` CLI 接受 flag,执行返
+  友好 error + exit code 1
+- [ ] `ccteam doctor` 输出 codex CLI 检测信息(present / not-found 都不 fail)
+- [ ] interfaces.md §5.5 `team.yaml` schema 加 `kind` + `sessions[]` 字段
+- [ ] 单元测试:`CodexAdapter::spawn_session` 返 NotImplemented + 错误
+  消息含 V0.3.2 引用;`team.yaml` parse 时 `harness: codex` 被接受不 fail
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 5 测试
+
+---
+
+## 5. F48 — `kind: flex` team kind
+
+### 5.1 问题
+
+V0.1/V0.2/V0.3 的 ccteam 团队都是 phase-driven(`workflow` 暗含),
+`parallelism: multi_session` 是 phase 级字段(per-phase fan-out 拓扑),
+不是 team 级 kind。
+
+V0.3.1 需要一支**空 phase 的 team**:用户起项目后,ccteam **不**注入 phase
+prompt,**不**跑 auto_loop,**不**做 golden_rules check;但 hooks /
+progress.jsonl / silence_classifier / cost watcher / 跨项目 memory bridge
+**仍跑**(observability 全保留)。
+
+### 5.2 设计
+
+#### 5.2.1 `team.yaml::kind` 新字段
+
+`crates/ccteam-core/src/team.rs::TeamSpec` 加字段:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TeamSpec {
+    pub name: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+
+    /// V0.3.1 F48 — team kind. Defaults to `workflow` so V0.1 / V0.2 /
+    /// V0.3 yamls (which omit this field) parse unchanged.
+    ///
+    /// - `workflow` — phase-driven, single tmux session (default; dev /
+    ///   meta-agent / `ccteam-project-creator`)
+    /// - `multi_workflow` — phase-driven, master + predefined sub-modules
+    ///   (research; existing `parallelism: multi_session` semantics)
+    /// - `flex` — empty phase, user drives sessions adhoc; ccteam observes
+    ///   + records + provides controls. No auto_loop / phase prompt /
+    ///   golden_rules. silence/cost/hooks/progress/memory still run.
+    #[serde(default)]
+    pub kind: TeamKind,
+
+    /// V0.3.1 F47 — default session spec for `kind: flex` teams. Ignored
+    /// for `workflow` / `multi_workflow`. Used by team factory to bootstrap
+    /// initial sessions; user can `ccteam session add/rm` after.
+    #[serde(default)]
+    pub sessions: Vec<DefaultSessionSpec>,
+
+    // ... existing fields (description / phase_dir / retro_schema / ...)
+    // unchanged
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TeamKind {
+    Workflow,
+    MultiWorkflow,
+    Flex,
+}
+
+impl Default for TeamKind {
+    fn default() -> Self { Self::Workflow }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DefaultSessionSpec {
+    pub sid: String,                          // "claude-1" / "codex-1"
+    #[serde(default)]
+    pub harness: HarnessKind,                 // claude | codex
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HarnessKind {
+    Claude,
+    Codex,
+}
+
+impl Default for HarnessKind {
+    fn default() -> Self { Self::Claude }
+}
+```
+
+**back-compat**:V0.1/V0.2/V0.3 已 ship 的 `team.yaml`(`dev` / `research` /
+`meta-agent` / `ccteam-project-creator` / 用户自建)都不含 `kind`,`#[serde(default)]`
+解析为 `TeamKind::Workflow` — 行为完全不变。
+
+**校验**(`TeamSpec::validate`):
+- `kind: flex` 团队**必须**有空或缺失 `phase_dir`(或 `phases/` 目录不存在)
+  — 强制 flex 无 phase
+- `kind: flex` 团队**不允许**填 `auto_loop` / `escalate_grammar_extensions` /
+  `golden_rules`(parse 时 fail-loud — 用户明确知道 flex 团队 no phase
+  machinery)
+- `kind: flex` 团队**允许**填 `claude_md_template` / `aliases` / `description` /
+  `evergreen` / `cost_policy` / `sessions`
+- `kind: workflow / multi_workflow` 团队的 `sessions: []` 字段**忽略**(parse
+  时不 fail,但 doctor 跑出 warning 提示该字段只对 flex 有意义)
+
+#### 5.2.2 `kind` 与 `parallelism` 正交
+
+`kind` 是**team 级**字段(在 team.yaml),`parallelism` 仍是**phase 级**
+字段(在 phase markdown frontmatter)。两者关系:
+
+| kind | parallelism(phase 级) | 例 |
+|---|---|---|
+| `workflow` | per-phase: `solo` / `agent_team` | `dev`(V0.1+);phase 通常 solo |
+| `multi_workflow` | per-phase: `multi_session`(在 fan-out phase) | `research`(V0.2.2 alias 后 canonical 名) |
+| `flex` | N/A(无 phase) | 新 V0.3.1 |
+
+flex 团队**没有 phase**,所以 `parallelism` 字段不存在 — 不强制要求
+flex team yaml 写 `parallelism: multi_session` 之类,避免概念污染。
+
+#### 5.2.3 orchestrator behavior gating
+
+`crates/ccteam-core/src/orchestrator.rs` 的 tick 循环加 kind-aware
+helper:
+
+```rust
+impl TeamRuntime {
+    fn should_run_auto_loop(&self) -> bool {
+        match self.spec.kind {
+            TeamKind::Workflow | TeamKind::MultiWorkflow => true,
+            TeamKind::Flex => false,
+        }
+    }
+
+    fn should_inject_phase(&self) -> bool {
+        match self.spec.kind {
+            TeamKind::Workflow | TeamKind::MultiWorkflow => true,
+            TeamKind::Flex => false,
+        }
+    }
+
+    fn should_check_golden_rules(&self) -> bool {
+        match self.spec.kind {
+            TeamKind::Workflow | TeamKind::MultiWorkflow => true,
+            TeamKind::Flex => false,
+        }
+    }
+}
+```
+
+**保留启用**(flex 团队仍跑):
+- silence_classifier(F35,事件流监测,与 phase 无关)
+- cost watcher(F35 / V0.1 阈值 — soft warn 5/15/30min,hard kill 仅 cost
+  > $200)
+- hooks(`progress_append` / `cost_accumulate` / `parse_phase_end` /
+  `intercept_ask_decision` / `load_context`):全部跑;`parse_phase_end`
+  实际不会触发(flex 没 phase prompt → 没 PHASE_DONE: signal)但代码路径
+  存在不冲突
+- progress.jsonl 写入(进 `<slug>/<sid>.jsonl` 子文件,F49 落)
+- 跨项目 memory bridge(rules 文件读写)
+- enriched outbox(V0.2.2 F35,silence 触发的 escalation;flex 团队也会卡)
+
+#### 5.2.4 `claude_md_template` 在 flex 团队的语义
+
+flex 团队的 `<project>/CLAUDE.md` 仍由 `bootstrap_project` 写,模板从
+`team.yaml::claude_md_template`(已存在字段,V0.2 M0.16 ship)读取;flex
+团队的默认模板(seed yaml 自带)应**显式**告诉 session 内的 Claude:
+
+> "本项目是 flex 团队,无预定 phase。你按照原始 Claude Code 姿态自由
+> 工作即可。ccteam 在监测 progress.jsonl 与 cost,silence 长时会 escalate
+> 给 meta-agent / 用户 channel,不会主动 kill 你。需要并行 worker 时,
+> 跟 meta-agent 说 `ccteam session add <slug>` 起新 session。"
+
+模板里**不**写"完成后写 PHASE_DONE: ..."之类协议关键字。
+
+#### 5.2.5 team factory `--kind=flex`
+
+`ccteam team init <name> --kind=flex` 生成的 staging tree:
+
+```
+~/.config/ccteam/teams/<name>/
+├── .claude-plugin/plugin.json     # plugin manifest(同 V0.2 M0.22)
+├── team.yaml                      # kind: flex + 默认 sessions[claude-1]
+├── README.md
+└── (无 phases/ 目录 — flex 团队无 phase)
+```
+
+跟 V0.2 M0.22 已 ship 的 `ccteam team init` 工厂一致,只是 phase 模板不
+scaffold(`init_team_staging` 检测 `kind: flex` 跳过 phase scaffold)。
+
+`ccteam team publish <name>` 把 staging 拷到 `~/.ccteam/teams/<name>/`(同
+V0.2 M0.22 行为);doctor 校验跳过 phase 引用(`kind: flex` 团队的
+`tools_required` 不必校验 phase 一致性)。
+
+### 5.3 不做(V0.3.1 内,V0.4 deferred)
+
+- **flex workflow promotion / demotion UX** — 用户在 session 里跑出
+  recurring pattern 后,把 N 条 progress 事件 promote 成一支冻结 phase;
+  反向:把已冻结 phase 拆回 flex。**这是 Fat Skills evolution 路径**(详
+  `thin-harness-fat-skills-architecture-improvement.md` §6.1),V0.3.1
+  ship 只 ship 空 base,V0.3.2 / V0.4 落 promotion 机制
+- **`flex_workflows.yaml` per-team 持久化 schema**(promotion 后冻结的 phase
+  存哪里) — V0.3.2 / V0.4
+- **flex 团队的 retro phase** — V0.3.2(retro_schema 字段虽然存在,但 retro
+  phase 是 phase machinery,flex 不跑;V0.3.2 用户跑完 promote 后再评估)
+- **flex 团队的 verdict_schema** — 同上
+- **flex 团队 plugin 形态强校验** — V0.4 evolve plugin schema 时再做
+- **flex 团队的并行预算 / max_concurrent_sessions 配置** — V0.4(用户先用,
+  撞性能墙再加)
+
+### 5.4 验收
+
+- [ ] `crates/ccteam-core/src/team.rs::TeamSpec` 加 `kind: TeamKind` +
+  `sessions: Vec<DefaultSessionSpec>` 字段,`#[serde(default)]` 保 V0.1/V0.2/V0.3
+  yaml 解析不变
+- [ ] `TeamSpec::validate` 拒绝 `kind: flex` + `golden_rules` / `escalate_grammar_extensions`
+  / 非空 phase_dir 的非法组合
+- [ ] orchestrator 三个 helper(`should_run_auto_loop` / `should_inject_phase` /
+  `should_check_golden_rules`)对 flex 返 false;tick 循环引用 helper 不再
+  字符串硬编码 `if state.team == ...`(strategic doc §3 红线)
+- [ ] `ccteam team init <name> --kind=flex` scaffold staging tree(无 `phases/`
+  目录)
+- [ ] `ccteam team publish <name>` flex 团队成功 publish 到 `~/.ccteam/teams/<name>/`
+- [ ] `doctor --validate-team <name>` 对 flex 团队跳过 phase 引用校验,只校
+  team.yaml + plugin.json 一致性
+- [ ] 已存在的 `dev` / `research` / `meta-agent` / `ccteam-project-creator` 团队
+  在 V0.3.1 升级后**完全无变化**(回归测试 fixture)
+- [ ] 单元测试:`TeamSpec` round-trip serialize / deserialize 含 `kind`;
+  flex bootstrap 写出的 `<project>/state.json` 字段(`team` / `parallelism: solo`
+  默认,无 phase 字段触发);interfaces.md §5.5 schema 同步
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 8 测试
+
+---
+
+## 6. F49 — Adhoc multi-session primitives
+
+### 6.1 问题
+
+V0.3 之前 ccteam 项目 = **单 tmux session**(except `parallelism: multi_session`
+的 fan-out phase,但那是 phase 级**预定义** sub-module 拓扑)。flex 团队
+要支持**adhoc**:用户起项目后任意时刻 `ccteam session add <slug>` 起新
+session,删 session,attach 到任一 session,混合 Claude+Codex(V0.3.1 codex
+spawn 仍 NotImplemented,但 schema 接得住)。
+
+multi_session 的 master + 预定义 sub-module 拓扑**不**适合 adhoc:
+
+- multi_session 是 phase 级配置,sub-module 列表来自 phase prompt(plan-eng
+  写 interface-contracts);flex 没 phase
+- multi_session sub-module 的 `state.json` 跟 master 同 schema,但子目录是
+  *代码*目录(`backend-api/` / `frontend-dashboard/`);adhoc session 不
+  对应代码目录(同一项目同一仓库,用户可能起 N session 都跑同一代码 — 例
+  CC 实现 + Codex review)
+
+### 6.2 设计
+
+#### 6.2.1 文件系统布局
+
+flex 项目目录:
+
+```
+~/projects/<team>-<slug>/                # project root,同 V0.3
+├── .ccteam/
+│   ├── state.json                       # master state(扩 sessions 字段,§6.2.2)
+│   ├── inbox/ outbox/                   # 项目级 inbox/outbox(同 V0.3)
+│   └── sessions/                        # NEW V0.3.1 F49
+│       ├── claude-1/
+│       │   ├── state.json               # per-session state(子集字段)
+│       │   ├── inbox/ outbox/           # per-session inbox/outbox(可选;
+│       │   │                            #  默认走项目级 — V0.3.2 评估细分)
+│       │   └── (per-session 工件 .md)
+│       ├── claude-2/
+│       └── codex-1/
+└── (项目代码 — flex 团队下,该目录可能空,可能用户手填或一开始就 git
+   clone 进来,ccteam 不假设)
+```
+
+**对比 V0.3 multi_session**(`docs/interfaces.md §1.3`):multi_session 把
+*代码*分到 `<slug>/backend-api/` / `<slug>/frontend-dashboard/` 子目录,
+sub-module 是**代码维度**;flex 把 *session*分到 `<slug>/.ccteam/sessions/<sid>/`,
+session 是**进程维度**,代码不分。两条独立机制,V0.3.1 F49 不复用 V0.3
+multi_session 路径(避免概念污染)。
+
+**progress.jsonl scoping**:
+
+```
+~/.ccteam/progress/
+├── <slug>.jsonl                         # 单 session 项目(workflow /
+│                                          multi_workflow,V0.3 兼容路径)
+└── <slug>/
+    ├── claude-1.jsonl                   # flex 项目 per-session(F49)
+    ├── claude-2.jsonl
+    └── codex-1.jsonl
+```
+
+flex 项目 progress 写入 `~/.ccteam/progress/<slug>/<sid>.jsonl`,文件名
+`<sid>` 不含 `<slug>` 前缀(子目录已分);workflow / multi_workflow 项目
+仍写 `<slug>.jsonl` flat(不动 V0.3 协议)。`hooks::progress_append` 解析
+`state.json::team_kind`(从项目目录推 — bootstrap 写入)决定路径形态。
+
+watcher(V0.3 M5.2 ship)默认 recursive 监 `~/.ccteam/progress/`,flex 子
+目录天然被覆盖。
+
+#### 6.2.2 master `state.json::sessions` 字段
+
+flex 项目的 master state.json 在 V0.3 字段基础上加:
+
+```json
+{
+  "slug": "my-flex-foo",
+  "team": "my-flex",
+  "team_kind": "flex",                              // F48 / F49 新字段
+  "tmux_session": "ccteam-my-flex-foo-claude-1",    // 第一个 session(legacy 兼容)
+  "sessions": {                                     // F49 新字段
+    "claude-1": {
+      "harness": "claude",
+      "tmux_session": "ccteam-my-flex-foo-claude-1",
+      "started_at": "2026-05-10T12:00:00Z",
+      "pid": 12345
+    },
+    "codex-1": {
+      "harness": "codex",
+      "tmux_session": "ccteam-my-flex-foo-codex-1",
+      "started_at": "2026-05-10T12:05:00Z",
+      "pid": null
+    }
+  },
+  "next_sid_seq": {                                 // sid 单调递增,删后不复用
+    "claude": 2,
+    "codex": 2
+  },
+  "...": "其他字段同 V0.3 §2.1"
+}
+```
+
+`team_kind: workflow | multi_workflow` 项目的 state.json 不写 `sessions:` /
+`next_sid_seq:`(serde 默认 `None` / `BTreeMap::new()`),完全 V0.3 兼容。
+
+#### 6.2.3 sid 格式
+
+`<harness>-<n>`,n 从 1 开始单调递增,**删后不复用**(避免 attach 错 session);
+全项目内唯一(不同 harness 各自计数 — `claude-1` 与 `codex-1` 共存)。
+`next_sid_seq[harness]` 字段记下一个可用 n。
+
+#### 6.2.4 tmux session 命名
+
+`ccteam-<slug>-<sid>`,如 `ccteam-my-flex-foo-claude-1` / `ccteam-my-flex-foo-codex-2`。
+**workflow / multi_workflow** 项目仍是 `ccteam-<slug>` 不带 sid 后缀(V0.3
+兼容);flex 项目第一个 session 也带 `-<sid>` 后缀(无歧义)。
+
+#### 6.2.5 CLI 设计
+
+```
+ccteam session add <slug> [--harness claude|codex] [--sid <name>]
+ccteam session ls <slug>
+ccteam session attach <slug> <sid>
+ccteam session rm <slug> <sid>
+```
+
+详细行为:
+
+| 子命令 | 行为 | 失败 |
+|---|---|---|
+| `add` | 调 `<HarnessAdapter>::spawn_session`(F46);写 master state.json `sessions[]`;tmux new-session;hooks 启动 | codex stub → friendly error;tmux 失败 → fail-loud + state 不写 |
+| `ls` | 读 master state.json `sessions{}` → 表格(sid / harness / tmux / started / pid / status from hooks last event) | 项目不存在 → 404 |
+| `attach` | tmux attach `ccteam-<slug>-<sid>` | session 不在 → fail-loud 列出可用 sid |
+| `rm` | 调 `shutdown_session`(graceful);tmux kill;清 master state.json sessions[sid];**这是唯一**显式 kill 路径 | 不在 → noop + warn |
+
+**红线 reminder**:`rm` 是**唯一**用户显式授权的 kill 路径。silence /
+cost / stale 不触发 kill(CLAUDE.md §三)。
+
+#### 6.2.6 跟 V0.3 multi_session 的边界
+
+`parallelism: multi_session` 仍**保留**给 workflow / multi_workflow 团队
+的 phase 级 fan-out(research 团队的 plan → fan-out → impl-parallel → fan-in
+拓扑)— **不动**,V0.3 ship 行为完全保持。
+
+flex 的 adhoc multi-session 是**新机制**,正交;workflow 团队的项目无法
+`ccteam session add`(因为该团队 `kind: workflow`,master state.json 没
+`sessions{}` 字段架构;CLI 检测 → friendly error "session add only works
+on flex teams")。
+
+### 6.3 不做(V0.3.1 内,V0.4 deferred)
+
+- **跨 session orchestration / 协调**(eg "claude-1 完成 implement 后自动
+  发 codex-1 review")— V0.4 channel adapter / pipeline 评估;V0.3.1 用户
+  自己 `/btw` 派
+- **session 级 inbox/outbox 细分** — 可选(`<sid>/inbox/`),V0.3.1 默认走
+  项目级 inbox/outbox;V0.3.2 if 用户撞 cross-talk 再加
+- **session 间共享 context / lessons** — V0.3.1 不做,session 各自跑;
+  cross-project memory bridge(`~/.claude/rules/`)正交不动
+- **N session > 配置阈值时拒绝 add** — V0.4(用户撞性能再加 max_sessions_per_project)
+- **session rename(`ccteam session rename ...`)** — V0.4(等同 slug rename
+  V0.3+ deferred 一起评估)
+- **flex 项目的 `interface-contracts.md`** — 没 fan-out / fan-in concept,
+  不需要
+
+### 6.4 验收
+
+- [ ] `~/projects/<team>-<slug>/.ccteam/sessions/<sid>/` 子目录在
+  `ccteam session add` 时创建
+- [ ] master `state.json::sessions{}` + `next_sid_seq{}` 字段写入并 round-trip
+  解析;V0.3 单 session 项目 state.json 不含这俩字段(serde default)
+- [ ] `~/.ccteam/progress/<slug>/<sid>.jsonl` 子目录路径在 hooks 写入时分流
+  (flex 团队);workflow / multi_workflow 项目仍 `<slug>.jsonl` flat
+- [ ] `ccteam session add <slug> --harness claude` happy path:tmux new-session +
+  state 写入 + hooks 起来 + claude bypass-perms session 启动
+- [ ] `ccteam session add <slug> --harness codex` 返友好 error(F47 stub)
+- [ ] `ccteam session ls <slug>` 返表格 + per-session status(从
+  per-session progress.jsonl 末事件推)
+- [ ] `ccteam session attach <slug> <sid>` 调 tmux attach;不存在 sid
+  → fail-loud 列可用
+- [ ] `ccteam session rm <slug> <sid>` graceful shutdown + tmux kill +
+  state 清理;**仅在显式调用时**触发 kill
+- [ ] sid 格式 `<harness>-<n>` 单调递增 + 删后不复用(`next_sid_seq` 字段
+  保护);单元测试覆盖 race(并发 add)
+- [ ] CLI 在 workflow / multi_workflow 团队上调 `ccteam session add` 返
+  friendly error("session subcommands only work on flex teams")
+- [ ] interfaces.md §1.3 / §2.1 schema 同步加 flex layout + state.json
+  sessions 字段
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 12 测试
+
+---
+
+## 7. F50 — Web 层更新
+
+### 7.1 问题
+
+V0.3 web UI(M5.0-M5.4 ship)假设单 session 项目;V0.3.1 引入 flex 团队 +
+adhoc multi-session 后:
+- dashboard 表格里 `phase` 列对 flex 项目无意义(没 phase)
+- project 详情页的 events / outbox / screenshot panel 应分到 N session
+- harness snapshot stream(F46)需要前端消费
+
+### 7.2 设计
+
+#### 7.2.1 dashboard `/`
+
+V0.3 列:`Slug / Team / Phase / Last event / Status badge / Cost`
+
+V0.3.1 加列:`Kind`(workflow / multi_workflow / flex)。`Phase` 列对 flex
+项目渲染 `—` 或 `manual`(空 string 渲染 `—` 更清晰)。`Status badge` 对
+flex 项目仍跑 silence_classifier 分类(主要 `Healthy` / `MidToolHung` /
+`PostStopLimbo` 等仍适用 — 与 phase 无关)。
+
+模板更新 `dashboard.html`:加一列;现 V0.3 测试 fixture 不破。
+
+#### 7.2.2 project 详情页 `/project/<slug>`
+
+**workflow / multi_workflow 项目(V0.3 行为)**:不变 — single session panel
++ events / outbox / screenshot 各自一份。
+
+**flex 项目(V0.3.1 新)**:
+- header:slug / team / kind=flex / cost / created_at;**无** current_phase
+- session cards section:每张卡 = 一个 session(`<sid>`)
+  - sid + harness badge(`claude` 蓝 / `codex` 绿)
+  - status(silence_classifier 分类,基于 per-session progress.jsonl)
+  - last event 时间
+  - 缩略屏幕截图(F38 reuse,`/screenshot/<slug>-<sid>.png`)
+  - "Attach" 按钮(实际是文档化 tmux command 复制按钮 — web 不能 `tmux
+    attach`,只能展示命令)
+  - "Detail" 链接 → `/session/<slug>/<sid>`
+- master events stream:聚合所有 session 的 progress events(SSE `/sse/project/<slug>`,
+  V0.3 已 ship — 自然消费 flex 项目的 sub-jsonl 文件,因为 watcher recursive
+  监 `~/.ccteam/progress/`)
+
+#### 7.2.3 新页 `/session/<slug>/<sid>`
+
+完整 session detail:
+
+- header:project slug + sid + harness + tmux session name + started_at
+- events stream(per-session SSE `/sse/project/<slug>/<sid>`)
+- per-session outbox(若 session 有自己 outbox 子目录;V0.3.1 默认共享项目
+  级,detail 页展示项目级)
+- screenshot:`<slug>-<sid>.png`(F38 `render_screenshot` 加 sid 参数)
+- harness panel:F46 `harness_snapshot` SSE 消费,model / context% / cost /
+  rate-limit
+- write actions sidebar(V0.3 M5.3 形态):`/btw` / `inject_decision` /
+  `pause` / `resume`,但**作用于 session 级 inbox**(`<slug>/.ccteam/sessions/<sid>/inbox/`)
+  — V0.3.1 默认仍写到项目级 inbox(简化 V0.3.2 评估细分)
+
+#### 7.2.4 SSE filter by sid
+
+V0.3 ship 的 `GET /sse/project/<slug>` 推所有 progress events;V0.3.1 加:
+
+| Path | 内容 |
+|---|---|
+| `GET /sse/project/<slug>/<sid>` | 单 session 过滤,server-side `msg.sid == <sid>`(EventMsg 加 `sid` 字段) |
+| `GET /sse/harness/<slug>` | 该 slug 下所有 session 的 harness_snapshot(F46) |
+| `GET /sse/harness/<slug>/<sid>` | 单 session harness_snapshot |
+
+`progress.jsonl` 的 sid 来自 hooks 写入(从 cwd 推 `<slug>/<sid>` 子目录,
+F49)。
+
+#### 7.2.5 screenshot endpoint 扩展
+
+V0.3:`GET /screenshot/<slug>.png` → `render_screenshot(slug, opts)`
+
+V0.3.1:`GET /screenshot/<slug>-<sid>.png` → `render_screenshot(slug, sid, opts)`,
+F38 `render_screenshot` 签名加可选 sid;old endpoint 保留(workflow 项目用)。
+
+flex 项目 dashboard 卡片用 `<slug>-<sid>.png`(每张 card 自己的 screenshot);
+workflow 项目仍 `<slug>.png`。
+
+### 7.3 不做(V0.3.1 内,V0.4 deferred)
+
+- **mobile-responsive layout for session cards** — V0.4
+- **session 拖拽 reorder / 标记 favorite** — V0.4
+- **跨 session 命令面板**(eg "在所有 sessions 同时 /btw <prompt>")— V0.4
+  pipeline 评估
+- **session 级 chart / 累计 token use 时序图** — V0.4
+- **search across sessions / 按 harness 过滤 dashboard** — V0.4
+- **flex workflow promotion UI**(选 N events → "promote to phase")— V0.4
+  Fat Skills evolution
+
+### 7.4 验收
+
+- [ ] dashboard `/` 加 `Kind` 列;现有 V0.3 e2e 测试不破(fixture project
+  默认 kind=workflow,新列 cell="workflow")
+- [ ] flex 项目的 dashboard `Phase` 列渲染 `—`
+- [ ] flex 项目的 `/project/<slug>` 渲染 N session cards + harness badges +
+  per-card screenshot
+- [ ] workflow / multi_workflow 项目的 `/project/<slug>` 渲染**完全不变**
+  (回归测试)
+- [ ] 新页 `/session/<slug>/<sid>` 200,header / events / harness panel /
+  write actions sidebar 完整
+- [ ] `GET /sse/project/<slug>/<sid>` server-side filter by sid 正确
+- [ ] `GET /sse/harness/<slug>` / `GET /sse/harness/<slug>/<sid>` SSE 推送
+  harness_snapshot
+- [ ] `GET /screenshot/<slug>-<sid>.png` 200 + PNG bytes;不存在 sid → 404
+- [ ] `GET /screenshot/<slug>.png` workflow 项目仍正常(V0.3 兼容)
+- [ ] askama 模板编译期类型检查不破
+- [ ] interfaces.md §15(web routes,V0.3 已写)加 V0.3.1 新 endpoint 段
+- [ ] `cargo test --workspace` 不退步;新增 ≥ 6 测试(reqwest hit + HTML
+  断言)
+
+---
+
+## 8. F51 — Chore + ship gate
+
+### 8.1 问题
+
+V0.3.1 ship 前需要:e2e 跨 flex 多 session + 截图 + harness snapshot + 写
+动作的端到端验证;workspace.version bump;CLAUDE.md baseline 回填;v0-2
+README pointer 更新;`docs/v0-3-1/e2e-retro.md` 落档。
+
+### 8.2 设计
+
+#### 8.2.1 e2e 测试
+
+新建 `crates/ccteam-web/tests/flex_e2e_test.rs`:
+
+- 起 ccteam-web server(rand port,127.0.0.1:0)
+- fixture 含 1 flex 项目 + 2 session(claude-1 + claude-2;codex-1 stub
+  返 NotImplemented 也覆盖 error 路径)
+- happy path:
+  1. `GET /` 200 → 表格含 kind=flex 行
+  2. `GET /project/<slug>` 200 → N session cards 渲染
+  3. `GET /session/<slug>/claude-1` 200 → events / harness panel
+  4. `GET /sse/project/<slug>/claude-1` 收 ≥ 1 progress event
+  5. `GET /sse/harness/<slug>/claude-1` 收 ≥ 1 harness_snapshot
+  6. `POST /api/<slug>/btw` 200 → inbox 文件落地
+  7. `GET /screenshot/<slug>-claude-1.png` 200 + PNG magic bytes(若 CI 无
+     tmux,504 + plain-text;两条路径都覆盖)
+- 不依赖真 tmux session;mock harness snapshot file 写入,触发 watcher
+- F47 codex error 路径:`ccteam session add <slug> --harness codex` 返 exit 1
+  + stderr 含 "trait-stub in V0.3.1"
+
+#### 8.2.2 retro 文档
+
+`docs/v0-3-1/e2e-retro.md` —— 模仿 V0.3 / V0.2.2 retro 模板:
+
+- 4-suite 跨 flex 多 session / harness adapter / web UI / codex stub
+- F46-F50 撞坑回顾 + dust patches(若有)
+- 跨浏览器(Chrome / Firefox / Safari macOS)spot-check session detail page
+- workflow / multi_workflow 项目的回归验证(V0.3 行为不破)
+
+#### 8.2.3 workspace.version bump
+
+`Cargo.toml::workspace.package.version` `"0.3.0"` → `"0.3.1"`。F51 PR commit
+subject `v0.3.1: ...` 前缀。
+
+#### 8.2.4 CLAUDE.md baseline 回填
+
+§一表格更新:
+
+| 项 | V0.3.1 后 |
+|---|---|
+| Workspace version | `0.3.1` |
+| 测试 baseline | 实测后填(估 738 + ~40 = ~780) |
+| 已 ship 里程碑 | 加 V0.3.1 行(F46-F51) |
+
+§六 易踩坑加一条:V0.3 → V0.3.1 升级注 — flex 团队 / `kind` 字段 / per-session
+state.json schema 兼容(V0.1/V0.2/V0.3 yaml 不动)。
+
+#### 8.2.5 docs sweep
+
+- `docs/v0-2/README.md`:V0.3 起始 pointer 更新为"已 ship V0.3 + V0.3.1 起始"
+- `docs/dev-coupling-audit.md`:F46-F51 close 标记
+- `docs/tech-design.md` §3.3 / §6.3 / §6.11 加 flex / HarnessAdapter / 多
+  session 段
+- `docs/interfaces.md` §1.3 / §2.1 / §5.5 / §15 增量补 V0.3.1 schema
+
+### 8.3 不做(V0.3.1 内,V0.4 deferred)
+
+- 性能 benchmark(>10 session simul) — V0.4
+- 跨平台 binary release — 现状 `cargo install` 已 ship
+- i18n — 永久 deferred
+
+### 8.4 验收
+
+- [ ] `crates/ccteam-web/tests/flex_e2e_test.rs` 端到端 happy path + codex
+  error path 通过
+- [ ] `Cargo.toml::workspace.package.version = "0.3.1"`
+- [ ] CLAUDE.md §一 baseline 表格更新(workspace.version + 实测测试数 +
+  V0.3.1 milestone 行)
+- [ ] CLAUDE.md §六 加 V0.3 → V0.3.1 升级注
+- [ ] `docs/v0-3-1/e2e-retro.md` 落档
+- [ ] `docs/v0-2/README.md` V0.3 pointer 更新
+- [ ] `docs/dev-coupling-audit.md` F46-F51 close 标记
+- [ ] `docs/tech-design.md` / `docs/interfaces.md` 增量段补完
+- [ ] `cargo test --workspace` 全绿,baseline ≥ 738 + V0.3.1 累计新增
+- [ ] clippy 不新增 warning(4 pre-existing 不算)
+
+---
+
+## 9. 已知风险 / 威胁模型
+
+### 9.1 statusline wrapper 安装破坏用户原脚本
+
+`ccteam doctor --install-statusline-adapter` 写
+`~/.claude/statusline-command.sh`,wrapper marker 保护用户手改段;但用户
+可能用 systemd / launchd / 其他自定义 source 路径替代该文件。
+
+**缓解**:
+- doctor `--dry-run` 模式输出 wrapper 内容供用户 review
+- 检测到现有非 marker 内容 → 备份原文件到 `~/.claude/statusline-command.sh.bak-<ts>`
+  然后写入 wrapper(保留逃生绳)
+- doctor 输出明确路径 + revert 命令文档
+
+### 9.2 flex 团队的 LAN-wide RCE 暴露面跟 V0.3 一致
+
+V0.3.1 不引入新 RCE 面 — 写动作仍走 V0.3 M5.3 ship 的 token auth
+middleware;flex 项目的 `/api/<slug>/btw` / `inject_decision` / `pause` /
+`resume` 复用同一 auth 路径。session 级 endpoint(`/api/<slug>/<sid>/btw`,
+若加 — V0.3.1 当前 default 走项目级)同一 token 校验。
+
+V0.3 PRD §9 的 LAN RCE 评估完全继承,不需新 ack。
+
+### 9.3 codex stub 错误消息可能被错误地解释为 fully implemented
+
+NotImplemented error 文本明确指向 PRD §F47 + research doc;但用户 / sub
+用户可能被 CLI flag 接受迷惑(以为 codex 至少能起来)。
+
+**缓解**:
+- `ccteam doctor` 输出 codex 状态 informational(present / not-found /
+  not-supported V0.3.1)
+- README.md / `docs/v0-3-1/README.md` § 关键设计决策 显式声明 codex 是
+  V0.3.1 stub
+- F47 验收 unit test 断言 error 文本含 "V0.3.1" 与 "deferred"
+
+### 9.4 多 session race condition
+
+并发 `ccteam session add <slug>` 两进程同时跑可能撞 sid 冲突(都拿 next_sid_seq
+= n)。
+
+**缓解**:
+- master state.json 写 atomic(`.tmp` + rename)+ pre-write read 后**再读一次**
+  最新 state(double-check + retry-on-conflict),retry 上限 3 次
+- 单元测试覆盖并发 add(spawn 2 并发 thread,断 sid 不冲突)
+- F49 ship 时**不**支持跨主机并发(单机内 race;跨主机 flex team 是 V0.4
+  评估,几乎用不到)
+
+### 9.5 flex 团队 workflow promotion 路径未设计可能后悔
+
+V0.3.1 ship 空 flex base,V0.3.2/V0.4 落 promotion;若 promotion 设计需要
+V0.3.1 已 ship 的字段不在,会要求 schema 演进。
+
+**缓解**:
+- `team.yaml::kind` 是 enum,promotion 后增加 `kind: hybrid` 等扩展不破现
+  yaml
+- `state.json::sessions{}` 是 BTreeMap,promotion 时加 `state.json::frozen_phases`
+  等并行字段不破现 schema
+- promotion 时若需要 source-of-truth 是 progress.jsonl 累积 events,这俩
+  本就完整存档;无 retroactive 数据丢失风险
+
+---
+
+## 10. 不在范围 / V0.4 deferred
+
+显式列出,future 贡献者不要 silently 拉回前移:
+
+### 10.1 phase 编排演进(全暂停)
+
+- **新 phase 定义 / 协议升级** — V0.3.1 不改 phase 任何机制
+- **Fat Skills 第一等对象升级**(`thin-harness-fat-skills-architecture-improvement.md`
+  §6.1)— V0.4
+- **CEO Plan / 10x Gate phase / Plan-Eng-Review 强化**(同上 doc §6.2-6.3)
+  — V0.4
+- **Context Pack / Tokenmaxxing 工程化**(同上 doc §6.4)— V0.4
+- **Review/QA Gate 矩阵**(critic_dimensions 数据驱动)— V0.4(M5)
+- **Builder Throughput Metrics**(同上 doc §6.8)— V0.4
+
+### 10.2 flex 团队 evolution 路径
+
+- **Workflow promotion / demotion UX**:flex 项目跑出 recurring pattern 后
+  promote N events 为冻结 phase;反向拆 phase 回 flex。涉及 `flex_workflows.yaml`
+  per-team 持久化 schema,V0.3.2 / V0.4 评估
+- **flex_workflows.yaml schema** — V0.4
+- **flex 团队 retro_schema / verdict_schema 启用** — V0.3.2 评估
+- **`max_concurrent_sessions_per_project` / 性能阈值** — V0.4
+- **session rename** — V0.4
+- **session 间共享 lessons / context** — V0.4
+
+### 10.3 Codex 完整支持
+
+- **`CodexAdapter::spawn_session` 实际 impl**(`codex` CLI 调用 / hook 写入)
+  — V0.3.2(`docs/research/ccteam-codex-integration.md` M1)
+- **codex statusline-equivalent ingestion** — V0.3.2
+- **`mcp__codex__codex` 注册给 meta-agent** — V0.3.2 / V0.4(同 doc §6.4)
+- **CodexExecRunner sub-skill runner** — V0.4(同 doc M2)
+- **Review/QA gate blocking** — V0.4(同 doc M3)
+- **Skill 双栈分发(`.agents/skills/`)+ AGENTS.md 模板** — V0.4(同 doc M4)
+- **Codex worker phase 实验性 team** — 永久评估(同 doc M5)
+
+### 10.4 自动化 pipeline
+
+- **CC implement → codex review 自动派单**(implement phase_done 自动起
+  codex sidecar)— V0.4 channel adapter 评估
+- **session 级 outbox / inbox 细分**(per-session 不共享项目级)— V0.3.2
+- **跨 session orchestration / coordinator** — V0.4
+
+### 10.5 Web UI 增强
+
+- **mobile-responsive layout** — V0.4
+- **flex workflow promotion UI**("promote N events to phase")— V0.4
+- **Per-session metric chart / token use 时序图** — V0.4
+- **跨 session search / filter** — V0.4
+- **session 拖拽 reorder / favorite mark** — V0.4
+
+### 10.6 永久 deferred
+
+- **Multi-user / team 共享 ccteam 实例** — ccteam 单用户工具
+- **远程协作 / cloud session** — 同上
+- **i18n** — 中英混用文档标准
+- **statusline 数据进入 orchestrator 决策** — 破 SoT 红线
+
+---
+
+## 11. PR sequencing
+
+6 finding 落 6 个 PR,推荐顺序:
+
+| PR # | finding | branch | touchpoints | 依赖 |
+|---|---|---|---|---|
+| **PR #1** | **F46** HarnessAdapter trait + ClaudeCodeAdapter | `v0-3-1-harness-adapter` | 新 `crates/ccteam-core/src/harness.rs` / `ccteam doctor --install-statusline-adapter` / `~/.ccteam/harness/` 协议 / web SSE harness endpoint | 无 |
+| **PR #2** | **F47** CodexAdapter stub + harness 字段 | `v0-3-1-codex-stub` | `harness.rs` 加 CodexAdapter / `team.yaml::sessions[]` schema / `ccteam session add --harness` flag(F49 PR 完成后真正调用)/ doctor codex 检测 | PR #1(trait) |
+| **PR #3** | **F48** kind: flex team kind | `v0-3-1-flex-kind` | `team.rs::TeamSpec` kind/sessions 字段 / orchestrator behavior gating helpers / team factory `--kind=flex` / claude_md_template seed | 无(不强依赖 PR #1/#2 — 但**推荐**在 #2 后做以让 sessions[] 字段定下) |
+| **PR #4** | **F49** Adhoc multi-session primitives | `v0-3-1-multi-session` | `ccteam session {add,ls,attach,rm}` CLI / per-session subdir / state.json sessions+next_sid_seq / progress.jsonl scoping / tmux 命名 | PR #1(spawn_session 调用)+ PR #3(kind:flex 项目才能 add) |
+| **PR #5** | **F50** Web 层更新 | `v0-3-1-web-flex` | dashboard kind 列 / project per-session cards / new `/session/<slug>/<sid>` 详情 / SSE filter by sid / screenshot 扩展 | PR #1(harness SSE)+ PR #4(per-session events / sid) |
+| **PR #6** | **F51** chore + ship gate | `v0-3-1-ship-gate` | flex_e2e_test.rs / workspace.version bump 0.3.0 → 0.3.1 / CLAUDE.md baseline / docs/v0-3-1/e2e-retro.md / docs sweep | PR #1-#5 全部 merge |
+
+依赖图:
+
+```
+PR #1 (F46 HarnessAdapter)  ── trait + ClaudeCodeAdapter,foundation
+   ↓
+PR #2 (F47 CodexAdapter stub)            (并行起点;只依 trait;CLI 真调用要 #4)
+   ↓
+PR #3 (F48 kind: flex)                   (不强依 #1/#2,但推荐 #2 后 sessions[] schema 定下)
+   ↓
+PR #4 (F49 multi-session) ───┐
+   ↓                          │
+PR #5 (F50 web flex) ────────┴──► PR #6 (F51 ship gate)
+```
+
+并行机会:
+- **PR #2 vs #3**:trait stub vs team kind,touch 不同模块,可同时 worktree
+- **PR #5 frontend**:跟 #4 backend 同时 worktree(冲突点只在 askama
+  template + web SSE 路由)
+
+**总计**:~1.5 kLOC + ~40 测试,~12-15 天(单人 5 天/周即 2.5-3 周;
+PR #2/#3 + PR #4/#5 并行可压到 ~10 天)。
+
+worktree 用法(详 dev-plan §8 briefing 模板):
+
+```
+git worktree add -b v0-3-1-<topic> /tmp/ccteam-v031-<topic> origin/main
+```
+
+跟 V0.2.2 / V0.3 一致;subagent briefing 含 PRD 章节 + 验收条目 + 红线
+grep 矩阵。
+
+---
+
+## 12. Workspace version bump
+
+`Cargo.toml::workspace.package.version` `"0.3.0"` → `"0.3.1"` 在 F51 PR 落地。
+
+V0.2.2 起立的政策:每 minor / patch release 必须 bump + commit subject
+`vX.Y.Z:` 前缀。
+
+V0.3.1 是 patch round 而非主版本(V0.4 才是下个主版本),version 跳 patch
+位(0.3.0 → 0.3.1)而非 minor 位。
+
+---
+
+## 13. CLAUDE.md baseline 更新 plan(F51 落)
+
+§一 表格更新:
+
+```markdown
+| Workspace version | **`0.3.1`**(V0.3.1 patch round 起跟版同步) |
+| 测试 baseline | **<实测>全绿** |
+| 已 ship 里程碑 | ... + **V0.3.1**:F46-F51(6 finding 跨 6 PR:HarnessAdapter trait +
+  CodexAdapter stub + flex team kind + adhoc multi-session + web flex 适配 +
+  ship gate)— 详 `docs/v0-3-1/README.md` |
+| 当前 next | V0.4 候选方向 — phase 编排演进恢复 + Codex 完整 + flex workflow
+  promotion + Fat Skills 第一等;deferred 项见 `docs/v0-3-1/prd.md §10` |
+```
+
+§六 易踩坑加:
+
+```
+- **V0.3 → V0.3.1 升级一次性迁移**(F46-F49):`team.yaml::kind` 字段 default
+  `workflow` 保 V0.1/V0.2/V0.3 yaml 解析不变;flex 团队 state.json `sessions{}`
+  + `next_sid_seq{}` 字段 serde default 不破老 state;`~/.ccteam/progress/`
+  flex 项目走 `<slug>/<sid>.jsonl` 子目录,workflow 项目仍 flat `<slug>.jsonl`
+  — hooks 解析 `team_kind` 自动分流;`ccteam doctor --install-statusline-adapter`
+  写 wrapper marker section 保护用户手改段
+```
+
+§三 红线 V0.3.1 不动:`progress.jsonl` SoT / 永不主动 kill / ccteam-core
+无 team 名字面量 — 三条 V0.3.1 反而**强化**(flex 团队靠 `team.yaml::kind`
+数据驱动,orchestrator 不写 `if team_name == "flex"`)。
+
+---
+
+## Changelog
+
+- 2026-05-10:**初稿**。基于 V0.3 ship 后用户在 dispatcher session 的
+  Telegram dialogue(messages 311-318)确认的战略 pivot;6 finding(F46-F51)
+  分布参考 V0.2.2 patch 模式;架构决策(`kind: flex` 与 `parallelism` 正交 /
+  adhoc session 不复用 multi_session 拓扑 / per-session subdir layout 在
+  `<project>/.ccteam/sessions/<sid>/` / progress.jsonl flex 项目走 `<slug>/<sid>.jsonl`
+  子目录 / sid 格式 `<harness>-<n>` 单调递增不复用 / tmux `ccteam-<slug>-<sid>`
+  命名)全部从 advisor 反馈 + ccteam-core 现状 audit 综合定;Codex stub 错误
+  消息文本指向本 PRD + research doc。base = `origin/main` `f9baf3f`(V0.3
+  ship 终点;workspace.version `0.3.0`,测试 baseline 738/0)。
+- 2026-05-10:research scratch 文件 `docs/research/v0-3-1-harness-adapter-plan.md`
+  里 5 个 open question 在本 PRD 定稿:
+  - Q1(install 入口):`ccteam doctor --install-statusline-adapter` 显式
+    flag,doctor 默认调用时也跑(同 V0.2.2 F39/F44 doctor 模式)
+  - Q2(用户原脚本策略):tee + 透传(保留用户自定义 footer);marker section
+    保护用户手改;原脚本 backup 逃生绳
+  - Q3(harness JSON lifecycle):**覆盖**(每条 stdin JSON 完整覆盖,简化;
+    delta 历史是 V0.4 deferred)
+  - Q4(meta-agent harness panel):是 — meta-agent session 也产 harness
+    snapshot(`~/.ccteam/harness/_meta-<handle>.json`)
+  - Q5(CodexAdapter V0.3.1 vs V0.3.2):V0.3.1 落 stub,V0.3.2 落 impl;
+    F47 验收明确 stub error 消息文本指向 V0.3.2


### PR DESCRIPTION
## Summary

- V0.3.1 strategic pivot: ccteam extends to session-layer farm + observability + cross-project memory bridge for Claude + Codex; phase orchestration evolution paused.
- New \`kind: flex\` team kind + adhoc multi-session primitives + HarnessAdapter trait (ClaudeCodeAdapter real impl, CodexAdapter trait stub).
- 6 findings (F46-F51) split across 6 PRs; F51 ships gate (workspace.version 0.3.0 → 0.3.1, CLAUDE.md baseline backfill).
- See PRD §9 (threat model) — V0.3.1 inherits V0.3 LAN RCE auth path; new risks are statusline wrapper + flex session race.

## Files
- \`docs/v0-3-1/prd.md\` — new (1254 lines)
- \`docs/v0-3-1/dev-plan.md\` — new (F46 full briefing; F47-F51 incremental on shared template)
- \`docs/v0-3-1/README.md\` — new
- \`docs/dev-coupling-audit.md\` — F46-F51 entries added
- \`docs/v0-2/README.md\` — V0.3 pointer updated to "+ V0.3.1 起始 (drafting)"

## Test plan

N/A — docs-only PR. \`cargo build --workspace\` passes (sanity check; no source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)