### PR TITLE
Simplify meta-agent canonical routing

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -408,7 +408,7 @@ fn which_claude() -> Option<String> {
 /// fail-fast error pointing the user at the missing team.yaml.
 ///
 /// Resolution order:
-/// 1. `dev` and `meta-agent` always succeed (legacy / bespoke paths).
+/// 1. `dev` and `meta-agent` always succeed (built-in / bespoke paths).
 /// 2. If `~/.ccteam/teams/<team>/team.yaml` is on disk, load + validate it.
 /// 3. V0.2.2 F40: scan every `~/.ccteam/teams/*/team.yaml` and accept
 ///    `team` when it matches a `spec.aliases` entry. Lets old projects'

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -51,7 +51,7 @@ pub use inbox::{
 };
 pub use meta_agent::{
     bootstrap_meta_project, meta_session_name, meta_slug, render_meta_role_prompt,
-    resolve_meta_slug, MetaBootstrapReport, META_SESSION_PREFIX, META_TEAM_NAME,
+    MetaBootstrapReport, META_SESSION_PREFIX, META_TEAM_NAME,
 };
 pub use memory_bridge::{
     install_into as install_memory_bridge_into, install_memory_bridge,

--- a/crates/ccteam-core/src/meta_agent.rs
+++ b/crates/ccteam-core/src/meta_agent.rs
@@ -66,35 +66,6 @@ pub fn meta_slug(user_handle: &str) -> Result<String> {
     Ok(format!("meta-{}", slugify(trimmed)))
 }
 
-/// Legacy meta-agent slug used before V0.3 follow-up:
-/// `<user>-meta`. Kept only so `doctor --install-meta-agent` can
-/// migrate existing installs without losing their state/outbox.
-fn legacy_meta_slug(user_handle: &str) -> Result<String> {
-    let trimmed = user_handle.trim();
-    if trimmed.is_empty() {
-        return Err(anyhow!("meta-agent user handle must be non-empty"));
-    }
-    Ok(format!("{}-meta", slugify(trimmed)))
-}
-
-/// Resolve the meta-agent slug that currently exists on disk.
-///
-/// New callers should use [`meta_slug`] for creation. Notification
-/// paths use this resolver so old `<user>-meta` installs still receive
-/// alerts until the user re-runs `doctor --install-meta-agent`, which
-/// migrates them to `meta-<user>`.
-pub fn resolve_meta_slug(paths: &CcteamPaths, user_handle: &str) -> Result<String> {
-    let slug = meta_slug(user_handle)?;
-    if paths.project_state(&slug).exists() {
-        return Ok(slug);
-    }
-    let legacy = legacy_meta_slug(user_handle)?;
-    if paths.project_state(&legacy).exists() {
-        return Ok(legacy);
-    }
-    Ok(slug)
-}
-
 /// `ccteam-meta-<user>` tmux session name.
 pub fn meta_session_name(user_handle: &str) -> Result<String> {
     let trimmed = user_handle.trim();
@@ -129,7 +100,6 @@ pub fn bootstrap_meta_project(
     user_handle: &str,
 ) -> Result<MetaBootstrapReport> {
     let slug = meta_slug(user_handle)?;
-    migrate_legacy_meta_project(paths, user_handle, &slug)?;
     let project_dir = paths.project_dir(&slug);
     let already_existed = paths.project_state(&slug).exists();
 
@@ -144,10 +114,8 @@ pub fn bootstrap_meta_project(
         bootstrap_project(paths, &slug, &request, META_TEAM_NAME)
             .context("bootstrap meta-agent project tree")?;
     }
-    // Always normalize the meta-agent's tmux_session name. New
-    // canonical slugs (`meta-<user>`) already line up with
-    // `ccteam-meta-<user>`, but migrated legacy projects need their
-    // state refreshed after the directory rename.
+    // Always normalize the meta-agent's state so re-running doctor
+    // repairs stale team/session fields inside the canonical project.
     let state_path = paths.project_state(&slug);
     let mut state = ProjectState::load(&state_path)
         .with_context(|| format!("reload meta state {}", state_path.display()))?;
@@ -172,56 +140,6 @@ pub fn bootstrap_meta_project(
         claude_md,
         already_existed,
     })
-}
-
-fn migrate_legacy_meta_project(
-    paths: &CcteamPaths,
-    user_handle: &str,
-    canonical_slug: &str,
-) -> Result<()> {
-    let legacy_slug = legacy_meta_slug(user_handle)?;
-    if legacy_slug == canonical_slug {
-        return Ok(());
-    }
-
-    let legacy_state = paths.project_state(&legacy_slug);
-    let canonical_state = paths.project_state(canonical_slug);
-    if !legacy_state.exists() || canonical_state.exists() {
-        return Ok(());
-    }
-
-    let legacy_dir = paths.project_dir(&legacy_slug);
-    let canonical_dir = paths.project_dir(canonical_slug);
-    if canonical_dir.exists() {
-        return Err(anyhow!(
-            "cannot migrate legacy meta-agent project `{}` to `{}`: target directory already exists",
-            legacy_dir.display(),
-            canonical_dir.display(),
-        ));
-    }
-
-    std::fs::create_dir_all(&paths.projects_root)
-        .with_context(|| format!("create {}", paths.projects_root.display()))?;
-    std::fs::rename(&legacy_dir, &canonical_dir)
-        .with_context(|| format!("rename {} -> {}", legacy_dir.display(), canonical_dir.display()))?;
-
-    let legacy_progress = paths.progress_jsonl(&legacy_slug);
-    let canonical_progress = paths.progress_jsonl(canonical_slug);
-    if legacy_progress.exists() && !canonical_progress.exists() {
-        if let Some(parent) = canonical_progress.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("create {}", parent.display()))?;
-        }
-        std::fs::rename(&legacy_progress, &canonical_progress).with_context(|| {
-            format!(
-                "rename {} -> {}",
-                legacy_progress.display(),
-                canonical_progress.display()
-            )
-        })?;
-    }
-
-    Ok(())
 }
 
 /// Result of `bootstrap_meta_project` — useful for the doctor command's
