### PR TITLE
Fix pane snapshots for meta-agent sessions

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -17,7 +17,7 @@ use ccteam_core::{
     write_global_helper_templates, write_global_phase_templates, CcteamPaths,
     HookCmdRewriteAction, HookCmdRewriteReport, InstallSkillOptions, LegacySkillAction,
     LegacySkillReport, MetaBootstrapReport, MigrationReport, OutboxEventKind, OutboxMessage,
-    PhaseState, PhaseTemplate, ProjectState, SessionMailbox,
+    PhaseState, PhaseTemplate, ProjectState, SessionMailbox, session_name_for_project,
     SkillInstallAction, TeamSpec, ToolSurfaceSnapshot, BUILTIN_SUBAGENTS, HELPER_TEMPLATES,
     PHASE_TEMPLATES,
 };
@@ -521,10 +521,10 @@ pub fn run_show(paths: &CcteamPaths, slug: &str, format: OutputFormat) -> Result
     })
 }
 
-/// `ccteam attach <slug>`. Execs `tmux attach -t ccteam-<slug>`. Exits
+/// `ccteam attach <slug>`. Execs `tmux attach -t <state.tmux_session>`. Exits
 /// successfully when the user detaches; non-zero on error.
-pub fn run_attach(slug: &str) -> Result<()> {
-    let session = TmuxSession::for_slug(slug);
+pub fn run_attach(paths: &CcteamPaths, slug: &str) -> Result<()> {
+    let session = TmuxSession::from_name(session_name_for_project(paths, slug));
     if !session.exists() {
         bail!("tmux session not running: {}", session.name());
     }
@@ -540,8 +540,8 @@ pub fn run_attach(slug: &str) -> Result<()> {
 
 /// `ccteam peek <slug>`. Returns the contents of the session's first
 /// pane via `tmux capture-pane -p`.
-pub fn run_peek(slug: &str) -> Result<String> {
-    let session = TmuxSession::for_slug(slug);
+pub fn run_peek(paths: &CcteamPaths, slug: &str) -> Result<String> {
+    let session = TmuxSession::from_name(session_name_for_project(paths, slug));
     if !session.exists() {
         bail!("tmux session not running: {}", session.name());
     }
@@ -867,7 +867,7 @@ pub struct DoctorOptions {
     /// paths).
     pub install_skill: bool,
     /// M1.0: bootstrap a meta-agent project for the given user handle.
-    /// `Some("rob")` ⇒ creates `~/projects/rob-meta/` and triggers
+    /// `Some("rob")` ⇒ creates `~/projects/meta-rob/` and triggers
     /// `install_skill` regardless of its standalone flag.
     pub install_meta_agent: Option<String>,
     /// M2.5: register `mcpServers.ccteam` in `~/.claude.json`.
@@ -1582,14 +1582,9 @@ fn render_install_meta_agent_report(paths: &CcteamPaths, user_handle: &str) -> R
         if report.already_existed { "refreshed" } else { "created" },
     ));
     out.push('\n');
-    out.push_str(&format!(
-        "tmux session     ccteam-meta-{}\n",
-        ccteam_core::meta_slug(user_handle)?.trim_end_matches("-meta"),
-    ));
-    out.push_str(&format!(
-        "attach with      tmux attach -t ccteam-meta-{}\n",
-        ccteam_core::meta_slug(user_handle)?.trim_end_matches("-meta"),
-    ));
+    let tmux_session = ccteam_core::meta_session_name(user_handle)?;
+    out.push_str(&format!("tmux session     {tmux_session}\n"));
+    out.push_str(&format!("attach with      tmux attach -t {tmux_session}\n"));
     out.push_str("\nrun `ccteam start --foreground` (in another terminal) to wake the meta session.\n");
     Ok(out)
 }
@@ -2177,6 +2172,22 @@ mod tests {
     }
 
     #[test]
+    fn run_peek_uses_state_tmux_session_for_meta_project() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        let mut state = ProjectState::initial_for_team("meta-cto".into(), "meta-agent".into());
+        state.tmux_session = "ccteam-meta-cto".into();
+        state.save(&paths.project_state("meta-cto")).unwrap();
+
+        let err = run_peek(&paths, "meta-cto").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("ccteam-meta-cto"),
+            "peek should target state.tmux_session, got: {msg}",
+        );
+    }
+
+    #[test]
     fn run_new_creates_slug_and_bootstrap_files() {
         ensure_isolation();
         let tmp = TempDir::new().unwrap();
@@ -2612,12 +2623,13 @@ mod tests {
         let report = run_doctor(&paths, opts).unwrap();
         assert!(report.contains("install-skill"), "skill install report missing");
         assert!(report.contains("install-meta-agent"), "meta install report missing");
-        assert!(report.contains("rob-meta"), "meta slug should be reported");
+        assert!(report.contains("meta-rob"), "meta slug should be reported");
 
         // Project directory exists.
-        assert!(paths.project_dir("rob-meta").is_dir());
-        let state = ProjectState::load(&paths.project_state("rob-meta")).unwrap();
+        assert!(paths.project_dir("meta-rob").is_dir());
+        let state = ProjectState::load(&paths.project_state("meta-rob")).unwrap();
         assert_eq!(state.team, "meta-agent");
+        assert_eq!(state.slug, "meta-rob");
         assert_eq!(state.tmux_session, "ccteam-meta-rob");
 
         // Skill landed under the redirected ~/.claude/. F44 reverts F39:

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -162,7 +162,7 @@ enum Command {
         #[arg(long, default_value_t = false)]
         install_skill: bool,
         /// Bootstrap a meta-agent project (M1.0) for the given user
-        /// handle. Creates `~/projects/<handle>-meta/` with the
+        /// handle. Creates `~/projects/meta-<handle>/` with the
         /// dispatcher role prompt + inbox/outbox dirs and (always)
         /// installs the `ccteam-control` skill. Pass the user handle as
         /// the value (e.g. `--install-meta-agent rob`).
@@ -272,7 +272,7 @@ enum WatchdogCommand {
         #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
         format: OutputFormat,
         /// Also write each surviving alert to
-        /// `~/projects/<handle>-meta/.ccteam/outbox/`. Pair with
+        /// `~/projects/meta-<handle>/.ccteam/outbox/`. Pair with
         /// `--user <handle>`.
         #[arg(long, default_value_t = false)]
         push: bool,
@@ -386,7 +386,10 @@ fn main() -> Result<()> {
         } => run_new(request, file, team, slug, no_auto_slug, auto_slug_model),
         Command::Ls { format } => run_ls(format),
         Command::Show { slug, format } => run_show(&slug, format),
-        Command::Attach { slug } => commands::run_attach(&slug),
+        Command::Attach { slug } => {
+            let paths = CcteamPaths::from_env()?;
+            commands::run_attach(&paths, &slug)
+        }
         Command::Peek { slug } => run_peek(&slug),
         Command::Progress { slug, tail } => {
             let paths = CcteamPaths::from_env()?;
@@ -726,7 +729,8 @@ fn run_show(slug: &str, format: OutputFormat) -> Result<()> {
 }
 
 fn run_peek(slug: &str) -> Result<()> {
-    let body = commands::run_peek(slug)?;
+    let paths = CcteamPaths::from_env()?;
+    let body = commands::run_peek(&paths, slug)?;
     print!("{body}");
     Ok(())
 }

--- a/crates/ccteam-cli/src/mcp_serve.rs
+++ b/crates/ccteam-cli/src/mcp_serve.rs
@@ -41,7 +41,7 @@ use ccteam_core::{
 };
 
 use crate::commands::{
-    collect_projects, collect_recent_events, run_show, OutputFormat,
+    collect_projects, collect_recent_events, run_peek, run_show, OutputFormat,
 };
 
 /// Stable MCP protocol version this server speaks. Newer client versions
@@ -210,7 +210,7 @@ fn tool_definitions() -> Vec<Value> {
             "inputSchema": json!({
                 "type": "object",
                 "properties": {
-                    "session": { "type": "string", "description": "Project slug OR meta session slug (e.g. 'rob-meta')." },
+                    "session": { "type": "string", "description": "Project slug OR meta session slug (e.g. 'meta-rob')." },
                     "content_type": { "type": "string", "description": "Content type: text|markdown (default 'text')." },
                     "body": { "type": "string", "description": "Message body (NL/markdown)." }
                 },
@@ -284,7 +284,7 @@ async fn call_tool(paths: &CcteamPaths, params: &Value) -> Result<Vec<Value>> {
     match name {
         "ccteam__ls" => Ok(text_content(tool_ls(paths)?)),
         "ccteam__show" => Ok(text_content(tool_show(paths, &args)?)),
-        "ccteam__peek" => Ok(text_content(tool_peek(&args)?)),
+        "ccteam__peek" => Ok(text_content(tool_peek(paths, &args)?)),
         "ccteam__progress" => Ok(text_content(tool_progress(paths, &args)?)),
         "ccteam__new" => Ok(text_content(tool_new(paths, &args)?)),
         "ccteam__pause" => {
@@ -390,20 +390,9 @@ fn tool_show(paths: &CcteamPaths, args: &Value) -> Result<String> {
     run_show(paths, &slug, OutputFormat::Json)
 }
 
-fn tool_peek(args: &Value) -> Result<String> {
+fn tool_peek(paths: &CcteamPaths, args: &Value) -> Result<String> {
     let slug = arg_string(args, "slug")?;
-    let session = ccteam_core::session_name_for_slug(&slug);
-    let output = std::process::Command::new("tmux")
-        .args(["capture-pane", "-p", "-t", &session])
-        .output()
-        .context("spawn tmux capture-pane")?;
-    if !output.status.success() {
-        return Err(anyhow!(
-            "tmux capture-pane failed: {}",
-            String::from_utf8_lossy(&output.stderr),
-        ));
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    run_peek(paths, &slug)
 }
 
 fn tool_progress(paths: &CcteamPaths, args: &Value) -> Result<String> {

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -140,7 +140,8 @@ pub use screenshot::{
     FONT_ENV as SCREENSHOT_FONT_ENV, ScreenshotResult,
 };
 pub use tmux::{
-    capture_pane_tail, capture_pane_with_ansi, pid_is_alive, query_pane_dims,
+    capture_pane_tail, capture_pane_with_ansi, capture_pane_with_ansi_from_session,
+    pid_is_alive, query_pane_dims, query_pane_dims_from_session, session_name_for_project,
     session_name_for_slug, tmux_available, TmuxSession,
 };
 pub use plugin_resolution::{

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -51,7 +51,7 @@ pub use inbox::{
 };
 pub use meta_agent::{
     bootstrap_meta_project, meta_session_name, meta_slug, render_meta_role_prompt,
-    MetaBootstrapReport, META_SESSION_PREFIX, META_TEAM_NAME,
+    resolve_meta_slug, MetaBootstrapReport, META_SESSION_PREFIX, META_TEAM_NAME,
 };
 pub use memory_bridge::{
     install_into as install_memory_bridge_into, install_memory_bridge,
@@ -140,9 +140,10 @@ pub use screenshot::{
     FONT_ENV as SCREENSHOT_FONT_ENV, ScreenshotResult,
 };
 pub use tmux::{
-    capture_pane_tail, capture_pane_with_ansi, capture_pane_with_ansi_from_session,
-    pid_is_alive, query_pane_dims, query_pane_dims_from_session, session_name_for_project,
-    session_name_for_slug, tmux_available, TmuxSession,
+    capture_pane_tail, capture_pane_tail_from_session, capture_pane_with_ansi,
+    capture_pane_with_ansi_from_session, pid_is_alive, query_pane_dims,
+    query_pane_dims_from_session, session_name_for_project, session_name_for_slug,
+    tmux_available, TmuxSession,
 };
 pub use plugin_resolution::{
     lookup_plugin_agent, plugins_to_enable, PluginAgent, KNOWN_PLUGIN_AGENTS,

--- a/crates/ccteam-core/src/meta_agent.rs
+++ b/crates/ccteam-core/src/meta_agent.rs
@@ -282,6 +282,23 @@ mod tests {
     }
 
     #[test]
+    fn render_role_prompt_uses_canonical_meta_project_path() {
+        let body = render_meta_role_prompt("rob");
+        assert!(
+            body.contains("~/projects/meta-rob/.ccteam/inbox/"),
+            "role prompt should mention canonical meta inbox path",
+        );
+        assert!(
+            body.contains("~/projects/meta-rob/.ccteam/outbox/"),
+            "role prompt should mention canonical meta outbox path",
+        );
+        assert!(
+            !body.contains("~/projects/rob-meta/"),
+            "role prompt must not point migrated meta-agents at the legacy path",
+        );
+    }
+
+    #[test]
     fn render_role_prompt_includes_seven_required_chapters() {
         // Per task brief §5: the role prompt must contain all seven
         // chapters covering identity / decision tree / dispatcher

--- a/crates/ccteam-core/src/meta_agent.rs
+++ b/crates/ccteam-core/src/meta_agent.rs
@@ -1,7 +1,7 @@
 //! Meta-agent session bootstrap (M1.0).
 //!
 //! The meta-agent is a ccteam-managed long tmux session under
-//! `~/projects/<user>-meta/` that the human user attaches to with
+//! `~/projects/meta-<user>/` that the human user attaches to with
 //! `tmux attach -t ccteam-meta-<user>` and talks to in NL. It dispatches
 //! project requests via `ccteam new`, monitors active projects, and
 //! routes inbox/outbox messages.
@@ -54,15 +54,45 @@ pub const META_SESSION_PREFIX: &str = "ccteam-meta-";
 const META_ROLE_PROMPT_TEMPLATE: &str =
     include_str!("templates/meta_agent_role.md");
 
-/// Build the meta-agent's project slug from a user handle. Slug is
-/// `<user>-meta`, slugified — so `Rob` and `rob` collapse to the same
-/// directory, which is what we want.
+/// Build the meta-agent's canonical project slug from a user handle.
+/// Slug is `meta-<user>`, slugified, matching the dedicated tmux
+/// session `ccteam-meta-<user>` and the team-prefixed convention used
+/// by regular project slugs such as `dev-...`.
 pub fn meta_slug(user_handle: &str) -> Result<String> {
     let trimmed = user_handle.trim();
     if trimmed.is_empty() {
         return Err(anyhow!("meta-agent user handle must be non-empty"));
     }
+    Ok(format!("meta-{}", slugify(trimmed)))
+}
+
+/// Legacy meta-agent slug used before V0.3 follow-up:
+/// `<user>-meta`. Kept only so `doctor --install-meta-agent` can
+/// migrate existing installs without losing their state/outbox.
+fn legacy_meta_slug(user_handle: &str) -> Result<String> {
+    let trimmed = user_handle.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("meta-agent user handle must be non-empty"));
+    }
     Ok(format!("{}-meta", slugify(trimmed)))
+}
+
+/// Resolve the meta-agent slug that currently exists on disk.
+///
+/// New callers should use [`meta_slug`] for creation. Notification
+/// paths use this resolver so old `<user>-meta` installs still receive
+/// alerts until the user re-runs `doctor --install-meta-agent`, which
+/// migrates them to `meta-<user>`.
+pub fn resolve_meta_slug(paths: &CcteamPaths, user_handle: &str) -> Result<String> {
+    let slug = meta_slug(user_handle)?;
+    if paths.project_state(&slug).exists() {
+        return Ok(slug);
+    }
+    let legacy = legacy_meta_slug(user_handle)?;
+    if paths.project_state(&legacy).exists() {
+        return Ok(legacy);
+    }
+    Ok(slug)
 }
 
 /// `ccteam-meta-<user>` tmux session name.
@@ -99,6 +129,7 @@ pub fn bootstrap_meta_project(
     user_handle: &str,
 ) -> Result<MetaBootstrapReport> {
     let slug = meta_slug(user_handle)?;
+    migrate_legacy_meta_project(paths, user_handle, &slug)?;
     let project_dir = paths.project_dir(&slug);
     let already_existed = paths.project_state(&slug).exists();
 
@@ -113,14 +144,14 @@ pub fn bootstrap_meta_project(
         bootstrap_project(paths, &slug, &request, META_TEAM_NAME)
             .context("bootstrap meta-agent project tree")?;
     }
-    // Always normalize the meta-agent's tmux_session name. bootstrap_project
-    // initializes it as `ccteam-<slug>` (which would yield `ccteam-rob-meta`),
-    // but the strategic doc + interfaces.md call for `ccteam-meta-<user>`
-    // — distinct prefix so meta sessions are visually separated from
-    // project sessions in `tmux ls`. Rewrite after bootstrap_project runs.
+    // Always normalize the meta-agent's tmux_session name. New
+    // canonical slugs (`meta-<user>`) already line up with
+    // `ccteam-meta-<user>`, but migrated legacy projects need their
+    // state refreshed after the directory rename.
     let state_path = paths.project_state(&slug);
     let mut state = ProjectState::load(&state_path)
         .with_context(|| format!("reload meta state {}", state_path.display()))?;
+    state.slug = slug.clone();
     state.team = META_TEAM_NAME.into();
     state.tmux_session = meta_session_name(user_handle)?;
     state.save(&state_path)?;
@@ -141,6 +172,56 @@ pub fn bootstrap_meta_project(
         claude_md,
         already_existed,
     })
+}
+
+fn migrate_legacy_meta_project(
+    paths: &CcteamPaths,
+    user_handle: &str,
+    canonical_slug: &str,
+) -> Result<()> {
+    let legacy_slug = legacy_meta_slug(user_handle)?;
+    if legacy_slug == canonical_slug {
+        return Ok(());
+    }
+
+    let legacy_state = paths.project_state(&legacy_slug);
+    let canonical_state = paths.project_state(canonical_slug);
+    if !legacy_state.exists() || canonical_state.exists() {
+        return Ok(());
+    }
+
+    let legacy_dir = paths.project_dir(&legacy_slug);
+    let canonical_dir = paths.project_dir(canonical_slug);
+    if canonical_dir.exists() {
+        return Err(anyhow!(
+            "cannot migrate legacy meta-agent project `{}` to `{}`: target directory already exists",
+            legacy_dir.display(),
+            canonical_dir.display(),
+        ));
+    }
+
+    std::fs::create_dir_all(&paths.projects_root)
+        .with_context(|| format!("create {}", paths.projects_root.display()))?;
+    std::fs::rename(&legacy_dir, &canonical_dir)
+        .with_context(|| format!("rename {} -> {}", legacy_dir.display(), canonical_dir.display()))?;
+
+    let legacy_progress = paths.progress_jsonl(&legacy_slug);
+    let canonical_progress = paths.progress_jsonl(canonical_slug);
+    if legacy_progress.exists() && !canonical_progress.exists() {
+        if let Some(parent) = canonical_progress.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        std::fs::rename(&legacy_progress, &canonical_progress).with_context(|| {
+            format!(
+                "rename {} -> {}",
+                legacy_progress.display(),
+                canonical_progress.display()
+            )
+        })?;
+    }
+
+    Ok(())
 }
 
 /// Result of `bootstrap_meta_project` — useful for the doctor command's
@@ -173,9 +254,9 @@ mod tests {
     }
 
     #[test]
-    fn meta_slug_combines_user_with_meta_suffix() {
-        assert_eq!(meta_slug("rob").unwrap(), "rob-meta");
-        assert_eq!(meta_slug("Rob Test User").unwrap(), "rob-test-user-meta");
+    fn meta_slug_uses_meta_prefix() {
+        assert_eq!(meta_slug("rob").unwrap(), "meta-rob");
+        assert_eq!(meta_slug("Rob Test User").unwrap(), "meta-rob-test-user");
     }
 
     #[test]
@@ -254,13 +335,14 @@ mod tests {
         let p = paths(&tmp);
         let report = bootstrap_meta_project(&p, "rob").unwrap();
 
-        assert_eq!(report.slug, "rob-meta");
+        assert_eq!(report.slug, "meta-rob");
         assert!(report.project_dir.is_dir());
         assert!(report.claude_md.is_file());
         assert!(p.project_state(&report.slug).is_file());
 
         let state = ProjectState::load(&p.project_state(&report.slug)).unwrap();
         assert_eq!(state.team, META_TEAM_NAME);
+        assert_eq!(state.slug, "meta-rob");
         // tmux name uses the dedicated `ccteam-meta-<user>` prefix
         // rather than `ccteam-<slug>` so it visually separates from
         // project sessions in `tmux ls`.
@@ -284,11 +366,36 @@ mod tests {
 
         // Tamper with CLAUDE.md, re-run, verify it gets refreshed and the
         // tampering is gone.
-        let cm = p.project_dir("rob-meta").join("CLAUDE.md");
+        let cm = p.project_dir("meta-rob").join("CLAUDE.md");
         std::fs::write(&cm, "stale\n").unwrap();
         let report = bootstrap_meta_project(&p, "rob").unwrap();
         assert!(report.already_existed);
         let body = std::fs::read_to_string(&cm).unwrap();
         assert!(body.contains("决策树"), "role prompt should be re-rendered");
+    }
+
+    #[test]
+    fn bootstrap_meta_project_migrates_legacy_user_meta_directory() {
+        isolation();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let legacy = p.project_dir("rob-meta");
+        std::fs::create_dir_all(legacy.join(".ccteam")).unwrap();
+        let mut state = ProjectState::initial_for_team("rob-meta".into(), META_TEAM_NAME.into());
+        state.tmux_session = "ccteam-meta-rob".into();
+        state.save(&p.project_state("rob-meta")).unwrap();
+        std::fs::create_dir_all(p.progress_dir()).unwrap();
+        std::fs::write(p.progress_jsonl("rob-meta"), "{}\n").unwrap();
+
+        let report = bootstrap_meta_project(&p, "rob").unwrap();
+
+        assert_eq!(report.slug, "meta-rob");
+        assert!(!p.project_dir("rob-meta").exists());
+        assert!(p.project_dir("meta-rob").is_dir());
+        assert!(!p.progress_jsonl("rob-meta").exists());
+        assert!(p.progress_jsonl("meta-rob").exists());
+        let state = ProjectState::load(&p.project_state("meta-rob")).unwrap();
+        assert_eq!(state.slug, "meta-rob");
+        assert_eq!(state.tmux_session, "ccteam-meta-rob");
     }
 }

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -40,7 +40,7 @@ use crate::silence_classifier::{
     self, LastEventSummary, LimboAction, SilenceClass, MAX_LIMBO_RETRY,
 };
 use crate::stall::{self, StallLevel, StallThresholds};
-use crate::tmux::capture_pane_tail;
+use crate::tmux::capture_pane_tail_from_session;
 use crate::state::{PhaseHistoryEntry, PhaseState, ProjectState};
 use crate::subskill::{self, ClaudePRunner, SubSkillRunner};
 use crate::team::TeamSpec;
@@ -1959,7 +1959,8 @@ impl Orchestrator {
             .with_context(|| format!("create {}", cc.display()))?;
         let outbox_path = cc.join("needs_attention.outbox.json");
 
-        let pane = capture_pane_tail(slug, 30, false).unwrap_or_default();
+        let pane = capture_pane_tail_from_session(&state.tmux_session, 30, false)
+            .unwrap_or_default();
         let last_event_summary = last_event.map(LastEventSummary::from_value);
         let reason = format!(
             "F36 pending-inject timeout phase={phase} max_defer_minutes={budget}",
@@ -2187,7 +2188,8 @@ impl Orchestrator {
         // Pane tail is best-effort — classifier red line: if tmux is
         // unavailable the outbox still ships, the meta-agent surfaces
         // the rest.
-        let pane = capture_pane_tail(slug, 30, false).unwrap_or_default();
+        let pane = capture_pane_tail_from_session(&state.tmux_session, 30, false)
+            .unwrap_or_default();
 
         let classification = if limbo_capped {
             "limbo_capped"

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -84,8 +84,8 @@ pub fn random_suffix() -> String {
 ///    output so the caller never gets an empty slug.
 ///
 /// **`slugify()` is not modified** — it still backs the meta-agent
-/// `<handle>-meta` path where the input is already a short user
-/// handle that should be used verbatim.
+/// `meta-<handle>` path where the handle should be normalized
+/// verbatim.
 pub fn slugify_brief(input: &str) -> String {
     const STOP_WORDS: &[&str] = &[
         "a", "an", "the", "of", "to", "for", "with", "that", "and", "or", "in", "on",
@@ -145,8 +145,8 @@ pub fn slugify_brief(input: &str) -> String {
 /// retry.
 ///
 /// Meta-agent projects don't go through this function — they use
-/// `meta_slug(handle)` which hand-crafts `<handle>-meta` (suffix
-/// convention established before F22; rules don't scope to meta).
+/// `meta_slug(handle)` which hand-crafts `meta-<handle>` so the
+/// directory aligns with the `ccteam-meta-<handle>` tmux session.
 pub fn pick_unused_slug(
     paths: &CcteamPaths,
     base: &str,

--- a/crates/ccteam-core/src/screenshot.rs
+++ b/crates/ccteam-core/src/screenshot.rs
@@ -50,7 +50,10 @@ use imageproc::rect::Rect;
 use vt100::Parser;
 
 use crate::paths::CcteamPaths;
-use crate::tmux::{capture_pane_with_ansi, query_pane_dims};
+use crate::tmux::{
+    capture_pane_with_ansi_from_session, query_pane_dims_from_session,
+    session_name_for_project,
+};
 
 pub mod ansi_palette;
 
@@ -100,26 +103,29 @@ pub fn render_screenshot(
     slug: &str,
     lines: usize,
 ) -> ScreenshotResult {
+    let session_name = session_name_for_project(paths, slug);
+
     // 1. tmux capture (ANSI escapes preserved).
-    let ansi_bytes = match capture_pane_with_ansi(slug, lines) {
+    let ansi_bytes = match capture_pane_with_ansi_from_session(&session_name, lines) {
         Ok(Some(b)) => b,
         Ok(None) => {
             tracing::warn!(
                 "screenshot: tmux capture-pane returned no output for slug `{slug}` \
-                 (session missing or tmux failed)"
+                 session `{session_name}` (session missing or tmux failed)"
             );
             return Ok(None);
         }
         Err(err) => {
             tracing::warn!(
-                "screenshot: tmux capture-pane failed for slug `{slug}`: {err:#}"
+                "screenshot: tmux capture-pane failed for slug `{slug}` \
+                 session `{session_name}`: {err:#}"
             );
             return Ok(None);
         }
     };
 
     // 2. pane dims (rows × cols) — fall back to 80×24 when query fails.
-    let (rows, cols) = match query_pane_dims(slug) {
+    let (rows, cols) = match query_pane_dims_from_session(&session_name) {
         Ok(Some((r, c))) => (r as usize, c as usize),
         _ => (FALLBACK_DIMS.0 as usize, FALLBACK_DIMS.1 as usize),
     };

--- a/crates/ccteam-core/src/templates/meta_agent_role.md
+++ b/crates/ccteam-core/src/templates/meta_agent_role.md
@@ -141,7 +141,7 @@ ccteam decisions --format json   # 结构化,适合你 jq 筛选
 
 ## 6. inbox 处理
 
-orchestrator 会把外部消息(终端 attach 输入 / 未来 channel adapter)写到 `~/projects/__USER_HANDLE__-meta/.ccteam/inbox/msg-*.md`。
+orchestrator 会把外部消息(终端 attach 输入 / 未来 channel adapter)写到 `~/projects/meta-__USER_HANDLE__/.ccteam/inbox/msg-*.md`。
 
 文件 schema 见 ccteam interfaces §3.4.2。每条文件长这样:
 
@@ -162,7 +162,7 @@ content_type: text
 1. orchestrator 看到新文件后会用 `tmux send-keys` 把消息正文直接注入到你的对话流(idle 时直接发,忙时用 `/btw` 排队)
 2. 所以**多数情况下你不必主动读 inbox 目录**——消息会自然出现在你的对话里
 3. 处理完一条 inbox 后,orchestrator 自动删掉对应文件;你也不必负责 ack
-4. **特例**:context reset 后新 session 启动时,可能会有未处理的 inbox 文件累积。这时你可以 `Bash: ls ~/projects/__USER_HANDLE__-meta/.ccteam/inbox/` 看一眼
+4. **特例**:context reset 后新 session 启动时,可能会有未处理的 inbox 文件累积。这时你可以 `Bash: ls ~/projects/meta-__USER_HANDLE__/.ccteam/inbox/` 看一眼
 
 ## 7. Watchdog 角色(V0.2 M0.21)
 
@@ -271,7 +271,7 @@ watchdog 角色是 "克制规则"(§3) 的特例 —— 你**仍然不写代码�
 
 ```markdown
 用 Write 工具,路径:
-~/projects/__USER_HANDLE__-meta/.ccteam/outbox/reply-<ISO-ts-紧凑去冒号>-<3位序号>.md
+~/projects/meta-__USER_HANDLE__/.ccteam/outbox/reply-<ISO-ts-紧凑去冒号>-<3位序号>.md
 
 文件内容(完整 frontmatter + body):
 

--- a/crates/ccteam-core/src/tmux.rs
+++ b/crates/ccteam-core/src/tmux.rs
@@ -31,11 +31,12 @@ pub fn session_name_for_slug(slug: &str) -> String {
 /// Resolve the live tmux session name for a project slug.
 ///
 /// Most projects use the conventional `ccteam-<slug>` name, but
-/// meta-agent sessions intentionally do not: slug `cto-meta` maps to
-/// tmux session `ccteam-meta-cto`. `state.json.tmux_session` is the
-/// source of truth for those cases. If the state is missing or malformed
-/// we fall back to the conventional name so diagnostic surfaces continue
-/// to degrade the same way older builds did.
+/// meta-agent sessions intentionally use `ccteam-meta-<handle>`.
+/// `state.json.tmux_session` is the source of truth for those cases,
+/// including legacy installs whose slug was `<handle>-meta`. If the
+/// state is missing or malformed we fall back to the conventional name
+/// so diagnostic surfaces continue to degrade the same way older builds
+/// did.
 pub fn session_name_for_project(paths: &CcteamPaths, slug: &str) -> String {
     let fallback = session_name_for_slug(slug);
     let state_path = paths.project_state(slug);
@@ -275,12 +276,26 @@ impl TmuxSession {
 /// instead (which returns raw bytes for `vt100::Parser`).
 pub fn capture_pane_tail(slug: &str, lines: usize, with_ansi: bool) -> Option<String> {
     let session = session_name_for_slug(slug);
+    capture_pane_tail_from_session(&session, lines, with_ansi)
+}
+
+/// Capture pane tail by exact tmux session name.
+///
+/// Prefer this for project-scoped call sites that already loaded
+/// `state.json.tmux_session`; meta-agent projects use tmux session
+/// `ccteam-meta-<handle>`, and legacy installs may still have a
+/// `<handle>-meta` slug on disk.
+pub fn capture_pane_tail_from_session(
+    session_name: &str,
+    lines: usize,
+    with_ansi: bool,
+) -> Option<String> {
     let mut cmd = Command::new("tmux");
     cmd.arg("capture-pane").arg("-p");
     if with_ansi {
         cmd.arg("-e");
     }
-    cmd.args(["-t", &session, "-S", &format!("-{lines}")]);
+    cmd.args(["-t", session_name, "-S", &format!("-{lines}")]);
     let output = cmd.output().ok()?;
     if !output.status.success() {
         return None;

--- a/crates/ccteam-core/src/tmux.rs
+++ b/crates/ccteam-core/src/tmux.rs
@@ -18,11 +18,31 @@ use std::process::Command;
 
 use anyhow::{anyhow, bail, Context, Result};
 
+use crate::paths::CcteamPaths;
+use crate::state::ProjectState;
+
 pub const SESSION_PREFIX: &str = "ccteam-";
 
 /// Build the conventional tmux session name for a project slug.
 pub fn session_name_for_slug(slug: &str) -> String {
     format!("{SESSION_PREFIX}{slug}")
+}
+
+/// Resolve the live tmux session name for a project slug.
+///
+/// Most projects use the conventional `ccteam-<slug>` name, but
+/// meta-agent sessions intentionally do not: slug `cto-meta` maps to
+/// tmux session `ccteam-meta-cto`. `state.json.tmux_session` is the
+/// source of truth for those cases. If the state is missing or malformed
+/// we fall back to the conventional name so diagnostic surfaces continue
+/// to degrade the same way older builds did.
+pub fn session_name_for_project(paths: &CcteamPaths, slug: &str) -> String {
+    let fallback = session_name_for_slug(slug);
+    let state_path = paths.project_state(slug);
+    match ProjectState::load(&state_path) {
+        Ok(state) if !state.tmux_session.trim().is_empty() => state.tmux_session,
+        _ => fallback,
+    }
 }
 
 /// Handle to a (possibly non-existent) tmux session. Methods are
@@ -294,6 +314,16 @@ pub fn capture_pane_tail(slug: &str, lines: usize, with_ansi: bool) -> Option<St
 /// `String` for NL surface use; this one keeps raw bytes for `vt100`.
 pub fn capture_pane_with_ansi(slug: &str, lines: usize) -> Result<Option<Vec<u8>>> {
     let name = session_name_for_slug(slug);
+    capture_pane_with_ansi_from_session(&name, lines)
+}
+
+/// Capture a tmux pane by exact session name. Use this when the
+/// caller has already resolved `state.json.tmux_session` instead of a
+/// conventional project slug.
+pub fn capture_pane_with_ansi_from_session(
+    session_name: &str,
+    lines: usize,
+) -> Result<Option<Vec<u8>>> {
     let lines_arg = format!("-{lines}");
     let output = Command::new("tmux")
         .args([
@@ -301,12 +331,12 @@ pub fn capture_pane_with_ansi(slug: &str, lines: usize) -> Result<Option<Vec<u8>
             "-e",
             "-p",
             "-t",
-            &name,
+            session_name,
             "-S",
             &lines_arg,
         ])
         .output()
-        .with_context(|| format!("spawn tmux capture-pane for {name}"))?;
+        .with_context(|| format!("spawn tmux capture-pane for {session_name}"))?;
     if !output.status.success() {
         return Ok(None);
     }
@@ -318,17 +348,22 @@ pub fn capture_pane_with_ansi(slug: &str, lines: usize) -> Result<Option<Vec<u8>
 /// `Ok(None)` on session-missing / tmux failure.
 pub fn query_pane_dims(slug: &str) -> Result<Option<(u16, u16)>> {
     let name = session_name_for_slug(slug);
+    query_pane_dims_from_session(&name)
+}
+
+/// Query pane dimensions by exact tmux session name.
+pub fn query_pane_dims_from_session(session_name: &str) -> Result<Option<(u16, u16)>> {
     let output = Command::new("tmux")
         .args([
             "display-message",
             "-p",
             "-t",
-            &name,
+            session_name,
             "-F",
             "#{pane_height} #{pane_width}",
         ])
         .output()
-        .with_context(|| format!("spawn tmux display-message for {name}"))?;
+        .with_context(|| format!("spawn tmux display-message for {session_name}"))?;
     if !output.status.success() {
         return Ok(None);
     }

--- a/crates/ccteam-core/src/watchdog.rs
+++ b/crates/ccteam-core/src/watchdog.rs
@@ -38,7 +38,7 @@ use crate::inbox::{
     outbox_filename, OutboxEventKind, OutboxFrontMatter, OutboxMessage, OutboxPriority,
     LATEST_SCHEMA_VERSION,
 };
-use crate::meta_agent::meta_slug;
+use crate::meta_agent::resolve_meta_slug;
 use crate::paths::CcteamPaths;
 use crate::state::ProjectState;
 
@@ -443,7 +443,7 @@ fn keep(alert: &WatchdogAlert, config: &WatchdogConfig) -> bool {
 }
 
 /// Render an alert into a meta-agent outbox file under
-/// `~/projects/<user-handle>-meta/.ccteam/outbox/`. Returns the path
+/// `~/projects/meta-<user-handle>/.ccteam/outbox/`. Returns the path
 /// written. The meta-agent's own session reads its outbox and surfaces
 /// each entry in NL.
 ///
@@ -456,7 +456,7 @@ pub fn push_alert_to_meta_outbox(
     user_handle: &str,
     alert: &WatchdogAlert,
 ) -> Result<PathBuf> {
-    let slug = meta_slug(user_handle)?;
+    let slug = resolve_meta_slug(paths, user_handle)?;
     let outbox_dir = paths
         .project_ccteam_dir(&slug)
         .join("outbox");
@@ -797,6 +797,11 @@ mod tests {
         };
         let path = push_alert_to_meta_outbox(&p, "rob", &alert).unwrap();
         assert!(path.exists());
+        assert!(
+            path.starts_with(p.project_ccteam_dir("meta-rob").join("outbox")),
+            "watchdog should write to canonical meta slug; got {}",
+            path.display(),
+        );
         let body = std::fs::read_to_string(&path).unwrap();
         assert!(body.contains("watchdog: daemon_down"));
         assert!(body.contains("event_kind: escalation"));

--- a/crates/ccteam-core/tests/m1_meta_dispatch_test.rs
+++ b/crates/ccteam-core/tests/m1_meta_dispatch_test.rs
@@ -82,14 +82,14 @@ fn count_active_regular_excludes_meta_team() {
     b.phase_state = PhaseState::AutoLocked;
     let mut idle = ProjectState::initial("p-3".into());
     idle.phase_state = PhaseState::Idle;
-    let mut meta = ProjectState::initial_for_team("rob-meta".into(), META_TEAM_NAME.into());
+    let mut meta = ProjectState::initial_for_team("meta-rob".into(), META_TEAM_NAME.into());
     meta.phase_state = PhaseState::InFlight; // even if mislabeled, it shouldn't count
 
     let projects = vec![
         ("p-1".into(), a),
         ("p-2".into(), b),
         ("p-3".into(), idle),
-        ("rob-meta".into(), meta),
+        ("meta-rob".into(), meta),
     ];
     assert_eq!(orch.count_active_regular(&projects), 2);
 }
@@ -388,13 +388,13 @@ fn meta_project_does_not_consume_concurrency_budget() {
     a.phase_state = PhaseState::InFlight;
     let mut b = ProjectState::initial("p2".into());
     b.phase_state = PhaseState::InFlight;
-    let mut meta = ProjectState::initial_for_team("rob-meta".into(), META_TEAM_NAME.into());
+    let mut meta = ProjectState::initial_for_team("meta-rob".into(), META_TEAM_NAME.into());
     meta.phase_state = PhaseState::InFlight;
 
     let projects = vec![
         ("p1".into(), a),
         ("p2".into(), b),
-        ("rob-meta".into(), meta),
+        ("meta-rob".into(), meta),
     ];
     assert_eq!(orch.count_active_regular(&projects), 2);
     assert!(
@@ -402,4 +402,3 @@ fn meta_project_does_not_consume_concurrency_budget() {
         "meta should leave at least one budget slot",
     );
 }
-

--- a/crates/ccteam-core/tests/tmux_test.rs
+++ b/crates/ccteam-core/tests/tmux_test.rs
@@ -6,7 +6,8 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use ccteam_core::tmux::{pid_is_alive, tmux_available, TmuxSession};
+use ccteam_core::tmux::{pid_is_alive, session_name_for_project, tmux_available, TmuxSession};
+use ccteam_core::{CcteamPaths, ProjectState};
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -44,6 +45,38 @@ fn skip_if_no_tmux(test_name: &str) -> bool {
         return true;
     }
     false
+}
+
+fn fake_paths(root: &std::path::Path) -> CcteamPaths {
+    CcteamPaths {
+        root: root.join(".ccteam"),
+        projects_root: root.join("projects"),
+    }
+}
+
+#[test]
+fn session_name_for_project_falls_back_to_slug_when_state_missing() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+
+    assert_eq!(
+        session_name_for_project(&paths, "dev-openclaw-download"),
+        "ccteam-dev-openclaw-download"
+    );
+}
+
+#[test]
+fn session_name_for_project_uses_state_tmux_session() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    let mut state = ProjectState::initial_for_team("cto-meta".into(), "meta-agent".into());
+    state.tmux_session = "ccteam-meta-cto".into();
+    state.save(&paths.project_state("cto-meta")).unwrap();
+
+    assert_eq!(
+        session_name_for_project(&paths, "cto-meta"),
+        "ccteam-meta-cto"
+    );
 }
 
 #[test]

--- a/crates/ccteam-hooks/src/parse_phase_end.rs
+++ b/crates/ccteam-hooks/src/parse_phase_end.rs
@@ -203,7 +203,9 @@ pub fn parse_phase_end(paths: &CcteamPaths, stdin: &Value) -> Result<ParseDecisi
         // the stall so the watchdog surfaces it. Claude Code carries
         // `stop_hook_active: true` on the second Stop entry so a phase
         // that keeps producing nothing won't loop forever.
-        let pane_tail = tmux::capture_pane_tail(&slug, 30, false);
+        let tmux_session = tmux::session_name_for_project(paths, &slug);
+        let pane_tail =
+            tmux::capture_pane_tail_from_session(&tmux_session, 30, false);
         write_needs_attention_outbox(
             cwd_path,
             &slug,

--- a/crates/ccteam-web/src/routes/pane_snapshot.rs
+++ b/crates/ccteam-web/src/routes/pane_snapshot.rs
@@ -8,7 +8,7 @@
 //! as a fallback.
 
 use axum::{
-    extract::Path,
+    extract::{Path, State},
     http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
@@ -24,11 +24,13 @@ pub fn router() -> Router<AppState> {
     Router::new().route("/api/{slug}/pane-snapshot.ansi", get(handle_pane_snapshot))
 }
 
-async fn handle_pane_snapshot(Path(slug): Path<String>) -> Response {
-    let capture_slug = slug.clone();
-    let capture =
-        tokio::task::spawn_blocking(move || capture_snapshot_bytes(&capture_slug, SNAPSHOT_LINES))
-            .await;
+async fn handle_pane_snapshot(State(app): State<AppState>, Path(slug): Path<String>) -> Response {
+    let session_name = ccteam_core::session_name_for_project(app.paths.as_ref(), &slug);
+    let capture_session_name = session_name.clone();
+    let capture = tokio::task::spawn_blocking(move || {
+        capture_snapshot_bytes(&capture_session_name, SNAPSHOT_LINES)
+    })
+    .await;
 
     let Some((bytes, rows, cols)) = (match capture {
         Ok(Ok(Some(snapshot))) => Some(snapshot),
@@ -52,7 +54,7 @@ async fn handle_pane_snapshot(Path(slug): Path<String>) -> Response {
     }) else {
         return (
             StatusCode::GATEWAY_TIMEOUT,
-            "pane snapshot unavailable: tmux session not found\n",
+            format!("pane snapshot unavailable: tmux session not found: {session_name}\n"),
         )
             .into_response();
     };
@@ -81,12 +83,15 @@ async fn handle_pane_snapshot(Path(slug): Path<String>) -> Response {
         .into_response()
 }
 
-fn capture_snapshot_bytes(slug: &str, lines: usize) -> anyhow::Result<Option<(Vec<u8>, u16, u16)>> {
-    let bytes = match ccteam_core::capture_pane_with_ansi(slug, lines)? {
+fn capture_snapshot_bytes(
+    session_name: &str,
+    lines: usize,
+) -> anyhow::Result<Option<(Vec<u8>, u16, u16)>> {
+    let bytes = match ccteam_core::capture_pane_with_ansi_from_session(session_name, lines)? {
         Some(b) => b,
         None => return Ok(None),
     };
-    let (rows, cols) = match ccteam_core::query_pane_dims(slug) {
+    let (rows, cols) = match ccteam_core::query_pane_dims_from_session(session_name) {
         Ok(Some((r, c))) if r > 0 && c > 0 => (r, c),
         Ok(Some(_)) | Ok(None) | Err(_) => FALLBACK_DIMS,
     };

--- a/crates/ccteam-web/tests/pane_snapshot_test.rs
+++ b/crates/ccteam-web/tests/pane_snapshot_test.rs
@@ -6,7 +6,7 @@
 
 use std::net::SocketAddr;
 
-use ccteam_core::CcteamPaths;
+use ccteam_core::{CcteamPaths, ProjectState};
 use ccteam_web::{router_with_state, AppState};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
@@ -54,5 +54,27 @@ async fn pane_snapshot_returns_504_when_tmux_session_missing() {
     assert!(
         body.contains("pane snapshot"),
         "504 body should mention pane snapshot degraded reason; got: {body}",
+    );
+}
+
+#[tokio::test]
+async fn pane_snapshot_uses_state_tmux_session_for_meta_projects() {
+    let tmp = TempDir::new().unwrap();
+    let paths = fake_paths(tmp.path());
+    std::fs::create_dir_all(paths.progress_dir()).unwrap();
+    let mut project = ProjectState::initial_for_team("cto-meta".into(), "meta-agent".into());
+    project.tmux_session = "ccteam-meta-cto".into();
+    project.save(&paths.project_state("cto-meta")).unwrap();
+
+    let state = AppState::new(paths);
+    let addr = spawn_server(state).await;
+
+    let url = format!("http://{addr}/api/cto-meta/pane-snapshot.ansi");
+    let resp = reqwest::get(&url).await.expect("GET pane snapshot");
+    assert_eq!(resp.status(), 504);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("ccteam-meta-cto"),
+        "degraded response should identify the state-backed tmux session; got: {body}",
     );
 }


### PR DESCRIPTION
Pane snapshot rendering previously derived the tmux target from the project slug, which breaks meta-agent projects where the slug is cto-meta but the live session is ccteam-meta-cto.

Add a state-backed session resolver that falls back to the conventional ccteam-<slug> name, wire both the xterm ANSI endpoint and PNG screenshot fallback through exact tmux session helpers, and include the resolved session in degraded pane snapshot responses for easier diagnosis.

Cover the cto-meta mapping with core resolver tests and a web endpoint regression test.