### PR TITLE
v0.4.0-f62: Real CodexAdapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -676,74 +676,39 @@ pub fn run_resume(paths: &CcteamPaths, slug: &str) -> Result<()> {
 // V0.3.1 F49 — `ccteam session` handlers for flex teams
 // =====================================================================
 
-/// Add a registered harness session to a flex project. Claude sessions
-/// spawn under `ccteam-<slug>-<sid>` and record in the master
-/// `state.json::sessions` map. Codex intentionally keeps F47's
-/// `NotImplemented` path until the V0.3.2 adapter lands.
+/// Add a registered harness session to a flex project. Both claude
+/// and codex sessions spawn under `ccteam-<slug>-<sid>` via the
+/// harness's adapter and record in the master `state.json::sessions`
+/// map. Codex went real in V0.4.0 F62 (replaces V0.3.1 F47 stub).
 pub fn run_session_add(slug: &str, harness: ccteam_core::HarnessKind) -> Result<()> {
     use ccteam_core::{
-        harness_sid_prefix, ClaudeCodeAdapter, CodexAdapter, HarnessAdapter, HarnessError,
-        HarnessKind, SessionRecord, SpawnOpts, TeamKind,
+        harness_sid_prefix, ClaudeCodeAdapter, CodexAdapter, HarnessAdapter, HarnessKind,
+        SessionRecord, SpawnOpts, TeamKind,
     };
 
-    match harness {
-        HarnessKind::Codex => {
-            // Construct minimal SpawnOpts — every value is a placeholder
-            // because the stub returns `NotImplemented` before reading
-            // any of them. We still pass a realistic shape (cwd =
-            // `~/projects/<slug>`) so V0.3.2's real impl can swap in
-            // here without changing the caller.
-            let cwd = ccteam_core::CcteamPaths::from_env()
-                .map(|p| p.project_dir(slug))
-                .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
-            let opts = SpawnOpts {
-                harness: "codex",
-                slug: slug.to_string(),
-                sid: "codex-1".to_string(),
-                cwd,
-                extra_args: Vec::new(),
-            };
-            match CodexAdapter::new().spawn_session(opts) {
-                Ok(_handle) => bail!(
-                    "internal error: V0.3.1 CodexAdapter::spawn_session returned Ok — \
-                     the stub must return NotImplemented (PRD §F47); \
-                     please file a bug",
-                ),
-                Err(HarnessError::NotImplemented { harness, reason }) => {
-                    bail!(
-                        "ccteam session add --harness=codex: harness `{harness}` is \
-                         deferred to V0.3.2 — {reason}",
-                    );
-                }
-                Err(other) => {
-                    // Any other error variant means the stub regressed
-                    // (e.g. someone added a real spawn path that fails
-                    // before reaching NotImplemented). Surface verbatim.
-                    bail!(
-                        "ccteam session add --harness=codex: unexpected error from \
-                         CodexAdapter (V0.3.1 must always return NotImplemented): {other}",
-                    );
-                }
-            }
-        }
+    let paths = CcteamPaths::from_env()?;
+    let state_path = paths.project_state(slug);
+    let mut state = load_project_state(&paths, slug)?;
+    refresh_state_team_kind(&paths, &mut state)?;
+    if state.team_kind != TeamKind::Flex {
+        bail_session_requires_flex(&state)?;
+    }
+
+    let sid = state.allocate_sid(harness);
+    let session_dir = paths.project_session_dir(slug, &sid);
+    std::fs::create_dir_all(session_dir.join("inbox"))
+        .with_context(|| format!("create {}", session_dir.join("inbox").display()))?;
+    std::fs::create_dir_all(session_dir.join("outbox"))
+        .with_context(|| format!("create {}", session_dir.join("outbox").display()))?;
+
+    // Adapter dispatch — every harness shares the SpawnOpts schema so
+    // the call sites differ only in which `Adapter::new()` runs. The
+    // V0.3.1 F47 codex branch returned NotImplemented; V0.4.0 F62
+    // swaps in the real tmux + codex CLI implementation.
+    let handle = match harness {
         HarnessKind::Claude => {
-            let paths = CcteamPaths::from_env()?;
-            let state_path = paths.project_state(slug);
-            let mut state = load_project_state(&paths, slug)?;
-            refresh_state_team_kind(&paths, &mut state)?;
-            if state.team_kind != TeamKind::Flex {
-                bail_session_requires_flex(&state)?;
-            }
-
-            let sid = state.allocate_sid(harness);
-            let session_dir = paths.project_session_dir(slug, &sid);
-            std::fs::create_dir_all(session_dir.join("inbox"))
-                .with_context(|| format!("create {}", session_dir.join("inbox").display()))?;
-            std::fs::create_dir_all(session_dir.join("outbox"))
-                .with_context(|| format!("create {}", session_dir.join("outbox").display()))?;
-
             let adapter = ClaudeCodeAdapter::new();
-            let handle = adapter
+            adapter
                 .spawn_session(SpawnOpts {
                     harness: adapter.name(),
                     slug: slug.to_string(),
@@ -751,32 +716,44 @@ pub fn run_session_add(slug: &str, harness: ccteam_core::HarnessKind) -> Result<
                     cwd: session_dir.clone(),
                     extra_args: Vec::new(),
                 })
-                .map_err(|err| anyhow::anyhow!("{err}"))?;
-
-            let was_empty = state.sessions.is_empty();
-            if was_empty {
-                state.tmux_session = handle.tmux_session.clone();
-                state.claude_pid = handle.pid.and_then(|pid| i32::try_from(pid).ok());
-            }
-            state.sessions.insert(
-                sid.clone(),
-                SessionRecord {
-                    harness,
-                    tmux_session: handle.tmux_session.clone(),
-                    started_at: handle.started_at,
-                    pid: handle.pid,
-                },
-            );
-            state.save(&state_path)?;
-            println!(
-                "added session {sid} ({}) for {slug}\n  tmux: {}\n  cwd: {}",
-                harness_sid_prefix(harness),
-                handle.tmux_session,
-                session_dir.display(),
-            );
-            Ok(())
+                .map_err(|err| anyhow::anyhow!("{err}"))?
         }
+        HarnessKind::Codex => {
+            let adapter = CodexAdapter::new();
+            adapter
+                .spawn_session(SpawnOpts {
+                    harness: adapter.name(),
+                    slug: slug.to_string(),
+                    sid: sid.clone(),
+                    cwd: session_dir.clone(),
+                    extra_args: Vec::new(),
+                })
+                .map_err(|err| anyhow::anyhow!("{err}"))?
+        }
+    };
+
+    let was_empty = state.sessions.is_empty();
+    if was_empty {
+        state.tmux_session = handle.tmux_session.clone();
+        state.claude_pid = handle.pid.and_then(|pid| i32::try_from(pid).ok());
     }
+    state.sessions.insert(
+        sid.clone(),
+        SessionRecord {
+            harness,
+            tmux_session: handle.tmux_session.clone(),
+            started_at: handle.started_at,
+            pid: handle.pid,
+        },
+    );
+    state.save(&state_path)?;
+    println!(
+        "added session {sid} ({}) for {slug}\n  tmux: {}\n  cwd: {}",
+        harness_sid_prefix(harness),
+        handle.tmux_session,
+        session_dir.display(),
+    );
+    Ok(())
 }
 
 /// Print one row per registered flex session.
@@ -1334,7 +1311,7 @@ fn render_codex_detection_line() -> String {
 
 fn fallback_not_found_line() -> String {
     String::from(
-        "[ccteam] codex CLI: not found (V0.3.1 trait-stub only; install codex CLI for V0.3.2+ — see docs/research/ccteam-codex-integration.md)\n",
+        "[ccteam] codex CLI: not found (install for V0.4.0 CodexAdapter — see docs/research/ccteam-codex-integration.md)\n",
     )
 }
 

--- a/crates/ccteam-cli/tests/session_cli_test.rs
+++ b/crates/ccteam-cli/tests/session_cli_test.rs
@@ -190,33 +190,33 @@ fn session_add_claude_spawns_tmux_session_and_records_state() {
 }
 
 #[test]
-fn session_add_codex_exits_with_v0_3_2_pointer() {
-    // F47 verification target — exercises CodexAdapter::spawn_session's
-    // NotImplemented error path through the full CLI stack.
+fn session_add_codex_no_longer_returns_v0_3_1_stub_error() {
+    // V0.4.0 F62 regression guard: CodexAdapter::spawn_session is no
+    // longer the V0.3.1 NotImplemented stub. Invoking
+    // `ccteam session add --harness=codex` against a non-existent
+    // project must fail with the *project-not-found* path (or the
+    // tmux/codex-CLI not-found path on hosts without those bins) —
+    // never with the legacy "V0.3.2 deferral" stub message.
     let out = Command::new(cct_bin())
         .args(["session", "add", "some-slug", "--harness=codex"])
         .output()
         .expect("spawn ccteam session add --harness=codex");
     assert!(
         !out.status.success(),
-        "ccteam session add --harness=codex must exit non-zero (V0.3.1 stub); \
+        "ccteam session add --harness=codex against unknown project must exit non-zero; \
          stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),
     );
-    assert_eq!(
-        out.status.code(),
-        Some(1),
-        "ccteam session add --harness=codex should exit code 1",
-    );
     let stderr = String::from_utf8_lossy(&out.stderr);
+    // Legacy V0.3.1 stub strings must not surface anymore.
     assert!(
-        stderr.contains("V0.3.2"),
-        "stderr should cite V0.3.2 deferral; got:\n{stderr}",
+        !stderr.contains("trait-stub in V0.3.1"),
+        "V0.3.1 stub message leaked post-F62; got:\n{stderr}",
     );
     assert!(
-        stderr.contains("docs/research/ccteam-codex-integration.md"),
-        "stderr should cite codex-integration research doc; got:\n{stderr}",
+        !stderr.contains("deferred to V0.3.2"),
+        "V0.3.1 stub deferral message leaked post-F62; got:\n{stderr}",
     );
 }
 

--- a/crates/ccteam-core/Cargo.toml
+++ b/crates/ccteam-core/Cargo.toml
@@ -37,3 +37,18 @@ ab_glyph = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+
+# V0.4.0 F62 — codex-tests serialises tmux-touching integration tests
+# so concurrent CodexAdapter spawn/shutdown checks don't race on the
+# shared `tmux` server. Pinned to the same major as ccteam-web's
+# dev-dependency for cargo dedup.
+serial_test = "3"
+
+[features]
+default = []
+# V0.4.0 F62 — gates CodexAdapter integration tests
+# (`crates/ccteam-core/tests/codex_adapter_test.rs`). The tests require
+# `tmux` on PATH and exercise the real `codex` CLI when present.
+# Default feature set excludes them so CI without those binaries still
+# passes; opt in with `cargo test --features codex-tests`.
+codex-tests = []

--- a/crates/ccteam-core/src/harness.rs
+++ b/crates/ccteam-core/src/harness.rs
@@ -53,9 +53,12 @@ use crate::tmux::{session_name_for_slug, TmuxSession};
 pub const DEFAULT_CLAUDE_SID: &str = "claude-1";
 
 /// Adapter contract for any LLM "harness" ccteam may host inside a
-/// tmux session. V0.3.1 F46 ships [`ClaudeCodeAdapter`]; F47 will add
-/// `CodexAdapter` as a stub returning `Err(NotImplemented)` from every
-/// fallible method.
+/// tmux session. V0.3.1 F46 shipped [`ClaudeCodeAdapter`]; V0.3.1 F47
+/// landed `CodexAdapter` as a trait stub that returned
+/// `Err(NotImplemented)`; V0.4.0 F62 replaced that stub with a real
+/// tmux + codex CLI implementation. The `NotImplemented` error
+/// variant remains on [`HarnessError`] for any future harness whose
+/// integration ships in stages.
 ///
 /// Implementations are stateless — a single `'static` instance can be
 /// shared across all sessions of that harness type. Callers choose the
@@ -204,11 +207,13 @@ pub enum HarnessError {
     /// timed out or tmux refused the kill request.
     #[error("shutdown failed: {0}")]
     ShutdownFailed(String),
-    /// Adapter declares the surface unsupported. F47's `CodexAdapter`
-    /// returns this from every fallible method until V0.3.2 fills it
-    /// in; the `&'static str` payloads keep const-string callsites
+    /// Adapter declares the surface unsupported. V0.3.1 F47 used this
+    /// for the `CodexAdapter` stub until V0.4.0 F62 swapped in the
+    /// real implementation. The variant is preserved on the enum for
+    /// any future harness whose integration lands in stages; the
+    /// `&'static str` payloads keep const-string callsites
     /// allocation-free.
-    #[error("harness '{harness}' not implemented in V0.3.1: {reason}")]
+    #[error("harness '{harness}' not implemented: {reason}")]
     NotImplemented {
         harness: &'static str,
         reason: &'static str,
@@ -378,50 +383,162 @@ fn send_exit_command(tmux_session: &str) -> std::io::Result<()> {
 }
 
 // =====================================================================
-// CodexAdapter (V0.3.1 F47 — trait-stub only)
+// CodexAdapter (V0.4.0 F62 — real tmux + codex CLI implementation)
 // =====================================================================
 
-/// V0.3.1 F47 [`HarnessAdapter`] stub for OpenAI's `codex` CLI. Every
-/// fallible method returns [`HarnessError::NotImplemented`] with a
-/// `&'static str` reason pointing operators at the V0.3.2 tracking
-/// doc + the upstream codex integration research note.
+/// V0.4.0 F62 [`HarnessAdapter`] implementation for OpenAI's `codex`
+/// CLI. Replaces the V0.3.1 F47 trait stub (which returned
+/// [`HarnessError::NotImplemented`] from every fallible method).
 ///
-/// The stub exists so:
+/// Architecture (`docs/v0-4-0/prd.md` §6.5 + dev-plan §4):
 ///
-/// 1. F47 PR can land the **trait shape** (`harness: codex` accepted
-///    by `team.yaml::sessions[]` and `ccteam session add --harness codex`)
-///    without F47 also having to ship the real Codex bridge — that
-///    work is `~month` of integration plumbing tracked in
-///    `docs/research/ccteam-codex-integration.md` M1-M5.
-/// 2. V0.3.2's real `CodexAdapter` impl can swap into this slot
-///    without touching any caller (the trait surface is closed).
-/// 3. Users who flip `--harness codex` early get a friendly error
-///    pointing to the tracking issue rather than panic / silent fall
-///    back to claude.
+/// - **Transport**: tmux long-session, mirroring `ClaudeCodeAdapter`.
+///   A detached tmux session named `ccteam-<slug>-<sid>` hosts the
+///   `codex` process; `pane_pid` is read once post-spawn for liveness
+///   checks. Distinct from F61's ClaudeCode `--bg` job_id path — codex
+///   does not (yet) expose an equivalent background-runner protocol,
+///   so tmux remains the canonical session container.
+/// - **Status channel**: codex has no native statusline / stdin-JSON
+///   surface. [`Self::ingest_snapshot`] reads the last few lines of
+///   the tmux pane via `capture-pane -p` and greps for a
+///   `CODEX_STATUS: <json>` marker line that the codex agent (or the
+///   workflow's role .md) is expected to print after each turn. When
+///   no marker is found, the adapter returns a permissive default
+///   snapshot (`ctx_pct=0`, `cost=0`, model="codex") rather than
+///   failing — the snapshot pipeline is presentation-only (red line
+///   in CLAUDE.md §三 / PRD §3.3), so a missing tail is not an error.
+/// - **State observation file**: a `~/.ccteam/codex/<sid>/state.json`
+///   is written at spawn time mirroring `ClaudeCodeAdapter`'s
+///   statusline dual-write file shape. This lets F66 orchestrator
+///   surfaces consume codex state through the same observe-file
+///   pattern as claude. Best-effort write: a failing write does not
+///   block spawn (we still own the tmux session).
+/// - **Shutdown**: graceful `q\r` send-keys (codex's documented
+///   quit-bind), 500ms grace period, then `tmux kill-session -t
+///   <name>` fallback. Only kills the session we own (matched by the
+///   `SessionHandle::tmux_session` name) — never `kill-server` or
+///   pattern-matched kills (red line in this PR's grep checks).
 ///
 /// Stateless zero-size — share one `'static` instance.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CodexAdapter;
 
-/// V0.3.1 F47 stub reason — a single harmonized constant referenced
-/// from every `HarnessAdapter` method. Keeping this `&'static str`
-/// preserves the `NotImplemented::reason: &'static str` contract
-/// (CLAUDE.md §三 / PRD §4.2.1) so the stub is allocation-free.
+/// Marker line the codex agent prints in its tmux pane to publish
+/// state to the observer (PRD §6.5 + dev-plan §3.2). The parser greps
+/// the last few `capture-pane` lines for this prefix and JSON-decodes
+/// the trailing payload. Spelled out as a `&'static str` so callers
+/// (tests, future code-gen) can pattern-match the same literal.
+pub const CODEX_STATUS_MARKER: &str = "CODEX_STATUS:";
+
+/// Number of trailing pane lines an observer (the F66 watcher, the
+/// integration test in `tests/codex_adapter_test.rs`) is expected to
+/// capture from a codex tmux session before feeding the pane body to
+/// [`CodexAdapter::ingest_snapshot`]. Five lines balances signal
+/// (codex agents typically print the marker as the last line of a
+/// reply) against pane noise (longer tails may include earlier
+/// snapshots whose JSON has since been superseded). Bumped via PR if
+/// real-world agents start emitting status further from the tail.
 ///
-/// Both substrings the F47 verification tests check — `"V0.3.2"` and
-/// `"docs/research/ccteam-codex-integration.md"` — are present here,
-/// so any caller pattern-matching `NotImplemented { harness: "codex",
-/// reason }` can rely on both citations being available.
-const CODEX_NOT_IMPLEMENTED_REASON: &str =
-    "Codex adapter is trait-stub in V0.3.1; full Codex CLI integration deferred to V0.3.2+ \
-     — see docs/research/ccteam-codex-integration.md M1-M5 and docs/v0-3-1/prd.md §F47. \
-     Use --harness=claude or wait for V0.3.2.";
+/// `ingest_snapshot` itself ignores tail size — it scans every line
+/// the caller passed in — but exposing the constant lets callers and
+/// tests agree on the canonical capture window.
+pub const CODEX_STATUS_TAIL_LINES: usize = 5;
 
 impl CodexAdapter {
     /// Build a fresh `CodexAdapter`. Const so callers can write
     /// `static CX: CodexAdapter = CodexAdapter::new();`.
     pub const fn new() -> Self {
         Self
+    }
+
+    /// Resolve `~/.ccteam/codex/<sid>/state.json` for a session. The
+    /// directory mirrors the F46 `harness/` dual-write layout — one
+    /// directory per harness so observer code can iterate cleanly.
+    ///
+    /// Returns `None` if `CcteamPaths::from_env()` fails (HOME unset
+    /// in some test contexts) — the caller treats that as a soft
+    /// no-op and still owns the tmux session.
+    fn state_json_path(sid: &str) -> Option<PathBuf> {
+        let paths = CcteamPaths::from_env().ok()?;
+        Some(paths.root.join("codex").join(sid).join("state.json"))
+    }
+
+    /// Best-effort write of the initial `state.json` post-spawn. Shape
+    /// mirrors what `ClaudeCodeAdapter`'s statusline dual-write
+    /// produces so the F66 / F65 orchestrator's observer can read both
+    /// harnesses uniformly. Silent failure: returns `Ok(())` even if
+    /// the directory create or rename failed (we logged the warn) so
+    /// `spawn_session` doesn't propagate a non-fatal observer error
+    /// to the caller's `SessionHandle` flow.
+    fn write_initial_state(sid: &str, pid: Option<u32>) {
+        let Some(target) = Self::state_json_path(sid) else {
+            return;
+        };
+        let body = serde_json::json!({
+            "status": "starting",
+            "pid": pid,
+            "model": "codex",
+            "context_pct": 0,
+            "cost_usd": 0.0,
+        });
+        let raw = match serde_json::to_string(&body) {
+            Ok(s) => s,
+            Err(err) => {
+                tracing::warn!(error = %err, sid = %sid, "codex state.json serialise");
+                return;
+            }
+        };
+        if let Some(parent) = target.parent() {
+            if let Err(err) = std::fs::create_dir_all(parent) {
+                tracing::warn!(error = %err, path = %parent.display(), "codex state.json mkdir");
+                return;
+            }
+        }
+        if let Err(err) = std::fs::write(&target, raw.as_bytes()) {
+            tracing::warn!(error = %err, path = %target.display(), "codex state.json write");
+        }
+    }
+
+    /// Parse a tmux `capture-pane -p` body for the `CODEX_STATUS:`
+    /// marker line. Returns the JSON payload of the **last** matching
+    /// line (most recent status wins). Free function so tests can
+    /// drive it without spawning tmux.
+    fn parse_status_line(pane: &str) -> Option<serde_json::Value> {
+        pane.lines()
+            .rev()
+            .find_map(|line| line.trim().strip_prefix(CODEX_STATUS_MARKER))
+            .and_then(|rest| serde_json::from_str(rest.trim()).ok())
+    }
+
+    /// Build a `HarnessSnapshot` from a parsed `CODEX_STATUS:` JSON
+    /// payload (or `None` for the fallback shape). Field set matches
+    /// `HarnessSnapshot`'s normalized shape; codex-side keys are
+    /// optional and pluck through the existing `pluck_*` helpers for
+    /// forward-compat with future codex agent contracts.
+    fn snapshot_from_status(payload: Option<serde_json::Value>) -> HarnessSnapshot {
+        let value = payload.unwrap_or(serde_json::Value::Null);
+        let model_display_name = pluck_str(&value, &["model"])
+            .or_else(|| pluck_str(&value, &["model_display_name"]))
+            .unwrap_or_else(|| "codex".to_string());
+        let context_used_pct = pluck_pct(&value, &["context_pct"])
+            .or_else(|| pluck_pct(&value, &["context_used_pct"]))
+            .unwrap_or(0);
+        let cost_usd_total = pluck_f64(&value, &["cost_usd"])
+            .or_else(|| pluck_f64(&value, &["cost_usd_total"]))
+            .unwrap_or(0.0);
+        let rate_limit_pct = pluck_pct(&value, &["rate_limit_pct"]);
+        let cwd = pluck_str(&value, &["cwd"]).map(PathBuf::from);
+
+        HarnessSnapshot {
+            harness: "codex".to_string(),
+            model_display_name,
+            context_used_pct,
+            cost_usd_total,
+            rate_limit_pct,
+            cwd,
+            raw: value,
+            captured_at: Utc::now(),
+        }
     }
 }
 
@@ -430,26 +547,131 @@ impl HarnessAdapter for CodexAdapter {
         "codex"
     }
 
-    fn ingest_snapshot(&self, _raw: &str) -> Result<HarnessSnapshot, HarnessError> {
-        Err(HarnessError::NotImplemented {
-            harness: "codex",
-            reason: CODEX_NOT_IMPLEMENTED_REASON,
+    /// Ingest a tmux pane capture (passed as `raw`) for codex status
+    /// data. Unlike [`ClaudeCodeAdapter::ingest_snapshot`] which
+    /// consumes structured statusline JSON, this method accepts the
+    /// raw tmux pane body (caller is the observer that already ran
+    /// `capture-pane -p`) and greps for the `CODEX_STATUS:` marker.
+    ///
+    /// Permissive: missing / malformed marker returns the fallback
+    /// snapshot (`model="codex"`, zero pct/cost) rather than failing.
+    /// The snapshot pipeline is presentation-only — see CLAUDE.md
+    /// §三 / PRD §3.3.
+    fn ingest_snapshot(&self, raw: &str) -> Result<HarnessSnapshot, HarnessError> {
+        let payload = Self::parse_status_line(raw);
+        Ok(Self::snapshot_from_status(payload))
+    }
+
+    /// Spawn a codex tmux session. The command is `codex` with
+    /// `opts.extra_args` appended verbatim — callers (F65 meta-agent
+    /// MCP `spawn_agent`, the F49 CLI surface) thread role-specific
+    /// arguments (`exec --sandbox workspace-write --cd <cwd>`, prompt
+    /// strings, etc.) through `extra_args` to stay schema-stable.
+    /// When `extra_args` is empty, codex starts in default interactive
+    /// mode and waits for human input on the tmux pane.
+    fn spawn_session(&self, opts: SpawnOpts) -> Result<SessionHandle, HarnessError> {
+        let tmux_session = format!("{}-{}", session_name_for_slug(&opts.slug), opts.sid)
+            // session_name_for_slug already prepends "ccteam-", so the
+            // result is "ccteam-<slug>-<sid>" matching the F49 spec.
+            .trim_start_matches('-')
+            .to_string();
+
+        // Defense in depth: refuse to spawn over an existing session
+        // — that would mean the F49 master state.json::next_sid_seq
+        // bookkeeping drifted and reused a sid.
+        let session = TmuxSession::from_name(tmux_session.clone());
+        if session.exists() {
+            return Err(HarnessError::SpawnFailed(format!(
+                "tmux session already exists: {tmux_session} \
+                 (sid collision; F49 next_sid_seq accounting drifted)"
+            )));
+        }
+
+        // Base argv: bare `codex` so the session is interactive by
+        // default; F65 passes `exec --sandbox … "--cd" <cwd>` etc. via
+        // `extra_args`. Mirrors `ClaudeCodeAdapter`'s argv layout.
+        let mut argv: Vec<String> = vec!["codex".to_string()];
+        argv.extend(opts.extra_args.iter().cloned());
+        let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+
+        session
+            .start(&opts.cwd, &argv_refs)
+            .map_err(|err| HarnessError::SpawnFailed(format!("tmux new-session: {err:#}")))?;
+
+        let pid = session
+            .pane_pid()
+            .ok()
+            .flatten()
+            .and_then(|n| u32::try_from(n).ok());
+
+        // Best-effort observe-file write so F66's reader sees a fresh
+        // state.json immediately. Failure is logged and swallowed —
+        // the tmux session is the source of truth, not this file.
+        Self::write_initial_state(&opts.sid, pid);
+
+        Ok(SessionHandle {
+            tmux_session,
+            harness: self.name().to_string(),
+            sid: opts.sid,
+            pid,
+            started_at: Utc::now(),
         })
     }
 
-    fn spawn_session(&self, _opts: SpawnOpts) -> Result<SessionHandle, HarnessError> {
-        Err(HarnessError::NotImplemented {
-            harness: "codex",
-            reason: CODEX_NOT_IMPLEMENTED_REASON,
-        })
+    /// Graceful shutdown of a codex tmux session. Sends `q` + Enter
+    /// (codex's documented quit binding), waits 500ms for the process
+    /// to drain, then `tmux kill-session -t <handle.tmux_session>` as
+    /// the authoritative cleanup. Targets only the named session — no
+    /// `kill-server` / pattern kills (red line CLAUDE.md §三).
+    fn shutdown_session(&self, handle: &SessionHandle) -> Result<(), HarnessError> {
+        let session = TmuxSession::from_name(handle.tmux_session.clone());
+        if !session.exists() {
+            // Already gone — treat as success (idempotent, matches the
+            // ClaudeCodeAdapter shutdown contract).
+            return Ok(());
+        }
+        if let Err(err) = send_codex_quit_keys(&handle.tmux_session) {
+            tracing::warn!(
+                error = %err,
+                session = %handle.tmux_session,
+                "CodexAdapter::shutdown_session: send-keys q failed; \
+                 falling through to tmux kill-session",
+            );
+        }
+        std::thread::sleep(Duration::from_millis(500));
+        if session.exists() {
+            session.kill().map_err(|err| {
+                HarnessError::ShutdownFailed(format!("tmux kill-session: {err:#}"))
+            })?;
+        }
+        Ok(())
     }
+}
 
-    fn shutdown_session(&self, _handle: &SessionHandle) -> Result<(), HarnessError> {
-        Err(HarnessError::NotImplemented {
-            harness: "codex",
-            reason: CODEX_NOT_IMPLEMENTED_REASON,
-        })
+/// Send `q` + Enter to the named tmux session — codex's standard
+/// quit keybinding. Separate from `send_exit_command` (Claude Code's
+/// `/exit` slash-command) so the two harnesses' shutdown grammars
+/// stay distinct.
+fn send_codex_quit_keys(tmux_session: &str) -> std::io::Result<()> {
+    let send_lit = Command::new("tmux")
+        .args(["send-keys", "-t", tmux_session, "-l", "--", "q"])
+        .output()?;
+    if !send_lit.status.success() {
+        return Err(std::io::Error::other(format!(
+            "tmux send-keys -l q: {}",
+            String::from_utf8_lossy(&send_lit.stderr)
+        )));
     }
+    let send_enter = Command::new("tmux")
+        .args(["send-keys", "-t", tmux_session, "Enter"])
+        .output()?;
+    if !send_enter.status.success() {
+        return Err(std::io::Error::other(format!(
+            "tmux send-keys Enter: {}",
+            String::from_utf8_lossy(&send_enter.stderr)
+        )));
+    }
+    Ok(())
 }
 
 // =====================================================================
@@ -530,10 +752,7 @@ pub fn write_harness_snapshot(paths: &CcteamPaths, cwd: &Path, raw: &str) -> std
         std::fs::create_dir_all(parent)?;
     }
     let tmp = match target.file_name() {
-        Some(name) => target.with_file_name(format!(
-            "{}.tmp",
-            name.to_str().unwrap_or("snapshot")
-        )),
+        Some(name) => target.with_file_name(format!("{}.tmp", name.to_str().unwrap_or("snapshot"))),
         None => return Ok(false),
     };
     std::fs::write(&tmp, raw.as_bytes())?;
@@ -708,9 +927,7 @@ mod tests {
     #[test]
     fn ingest_malformed_json_returns_ingest_failed() {
         let raw = r#"{"model": "broken"#;
-        let err = ClaudeCodeAdapter::new()
-            .ingest_snapshot(raw)
-            .unwrap_err();
+        let err = ClaudeCodeAdapter::new().ingest_snapshot(raw).unwrap_err();
         assert!(matches!(err, HarnessError::IngestFailed(_)));
     }
 
@@ -753,9 +970,7 @@ mod tests {
         assert!(target.exists());
         assert_eq!(std::fs::read_to_string(&target).unwrap(), raw);
         // No leftover .tmp.
-        let tmp_target = paths
-            .harness_dir()
-            .join("dev-foo-claude-1.json.tmp");
+        let tmp_target = paths.harness_dir().join("dev-foo-claude-1.json.tmp");
         assert!(!tmp_target.exists());
     }
 
@@ -796,14 +1011,14 @@ mod tests {
         assert!(ClaudeCodeAdapter::new().subagent_states(&snap).is_empty());
     }
 
-    // ----- CodexAdapter (V0.3.1 F47 stub) -----
+    // ----- CodexAdapter (V0.4.0 F62 real implementation) -----
     //
-    // Every fallible method must return `HarnessError::NotImplemented`
-    // with `&'static str` payloads citing both V0.3.2 and the
-    // codex-integration research doc (PRD §F47 §4.2.1). The reason
-    // strings are harmonized across all three methods so callers
-    // (including the F49 `ccteam session add` CLI surface) can match
-    // the same two substrings on every method.
+    // Unit tests cover the pure-Rust surfaces that don't need tmux or
+    // the codex CLI: name stability, snapshot parsing, fallback shape,
+    // status JSON round-trip. The tmux-bearing surfaces
+    // (`spawn_session`, `shutdown_session`) live in
+    // `crates/ccteam-core/tests/codex_adapter_test.rs` under the
+    // `codex-tests` feature gate (PR §3.5).
 
     #[test]
     fn codex_adapter_name_is_codex() {
@@ -815,65 +1030,75 @@ mod tests {
     }
 
     #[test]
-    fn codex_adapter_spawn_returns_not_implemented_with_v0_3_2_reason() {
-        let opts = SpawnOpts {
-            harness: "codex",
-            slug: "flex-foo".into(),
-            sid: "codex-1".into(),
-            cwd: PathBuf::from("/tmp"),
-            extra_args: Vec::new(),
-        };
-        match CodexAdapter::new().spawn_session(opts).unwrap_err() {
-            HarnessError::NotImplemented { harness, reason } => {
-                assert_eq!(harness, "codex");
-                assert!(
-                    reason.contains("V0.3.2"),
-                    "reason should cite V0.3.2: {reason}",
-                );
-                assert!(
-                    reason.contains("docs/research/ccteam-codex-integration.md"),
-                    "reason should cite codex-integration research doc: {reason}",
-                );
-            }
-            other => panic!("expected NotImplemented, got {other:?}"),
-        }
+    fn codex_adapter_ingest_empty_pane_returns_fallback_snapshot() {
+        // No CODEX_STATUS line → permissive fallback (snapshot pipeline
+        // is presentation-only; PRD §3.3). model="codex", zero pct/cost.
+        let snap = CodexAdapter::new()
+            .ingest_snapshot("")
+            .expect("permissive fallback");
+        assert_eq!(snap.harness, "codex");
+        assert_eq!(snap.model_display_name, "codex");
+        assert_eq!(snap.context_used_pct, 0);
+        assert_eq!(snap.cost_usd_total, 0.0);
+        assert_eq!(snap.rate_limit_pct, None);
+        assert!(snap.cwd.is_none());
     }
 
     #[test]
-    fn codex_adapter_ingest_returns_not_implemented() {
-        match CodexAdapter::new().ingest_snapshot("{}").unwrap_err() {
-            HarnessError::NotImplemented { harness, reason } => {
-                assert_eq!(harness, "codex");
-                assert!(reason.contains("V0.3.2"));
-                assert!(reason.contains("docs/research/ccteam-codex-integration.md"));
-            }
-            other => panic!("expected NotImplemented, got {other:?}"),
-        }
+    fn codex_adapter_ingest_status_line_parses() {
+        let pane = "(some scrollback)\n\
+                    CODEX_STATUS: {\"model\":\"o3\",\"context_pct\":42,\"cost_usd\":1.25}\n\
+                    (trailing prompt)\n";
+        let snap = CodexAdapter::new().ingest_snapshot(pane).unwrap();
+        assert_eq!(snap.harness, "codex");
+        assert_eq!(snap.model_display_name, "o3");
+        assert_eq!(snap.context_used_pct, 42);
+        assert!((snap.cost_usd_total - 1.25).abs() < 1e-9);
     }
 
     #[test]
-    fn codex_adapter_shutdown_returns_not_implemented() {
-        let handle = SessionHandle {
-            tmux_session: "ccteam-flex-foo-codex-1".into(),
-            harness: "codex".into(),
-            sid: "codex-1".into(),
-            pid: None,
-            started_at: Utc::now(),
-        };
-        match CodexAdapter::new().shutdown_session(&handle).unwrap_err() {
-            HarnessError::NotImplemented { harness, reason } => {
-                assert_eq!(harness, "codex");
-                assert!(reason.contains("V0.3.2"));
-                assert!(reason.contains("docs/research/ccteam-codex-integration.md"));
+    fn codex_adapter_ingest_last_status_line_wins() {
+        // Two markers: the most recent (deepest in the pane) is used.
+        let pane = "CODEX_STATUS: {\"model\":\"o1\",\"context_pct\":10}\n\
+                    intermediate\n\
+                    CODEX_STATUS: {\"model\":\"o3\",\"context_pct\":80}\n";
+        let snap = CodexAdapter::new().ingest_snapshot(pane).unwrap();
+        assert_eq!(snap.model_display_name, "o3");
+        assert_eq!(snap.context_used_pct, 80);
+    }
+
+    #[test]
+    fn codex_adapter_ingest_malformed_json_falls_back_silently() {
+        // Marker line is present but JSON is broken → fallback shape;
+        // no error propagated. Snapshot pipeline must not panic.
+        let pane = "CODEX_STATUS: { broken json\n";
+        let snap = CodexAdapter::new().ingest_snapshot(pane).unwrap();
+        assert_eq!(snap.model_display_name, "codex");
+        assert_eq!(snap.context_used_pct, 0);
+    }
+
+    #[test]
+    fn codex_adapter_does_not_return_not_implemented() {
+        // Regression guard for F62: pure-Rust surfaces (ingest, name)
+        // must never produce `HarnessError::NotImplemented`. Spawn /
+        // shutdown depend on tmux and are exercised under the
+        // `codex-tests` feature, but pattern-matching here covers the
+        // ingest path with a dummy input. Compile-level: if anyone
+        // re-introduces the stub, this match-arm panics.
+        let res = CodexAdapter::new().ingest_snapshot("");
+        match res {
+            Ok(_) => {}
+            Err(HarnessError::NotImplemented { .. }) => {
+                panic!("CodexAdapter must not return NotImplemented post-F62")
             }
-            other => panic!("expected NotImplemented, got {other:?}"),
+            Err(other) => panic!("unexpected ingest error: {other:?}"),
         }
     }
 
     #[test]
     fn codex_adapter_subagent_states_default_empty() {
-        // Mirrors `subagent_states_default_empty_for_v0_3_1` — the
-        // stub uses the trait's default `Vec::new()` impl.
+        // Mirrors `subagent_states_default_empty_for_v0_3_1`. Codex's
+        // subagent surface is still TBD pending upstream API.
         let snap = HarnessSnapshot {
             harness: "codex".into(),
             model_display_name: "X".into(),

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -44,7 +44,8 @@ pub use actions::{
 };
 pub use harness::{
     derive_harness_path, write_harness_snapshot, ClaudeCodeAdapter, CodexAdapter, HarnessAdapter,
-    HarnessError, HarnessSnapshot, SessionHandle, SpawnOpts, SubagentState,
+    HarnessError, HarnessSnapshot, SessionHandle, SpawnOpts, SubagentState, CODEX_STATUS_MARKER,
+    CODEX_STATUS_TAIL_LINES,
 };
 pub use dag::{dev_dag, Dag};
 pub use auto_loop::{AutoLoopDecision, AutoLoopFrontMatter, AutoLoopState};

--- a/crates/ccteam-core/tests/codex_adapter_test.rs
+++ b/crates/ccteam-core/tests/codex_adapter_test.rs
@@ -1,0 +1,371 @@
+//! V0.4.0 F62 - integration tests for the real `CodexAdapter`.
+//!
+//! These tests require `tmux` on PATH and exercise the `codex` CLI
+//! when present. They're gated behind the `codex-tests` feature so
+//! default CI runs (without tmux / codex installed) stay green; the
+//! same gate documented in `crates/ccteam-core/Cargo.toml`.
+//!
+//! Each test uses a unique tmux session name (`ccteam-f62-test-…`)
+//! plus a `Drop` guard so panicking tests still clean up the tmux
+//! session they created. Tests are serialised via the `serial_test`
+//! crate so concurrent spawn/shutdown calls don't race the shared
+//! tmux server.
+//!
+//! Tests skip gracefully (with an `eprintln!` notice + early return)
+//! when:
+//!
+//! - `tmux` is missing on PATH
+//! - `codex` is missing on PATH **and** the test would actually need
+//!   it to make progress (spawn / shutdown). Parser-only tests run
+//!   regardless because they don't touch tmux at all.
+//!
+//! Maps to `docs/v0-4-0/dev-plan.md` §4.1 #3.5 — five canary tests
+//! pinning the post-F62 contract.
+
+#![cfg(feature = "codex-tests")]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ccteam_core::tmux::{tmux_available, TmuxSession};
+use ccteam_core::{
+    CodexAdapter, HarnessAdapter, HarnessError, HarnessSnapshot, SessionHandle, SpawnOpts,
+    CODEX_STATUS_TAIL_LINES,
+};
+use chrono::Utc;
+use serial_test::serial;
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_slug(test_name: &str) -> String {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("f62-{test_name}-{pid}-{n}")
+}
+
+/// Cleanup wrapper: kills the named tmux session on drop. Used so
+/// panicking tests still leave a clean tmux server behind.
+struct ScopedTmux {
+    name: String,
+}
+
+impl ScopedTmux {
+    fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl Drop for ScopedTmux {
+    fn drop(&mut self) {
+        let session = TmuxSession::from_name(self.name.clone());
+        let _ = session.kill();
+    }
+}
+
+fn skip_if_no_tmux(test_name: &str) -> bool {
+    if !tmux_available() {
+        eprintln!("[skip] {test_name}: tmux not on PATH");
+        return true;
+    }
+    false
+}
+
+/// Stand up a tiny fake `codex` binary on PATH for tests that need a
+/// long-running pane process but don't want to depend on the real
+/// codex CLI being installed. The shell script blocks on `read` so
+/// tmux keeps the pane alive until shutdown_session sends `q\r`.
+/// Returns the temp dir (drop frees the bin) and the modified PATH.
+fn install_fake_codex() -> (tempfile::TempDir, std::ffi::OsString) {
+    let tmp = tempfile::tempdir().expect("tempdir for fake codex");
+    let bin = tmp.path().join("codex");
+    std::fs::write(
+        &bin,
+        "#!/bin/sh\ntrap 'exit 0' TERM INT QUIT\n\
+         echo 'CODEX_STATUS: {\"model\":\"fake\",\"context_pct\":0,\"cost_usd\":0.0}'\n\
+         while read line; do\n  if [ \"$line\" = q ]; then exit 0; fi\ndone\nexit 0\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&bin, perms).unwrap();
+    }
+    let mut path = std::ffi::OsString::from(tmp.path());
+    if let Some(existing) = std::env::var_os("PATH") {
+        path.push(":");
+        path.push(existing);
+    }
+    (tmp, path)
+}
+
+/// Tail-capture a tmux pane (max `CODEX_STATUS_TAIL_LINES` lines).
+/// Used to drive `ingest_snapshot` against a real session — matches
+/// the contract F66's watcher will follow.
+fn capture_tail(session_name: &str) -> String {
+    let output = Command::new("tmux")
+        .args([
+            "capture-pane",
+            "-p",
+            "-t",
+            session_name,
+            "-S",
+            &format!("-{CODEX_STATUS_TAIL_LINES}"),
+        ])
+        .output();
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
+        _ => String::new(),
+    }
+}
+
+// =====================================================================
+// t01 — spawn_session creates a tmux session
+// =====================================================================
+
+#[test]
+#[serial]
+fn t01_spawn_creates_tmux_session() {
+    let test = "t01_spawn_creates_tmux_session";
+    if skip_if_no_tmux(test) {
+        return;
+    }
+    let (_fake_bin, path) = install_fake_codex();
+    // We can't pass env to TmuxSession::start directly, but `tmux`
+    // inherits the parent process's PATH for the spawned child.
+    let prev_path = std::env::var_os("PATH");
+    std::env::set_var("PATH", &path);
+
+    let slug = unique_slug("t01");
+    let expected_name = format!("ccteam-{slug}-codex-1");
+    let _guard = ScopedTmux::new(expected_name.clone());
+
+    let opts = SpawnOpts {
+        harness: "codex",
+        slug: slug.clone(),
+        sid: "codex-1".into(),
+        cwd: std::env::temp_dir(),
+        extra_args: Vec::new(),
+    };
+    let handle = CodexAdapter::new()
+        .spawn_session(opts)
+        .expect("spawn_session succeeds with fake codex on PATH");
+    assert_eq!(handle.tmux_session, expected_name);
+    assert_eq!(handle.harness, "codex");
+    assert_eq!(handle.sid, "codex-1");
+    assert!(
+        TmuxSession::from_name(expected_name.clone()).exists(),
+        "tmux session must exist post-spawn"
+    );
+
+    // Restore PATH so subsequent tests aren't polluted.
+    if let Some(p) = prev_path {
+        std::env::set_var("PATH", p);
+    } else {
+        std::env::remove_var("PATH");
+    }
+}
+
+// =====================================================================
+// t02 — ingest_snapshot fallback (pane lacks CODEX_STATUS marker)
+// =====================================================================
+
+#[test]
+fn t02_ingest_snapshot_fallback() {
+    // Pure-Rust path; no tmux needed. Empty pane + non-status content
+    // both fall back to the same shape: model="codex", zero pct/cost.
+    let adapter = CodexAdapter::new();
+
+    let empty = adapter.ingest_snapshot("").unwrap();
+    assert_eq!(empty.model_display_name, "codex");
+    assert_eq!(empty.context_used_pct, 0);
+    assert_eq!(empty.cost_usd_total, 0.0);
+
+    let noise = adapter
+        .ingest_snapshot("user@host:~$ codex\nthinking...\n[some output]\n")
+        .unwrap();
+    assert_eq!(noise.model_display_name, "codex");
+    assert!(noise.cwd.is_none());
+    assert!(noise.rate_limit_pct.is_none());
+}
+
+// =====================================================================
+// t03 — ingest_snapshot parses a real CODEX_STATUS: line
+// =====================================================================
+
+#[test]
+fn t03_ingest_snapshot_parse() {
+    let pane = "preamble line\n\
+                CODEX_STATUS: {\"model\":\"o3-pro\",\"context_pct\":58,\"cost_usd\":2.5,\"rate_limit_pct\":12}\n\
+                $ \n";
+    let snap = CodexAdapter::new().ingest_snapshot(pane).unwrap();
+    assert_eq!(snap.harness, "codex");
+    assert_eq!(snap.model_display_name, "o3-pro");
+    assert_eq!(snap.context_used_pct, 58);
+    assert!((snap.cost_usd_total - 2.5).abs() < 1e-9);
+    assert_eq!(snap.rate_limit_pct, Some(12));
+    // raw retains the full upstream JSON for forward-compat.
+    assert_eq!(snap.raw["model"], "o3-pro");
+}
+
+// =====================================================================
+// t04 — shutdown_session kills the tmux session
+// =====================================================================
+
+#[test]
+#[serial]
+fn t04_shutdown_kills_session() {
+    let test = "t04_shutdown_kills_session";
+    if skip_if_no_tmux(test) {
+        return;
+    }
+    let (_fake_bin, path) = install_fake_codex();
+    let prev_path = std::env::var_os("PATH");
+    std::env::set_var("PATH", &path);
+
+    let slug = unique_slug("t04");
+    let expected_name = format!("ccteam-{slug}-codex-1");
+    let _guard = ScopedTmux::new(expected_name.clone());
+
+    let handle = CodexAdapter::new()
+        .spawn_session(SpawnOpts {
+            harness: "codex",
+            slug: slug.clone(),
+            sid: "codex-1".into(),
+            cwd: std::env::temp_dir(),
+            extra_args: Vec::new(),
+        })
+        .expect("spawn for shutdown test");
+    assert!(TmuxSession::from_name(expected_name.clone()).exists());
+
+    CodexAdapter::new()
+        .shutdown_session(&handle)
+        .expect("shutdown_session ok");
+    assert!(
+        !TmuxSession::from_name(expected_name.clone()).exists(),
+        "tmux session must be gone post-shutdown"
+    );
+
+    // Idempotent: shutting down an already-dead session is Ok.
+    CodexAdapter::new()
+        .shutdown_session(&handle)
+        .expect("idempotent shutdown");
+
+    if let Some(p) = prev_path {
+        std::env::set_var("PATH", p);
+    } else {
+        std::env::remove_var("PATH");
+    }
+}
+
+// =====================================================================
+// t05 — CodexAdapter no longer returns NotImplemented from any path
+// =====================================================================
+
+#[test]
+fn t05_codex_not_implemented_removed() {
+    // Regression guard for F62. None of the three fallible methods may
+    // return `HarnessError::NotImplemented`:
+    //
+    // - `ingest_snapshot` always succeeds with a fallback when input
+    //   lacks a status marker.
+    // - `spawn_session` returns `SpawnFailed` (not NotImplemented) when
+    //   tmux/codex are missing on this host.
+    // - `shutdown_session` is idempotent on missing sessions (Ok).
+    let adapter = CodexAdapter::new();
+
+    // Ingest never NotImplemented.
+    let snap_res = adapter.ingest_snapshot("");
+    assert!(
+        !matches!(snap_res, Err(HarnessError::NotImplemented { .. })),
+        "ingest_snapshot must not return NotImplemented: {snap_res:?}"
+    );
+
+    // Shutdown on a non-existent session returns Ok (idempotent), not
+    // NotImplemented.
+    let phantom = SessionHandle {
+        tmux_session: format!("ccteam-{}-phantom", unique_slug("t05")),
+        harness: "codex".into(),
+        sid: "codex-99".into(),
+        pid: None,
+        started_at: Utc::now(),
+    };
+    let shutdown_res = adapter.shutdown_session(&phantom);
+    assert!(
+        !matches!(shutdown_res, Err(HarnessError::NotImplemented { .. })),
+        "shutdown_session must not return NotImplemented: {shutdown_res:?}"
+    );
+
+    // Spawn with a bogus slug + missing tmux/codex still must NOT
+    // return NotImplemented — at worst SpawnFailed.
+    let opts = SpawnOpts {
+        harness: "codex",
+        slug: unique_slug("t05spawn"),
+        sid: "codex-1".into(),
+        cwd: PathBuf::from("/nonexistent-dir-f62"),
+        extra_args: Vec::new(),
+    };
+    let spawn_res = adapter.spawn_session(opts);
+    assert!(
+        !matches!(spawn_res, Err(HarnessError::NotImplemented { .. })),
+        "spawn_session must not return NotImplemented: {spawn_res:?}"
+    );
+    // Cleanup whatever tmux session may have spawned.
+    if let Ok(handle) = &spawn_res {
+        let _ = TmuxSession::from_name(handle.tmux_session.clone()).kill();
+    }
+}
+
+// =====================================================================
+// extra — end-to-end CODEX_STATUS round-trip via tmux capture-pane
+// =====================================================================
+
+#[test]
+#[serial]
+fn e2e_spawn_capture_parse_shutdown_round_trip() {
+    let test = "e2e_spawn_capture_parse_shutdown_round_trip";
+    if skip_if_no_tmux(test) {
+        return;
+    }
+    let (_fake_bin, path) = install_fake_codex();
+    let prev_path = std::env::var_os("PATH");
+    std::env::set_var("PATH", &path);
+
+    let slug = unique_slug("e2e");
+    let expected_name = format!("ccteam-{slug}-codex-1");
+    let _guard = ScopedTmux::new(expected_name.clone());
+
+    let adapter = CodexAdapter::new();
+    let handle = adapter
+        .spawn_session(SpawnOpts {
+            harness: "codex",
+            slug: slug.clone(),
+            sid: "codex-1".into(),
+            cwd: std::env::temp_dir(),
+            extra_args: Vec::new(),
+        })
+        .expect("spawn for e2e round-trip");
+
+    // Give the fake codex a moment to print its CODEX_STATUS line.
+    std::thread::sleep(std::time::Duration::from_millis(200));
+    let pane = capture_tail(&handle.tmux_session);
+    let snap: HarnessSnapshot = adapter.ingest_snapshot(&pane).unwrap();
+    // Either the fake printed the marker (model=fake) or pane
+    // capture was empty (model=codex fallback). Both are valid.
+    assert!(
+        snap.model_display_name == "fake" || snap.model_display_name == "codex",
+        "model should be fake or codex fallback; got {}",
+        snap.model_display_name,
+    );
+
+    adapter.shutdown_session(&handle).unwrap();
+    assert!(!TmuxSession::from_name(expected_name.clone()).exists());
+
+    if let Some(p) = prev_path {
+        std::env::set_var("PATH", p);
+    } else {
+        std::env::remove_var("PATH");
+    }
+}

--- a/crates/ccteam-web/tests/flex_e2e_test.rs
+++ b/crates/ccteam-web/tests/flex_e2e_test.rs
@@ -319,21 +319,28 @@ async fn v0_3_1_flex_dashboard_session_sse_harness_and_actions() {
 }
 
 #[test]
-fn v0_3_1_codex_adapter_remains_trait_stub() {
-    let err = CodexAdapter::new()
-        .spawn_session(SpawnOpts {
-            harness: "codex",
-            slug: "flex-e2e".into(),
-            sid: "codex-1".into(),
-            cwd: std::env::temp_dir(),
-            extra_args: Vec::new(),
-        })
-        .expect_err("CodexAdapter must stay stubbed in V0.3.1");
-    let msg = err.to_string();
-    assert!(msg.contains("trait-stub in V0.3.1"), "msg={msg}");
-    assert!(msg.contains("V0.3.2"), "msg={msg}");
-    assert!(
-        msg.contains("docs/research/ccteam-codex-integration.md"),
-        "msg={msg}",
-    );
+fn v0_4_0_codex_adapter_is_no_longer_trait_stub() {
+    // V0.4.0 F62 replaces V0.3.1's NotImplemented stub with a real
+    // tmux + codex CLI implementation. This regression guard pins
+    // that contract: the pure-Rust `ingest_snapshot` path is now
+    // permissive (returns a fallback snapshot for empty pane bodies)
+    // and never produces `NotImplemented`. Spawn / shutdown surfaces
+    // are tmux-dependent and live under the `codex-tests` feature.
+    let adapter = CodexAdapter::new();
+    let snap = adapter
+        .ingest_snapshot("")
+        .expect("ingest fallback must succeed post-F62");
+    assert_eq!(snap.harness, "codex");
+    assert_eq!(snap.model_display_name, "codex");
+    assert_eq!(snap.context_used_pct, 0);
+    // SpawnOpts still round-trip cleanly — schema unchanged across
+    // F62. (We do NOT call spawn_session here; that's covered by the
+    // codex-tests feature-gated integration test.)
+    let _opts = SpawnOpts {
+        harness: "codex",
+        slug: "flex-e2e".into(),
+        sid: "codex-1".into(),
+        cwd: std::env::temp_dir(),
+        extra_args: Vec::new(),
+    };
 }

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -815,6 +815,15 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 - **优先级**:**P0**(V0.4.0 重构基石,F64 / F65 / F66 全部依赖)。
 - **来源**:`docs/v0-4-0/prd.md §6.1` + `docs/v0-4-0/prd.md §F63` + `docs/v0-4-0/dev-plan.md §5`。
 
+### F62 — V0.3.1 F47 CodexAdapter `NotImplemented` 桩(V0.3.3 → V0.4.0 slip;2026-05-14 加;**2026-05-14 V0.4.0 PR #3 ship,close**)
+
+- **文件:行号**:`crates/ccteam-core/src/harness.rs::CodexAdapter`(V0.3.1 F47 ship 时三个 fallible 方法全返 `HarnessError::NotImplemented`,`CODEX_NOT_IMPLEMENTED_REASON` const 指向 V0.3.2 / `docs/research/ccteam-codex-integration.md`);`crates/ccteam-cli/src/commands.rs::run_session_add` codex 分支(对 stub 做 `NotImplemented` 解包并打印 deferral 错误);`crates/ccteam-web/tests/flex_e2e_test.rs::v0_3_1_codex_adapter_remains_trait_stub`;`crates/ccteam-cli/tests/session_cli_test.rs::session_add_codex_exits_with_v0_3_2_pointer`。
+- **现状**:V0.3.1 PRD §10.3 + V0.3.1 README erratum 把 CodexAdapter 真实实现 slip 到 V0.3.3;V0.4.0 架构重写(F60-F69)随手吸收。stub 阻止 flex team 真混用 claude + codex(`ccteam session add --harness=codex` 永远 exit 1)。
+- **是否真 dev-specific**:**否——multi-harness 编排基础设施缺口。** 所有用 codex 做 review/QA gate 的 team(F65 ui-quality-loop sample 即依赖此)都受影响。
+- **解耦方案(已 ship)**:`CodexAdapter::spawn_session` 走 `tmux new-session -d -s ccteam-<slug>-<sid> codex [extra_args...]`,挂自己 spawn 的 session(精确 `-t <name>` 不波及他人);`ingest_snapshot` 接收 tmux `capture-pane -p` 文本,grep `CODEX_STATUS: <json>` marker 行解析,无 marker → permissive fallback snapshot(`model="codex"`,`ctx_pct=0`,`cost=0`,不报 error;snapshot 流是 presentation-only,见 CLAUDE.md §三);`shutdown_session` 发 `q\r` send-keys → 500ms grace → `tmux kill-session -t <name>` 兜底,幂等于"已死"。初始 `~/.ccteam/codex/<sid>/state.json` 写 `{status:"starting", pid, model:"codex", context_pct:0, cost_usd:0}`(镜像 CC statusline dual-write 形,F66 watcher 统一消费)。`CODEX_STATUS_MARKER` + `CODEX_STATUS_TAIL_LINES` 通过 `pub use` 公开给 watcher / 测试。`crates/ccteam-cli/src/commands.rs::run_session_add` codex 分支与 claude 分支合并,共享 sid 分配 / session_dir 创建 / state.json 写入路径。`crates/ccteam-core/Cargo.toml` 加 `[features] codex-tests = []` + `serial_test` dev-dep;`crates/ccteam-core/tests/codex_adapter_test.rs` 新文件 6 测试(t01 spawn 创建 tmux session、t02 ingest fallback、t03 ingest parse、t04 shutdown 幂等清理、t05 三方法均不返 NotImplemented、e2e 走 fake codex shell 一次性 round-trip)`#[serial]` 串行化、`tmux_available()` 软跳过;`flex_e2e_test.rs` / `session_cli_test.rs` 老 stub 断言改为反向 regression guard。
+- **优先级**:**P0**(multi-harness gating)。
+- **来源**:`docs/v0-3-1/prd.md §10.3` erratum + `docs/v0-4-0/prd.md §F62` + `docs/v0-4-0/dev-plan.md §4`。
+
 ### F40 — `product-research` team 名冗长 + 领域名缺位(2026-05-09 加;**已修复:2026-05-09(V0.2.2 PR #6 alias 软迁移)**)
 
 - **文件:行号**:`teams/product-research/team.yaml::name`(M3.4 起的字面值)


### PR DESCRIPTION
## Summary

V0.4.0 PR #3 — Replace V0.3.1 F47 `NotImplemented` stub with real `CodexAdapter` implementation: tmux + `codex` CLI spawn, `capture-pane` + `CODEX_STATUS:` marker parser, graceful shutdown (`q\r` → `kill-session` fallback).

Maps to:
- `docs/v0-4-0/prd.md` §F62 + §6.5
- `docs/v0-4-0/dev-plan.md` §4
- `docs/dev-coupling-audit.md` F62 (V0.3.1 F47 erratum slip resolved)

## Scope

- `crates/ccteam-core/src/harness.rs` — CodexAdapter real impl:
  - `spawn_session`: tmux new-session + codex (interactive default; args via `extra_args` pass-through)
  - `ingest_snapshot`: parse `CODEX_STATUS:` JSON from tail of capture-pane; permissive fallback
  - `shutdown_session`: `q\r` → wait → `kill-session -t <name>` fallback
  - New public consts: `CODEX_STATUS_MARKER`, `CODEX_STATUS_TAIL_LINES`
- `Cargo.toml`: `[features] codex-tests = []` + `serial_test` dev-dep
- New: `crates/ccteam-core/tests/codex_adapter_test.rs` (6 tests, `#[serial]`, fake-codex shell script for CI hosts)
- `commands.rs`: codex branch in `run_session_add` merges with claude branch (no more NotImplemented short-circuit)
- Reverse regression guards in `session_cli_test.rs` + `flex_e2e_test.rs`

## Codex CLI signature note

`references/codex/codex-rs/` not in this env. Per `docs/research/ccteam-codex-integration.md` §7.2, documented shape is `codex exec --sandbox <mode> --cd <dir> "<prompt>"` (one-shot — incompatible with tmux long-session). Implementation defers concrete argv to `SpawnOpts.extra_args` (callers thread proper args); default argv is bare `codex`. F66 orchestrator will supply real argv.

Initial state.json mirrors CC layout at `~/.ccteam/codex/<sid>/state.json` (best-effort write; failure logs warn).

## Tests

- `cargo test --workspace` default: **866/0 → 868/0** (+2 net: +6 in-file codex unit + 6 codex-tests gated − 4 removed stub tests)
- `cargo test --workspace --features ccteam-core/codex-tests`: 874/0
- Red-line greps: clean (NotImplemented removed, kill-server unused, only kill-session via `-t <name>`)

## Test plan

- [x] `cargo test --workspace --locked` 868/0
- [x] `cargo test --workspace --features ccteam-core/codex-tests` 874/0
- [x] Red-line grep matrix clean (see dev-plan §4.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)