### PR TITLE
v0.4.0-f69-docs: Examples + user-manual + migration-guide scaffolding

### DIFF
--- a/docs/v0-4-0/e2e-retro.md
+++ b/docs/v0-4-0/e2e-retro.md
@@ -1,0 +1,147 @@
+# V0.4.0 e2e Retro
+
+> F69 ship gate 验收记录。本文档由主 session 在 ship 前补充。
+>
+> 当前状态：**skeleton（占位）** — F69 docs prep PR 创建了本文件骨架，
+> 待 F60-F68 全部 merge 后，主 session 跑完整 ship gate 验收命令并填入
+> 实际输出。
+
+---
+
+## 1. Ship gate 命令执行结果
+
+- [ ] `cargo test --workspace` baseline: TBD（期望 ≥ 866，failed = 0）
+- [ ] `cargo clippy --workspace --all-targets`: TBD（期望 ≤ 9，pre-existing baseline）
+- [ ] `cargo fmt -- --check $(git diff --name-only origin/main..HEAD | grep '\.rs$')`: TBD
+- [ ] `cargo build --workspace --release`: TBD（期望 0 errors）
+- [ ] 完整红线 grep 矩阵（[`dev-plan.md`](dev-plan.md) §12）: TBD
+
+### 1.1 红线 grep 矩阵实际输出
+
+```
+TBD — 主 session 在 ship gate 时贴 §12 所有命令的实际输出
+```
+
+---
+
+## 2. 发现的问题 + 修复记录
+
+> F60-F68 ship 过程中发现的需要 cross-cutting 修复的问题，集中在这里记录。
+
+TBD
+
+---
+
+## 3. 手动 smoke test 结果
+
+### 3.1 Workflow 启动
+
+```bash
+ccteam run smoke-test 2>&1 | head -20
+```
+
+期望：`workflow_start` event 出现，不 panic。
+
+实际：TBD
+
+### 3.2 Web UI
+
+```bash
+ccteam web --bind 127.0.0.1:7331 &
+curl -s http://127.0.0.1:7331/health | python3 -m json.tool
+curl -s http://127.0.0.1:7331/api/v1/projects | python3 -m json.tool | head -20
+```
+
+期望：health OK，projects 返回 JSON 列表（含 `workflow_summary` 字段）。
+
+实际：TBD
+
+### 3.3 Manual trigger smoke
+
+```bash
+ccteam ctl spawn-agent --slug smoke-test --role worker
+ccteam ctl observe --slug smoke-test
+```
+
+期望：session 出现，state.json 可读。
+
+实际：TBD
+
+### 3.4 Artifact trigger smoke
+
+```bash
+# 1. 启动 workflow 后写 artifact 文件
+echo "test" > .ccteam/issues/smoke-001.md
+
+# 2. 检查下游 agent 是否被自动 spawn
+sleep 3
+ccteam ctl observe --slug smoke-test
+```
+
+期望：fixer 自动 spawn。
+
+实际：TBD
+
+### 3.5 Gate 解锁 smoke
+
+```bash
+ccteam ctl trigger-gate --slug smoke-test --gate shipper
+sleep 2
+ccteam ctl observe --slug smoke-test
+```
+
+期望：shipper session 启动。
+
+实际：TBD
+
+---
+
+## 4. Playwright e2e 前端测试
+
+```bash
+cd crates/ccteam-web/web && npm run test 2>&1 | tail -10
+```
+
+期望：全绿（或 skip 说明原因）。
+
+实际：TBD
+
+---
+
+## 5. V0.4.1 candidates / Known issues
+
+> ship 过程中识别但本轮不修的事项，记录在这里供下个 patch round 处理。
+
+TBD
+
+---
+
+## 6. Ship 总结
+
+- workspace version bump：`0.3.2` → `0.4.0` — TBD
+- CLAUDE.md baseline 更新：TBD
+- 文档清单：
+  - [ ] `docs/v0-4-0/prd.md` — locked（F69 前已 ship）
+  - [ ] `docs/v0-4-0/dev-plan.md` — locked（F69 前已 ship）
+  - [ ] `docs/v0-4-0/README.md` — locked（F69 前已 ship）
+  - [ ] `docs/v0-4-0/user-manual.md` — F69 docs prep 写完
+  - [ ] `docs/v0-4-0/migration-guide.md` — F69 docs prep 写完
+  - [ ] `docs/v0-4-0/e2e-retro.md` — 本文件（ship 时填）
+  - [ ] `examples/workflows/*` — F69 docs prep 写完
+  - [ ] `CLAUDE.md §一` — ship 时回填新 baseline + version
+  - [ ] `docs/dev-coupling-audit.md` — F60-F69 entry 全量
+  - [ ] `docs/interfaces.md` — workflow.yaml schema + 17 个 MCP 工具签名
+- ship 决策：TBD（go / no-go）
+
+---
+
+## 7. 后续 patch round 起点
+
+V0.4.0 ship 后，下一个 patch round 候选（V0.4.1）：
+
+- TBD（按本次 e2e 中发现的问题列）
+
+---
+
+> **本文件待补充**。F69 docs prep PR 只占位，
+> 主 session 在 ship gate 时按上述模板填入实际命令输出 + 决策记录。