@@ -291,10 +209,6 @@ mod tests {
         assert!(
             body.contains("~/projects/meta-rob/.ccteam/outbox/"),
             "role prompt should mention canonical meta outbox path",
-        );
-        assert!(
-            !body.contains("~/projects/rob-meta/"),
-            "role prompt must not point migrated meta-agents at the legacy path",
         );
     }
 
@@ -391,28 +305,4 @@ mod tests {
         assert!(body.contains("决策树"), "role prompt should be re-rendered");
     }
 
-    #[test]
-    fn bootstrap_meta_project_migrates_legacy_user_meta_directory() {
-        isolation();
-        let tmp = tempfile::TempDir::new().unwrap();
-        let p = paths(&tmp);
-        let legacy = p.project_dir("rob-meta");
-        std::fs::create_dir_all(legacy.join(".ccteam")).unwrap();
-        let mut state = ProjectState::initial_for_team("rob-meta".into(), META_TEAM_NAME.into());
-        state.tmux_session = "ccteam-meta-rob".into();
-        state.save(&p.project_state("rob-meta")).unwrap();
-        std::fs::create_dir_all(p.progress_dir()).unwrap();
-        std::fs::write(p.progress_jsonl("rob-meta"), "{}\n").unwrap();
-
-        let report = bootstrap_meta_project(&p, "rob").unwrap();
-
-        assert_eq!(report.slug, "meta-rob");
-        assert!(!p.project_dir("rob-meta").exists());
-        assert!(p.project_dir("meta-rob").is_dir());
-        assert!(!p.progress_jsonl("rob-meta").exists());
-        assert!(p.progress_jsonl("meta-rob").exists());
-        let state = ProjectState::load(&p.project_state("meta-rob")).unwrap();
-        assert_eq!(state.slug, "meta-rob");
-        assert_eq!(state.tmux_session, "ccteam-meta-rob");
-    }
 }

--- a/crates/ccteam-core/src/projects.rs
+++ b/crates/ccteam-core/src/projects.rs
@@ -1140,9 +1140,9 @@ mod tests {
         // prompt overwrites the file via a different path), so the
         // generic body is the right fallback. This guards against
         // accidentally writing "" as the body.
-        let body = render_project_claude_md("rob-meta", "meta-agent");
+        let body = render_project_claude_md("meta-rob", "meta-agent");
         assert!(!body.is_empty());
-        assert!(body.contains("- slug: rob-meta"));
+        assert!(body.contains("- slug: meta-rob"));
         assert!(body.contains("- team: meta-agent"));
     }
 