--- a/docs/v0-4-0/migration-guide.md
+++ b/docs/v0-4-0/migration-guide.md
@@ -1,0 +1,424 @@
+# V0.3.x → V0.4.0 迁移指南
+
+> 本文档面向有 V0.3.x phase 驱动项目（`team.yaml::kind: workflow` + `phases:`
+> 列表）的用户。V0.4.0 是 ccteam 的**架构级重构**，phase 模板系统全部
+> 删除——本指南帮你把存量项目迁移到新的 `workflow.yaml` + agent role 模型。
+>
+> 如果你是 V0.4.0 新用户（从未跑过 phase 驱动 workflow），可跳过本文，
+> 直接看 [`user-manual.md`](user-manual.md) §2 快速上手。
+
+---
+
+## 1. 为什么要迁移
+
+V0.3.x 的 `team.yaml::kind: workflow` 模式下，每个 phase 的 prompt 和
+执行顺序是 ccteam 控制的。V0.4.0 把这层完全删掉，原因（详 [`prd.md`](prd.md) §1）：
+
+- **phase prompt 模板和 Claude Code 内置任务规划能力竞争**——
+  inject_directives / golden_rules 实际是在和 `~/.claude/CLAUDE.md` +
+  subagent 机制打架，用户真实 prompt 被稀释
+- **workflow 不可定制**——每加一种业务 workflow 要改 ccteam 核心代码，
+  而不是写一个 YAML
+- **可观测性倒置**——orchestrator 管 prompt，但对"哪个 agent 读了哪个文件"
+  一无所知；artifact-driven 模型把这层信息变成 first-class state
+
+迁移后你将获得：
+
+- workflow 行为完全由你的 `.claude/agents/*.md` 控制（Claude Code 原生格式）
+- 多 agent 并行执行（V0.3.x phase DAG 是顺序的）
+- 自然支持 `claude --bg` + Agent View 监控
+- progress.jsonl 新增 artifact event / gate event 类型，可观测性更强
+
+---
+
+## 2. 不再支持的内容
+
+### 2.1 EOL 配置
+
+`team.yaml` 的以下字段**不再被 orchestrator 支持**：
+
+```yaml
+# V0.3.x team.yaml（V0.4.0 拒绝加载）
+kind: workflow                   # 删除（或改 kind: flex）
+phases:                          # 全部删除
+  - name: plan-eng
+    prompt: |
+      ...
+    inject_directives: [...]
+    golden_rules: [...]
+    decision_mode: strict
+    escalate_grammar: [...]
+  - name: implement
+    ...
+```
+
+V0.4.0 orchestrator 读到 `phases:` 字段会 hard error（明确的 fail-fast，
+避免静默忽略导致 phase 不跑的困惑）。
+
+### 2.2 EOL CLI 子命令
+
+下列子命令在 V0.4.0 移除：
+
+| V0.3.x 命令 | V0.4.0 替代 |
+|---|---|
+| `ccteam phase advance` | 无（phase 概念删除）|
+| `ccteam phase rerun` | `ccteam ctl spawn-agent --role <role>` |
+| `ccteam phase skip` | 无（artifact-driven 无顺序语义） |
+| `ccteam doctor --check-phase-dag` | `ccteam doctor --check-workflow` |
+
+### 2.3 progress.jsonl event 类型变化
+
+V0.3.x 的下列 event 类型**保留**，但语义可能不同：
+
+| Event 类型 | V0.3.x 含义 | V0.4.0 含义 |
+|---|---|---|
+| `phase_start` / `phase_end` | phase 状态机 | **不再产生**；新写 progress.jsonl 不出现 |
+| `session_start` / `session_end` | tmux session 生命周期 | 改名 `agent_spawn` / `agent_done` |
+| `cost_update` | cost 累计 | 保留，语义不变 |
+| `escalation` | fix-loop 3 次顶 | 保留 |
+
+V0.4.0 新增 event 类型：
+
+- `workflow_start` / `workflow_done`：workflow 整体生命周期
+- `agent_spawn` / `agent_done`：agent session 生命周期
+- `artifact_created` / `artifact_consumed`：artifact 文件事件
+- `gate_locked` / `gate_unlocked`：Gate 状态变化
+- `parallelism_changed`：动态调节 parallelism 记录
+
+---
+
+## 3. 自动迁移工具
+
+```bash
+ccteam doctor --migrate-phase-to-workflow
+```
+
+该命令的行为：
+
+### 3.1 检测阶段
+
+扫描 `~/projects/<team>-<slug>/team.yaml`，找出所有满足条件的项目：
+
+- `kind: workflow`
+- 含 `phases:` 字段且非空
+
+每个匹配项目，命令打印：
+
+```
+[match] dev-myproject:
+  - phases: [plan-eng, implement, review, retro]
+  - team.yaml path: /home/user/projects/dev-myproject/team.yaml
+```
+
+### 3.2 生成阶段
+
+对每个匹配项目，生成：
+
+1. **`workflow.yaml`**（项目根）：把 phase DAG 翻译成 artifact-trigger
+   连线。常见映射：
+
+   ```yaml
+   # 生成的 workflow.yaml
+   name: <slug>-migrated
+   description: "Auto-migrated from V0.3.x phase DAG"
+
+   agents:
+     plan-eng:
+       executor: claude
+       trigger: manual                       # 第一个 phase → manual
+       output: .ccteam/plan/
+
+     implement:
+       executor: claude
+       trigger: watch:.ccteam/plan/          # 顺序连线 → watch
+       parallelism: 1                        # 保守起步，不并发
+       input: .ccteam/plan/
+       output: .ccteam/code/
+
+     review:
+       executor: claude
+       trigger: watch:.ccteam/code/
+       input: .ccteam/code/
+       output: .ccteam/review/
+
+     retro:
+       executor: claude
+       trigger: gate                         # 最后一个 phase → gate（需人解锁）
+       input: .ccteam/review/
+   ```
+
+2. **`.claude/agents/<phase-name>.md`**（每个 phase 一个文件）：把原
+   `phases[].prompt` 内容搬到 markdown 正文，frontmatter 用默认值：
+
+   ```markdown
+   ---
+   name: plan-eng
+   description: "Auto-migrated from V0.3.x phase 'plan-eng'"
+   tools: Read, Write, Edit, Grep, Glob, Bash
+   model: opus
+   ---
+
+   <原 phases[0].prompt 内容>
+
+   ## ccteam 注入的环境变量
+
+   - `$CCTEAM_PROJECT_SLUG`: 项目 slug
+   - `$CCTEAM_INPUT`: 输入目录（前一个 phase 的 output）
+   - `$CCTEAM_OUTPUT`: 输出目录（写完后下游 phase 自动触发）
+
+   请把你的产出写到 `$CCTEAM_OUTPUT/` 目录，文件名含时间戳 +
+   short-id 以避免冲突。
+   ```
+
+3. **备份原 `team.yaml`** 到 `team.yaml.v0-3-bak`，新 `team.yaml`
+   去掉 `phases:` 字段、`kind:` 改为 `flex`（V0.4.0 中 `kind: flex`
+   = workflow-driven 模式的承载，详 [`prd.md`](prd.md) §9.2）。
+
+### 3.3 报告阶段
+
+命令结束时打印总结：
+
+```
+Migration summary:
+  - 3 projects migrated
+  - workflow.yaml created: 3
+  - .claude/agents/*.md created: 12
+  - team.yaml.v0-3-bak created: 3
+
+Next steps:
+  1. Review each .claude/agents/<role>.md and tighten prompts
+  2. Review workflow.yaml — adjust parallelism, trigger types
+  3. Test with: ccteam run <slug> + ccteam ctl spawn-agent --role <first>
+  4. Delete team.yaml.v0-3-bak when satisfied
+```
+
+---
+
+## 4. 手动 review 清单
+
+自动迁移**只是结构性转换**，不修改任何 prompt 内容。你需要逐个 review：
+
+### 4.1 Prompt 内容
+
+打开每个 `.claude/agents/<role>.md`，检查：
+
+- [ ] **input/output 路径**：原 phase prompt 可能写死了 `inbox/` /
+  `outbox/` 之类的硬编码路径——改成 `$CCTEAM_INPUT` / `$CCTEAM_OUTPUT`
+- [ ] **phase 间引用**：原 prompt 可能说"上一个 phase 写了 plan.md"——
+  V0.4.0 是 artifact 目录扫描，可能有多个文件；改成 "扫描
+  `$CCTEAM_INPUT/` 中所有未处理文件"
+- [ ] **ccteam 内置指令引用**：原 prompt 可能引用 `inject_directives` 内容
+  （如"按红线 1-5 执行"）——这些指令在 V0.4.0 不再注入，需要把内容
+  inline 进 agent prompt 或 `~/.claude/CLAUDE.md`
+- [ ] **escalation 语法**：原 phase 可能用 `escalate_grammar` 触发
+  escalation——V0.4.0 改用 `ccteam__signal` MCP 工具或 progress.jsonl
+  `escalation` event 自描述
+
+### 4.2 Trigger 类型选择
+
+自动迁移把所有"中间 phase" 一律设为 `trigger: watch:<前置 output>`。
+但实际场景中：
+
+- **真正需要并行的 phase**（如 fixer）→ 改 `parallelism: 5+`
+- **每次只跑一次的 phase**（如 plan-eng）→ 改 `trigger: manual`
+- **依赖人决策的 phase**（如 ship）→ 改 `trigger: gate`
+- **定时巡检的 phase**（V0.3.x 没有这个概念）→ 改 `trigger: schedule`
+
+review 时问自己：这个 phase 真的"一来文件就跑"吗？还是更适合
+"meta-agent 决定什么时候跑"？
+
+### 4.3 Parallelism 调整
+
+默认 `parallelism: 1`（保守）。如果原 phase 的工作天然可分割（每
+issue 一个 fix、每文件一个 review），可以提到 5-10。建议：
+
+- 第一次跑 smoke：保持 1，确认逻辑稳定
+- 第二次跑：提到 3 看 cost / 速度
+- 稳定后：按 budget 决定上限
+
+### 4.4 Agent role 文件 frontmatter
+
+自动生成的 frontmatter 是默认值：
+
+```yaml
+---
+name: <role>
+description: Auto-migrated from V0.3.x phase '<role>'
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: opus
+---
+```
+
+按需调整：
+
+- `description`：改成更具体的一句话（Claude Code 选 agent 时看这个）
+- `tools`：只列真正需要的（reviewer 可能不需要 Edit；shipper 需要 gh CLI 的话加 `Bash` 但说明用途）
+- `model`：简单 fix 用 sonnet 省钱；复杂 review 用 opus 提质量
+
+---
+
+## 5. 顺序 vs 事件驱动语义差异（核心理解点）
+
+V0.3.x phase DAG 是**顺序**的：phase A 完全跑完 → phase B 开始。
+V0.4.0 artifact-trigger 是**事件驱动**的：A 写一个文件 → 一个 B session
+立即启动；A 写另一个 → 又一个 B session 启动（如果 parallelism 允许）。
+
+这带来几个语义差异：
+
+### 5.1 "完成"的定义不同
+
+V0.3.x：phase A "完成" = orchestrator 收到 phase_end event。
+V0.4.0：agent A "完成" = artifact 文件写完。**单个 agent 可以产出多个
+artifact**——每个 artifact 都触发下游。
+
+如果你的原 phase A 是 "agent 干完一堆事，最后写一个汇总 report"，
+V0.4.0 下要决定：
+
+- 仍然只写一个 report → 下游 watch 看到 report 出现就跑（语义不变）
+- 改成每完成一个子任务就写一个 artifact → 下游可以并行（推荐）
+
+### 5.2 顺序保证消失
+
+V0.3.x：phase A → B → C，保证 B 看到 A 完整产物。
+V0.4.0：A 写 file1，B1 启动；A 又写 file2，B2 启动。**B1 和 B2 之间没有
+顺序保证**，且都不等 A 完成。
+
+如果你的 workflow 依赖严格顺序（如 build → test → deploy 必须串行），
+有两种处理方式：
+
+1. **保持串行**：把每个 phase 的 parallelism 设为 1，下游 trigger 看
+   "summary" 文件而非 "intermediate" 文件——agent 内部完成所有子任务
+   后再写 summary
+2. **用 Gate 控制**：在需要串行边界处插一个 `trigger: gate` agent，
+   meta-agent 决定何时解锁
+
+### 5.3 Context 管理
+
+V0.3.x：phase 边界 orchestrator 决定是否 reset CC session（`/exit` +
+新 session）。
+V0.4.0：每个 agent session 是独立的 `claude --bg --agent <role>`，
+**天然独立 context**。不需要 orchestrator 干预 context reset——每次
+spawn 都是新 session。
+
+这意味着：
+
+- 原 phase 间 "share context" 的隐式假设失效 → 必须通过 artifact 文件
+  显式传递信息
+- 不再需要 `ccteam doctor --check-cache-cost` 之类的 phase 边界优化
+- agent prompt 不要假设"上一轮"的状态——总是从 artifact 读
+
+---
+
+## 6. 边角 case + 已知限制
+
+### 6.1 V0.3.x 用了 `inject_directives` / `golden_rules` 的项目
+
+原 phase 配置可能有：
+
+```yaml
+phases:
+  - name: plan-eng
+    prompt: "..."
+    inject_directives:
+      - "always use cargo test --workspace"
+      - "escalate on third failure"
+    golden_rules:
+      - "no global state"
+```
+
+V0.4.0 这些字段不再注入。自动迁移**不会**自动把这些规则 inline 到
+agent prompt——你必须手动决定：
+
+- 用户级规则 → 写到 `~/.claude/CLAUDE.md`（所有项目共享）
+- 项目级规则 → 写到 `<project>/CLAUDE.md`（Claude Code 自动读取）
+- 单 agent 级规则 → inline 到 `.claude/agents/<role>.md` 的正文
+
+### 6.2 V0.3.x 用了 `decision_mode: strict` 的项目
+
+原 phase 通过 `decision_mode` 强制 agent 输出严格 schema。V0.4.0
+没有这个机制——需要在 agent prompt 里显式写出 schema 要求，并在
+artifact 文件名 / 内容上加 lint 步骤（reviewer agent 检查）。
+
+### 6.3 跨项目记忆（M4）
+
+V0.3.x M4 跨项目记忆通过 `~/.claude/rules/ccteam-lessons-<team>.md` 实现
+（详 tech-design §3.7）。V0.4.0 **不变**——meta-agent 通过 Claude Code
+原生 `/memory` 命令读写，ccteam-core 零检索代码。这条迁移路径上不需
+要做任何事。
+
+### 6.4 meta-agent 自身
+
+V0.3.x 的 meta-agent session 仍然由 ccteam 起（`<handle>-meta` 后缀路径）。
+V0.4.0 这个机制**不变**。但 meta-agent 的 prompt 需要更新——
+新增 7 个 MCP 工具的说明：
+
+```bash
+ccteam doctor --update-meta-agent
+```
+
+这会更新所有 meta-agent 项目的 `~/.claude/CLAUDE.md` 中 ccteam 工具列表段
+（marker section `<!-- ccteam-managed:mcp-tools begin/end -->` 内）。
+
+### 6.5 flex 模式项目
+
+V0.3.x 中 `team.yaml::kind: flex` 模式（多 session 自由编排）在 V0.4.0
+被 `workflow.yaml` 完全取代——`kind: flex` 的语义重写为：
+"加载 workflow.yaml 而非走 phase DAG"。已有 flex 项目影响：
+
+- `state.json::sessions{}` 字段保留（用于 session id 分配）
+- `~/.ccteam/progress/<slug>/<sid>.jsonl` per-session 路径保留
+- 旧 flex CLI（如 `ccteam ctl flex-new`）替换为 `ccteam ctl spawn-agent`
+
+自动迁移工具会把 flex 项目识别为"已是 workflow"状态，跳过转换，
+但仍需要你手动写 `workflow.yaml`（自动迁移不会生成无 phase 的项目的
+workflow.yaml）。
+
+---
+
+## 7. 迁移后验证
+
+```bash
+# 1. 验证 workflow.yaml schema
+ccteam ctl validate-workflow --slug <slug>
+# 期望：no errors
+
+# 2. 验证所有 agent role 文件存在
+ccteam doctor --check-workflow --slug <slug>
+# 期望：all agent role files present
+
+# 3. dry-run（不实际 spawn，只验证 trigger 注册）
+ccteam run --dry-run --slug <slug>
+# 期望：watcher 注册成功，无 error
+
+# 4. smoke 测试 — manual trigger
+ccteam ctl spawn-agent --slug <slug> --role <first-role>
+ccteam ctl observe --slug <slug>
+# 期望：可以看到 session 启动
+
+# 5. 端到端测试 — 一轮跑通
+# 用最低 parallelism 跑一遍，确认 artifact 流转 + Gate 解锁正常
+```
+
+确认全部 OK 后，删除 `team.yaml.v0-3-bak` 备份。
+
+---
+
+## 8. 求助
+
+迁移过程中遇到问题：
+
+1. 先查 [`user-manual.md`](user-manual.md) §10 故障排查 FAQ
+2. 看 `~/.ccteam/logs/<slug>.log` orchestrator 日志
+3. 看 [`prd.md`](prd.md) §9 设计层面对迁移路径的论证
+4. 如果是 ccteam 本身 bug → 在仓库提 issue，附 `team.yaml`（脱敏后）+
+   `ccteam doctor --version` 输出 + 错误日志
+
+---
+
+## 9. 进一步阅读
+
+- [`user-manual.md`](user-manual.md) — V0.4.0 完整用户手册
+- [`prd.md`](prd.md) §9 — 迁移路径的设计论证
+- [`prd.md`](prd.md) §5 — 删除清单（被删的代码 ~3500 LOC 细目）
+- [`README.md`](README.md) — V0.4.0 文档索引
+- [`../../examples/workflows/`](../../examples/workflows/) — 可参考的示例 workflow

--- a/docs/v0-4-0/user-manual.md
+++ b/docs/v0-4-0/user-manual.md
@@ -1,0 +1,497 @@
+# ccteam V0.4.0 用户手册
+
+> 本手册面向**ccteam V0.4.0 终端用户**：日常用 `ccteam` 编排 Claude Code /
+> Codex 多 agent workflow 的开发者。架构理论 / 设计决策见 [`prd.md`](prd.md)；
+> 从 V0.3.x 升级见 [`migration-guide.md`](migration-guide.md)。
+
+---
+
+## 1. 概述
+
+V0.4.0 是 ccteam 的**架构级重构**。核心变化：
+
+- **Phase 模板系统全部删除**——ccteam 不再预定义 `plan-eng` / `implement` /
+  `review` 这类固定 phase。每个项目的 workflow 由用户的 `workflow.yaml`
+  完全定义。
+- **Agent-as-Network 模型**——`workflow.yaml` 只描述 agent 之间的连线
+  （触发条件 + artifact 目录）；**ccteam 不向 workflow.yaml 注入任何 prompt**。
+  agent 行为完全由各自的 `.claude/agents/<role>.md` 定义（Claude Code 原生
+  subagent 文件格式）。
+- **Claude Code Agent View 原生集成**——`claude --bg --agent <role>` 派发
+  后台 session，ccteam 不再用 tmux 当 Claude Code 的宿主，也不再解析 statusline
+  JSON；session 状态从 `~/.claude/jobs/<id>/state.json` 读取。
+- **Artifact-driven 触发**——agent 间唯一通信媒介是文件系统目录。一个
+  agent 写文件到 output 目录 → inotify watcher 检测到 → 自动 spawn 下游 agent。
+
+V0.4.0 的目标：**100 个 agent 可同时并行运行**；人只在目标输入和最终 review
+出现，中间全程 autonomous。
+
+---
+
+## 2. 快速上手（5 分钟跑通 ui-quality-loop）
+
+### 第 1 步：创建项目
+
+```bash
+ccteam new ui-quality --team dev
+```
+
+这会在 `~/projects/dev-ui-quality/` 创建一个新项目目录（slug 自动带 team
+前缀）。`cd ~/projects/dev-ui-quality`。
+
+### 第 2 步：拷贝 workflow + agent 模板
+
+```bash
+# workflow 拓扑
+cp ~/workplace/agents/ccteam/examples/workflows/ui-quality-loop.yaml ./workflow.yaml
+
+# agent 行为定义
+mkdir -p .claude/agents
+cp ~/workplace/agents/ccteam/examples/workflows/agents/{explorer,fixer,reviewer,shipper}.md .claude/agents/
+```
+
+随后 review 并按你的项目改写 `.claude/agents/*.md` 正文 prompt。模板是
+通用骨架，真实 prompt 应描述你的代码栈、UI 规范、验收标准。
+
+### 第 3 步：启动 orchestrator
+
+```bash
+ccteam run dev-ui-quality
+```
+
+orchestrator 启动时：
+
+1. 加载 `workflow.yaml` 并验证（任何 `prompt:` 字段会被 reject）
+2. 验证每个 agent role 都有对应 `.claude/agents/<role>.md`
+3. 注册 inotify watcher 到所有 `watch:` trigger 的路径
+4. 初始化 Gate 状态（默认 locked）
+5. progress.jsonl 写入 `workflow_start` event
+
+### 第 4 步：在 web UI 看 workflow 拓扑
+
+```bash
+ccteam web --bind 127.0.0.1:7331
+# 浏览器打开 http://127.0.0.1:7331/app/projects/dev-ui-quality
+```
+
+可以看到：
+
+- workflow 拓扑图（agent 节点 + trigger 边）
+- artifact 目录浏览（`.ccteam/issues/` / `.ccteam/fixes/` / ...）
+- 当前活跃 session 列表（live 监控走 `claude agents`，web UI 只展示摘要）
+- Gate 状态 + 解锁按钮
+- progress.jsonl 实时流（SSE）
+
+### 第 5 步：触发首轮
+
+通过 meta-agent（推荐）或 CLI：
+
+```bash
+# 通过 meta-agent session（自然语言）
+# 跟 meta-agent 说："现在跑一轮 explorer，让它探索登录页的 UI 问题"
+
+# 或直接 CLI
+ccteam ctl spawn-agent --slug dev-ui-quality --role explorer
+```
+
+之后整个 workflow 自动运转：explorer → 写 issues → watcher 触发 fixer ×
+N（并行）→ 写 fixes → 触发 reviewer → 写 verdicts。
+
+### 第 6 步：解锁 Gate 发布
+
+reviewer 攒够 pass 的 verdict 后，在 web UI 点击 shipper 的 unlock 按钮，
+或 CLI：
+
+```bash
+ccteam ctl trigger-gate --slug dev-ui-quality --gate shipper
+```
+
+shipper 启动 → 整合 fix → 创建 PR → 写 ship-log → 完成。
+
+---
+
+## 3. `workflow.yaml` 完整 schema
+
+```yaml
+name: <string>                # 必填，workflow 名（唯一标识，progress.jsonl 关联用）
+description: <string>         # 可选，给 web UI 展示
+
+agents:
+  <role>:                     # role 名必须有对应 .claude/agents/<role>.md
+    executor: claude | codex  # 必填
+    trigger:                  # 必填，4 选 1
+      manual                  # meta-agent / CLI 显式触发
+      schedule                # 定时（搭配 interval 字段）
+      watch:<path>            # 监听 artifact 目录，新文件即触发
+      gate                    # 等 Gate 解锁（trigger_gate MCP 工具）
+    interval: <duration>      # 仅 trigger: schedule 有效（如 "5m"、"1h"、"30s"）
+    input: <path>             # 可选，通过 CCTEAM_INPUT env 注入；相对项目根
+    output: <path>            # 可选，通过 CCTEAM_OUTPUT env 注入；相对项目根
+    parallelism: <int>        # 可选，默认 1；watch trigger 下最大并发 session 数
+    timeout: <duration>       # 可选，默认无；超时后 meta-agent 收 signal
+    on_timeout: escalate | retry | skip  # 可选，默认 escalate
+```
+
+### 字段说明
+
+| 字段 | 含义 | 必填 | 默认 |
+|---|---|---|---|
+| `name` | workflow 唯一标识 | 是 | - |
+| `description` | web UI 展示用 | 否 | - |
+| `agents.<role>.executor` | `claude` 或 `codex` | 是 | - |
+| `agents.<role>.trigger` | `manual`/`schedule`/`watch:<path>`/`gate` | 是 | - |
+| `agents.<role>.interval` | schedule trigger 的间隔 | 仅 schedule | - |
+| `agents.<role>.input` | 输入目录路径 | 否 | - |
+| `agents.<role>.output` | 输出目录路径 | 否 | - |
+| `agents.<role>.parallelism` | 最大并发 session | 否 | `1` |
+| `agents.<role>.timeout` | 单 session 超时 | 否 | 无 |
+| `agents.<role>.on_timeout` | 超时处理策略 | 否 | `escalate` |
+
+### Schema 红线
+
+| 禁止字段 | 原因 |
+|---|---|
+| `prompt:` | agent 行为由 `.claude/agents/*.md` 定义，不能在 workflow.yaml 里注入 |
+| `system_prompt:` | 同上 |
+| `messages:` | 同上 |
+| `model:` / `temperature:` 等 LLM 参数 | 写到 `.claude/agents/<role>.md` 的 frontmatter `model:` 字段 |
+
+orchestrator 启动时遇到任一禁止字段 = hard error，进程退出非零退出码。
+
+---
+
+## 4. Agent role 文件约定
+
+每个 workflow.yaml 中的 `<role>` 都需要对应一个 `.claude/agents/<role>.md`：
+
+```markdown
+---
+name: <role>                  # 必填，必须和 workflow.yaml 中 role 名一致
+description: <string>         # 必填，一句话说明（Claude Code 选择 agent 时用）
+tools: Read, Write, Bash, ... # 可选，列出该 agent 允许的工具
+model: opus | sonnet | haiku  # 可选，指定 Claude 模型
+color: red | green | blue ... # 可选，web UI 显示色
+---
+
+# 正文 prompt
+
+描述 agent 的任务、输入输出约定、验收标准。可以用 `$CCTEAM_INPUT` /
+`$CCTEAM_OUTPUT` 占位引用 ccteam 注入的环境变量。
+```
+
+### ccteam 注入的环境变量
+
+每次 spawn agent session 时，ccteam 设置以下环境变量：
+
+| Env var | 含义 | 何时有 |
+|---|---|---|
+| `CCTEAM_PROJECT_SLUG` | 当前项目 slug | 总是 |
+| `CCTEAM_ROLE` | 当前 agent role 名 | 总是 |
+| `CCTEAM_SESSION_ID` | 本次 spawn 的 session id | 总是 |
+| `CCTEAM_INPUT` | workflow.yaml `input:` 字段的绝对路径 | 配置了 `input:` 时 |
+| `CCTEAM_OUTPUT` | workflow.yaml `output:` 字段的绝对路径 | 配置了 `output:` 时 |
+| `CCTEAM_WORKFLOW_NAME` | 当前 workflow 名 | 总是 |
+| `CCTEAM_PROJECT_DIR` | 项目根目录绝对路径 | 总是 |
+
+agent prompt 直接 `$CCTEAM_INPUT` 引用即可（shell 风格展开）。
+
+---
+
+## 5. 四种 trigger 详解
+
+### 5.1 `manual`
+
+需要 meta-agent 或人显式调 `ccteam__spawn_agent(role, slug)` 才启动。
+适合：作为流程起点的 agent（如 `explorer`、`searcher`），或者作为应急
+backup（meta-agent 看到流程卡了，手动塞一个 worker）。
+
+```yaml
+explorer:
+  executor: claude
+  trigger: manual
+  output: .ccteam/issues/
+```
+
+### 5.2 `schedule`
+
+按 `interval` 间隔自动 spawn。适合：定时巡检、定时数据抓取。
+
+```yaml
+explorer:
+  executor: claude
+  trigger: schedule
+  interval: 10m          # 也支持 "1h" / "30s" 等
+  output: .ccteam/issues/
+```
+
+**注意**：interval 是**距离上一次 spawn 完成**的时间，不是 wall clock；
+也就是说如果一次 explorer 跑了 5 分钟，下一次会在 15 分钟后 spawn，
+而非 10 分钟。这是为了避免叠加。
+
+### 5.3 `watch:<path>`
+
+inotify 监听某个目录，新文件出现就 spawn 一个下游 agent。
+**这是 V0.4.0 最核心的 trigger 类型**。
+
+```yaml
+fixer:
+  executor: claude
+  trigger: watch:.ccteam/issues/
+  parallelism: 10
+  input: .ccteam/issues/
+  output: .ccteam/fixes/
+```
+
+行为：
+
+1. orchestrator 启动时 mkdir -p `.ccteam/issues/`（lazy 创建）
+2. 注册 inotify `IN_CLOSE_WRITE` 监听
+3. 新文件写完 → debounce 200ms（避免 partial write）→ 触发 spawn
+4. 检查当前 `fixer` session 数 < `parallelism` → spawn；否则 queue
+
+ccteam 不保证 fixer 处理"哪个" issue——fixer 自己 grab 一个未处理的
+issue（用 lock 文件约定），其他 fixer 跳过。详见
+`examples/workflows/agents/fixer.md` 的 "lock 文件协议"。
+
+### 5.4 `gate`
+
+等 Gate 解锁后才能启动。Gate 默认 locked，需要：
+
+- meta-agent 调 `ccteam__trigger_gate("<role>", slug)`
+- 或人在 web UI / CLI 点 unlock
+
+```yaml
+shipper:
+  executor: claude
+  trigger: gate
+  input: .ccteam/verdicts/
+```
+
+Gate 解锁后，shipper spawn 一次（不像 watch 会反复触发）。如果需要
+再跑一次，重新解锁。
+
+---
+
+## 6. Meta-agent MCP 工具（17 个）
+
+V0.4.0 在原 10 个工具基础上新增 7 个。完整列表：
+
+### 原有 10 个（V0.3.x 继承，部分实现更新）
+
+| 工具 | 用途 |
+|---|---|
+| `ccteam__new` | 创建新项目 |
+| `ccteam__ls` | 列出所有项目 |
+| `ccteam__show` | 查看项目详情 |
+| `ccteam__progress` | 读 progress.jsonl 状态 |
+| `ccteam__pause` | 暂停 workflow |
+| `ccteam__resume` | 恢复 workflow |
+| `ccteam__peek` | 查看 session 内容（read-only） |
+| `ccteam__send_to_session` | 向 session 发消息（旧 idle-aware 注入） |
+| `ccteam__inject_decision` | 注入决策点 |
+| （未列；详见 `interfaces.md`） | |
+
+### 新增 7 个（V0.4.0 F65 引入）
+
+| 工具 | 参数 | 用途 |
+|---|---|---|
+| `ccteam__spawn_agent` | `role, project_slug, input_path?` | 立即派一个 agent session（绕过 trigger）|
+| `ccteam__stop_agent` | `session_id` | 软停一个 agent session（写 stop signal 文件，不 kill）|
+| `ccteam__observe_agents` | `project_slug` | 列出当前所有 session 及其状态（读 state.json） |
+| `ccteam__signal` | `session_id, message` | 向运行中 session 发 /btw 风格消息（inbox 文件） |
+| `ccteam__set_parallelism` | `role, n` | 动态调整 role 的 parallelism 上限 |
+| `ccteam__trigger_gate` | `gate_name, project_slug` | 解锁 Gate，使 gate-trigger agent 可启动 |
+| `ccteam__get_artifact_summary` | `project_slug, path` | 读 artifact 目录摘要（文件数、最新 N 条、总大小） |
+
+meta-agent prompt 文档（`~/.claude/CLAUDE.md` 或 meta session 启动注入）
+应列出全部 17 个工具，让 meta-agent 知道可用能力。
+
+---
+
+## 7. Gate 解锁方式
+
+Gate 是 V0.4.0 的显式人机交互检查点。三种解锁方式：
+
+### 7.1 Web UI 点击
+
+```
+http://localhost:7331/app/projects/<slug>
+→ workflow 拓扑图
+→ 点 gate-trigger agent 的 [Unlock] 按钮
+→ 弹出确认（含 artifact 摘要 + 待发布条目数）
+→ 确认 → Gate 解锁
+```
+
+### 7.2 CLI
+
+```bash
+ccteam ctl trigger-gate --slug <slug> --gate <role>
+```
+
+### 7.3 Meta-agent 自动
+
+meta-agent 通过 `ccteam__trigger_gate` 自主决策解锁。**适合 low-risk
+场景**（如：reviewer 100% verdicts pass + cost < $5 → 自动解锁 shipper）。
+meta-agent prompt 应明确约束哪些情况下可自动解锁、哪些必须 surface 给人。
+
+---
+
+## 8. Parallelism 动态调节
+
+watch trigger 下的 `parallelism: N` 字段是**初始默认值**。运行时可以动态改：
+
+```bash
+# Meta-agent 调
+mcp__ccteam__ccteam__set_parallelism(role="fixer", n=5)
+
+# CLI 等价
+ccteam ctl set-parallelism --slug <slug> --role fixer --n 5
+```
+
+降速场景：
+
+- cost 烧太快 → 临时降到 2-3 试水
+- 某 agent 反复 escalate → 降到 1 让 meta-agent 介入排查
+- 上游 explorer 速度过慢，多并发 fixer 也没活干 → 降回默认
+
+升速场景：
+
+- 早期 smoke 后确认逻辑稳定 → 把 fixer parallelism 从 3 提到 10
+- cost budget 充足 + 任务积压 → 提到 20
+
+**注意**：实际并发数也受系统 cost budget guard 影响——见 §9。
+
+---
+
+## 9. Budget 检查（$200 上限）
+
+ccteam 跟踪每个项目累计 cost（读取 `state.json` 中的 `cost_usd` +
+聚合所有 session）。默认上限 **$200 / project**，超出后：
+
+1. progress.jsonl 写入 `budget_exceeded` event
+2. orchestrator 停止 spawn 新 session（**不主动 kill 在跑 session**——红线）
+3. web UI / meta-agent / CLI 都收到 alert
+4. 用户需要：
+   - 调 budget：`ccteam ctl set-budget --slug <slug> --limit 300`
+   - 或降 parallelism + 等已跑 session 完成
+   - 或暂停 workflow：`ccteam ctl pause --slug <slug>`
+
+软告警阈值（不自动 kill）：
+
+- $50 → progress.jsonl `cost_warning_50`
+- $100 → progress.jsonl `cost_warning_100`
+- $200 → `budget_exceeded` + 停止 spawn
+
+---
+
+## 10. 故障排查 FAQ
+
+### Q1: workflow 不启动？
+
+```bash
+# 检查 workflow.yaml 路径
+ls workflow.yaml  # 或 .ccteam/workflow.yaml
+# 检查 schema 是否合法
+ccteam ctl validate-workflow --slug <slug>
+# 看 orchestrator 日志
+tail ~/.ccteam/logs/<slug>.log
+```
+
+常见原因：
+
+- `workflow.yaml` 路径不在搜索列表（搜：项目根 / `.ccteam/workflow.yaml` /
+  `.ccteam/workflows/*.yaml`）
+- `prompt:` 字段被 reject
+- `.claude/agents/<role>.md` 缺失（schema 校验失败）
+
+### Q2: agent 不响应 / 看不到 session 出现？
+
+```bash
+# 查 Claude Code 原生 session 列表
+claude agents
+
+# 查 ccteam 这边的视角
+ccteam ctl observe --slug <slug>
+
+# 直接看 state.json
+ls ~/.claude/jobs/
+cat ~/.claude/jobs/<id>/state.json
+```
+
+常见原因：
+
+- `claude --bg --agent <role>` 实际没派起来（CC 版本 < 2.1.139？）
+- agent role 名不匹配 `.claude/agents/<role>.md`
+- parallelism 已满（看 `ccteam__observe_agents`）
+
+### Q3: artifact 触发失败？写了文件，下游没启动？
+
+```bash
+# 看 inotify watcher 日志
+grep "watcher" ~/.ccteam/logs/<slug>.log
+
+# 看 progress.jsonl 是否有 artifact_event
+ccteam ctl progress --slug <slug> | grep artifact
+```
+
+常见原因：
+
+- 文件写入用了 truncate-then-write（没有 `IN_CLOSE_WRITE`）→
+  建议改用原子写：写到 `.tmp` 再 `mv`
+- 文件路径不在 watch 列表（workflow.yaml `watch:` 字段拼错）
+- debounce 期内有其他文件覆盖（200ms 内）
+
+### Q4: cost 超支？
+
+```bash
+# 查累计 cost
+ccteam ctl show --slug <slug> | grep cost
+# 查每个 agent cost 占比
+ccteam ctl observe --slug <slug> --include-cost
+
+# 立即降速
+ccteam ctl set-parallelism --slug <slug> --role fixer --n 1
+
+# 看 budget_exceeded event
+ccteam ctl progress --slug <slug> | grep budget
+```
+
+常见原因：
+
+- parallelism 设太高 + agent context 没及时 reset
+- 某个 agent 进入 infinite loop（fix-loop escalation 应该 3 次顶住，
+  但偶发 race；查 progress.jsonl `escalation` event）
+- model 选择不当（用了 opus 跑简单 fix）
+
+---
+
+## 11. 从 V0.3.x 迁移
+
+如果你有 V0.3.x phase 驱动项目（`team.yaml::kind: workflow` + `phases:`
+列表）：
+
+```bash
+ccteam doctor --migrate-phase-to-workflow
+```
+
+这个命令会：
+
+1. 检测 `team.yaml::kind: workflow` 的项目
+2. 读取 `phases:` 列表
+3. 生成 `workflow.yaml` 骨架（按 phase 顺序连线）
+4. 生成 `.claude/agents/<phase-name>.md`（迁移 prompt 内容）
+5. 提示你 review 后删除旧 `phases` 字段
+
+完整迁移指南：[`migration-guide.md`](migration-guide.md)。
+
+---
+
+## 12. 进一步阅读
+
+- [`prd.md`](prd.md) — V0.4.0 PRD（架构哲学 + 设计决策）
+- [`migration-guide.md`](migration-guide.md) — V0.3.x phase → V0.4.0 workflow 迁移
+- [`e2e-retro.md`](e2e-retro.md) — F69 ship gate 验收记录
+- [`../tech-design.md`](../tech-design.md) — ccteam 系统设计 SoT
+- [`../interfaces.md`](../interfaces.md) — 协议参考（workflow.yaml schema /
+  MCP 工具签名 / progress.jsonl event 类型）
+- [`../../examples/workflows/`](../../examples/workflows/) — 可拷贝示例

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,159 @@
+# ccteam V0.4.0 示例 workflow
+
+> 本目录提供 V0.4.0 artifact-driven workflow 架构下的可拷贝参考示例。
+> 每个示例 = 一份 `workflow.yaml`（agent 拓扑）+ 一组 `.claude/agents/<role>.md`
+> （agent 行为定义）。**ccteam 不向 workflow.yaml 注入任何 prompt**——agent
+> 的行为完全由对应的 `.claude/agents/<role>.md` 文件决定。
+
+## 示例清单
+
+| 文件 | 场景 | 涉及 agent | 触发模式 |
+|---|---|---|---|
+| [`ui-quality-loop.yaml`](ui-quality-loop.yaml) | UI 质量持续巡检：探索 UI 问题 → 并行修复 → codex review → 人工 Gate → 发布 | explorer / fixer / reviewer / shipper | manual + watch + gate |
+| [`research-loop.yaml`](research-loop.yaml) | 研究信息收集：持续抓取 raw data → 并行评估提炼 insights → codex 审查 → 报告 | searcher / synthesizer / reviewer / reporter | manual + watch + gate |
+
+两个示例都用 4 个 agent 的"扇出 → 扇入 → Gate → 收尾"骨架，
+区别在 input/output 目录约定 + 业务语义。把任何一个当成新 workflow 的起点都行。
+
+## 怎么用（5 分钟跑通 ui-quality-loop）
+
+### 第 1 步：创建项目
+
+```bash
+ccteam new ui-quality --team dev
+# 项目落到 ~/projects/dev-ui-quality/（slug 自动带 team 前缀）
+cd ~/projects/dev-ui-quality
+```
+
+### 第 2 步：拷贝 workflow 模板
+
+```bash
+# 项目根 workflow.yaml（orchestrator 默认查找路径）
+cp ~/workplace/agents/ccteam/examples/workflows/ui-quality-loop.yaml ./workflow.yaml
+# 或放到 .ccteam/workflow.yaml（次选路径，与 .ccteam/ 状态目录同处）
+```
+
+### 第 3 步：拷贝 agent role 模板
+
+```bash
+mkdir -p .claude/agents
+cp ~/workplace/agents/ccteam/examples/workflows/agents/{explorer,fixer,reviewer,shipper}.md .claude/agents/
+```
+
+随后 **逐个 review 并按你的项目改写** `.claude/agents/*.md` 的正文 prompt。模板只是
+起点，真实 prompt 应描述你的具体 UI / 代码栈 / 验收标准。
+
+### 第 4 步：启动 orchestrator
+
+```bash
+ccteam run dev-ui-quality
+# 项目目录内 workflow.yaml 存在时，orchestrator 自动加载
+# 此时 watch trigger 已注册，gate 处于 locked 状态
+```
+
+### 第 5 步：触发首轮探索
+
+通过 meta-agent（自然语言）或直接调 MCP 工具：
+
+```bash
+# 走 meta-agent（推荐）：在 meta-agent session 里说 "现在跑一轮 explorer"
+# 或走 CLI 直接调 spawn_agent：
+ccteam ctl spawn-agent --slug dev-ui-quality --role explorer
+```
+
+explorer 把 UI 问题写到 `.ccteam/issues/`，inotify 自动触发 fixer 并发（最多
+10 个）→ fixer 写 `.ccteam/fixes/` → 触发 reviewer → 写 `.ccteam/verdicts/`。
+
+### 第 6 步：解锁 Gate 发布
+
+reviewer 攒够 verdict 后,在 ccteam-web UI 点击 "shipper" gate 的解锁按钮,
+或 CLI:
+
+```bash
+ccteam ctl trigger-gate --slug dev-ui-quality --gate shipper
+```
+
+shipper 启动,读取 verdict 列表执行发布动作。
+
+## workflow.yaml 字段速查（详见 `docs/v0-4-0/user-manual.md`）
+
+```yaml
+name: <string>                     # workflow 名，唯一标识
+description: <string>              # 可选
+
+agents:
+  <role>:                          # 必须有对应 .claude/agents/<role>.md
+    executor: claude | codex       # 执行环境
+    trigger:
+      manual                       # meta-agent 或 CLI 显式触发
+      schedule                     # 定时（搭配 interval: "5m")
+      watch:<path>                 # 监听 artifact 目录，新文件触发
+      gate                         # 等 Gate 解锁
+    interval: <duration>           # schedule trigger 专用
+    input: <path>                  # CCTEAM_INPUT env 注入
+    output: <path>                 # CCTEAM_OUTPUT env 注入
+    parallelism: <int>             # watch trigger 下的最大并发，默认 1
+    timeout: <duration>            # 可选
+    on_timeout: escalate|retry|skip
+```
+
+**禁止字段**：`prompt:` / `system_prompt:` / `messages:`——schema 级 hard error。
+agent 行为只能写在 `.claude/agents/<role>.md`。
+
+## Agent role 文件（`.claude/agents/<role>.md`）约定
+
+参考 `agents/` 子目录的 4 个模板（`explorer.md` / `fixer.md` /
+`reviewer.md` / `shipper.md`）。所有 agent 文件都遵循 Claude Code 原生格式：
+
+```markdown
+---
+name: <role>
+description: <一句话说明，用于 Claude Code 选择 agent>
+tools: Read, Write, Edit, Bash, ...
+model: opus | sonnet  # 可选
+---
+
+正文 prompt：描述 agent 的任务 / 输入输出约定 / 验收标准。
+```
+
+ccteam 在 spawn agent 时通过环境变量传递上下文：
+
+| Env var | 含义 |
+|---|---|
+| `CCTEAM_PROJECT_SLUG` | 当前项目 slug（如 `dev-ui-quality`）|
+| `CCTEAM_INPUT` | workflow.yaml 中 `input:` 字段的绝对路径 |
+| `CCTEAM_OUTPUT` | workflow.yaml 中 `output:` 字段的绝对路径 |
+| `CCTEAM_ROLE` | 当前 agent role 名 |
+| `CCTEAM_SESSION_ID` | 本次 spawn 的 session id |
+
+agent 在 prompt 里直接引用 `$CCTEAM_INPUT` / `$CCTEAM_OUTPUT` 即可。
+
+## 不直接拷贝模板的话
+
+如果你自己写新 workflow,只要遵守两条规则:
+
+1. `workflow.yaml` 里 **不写一行 prompt**——所有行为 → `.claude/agents/*.md`
+2. agent 间 **只通过 artifact 文件系统目录通信**——不依赖任何 RPC / 共享内存
+
+剩下的 ccteam 帮你管:trigger / parallelism / Gate / progress.jsonl / cost
+统计 / Web UI 拓扑可视化。
+
+## 进阶
+
+- **多 workflow**:一个项目里可以放多份 workflow.yaml(放到
+  `.ccteam/workflows/<name>.yaml`),meta-agent 通过 `select_workflow` 切换
+- **dynamic parallelism**:meta-agent 调用 `ccteam__set_parallelism("fixer", 5)`
+  动态降速,无需重启 orchestrator
+- **escalation**:fix-loop 撞 3 次顶,orchestrator 自动发 `escalate` signal
+  给 meta-agent;meta-agent 决策是改 prompt / 派更强的 model / 还是 surface 给人
+- **跨执行环境**:同一个 workflow 可以混用 `executor: claude` 和
+  `executor: codex`,artifact 目录是唯一通信媒介
+
+## 进一步阅读
+
+- [`../../docs/v0-4-0/user-manual.md`](../../docs/v0-4-0/user-manual.md) —
+  V0.4.0 完整用户手册
+- [`../../docs/v0-4-0/prd.md`](../../docs/v0-4-0/prd.md) —
+  架构哲学 + 核心抽象 + 三层架构
+- [`../../docs/v0-4-0/migration-guide.md`](../../docs/v0-4-0/migration-guide.md) —
+  V0.3.x phase 驱动项目迁移指南