--- a/crates/ccteam-core/src/tmux.rs
+++ b/crates/ccteam-core/src/tmux.rs
@@ -32,11 +32,9 @@ pub fn session_name_for_slug(slug: &str) -> String {
 ///
 /// Most projects use the conventional `ccteam-<slug>` name, but
 /// meta-agent sessions intentionally use `ccteam-meta-<handle>`.
-/// `state.json.tmux_session` is the source of truth for those cases,
-/// including legacy installs whose slug was `<handle>-meta`. If the
-/// state is missing or malformed we fall back to the conventional name
-/// so diagnostic surfaces continue to degrade the same way older builds
-/// did.
+/// `state.json.tmux_session` is the source of truth for those cases.
+/// If the state is missing or malformed we fall back to the
+/// conventional name so diagnostic surfaces still degrade cleanly.
 pub fn session_name_for_project(paths: &CcteamPaths, slug: &str) -> String {
     let fallback = session_name_for_slug(slug);
     let state_path = paths.project_state(slug);
@@ -283,8 +281,7 @@ pub fn capture_pane_tail(slug: &str, lines: usize, with_ansi: bool) -> Option<St
 ///
 /// Prefer this for project-scoped call sites that already loaded
 /// `state.json.tmux_session`; meta-agent projects use tmux session
-/// `ccteam-meta-<handle>`, and legacy installs may still have a
-/// `<handle>-meta` slug on disk.
+/// `ccteam-meta-<handle>`.
 pub fn capture_pane_tail_from_session(
     session_name: &str,
     lines: usize,

--- a/crates/ccteam-core/src/watchdog.rs
+++ b/crates/ccteam-core/src/watchdog.rs
@@ -38,7 +38,7 @@ use crate::inbox::{
     outbox_filename, OutboxEventKind, OutboxFrontMatter, OutboxMessage, OutboxPriority,
     LATEST_SCHEMA_VERSION,
 };
-use crate::meta_agent::resolve_meta_slug;
+use crate::meta_agent::meta_slug;
 use crate::paths::CcteamPaths;
 use crate::state::ProjectState;
 
@@ -456,7 +456,7 @@ pub fn push_alert_to_meta_outbox(
     user_handle: &str,
     alert: &WatchdogAlert,
 ) -> Result<PathBuf> {
-    let slug = resolve_meta_slug(paths, user_handle)?;
+    let slug = meta_slug(user_handle)?;
     let outbox_dir = paths
         .project_ccteam_dir(&slug)
         .join("outbox");

--- a/crates/ccteam-core/tests/tmux_test.rs
+++ b/crates/ccteam-core/tests/tmux_test.rs
@@ -69,12 +69,12 @@ fn session_name_for_project_falls_back_to_slug_when_state_missing() {
 fn session_name_for_project_uses_state_tmux_session() {
     let tmp = tempfile::TempDir::new().unwrap();
     let paths = fake_paths(tmp.path());
-    let mut state = ProjectState::initial_for_team("cto-meta".into(), "meta-agent".into());
+    let mut state = ProjectState::initial_for_team("meta-cto".into(), "meta-agent".into());
     state.tmux_session = "ccteam-meta-cto".into();
-    state.save(&paths.project_state("cto-meta")).unwrap();
+    state.save(&paths.project_state("meta-cto")).unwrap();
 
     assert_eq!(
-        session_name_for_project(&paths, "cto-meta"),
+        session_name_for_project(&paths, "meta-cto"),
         "ccteam-meta-cto"
     );
 }

--- a/crates/ccteam-web/tests/pane_snapshot_test.rs
+++ b/crates/ccteam-web/tests/pane_snapshot_test.rs
@@ -62,14 +62,14 @@ async fn pane_snapshot_uses_state_tmux_session_for_meta_projects() {
     let tmp = TempDir::new().unwrap();
     let paths = fake_paths(tmp.path());
     std::fs::create_dir_all(paths.progress_dir()).unwrap();
-    let mut project = ProjectState::initial_for_team("cto-meta".into(), "meta-agent".into());
+    let mut project = ProjectState::initial_for_team("meta-cto".into(), "meta-agent".into());
     project.tmux_session = "ccteam-meta-cto".into();
-    project.save(&paths.project_state("cto-meta")).unwrap();
+    project.save(&paths.project_state("meta-cto")).unwrap();
 
     let state = AppState::new(paths);
     let addr = spawn_server(state).await;
 
-    let url = format!("http://{addr}/api/cto-meta/pane-snapshot.ansi");
+    let url = format!("http://{addr}/api/meta-cto/pane-snapshot.ansi");
     let resp = reqwest::get(&url).await.expect("GET pane snapshot");
     assert_eq!(resp.status(), 504);
     let body = resp.text().await.unwrap();


### PR DESCRIPTION
Drop the temporary legacy meta-agent slug resolver and directory/progress migration path from doctor --install-meta-agent. New installs and refreshes now only operate on the canonical meta-<handle> project slug while keeping the tmux session name ccteam-meta-<handle>.

Route watchdog notifications directly to the canonical meta-agent outbox and remove the public resolve_meta_slug export. Refresh tmux and pane snapshot regression tests to exercise the canonical meta-cto project slug with the state-backed ccteam-meta-cto session.

Verification: cargo test --workspace; git diff --check. Note: cargo fmt --all -- --check currently reports unrelated pre-existing rustfmt drift across the workspace on main, so this patch avoids broad formatting churn.