--- a/examples/workflows/agents/explorer.md
+++ b/examples/workflows/agents/explorer.md
@@ -1,0 +1,68 @@
+---
+name: explorer
+description: 探索 web 项目的 UI 问题（视觉 bug、可访问性、性能瑕疵），把发现写成单独 issue 文件落到 $CCTEAM_OUTPUT 目录，供下游 fixer 并行修复。
+tools: Read, Grep, Glob, Bash, WebFetch
+model: sonnet
+---
+
+你是 ccteam workflow 里的 **explorer** agent。你的工作环境：
+
+- `CCTEAM_PROJECT_SLUG`：当前项目 slug（如 `dev-ui-quality`）
+- `CCTEAM_OUTPUT`：你要把发现写入的目录（绝对路径，通常是 `.ccteam/issues/`）
+- `CCTEAM_ROLE`：始终是 `explorer`
+- `CCTEAM_SESSION_ID`：本次 session id，可用于文件名前缀避免冲突
+
+## 任务
+
+巡检本项目的 UI 层（HTML/CSS/前端代码/运行中的页面），发现以下任一类问题：
+
+1. **视觉 bug**：错位、溢出、字体加载失败、颜色不一致
+2. **可访问性**：缺 alt、对比度低、键盘不可达、aria 缺失
+3. **性能瑕疵**：未懒加载图片、未压缩 bundle、阻塞 render 的脚本
+4. **响应式问题**：mobile 视口下的 layout 断裂
+
+每发现一个问题，写一个独立的 issue 文件到 `$CCTEAM_OUTPUT/`，文件名格式：
+
+```
+$CCTEAM_OUTPUT/<UTC_timestamp>-<short-id>.md
+```
+
+每个 issue 文件包含：
+
+```markdown
+# <一句话标题>
+
+## 位置
+<file:line 或 URL + 选择器>
+
+## 现象
+<用户视角的可观察现象，含截图链接 / 复现步骤>
+
+## 影响
+<谁受影响、阻塞何种使用场景>
+
+## 建议修复方向（可选）
+<不强制；fixer 会自己规划，但这里写大方向能减少 fixer round trip>
+```
+
+## 完成 = 写完文件
+
+ccteam 通过 inotify 监听 `$CCTEAM_OUTPUT/`，**文件写完即触发下游 fixer**。
+你不需要通知 orchestrator，也不需要等待 fixer 反馈。一轮 explorer session
+预期产出 5-15 个 issue 文件后即可 `/exit`。
+
+## 调用 ccteam MCP 工具（可选）
+
+如果用户装了 ccteam MCP server，你可以调：
+
+- `mcp__ccteam__ccteam__get_artifact_summary(slug=$CCTEAM_PROJECT_SLUG, path=".ccteam/issues/")`
+  查看已有 issue 列表，避免和 prior session 撞重复
+- `mcp__ccteam__ccteam__progress(slug=$CCTEAM_PROJECT_SLUG)` 查看当前 workflow 整体状态
+
+没装也不影响主任务。
+
+## 不要做的事
+
+- **不要**直接修代码——那是 fixer 的工作
+- **不要**写一个文件包含所有问题——必须一 issue 一文件，否则 fixer 无法并行
+- **不要**等待 fixer 完成——你的任务边界就是 `$CCTEAM_OUTPUT/` 写入完成

--- a/examples/workflows/agents/fixer.md
+++ b/examples/workflows/agents/fixer.md
@@ -1,0 +1,93 @@
+---
+name: fixer
+description: 读取 explorer 写出的单个 UI issue 文件，修复对应代码，把修复 diff 和说明写到 $CCTEAM_OUTPUT 目录，供下游 reviewer 验证。每个 fixer session 只处理一个 issue。
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: sonnet
+---
+
+你是 ccteam workflow 里的 **fixer** agent。你的工作环境：
+
+- `CCTEAM_PROJECT_SLUG`：当前项目 slug
+- `CCTEAM_INPUT`：issue 文件所在目录（绝对路径，通常 `.ccteam/issues/`）
+- `CCTEAM_OUTPUT`：你写修复结果的目录（绝对路径，通常 `.ccteam/fixes/`）
+- `CCTEAM_ROLE`：始终是 `fixer`
+- `CCTEAM_SESSION_ID`：本次 session id，必用于 output 文件名
+
+## 任务
+
+ccteam orchestrator 触发你的时机：`$CCTEAM_INPUT/` 出现了新 issue 文件。
+**多个 fixer session 可能同时跑**（workflow.yaml 中 `parallelism: 10`）。
+
+### 第 1 步：认领一个未处理的 issue
+
+```bash
+# 列出 issues 目录，找一个没有对应 fix 文件的 issue
+ls "$CCTEAM_INPUT"
+ls "$CCTEAM_OUTPUT"
+```
+
+issue 文件名格式：`<timestamp>-<short-id>.md`。对应 fix 文件名：
+`<timestamp>-<short-id>-fix.md`。**先 grab：在 `$CCTEAM_OUTPUT/`
+原子创建一个空 `<short-id>.lock` 文件**（用 `mkdir` 替代 touch 可避免 race）。
+其他并行 fixer session 看到 lock 就跳过。
+
+### 第 2 步：读取 + 理解
+
+```
+Read "$CCTEAM_INPUT/<issue-file>.md"
+```
+
+按 issue 描述定位代码，制定修复方案。如果 issue 模糊或与代码现状不符，
+**写 verdict file 到 `$CCTEAM_OUTPUT/<short-id>-fix.md` 标明 `status: cannot_reproduce`**——
+不要瞎修。
+
+### 第 3 步：执行修复
+
+直接用 Edit / Write 改源码。每个 fixer 在自己的 git worktree 中跑
+（orchestrator 自动 spawn 时设置），不影响其他 fixer。
+
+### 第 4 步：写 fix artifact
+
+```markdown
+# <对应 issue 标题>
+
+## 关联 issue
+$CCTEAM_INPUT/<issue-file>.md
+
+## 改动文件
+- <file1>:<lines>
+- <file2>:<lines>
+
+## 改动摘要
+<人话描述：改了什么、为什么这么改>
+
+## diff
+\`\`\`diff
+<git diff 输出>
+\`\`\`
+
+## 自测
+<本地验证手段：跑了什么命令、看到什么结果>
+
+## 风险
+<如有 breaking change 或边角 case，明示>
+```
+
+写到 `$CCTEAM_OUTPUT/<short-id>-fix.md`。
+
+### 第 5 步：结束
+
+写完即 done。ccteam 通过 inotify 监听 `$CCTEAM_OUTPUT/`，
+**文件写完触发下游 reviewer**。`/exit` 结束 session。
+
+## 调用 ccteam MCP 工具（可选）
+
+- `mcp__ccteam__ccteam__progress(slug=$CCTEAM_PROJECT_SLUG)` 看 workflow 整体状态
+- `mcp__ccteam__ccteam__get_artifact_summary` 看其他 fix 文件的格式参考
+
+## 红线
+
+- **不要**一次改多个 issue——一 fixer session 只处理一个 issue
+- **不要**跳过 lock 步骤——并行 fixer 撞同一个 issue 会浪费 cost
+- **不要**直接发 PR / push——发布是 shipper 的工作（在 Gate 之后）
+- **修不动就写 `status: cannot_reproduce`**——不要硬编强行交差

--- a/examples/workflows/agents/reviewer.md
+++ b/examples/workflows/agents/reviewer.md
@@ -1,0 +1,89 @@
+---
+name: reviewer
+description: 用独立审查视角（codex executor）评估 fixer 产出的修复质量，输出 verdict 文件到 $CCTEAM_OUTPUT，标明是否通过 + 详细问题 + 建议。
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+你是 ccteam workflow 里的 **reviewer** agent。在示例 workflow 中，
+本 agent 由 `executor: codex` 跑（独立模型 + 独立 context，
+避免和 fixer 同质 confirmation bias）。**agent role 文件格式与
+Claude executor 一致**，因为 ccteam 把 role 定义和 executor 解耦。
+
+你的工作环境：
+
+- `CCTEAM_PROJECT_SLUG`：当前项目 slug
+- `CCTEAM_INPUT`：fix artifact 目录（绝对路径，通常 `.ccteam/fixes/`）
+- `CCTEAM_OUTPUT`：你写 verdict 的目录（绝对路径，通常 `.ccteam/verdicts/`）
+- `CCTEAM_ROLE`：始终是 `reviewer`
+- `CCTEAM_SESSION_ID`：本次 session id
+
+## 任务
+
+orchestrator 触发你的时机：`$CCTEAM_INPUT/` 出现新 fix artifact。
+
+### 第 1 步：认领一个未审查的 fix
+
+约定：fix 文件名 `<short-id>-fix.md`，对应 verdict 文件名
+`<short-id>-verdict.md`。先在 `$CCTEAM_OUTPUT/` 原子创建
+`<short-id>.lock` 占位（mkdir 替代 touch）。
+
+### 第 2 步：独立审查
+
+读 fix artifact，然后**独立验证**：
+
+1. **回读源码**：不只看 diff，看修改后的完整 context（前后 30 行）
+2. **跑测试**：`cargo test` / `npm test` 等项目级命令
+3. **复现 issue**：尝试触发原 bug，确认 fix 真的解决
+4. **审查 side effect**：本次 fix 有没有引入新问题（lint / type 错误 /
+   性能退化 / 既有测试 break）
+
+### 第 3 步：写 verdict
+
+```markdown
+# Verdict: <pass | reject | needs_revision>
+
+## 关联 fix
+$CCTEAM_INPUT/<short-id>-fix.md
+
+## 关联 issue
+<追溯到 issue 路径>
+
+## 验证步骤
+1. <step 1：命令 + 结果>
+2. <step 2：...>
+...
+
+## 结论
+<pass / reject / needs_revision，附理由>
+
+## 发现的问题（若有）
+- 问题 1：...
+- 问题 2：...
+
+## 建议
+<可选：给 fixer / shipper 的具体建议>
+```
+
+写到 `$CCTEAM_OUTPUT/<short-id>-verdict.md`。
+
+### 第 4 步：结束
+
+写完即 done。下游 shipper 的 trigger 是 `gate`——
+meta-agent / 人会在 verdict 积累到一定数量后调
+`ccteam__trigger_gate("shipper")` 解锁。**reviewer 不直接触发
+shipper**。
+
+## 调用 ccteam MCP 工具（可选）
+
+- `mcp__ccteam__ccteam__get_artifact_summary(slug=$CCTEAM_PROJECT_SLUG, path=".ccteam/verdicts/")`
+  看现有 verdict pattern
+- `mcp__ccteam__ccteam__signal(session_id=<fixer-sid>, message="...")`
+  如果 verdict 是 `needs_revision`，可以直接给 fixer 发 /btw 风格 hint
+
+## 红线
+
+- **独立验证**，不只信 fix 文件里的 "自测" 字段——fixer 可能 confirmation bias
+- **不要**直接修代码——只 review、写 verdict
+- **不要**跳过 lock 步骤——并行 reviewer 撞同一个 fix 浪费 cost
+- **小问题用 needs_revision，硬阻塞用 reject**——避免一刀切，给 fixer 修复机会

--- a/examples/workflows/agents/shipper.md
+++ b/examples/workflows/agents/shipper.md
@@ -1,0 +1,110 @@
+---
+name: shipper
+description: 在 Gate 解锁后启动，读取已通过 review 的 verdict 列表，整合改动并执行发布流程（commit、PR 创建、merge、deploy）。本 agent 由 trigger:gate 触发，每个 workflow 通常只跑一次/批次。
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: opus
+---
+
+你是 ccteam workflow 里的 **shipper** agent。
+
+**关键区别：本 agent 的 trigger 是 `gate`**——也就是 meta-agent 或人
+显式调用 `ccteam__trigger_gate("shipper")` 之后才会被 spawn。你被
+启动 = `$CCTEAM_INPUT/` 已经有一批通过审查的 verdict，等待发布。
+
+你的工作环境：
+
+- `CCTEAM_PROJECT_SLUG`：当前项目 slug
+- `CCTEAM_INPUT`：verdict 目录（绝对路径，通常 `.ccteam/verdicts/`）
+- `CCTEAM_ROLE`：始终是 `shipper`
+- `CCTEAM_SESSION_ID`：本次 session id
+
+## 任务
+
+### 第 1 步：扫描通过的 verdict
+
+```bash
+# 列出所有 verdict 文件
+ls "$CCTEAM_INPUT"
+# 过滤 status: pass 的
+grep -l "^# Verdict: pass" "$CCTEAM_INPUT"/*-verdict.md
+```
+
+对每个 `pass` 的 verdict，追溯它对应的 fix artifact，再追溯到 git 改动。
+
+### 第 2 步：聚合 + 分类
+
+不一定一次性发布所有 fix。按 **风险等级 / 模块边界** 聚合：
+
+- 低风险样式改动 → 一个 PR
+- 涉及交互逻辑的 → 一个 PR
+- 涉及构建/依赖的 → 单独 PR
+
+每组写一个 PR description，引用对应 issue / fix / verdict 文件路径
+（让 reviewer 在 PR 时可追溯到 audit trail）。
+
+### 第 3 步：执行发布
+
+按用户 / meta-agent 在启动前留下的指令执行。常见步骤（**不一定全跑**，
+按项目约定）：
+
+```bash
+# 跑测试 + lint
+cargo test --workspace
+npm run test
+npm run lint
+
+# 创建 commit + PR
+git add -A
+git commit -m "fix(ui): <PR title>"
+git push -u origin <branch>
+gh pr create --title "..." --body "..."
+
+# 等 CI / 人 review 后 merge（一般 shipper 不主动 merge，留给人）
+```
+
+### 第 4 步：归档
+
+发布完成后，把已处理的 verdict 和对应 fix / issue 移到 archive 目录：
+
+```bash
+mkdir -p .ccteam/archive/$(date -u +%Y%m%d)
+mv $processed_verdicts $processed_fixes $processed_issues .ccteam/archive/<date>/
+```
+
+防止下次 explorer / fixer 重复处理。
+
+### 第 5 步：结束
+
+写一份 ship 总结到 `.ccteam/ship-log/<UTC_timestamp>-shipped.md`：
+
+```markdown
+# Ship Log <timestamp>
+
+## 发布 PR
+- #123: <title> — <verdict refs>
+- #124: ...
+
+## 涉及的 issue / fix / verdict 数量
+- issues: N
+- fixes: M
+- verdicts: K
+
+## 后续 follow-up
+<未发布的 / 卡 Gate 的 / 需要人决策的>
+```
+
+`/exit` 结束 session。
+
+## 调用 ccteam MCP 工具（可选）
+
+- `mcp__ccteam__ccteam__progress(slug=$CCTEAM_PROJECT_SLUG)` 看 workflow 整体状态
+- `mcp__ccteam__ccteam__signal` 通知 meta-agent 本次 ship 完成
+
+## 红线
+
+- **不要**绕过 Gate 自启动——本 agent 只能由 `trigger_gate` 显式启动
+- **不要**主动 merge 到 main——push branch 和 `gh pr create` 即停，
+  最终 merge 由人 / 上层 CI 决定
+- **不要**忽略 reject / needs_revision 的 verdict——只处理 `pass` 的
+- **必须**归档已处理 artifact——否则下一轮会重复
+- **必须**写 ship-log——audit trail 是 ccteam 控制平面的核心

--- a/examples/workflows/research-loop.yaml
+++ b/examples/workflows/research-loop.yaml
@@ -1,0 +1,29 @@
+# examples/workflows/research-loop.yaml
+# 场景：持续抓取原始数据 → 并行评估提炼 insights → codex 审查 → 报告
+
+name: research-loop
+description: 持续抓取 raw data → 并行评估提炼 insights → codex 审查 → 报告
+
+agents:
+  searcher:
+    executor: claude
+    trigger: manual
+    output: .ccteam/research/
+
+  synthesizer:
+    executor: claude
+    trigger: watch:.ccteam/research/
+    parallelism: 3
+    input: .ccteam/research/
+    output: .ccteam/synthesis/
+
+  reviewer:
+    executor: codex
+    trigger: watch:.ccteam/synthesis/
+    input: .ccteam/synthesis/
+    output: .ccteam/reviews/
+
+  reporter:
+    executor: claude
+    trigger: gate
+    input: .ccteam/reviews/

--- a/examples/workflows/ui-quality-loop.yaml
+++ b/examples/workflows/ui-quality-loop.yaml
@@ -1,0 +1,30 @@
+# examples/workflows/ui-quality-loop.yaml
+# 场景：对 web 项目持续探索 UI 问题 → 并行修复 → codex review → 人工 Gate → 发布
+# 拷贝本文件到项目根 workflow.yaml 或 .ccteam/workflow.yaml 使用
+
+name: ui-quality-loop
+description: 探索 UI 问题 → 并行修复 → codex review → 人工 Gate → 发布
+
+agents:
+  explorer:
+    executor: claude
+    trigger: manual
+    output: .ccteam/issues/
+
+  fixer:
+    executor: claude
+    trigger: watch:.ccteam/issues/
+    parallelism: 10
+    input: .ccteam/issues/
+    output: .ccteam/fixes/
+
+  reviewer:
+    executor: codex
+    trigger: watch:.ccteam/fixes/
+    input: .ccteam/fixes/
+    output: .ccteam/verdicts/
+
+  shipper:
+    executor: claude
+    trigger: gate
+    input: .ccteam/verdicts/


### PR DESCRIPTION
## Summary

V0.4.0 ship-gate docs scaffolding (subset of F69). Pure docs/examples, no Rust changes.

Maps to:
- `docs/v0-4-0/prd.md` §7 (示例 workflow) + §9 (迁移路径)
- `docs/v0-4-0/dev-plan.md` §11.1 + §11.4

## Scope (10 files, +1646 LOC, all docs/examples)

- `examples/workflows/ui-quality-loop.yaml` + `research-loop.yaml` + `README.md`
- `examples/workflows/agents/{explorer,fixer,reviewer,shipper}.md` (Claude Code subagent format)
- `docs/v0-4-0/user-manual.md` (497 LOC, full)
- `docs/v0-4-0/migration-guide.md` (424 LOC, full)
- `docs/v0-4-0/e2e-retro.md` (147 LOC, skeleton — ship gate fills in F69 final)

## Notes

Front-running F69 docs while F60-F63 are in flight (worktree-per-finding parallel). Zero file overlap with F60/F61/F62/F63. Final F69 PR will add: e2e tests, version bump 0.4.0, CLAUDE.md baseline.

## Test plan

- [x] No Rust changes — no test impact
- [x] YAML examples match PRD §7 spec verbatim
- [x] Agent .md templates use Claude Code native subagent frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)