### PR TITLE
v0.4.0 hotfix: wire F66 spawn_requests + ticker check_gates (fixes Trigger::Manual no-op)

### DIFF
--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -273,6 +273,8 @@ impl Orchestrator {
                 },
                 _ = ticker.tick() => {
                     self.poll_completions(slug, spec, project_dir, progress_path).await;
+                    self.check_spawn_requests(slug, spec, project_dir, progress_path).await;
+                    self.check_gates(slug, spec, project_dir, progress_path).await;
                     self.check_workflow_done(slug, spec, progress_path).await;
                 }
             }
@@ -532,6 +534,95 @@ impl Orchestrator {
 
         self.check_gates(slug, spec, project_dir, progress_path)
             .await;
+    }
+
+    /// Scan `.ccteam/spawn_requests/*.json` markers written by the F65
+    /// `ccteam__spawn_agent` MCP tool (or hand-written by users via the
+    /// migration-guide path). Each marker JSON carries `{"role": "...",
+    /// ...}`; orchestrator spawns the role and deletes the marker on
+    /// success. Failed spawns retain the marker for the next tick so
+    /// transient errors auto-retry (subject to fix-loop 3-strike
+    /// escalate per `bump_fail_count`).
+    ///
+    /// This is the V0.4.0 wiring for `Trigger::Manual` / `Trigger::Schedule`
+    /// agents — they have no natural fire path otherwise. `Trigger::Gate`
+    /// still goes through `check_gates`, and `Trigger::Watch` through the
+    /// inotify-driven `handle_artifact_event`. Manual roles are spawned
+    /// regardless of trigger kind once a marker shows up (lets users
+    /// force-fire any role for debug / replay).
+    async fn check_spawn_requests(
+        &self,
+        slug: &str,
+        spec: &WorkflowSpec,
+        project_dir: &std::path::Path,
+        progress_path: &std::path::Path,
+    ) {
+        let bucket = project_dir.join(".ccteam").join("spawn_requests");
+        let Ok(entries) = std::fs::read_dir(&bucket) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let role = match std::fs::read_to_string(&path)
+                .ok()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                .and_then(|v| v.get("role").and_then(|r| r.as_str()).map(String::from))
+            {
+                Some(r) => r,
+                None => {
+                    tracing::warn!(
+                        marker = ?path,
+                        "spawn_request missing `role` field; deleting"
+                    );
+                    let _ = std::fs::remove_file(&path);
+                    continue;
+                }
+            };
+            let Some(agent) = spec.agents.get(&role) else {
+                tracing::warn!(role, "spawn_request for unknown role; deleting");
+                let _ = std::fs::remove_file(&path);
+                continue;
+            };
+            // `try_spawn` swallows spawn errors internally (bumps
+            // fail_count + logs) and returns Ok(()), so we sample the
+            // fail counter to decide whether the marker should be kept
+            // for next-tick retry. The marker is deleted ONLY when a
+            // session actually came up; transient errors retain it.
+            let before = self
+                .fail_counts
+                .lock()
+                .await
+                .get(&role)
+                .copied()
+                .unwrap_or(0);
+            if let Err(err) = self
+                .try_spawn(slug, &role, agent, project_dir, progress_path)
+                .await
+            {
+                tracing::warn!(role, error = ?err, "spawn_request errored");
+                continue;
+            }
+            let after = self
+                .fail_counts
+                .lock()
+                .await
+                .get(&role)
+                .copied()
+                .unwrap_or(0);
+            if after > before {
+                tracing::warn!(
+                    role,
+                    "spawn_request retained for retry (fail_count {} → {})",
+                    before,
+                    after
+                );
+                continue;
+            }
+            let _ = std::fs::remove_file(&path);
+        }
     }
 
     /// Release a `Trigger::Gate` agent when its input dir has ≥1 file
@@ -810,6 +901,17 @@ impl Orchestrator {
         self.poll_completions(slug, spec, project_dir, progress_path)
             .await;
         self.check_workflow_done(slug, spec, progress_path).await;
+    }
+
+    pub async fn test_check_spawn_requests(
+        &self,
+        slug: &str,
+        spec: &WorkflowSpec,
+        project_dir: &std::path::Path,
+        progress_path: &std::path::Path,
+    ) {
+        self.check_spawn_requests(slug, spec, project_dir, progress_path)
+            .await;
     }
 
     pub async fn test_gate_override(

--- a/crates/ccteam-core/tests/orchestrator_thin_test.rs
+++ b/crates/ccteam-core/tests/orchestrator_thin_test.rs
@@ -165,6 +165,28 @@ fn watch_spec(role: &str, watch_rel: &str, parallelism: Option<u32>) -> Workflow
     }
 }
 
+fn manual_spec(role: &str) -> WorkflowSpec {
+    let mut agents = IndexMap::new();
+    agents.insert(
+        role.into(),
+        AgentSpec {
+            executor: Executor::Claude,
+            trigger: Trigger::Manual,
+            parallelism: None,
+            input: None,
+            output: None,
+            interval: None,
+            timeout: None,
+            on_timeout: None,
+        },
+    );
+    WorkflowSpec {
+        name: "test-manual-workflow".into(),
+        description: None,
+        agents,
+    }
+}
+
 fn gate_spec(role: &str, input_rel: &str) -> WorkflowSpec {
     let mut agents = IndexMap::new();
     agents.insert(
@@ -897,4 +919,114 @@ async fn t20_meta_agent_not_killed() {
     );
     // The meta-agent fake session is still on the books.
     assert_eq!(orch.test_running_count("meta-agent").await, 1);
+}
+
+// =====================================================================
+// V0.4.0-hotfix — spawn_requests marker consumer
+// =====================================================================
+
+const YAML_MANUAL_SPEC: &str = "\
+name: manual-test
+agents:
+  explorer:
+    executor: claude
+    trigger: manual
+";
+
+#[tokio::test]
+async fn t21_spawn_requests_marker_fires_manual_role() {
+    let (_pr, _cr, pdir, paths, _progress, slug) = make_project(YAML_MANUAL_SPEC);
+    let (orch, claude, _codex) = build_orchestrator(paths);
+    let spec = manual_spec("explorer");
+    let progress = orch.paths().progress_jsonl(&slug);
+
+    // User-side: write spawn_requests marker (mirrors F65
+    // `ccteam__spawn_agent` MCP tool or hand-written migration-guide path).
+    let bucket = pdir.join(".ccteam").join("spawn_requests");
+    std::fs::create_dir_all(&bucket).unwrap();
+    let marker = bucket.join("explorer-test.json");
+    std::fs::write(
+        &marker,
+        r#"{"role":"explorer","session_id":"explorer-test","requested_at":"2026-05-14T13:00:00Z","overrides":{}}"#,
+    )
+    .unwrap();
+
+    // Tick consumes the marker.
+    orch.test_check_spawn_requests(&slug, &spec, &pdir, &progress)
+        .await;
+
+    assert_eq!(claude.spawn_count(), 1, "marker must trigger spawn");
+    assert!(!marker.exists(), "successful spawn must delete the marker");
+}
+
+#[tokio::test]
+async fn t22_spawn_requests_unknown_role_deletes_marker() {
+    let (_pr, _cr, pdir, paths, _progress, slug) = make_project(YAML_MANUAL_SPEC);
+    let (orch, claude, _codex) = build_orchestrator(paths);
+    let spec = manual_spec("explorer");
+    let progress = orch.paths().progress_jsonl(&slug);
+
+    let bucket = pdir.join(".ccteam").join("spawn_requests");
+    std::fs::create_dir_all(&bucket).unwrap();
+    let marker = bucket.join("ghost.json");
+    std::fs::write(&marker, r#"{"role":"ghost","session_id":"ghost-x"}"#).unwrap();
+
+    orch.test_check_spawn_requests(&slug, &spec, &pdir, &progress)
+        .await;
+
+    assert_eq!(claude.spawn_count(), 0, "unknown role must not spawn");
+    assert!(!marker.exists(), "unknown role marker must be deleted");
+}
+
+#[tokio::test]
+async fn t23_spawn_requests_malformed_marker_deletes() {
+    let (_pr, _cr, pdir, paths, _progress, slug) = make_project(YAML_MANUAL_SPEC);
+    let (orch, claude, _codex) = build_orchestrator(paths);
+    let spec = manual_spec("explorer");
+    let progress = orch.paths().progress_jsonl(&slug);
+
+    let bucket = pdir.join(".ccteam").join("spawn_requests");
+    std::fs::create_dir_all(&bucket).unwrap();
+    let marker = bucket.join("bad.json");
+    std::fs::write(&marker, r#"{"no_role_field": true}"#).unwrap();
+
+    orch.test_check_spawn_requests(&slug, &spec, &pdir, &progress)
+        .await;
+
+    assert_eq!(claude.spawn_count(), 0);
+    assert!(!marker.exists(), "malformed marker must be deleted");
+}
+
+#[tokio::test]
+#[serial]
+async fn t24_spawn_requests_failed_spawn_retains_marker() {
+    let (_pr, _cr, pdir, paths, _progress, slug) = make_project(YAML_MANUAL_SPEC);
+    let (orch, claude, _codex) = build_orchestrator(paths);
+    let spec = manual_spec("explorer");
+    let progress = orch.paths().progress_jsonl(&slug);
+
+    let bucket = pdir.join(".ccteam").join("spawn_requests");
+    std::fs::create_dir_all(&bucket).unwrap();
+    let marker = bucket.join("explorer-retry.json");
+    std::fs::write(
+        &marker,
+        r#"{"role":"explorer","session_id":"explorer-retry"}"#,
+    )
+    .unwrap();
+
+    claude.fail_next(1);
+    orch.test_check_spawn_requests(&slug, &spec, &pdir, &progress)
+        .await;
+
+    assert_eq!(claude.spawn_count(), 0, "first spawn forced to fail");
+    assert!(
+        marker.exists(),
+        "failed spawn must retain marker for next-tick retry"
+    );
+
+    // Next tick succeeds.
+    orch.test_check_spawn_requests(&slug, &spec, &pdir, &progress)
+        .await;
+    assert_eq!(claude.spawn_count(), 1, "retry must spawn");
+    assert!(!marker.exists(), "successful retry must delete marker");
 }

--- a/docs/v0-4-0/user-manual.md
+++ b/docs/v0-4-0/user-manual.md
@@ -90,22 +90,50 @@ ccteam web --bind 127.0.0.1:7331
 - Gate 状态 + 解锁按钮
 - progress.jsonl 实时流（SSE）
 
-### 第 5 步：触发首轮
+### 第 5 步:触发首轮
 
 V0.4.0 没有 `ccteam ctl ...` CLI。手动触发的两条路径:
 
+#### Path A:meta-agent(推荐)
+
+一次性安装(全局,只跑一次):
+
 ```bash
-# A. 通过 meta-agent session(推荐) — 在 meta-agent 的 claude session 里说自然语言:
-#    "现在跑一轮 explorer,让它探索登录页的 UI 问题"
-#    meta-agent 会调 mcp__ccteam__ccteam__spawn_agent 工具。
-#
-# B. 直接写 marker 文件让 orchestrator 下一 tick 接走:
-mkdir -p .ccteam/spawn_requests
-cat > .ccteam/spawn_requests/explorer-$(date +%s).json <<'JSON'
-{ "role": "explorer", "ts": "$(date -u +%FT%TZ)" }
-JSON
-# orchestrator 5s 内扫到 → 调 spawn_session → 删 marker
+ccteam doctor --install-mcp        # 注册 ccteam MCP server 到 ~/.claude.json
+ccteam doctor --install-skill      # 安装 ccteam-control skill 到 ~/.claude/skills/
 ```
+
+之后**任何 claude session 都能看到 ccteam 的 17 个 MCP 工具**。开一个新
+claude session(或现有 session)直接说自然语言:
+
+> "现在跑一轮 explorer,让它探索登录页的 UI 问题"
+
+claude 会自动调 `mcp__ccteam__ccteam__spawn_agent` 工具 → orchestrator
+下一 tick(默认 5 s)看到 marker → 调 spawn_session。
+
+可选:专门的 meta-agent 项目(常驻 session,有项目上下文记忆):
+
+```bash
+ccteam doctor --install-meta-agent rob   # 把 rob 换成你的 handle
+# → 在 ~/projects/meta-rob/ 创建一个常驻 meta-agent 项目
+cd ~/projects/meta-rob
+claude   # 进 meta-agent session
+```
+
+#### Path B:直接写 marker 文件
+
+orchestrator 每 tick 扫 `.ccteam/spawn_requests/` 目录,carry `role`
+字段的 JSON 文件都会被 spawn:
+
+```bash
+mkdir -p .ccteam/spawn_requests
+echo '{"role":"explorer"}' > .ccteam/spawn_requests/explorer-$(date +%s).json
+# orchestrator 5s 内看到 → 调 spawn_session → 删 marker
+# 失败保留 marker 下一 tick 重试(3 次顶 escalate 到 meta-agent inbox)
+```
+
+只需 `role` 字段;`session_id` / `requested_at` / `overrides` 由 F65
+MCP 工具自动填,手写时省略也行。
 
 之后整个 workflow 自动运转:explorer → 写 issues → watcher 触发 fixer ×
 N(并行)→ 写 fixes → 触发 reviewer → 写 verdicts。
@@ -368,13 +396,18 @@ watch trigger 下的 `parallelism: N` 字段是**初始默认值**。运行时�
 # A. Meta-agent 调(推荐)
 mcp__ccteam__ccteam__set_parallelism(slug="<slug>", role="fixer", parallelism=5)
 
-# B. 直接写 override 文件
+# B. 直接写 override 文件(V0.4.1 才有热读 consumer — V0.4.0 暂只能重启
+#    orchestrator 让新值生效;markers 会保留供 V0.4.1 接走)
 mkdir -p ~/projects/<slug>/.ccteam
-cat > ~/projects/<slug>/.ccteam/workflow_overrides.json <<'JSON'
-{ "fixer": { "parallelism": 5 } }
-JSON
-# orchestrator 每 tick 热读该文件,合并到 in-memory parallelism map
+echo '{"fixer": {"parallelism": 5}}' \
+  > ~/projects/<slug>/.ccteam/workflow_overrides.json
 ```
+
+> ⚠️ V0.4.0 已实现 `spawn_requests` + `gate_override` 两个 marker bucket 的
+> consumer(F66 + V0.4.0 hotfix)。其余 marker bucket(`workflow_overrides.json`
+> 热读、`signal/<role>_<sid>` SIGSTOP/SIGCONT、`stop_signal/<role>_<sid>`
+> 软停)是 F65 写、F66 还没接的 — V0.4.1 P0 候选。当前只能通过 `ccteam stop`
+> + 改 `workflow.yaml::parallelism` 字段 + `ccteam start` 重启来调。
 
 降速场景：
 
@@ -405,6 +438,28 @@ ccteam 跟踪每个项目累计 cost(聚合 `progress.jsonl` 的 `agent_done.cos
    - 或降 parallelism + 等已跑 session 完成(见 §8)
    - 或停 daemon:`ccteam stop`(SIGTERM 通过 pidfile,**不杀 session**,
      restart 时 `ccteam start` 重新挂载)
+
+---
+
+## 9.5 V0.4.0 V0.3.x inbox 行为变化
+
+V0.3.x 中 `mcp__ccteam__ccteam__send_to_session` / `inject_decision` 等工具
+向 `<project>/.ccteam/inbox/*.md` 写消息,daemon 通过 `/btw` send-keys
+注入到 tmux 中正在跑的 claude session。**V0.4.0 没有这条路径**:
+
+- `claude --bg --agent` 启动的 session 是一次性的(spawn → run → exit),
+  没有"持续运行接收消息"的语义
+- 写入 `<project>/.ccteam/inbox/*.md` 在 V0.4.0 **没有 consumer**,文件
+  会累积但不会触发任何事情(无日志、无 error)
+- meta-agent 用 `ccteam__signal` 工具发的 btw 也会落到 inbox,V0.4.0
+  同样无效
+
+V0.4.0 等价做法:**briefing 写到 `.claude/agents/<role>.md` 里**,新一轮
+spawn 会读到。要给 in-flight session 实时反馈 → 设计成一个新 role 用
+`watch:` 监听某个 artifact dir,从那里推送上下文。
+
+V0.4.1 候选:让 `inbox/*.md` 在下一次 spawn 同 role 时作为 stdin 注入到
+新 session(自动作为 briefing 的一部分)。
 
 ---
 


### PR DESCRIPTION
## Problem (user report)

`ccteam start --foreground` runs fine but `trigger: manual` agents (explorer / etc. from `examples/workflows/ui-quality-loop.yaml`) **never fire**, even after writing `.ccteam/spawn_requests/<role>-<ts>.json` markers per the user-manual / migration-guide instructions.

Also: heredoc shell-expansion bug in user-manual §5 Path B produced literal `$(date -u +%FT%TZ)` in the user's spawn_requests file.

## Root cause — 2 latent V0.4.0 bugs

1. **F66 never had a `spawn_requests/` consumer.** F65 wrote the marker contract with `// F66 will read this` comments, but F66 only consumed `gate_override/`. **`trigger: manual` / `trigger: schedule` agents had no fire path in V0.4.0.**
2. **`check_gates` was only called from `handle_artifact_event`**, so `gate_override/` force-fire only worked when an artifact event came in first. Idle workflows sat indefinitely.

## Fix

### Code (`crates/ccteam-core/src/orchestrator.rs`)

- New `Orchestrator::check_spawn_requests`: scans `<project>/.ccteam/spawn_requests/*.json`, parses `role` field, validates against workflow.yaml, calls `try_spawn`. Sample fail_count before/after to decide marker delete (success) vs retain (transient failure → next-tick retry). Unknown role / malformed marker is deleted to avoid forever-pending files.
- `event_loop` ticker now calls `check_spawn_requests` + `check_gates` every tick (5s), in addition to the existing `handle_artifact_event`-driven path.
- Test surface `Orchestrator::test_check_spawn_requests` mirrors `test_gate_override`.

### Tests (+4)

- t21_spawn_requests_marker_fires_manual_role
- t22_spawn_requests_unknown_role_deletes_marker
- t23_spawn_requests_malformed_marker_deletes
- t24_spawn_requests_failed_spawn_retains_marker (with mock fail-then-success)

All 5 spawn_requests + gate_override tests pass.

### Docs (`docs/v0-4-0/user-manual.md`)

- **§5 Path A**: concrete setup steps — `ccteam doctor --install-mcp` + `--install-skill` + `--install-meta-agent` (was "meta-agent 不知道怎么搞" per user feedback).
- **§5 Path B**: fix heredoc shell-expansion bug. Simplify to `echo '{"role":"explorer"}' > ...` — `role` is the only required field the new consumer reads.
- **§8 Parallelism**: explicit warning that `workflow_overrides.json` hot-read is V0.4.1 candidate, not wired in V0.4.0. Recommend `ccteam stop` + edit `workflow.yaml` + `ccteam start` instead.
- **§9.5 new**: V0.3.x inbox/btw behaviour gap — writing `<project>/.ccteam/inbox/*.md` succeeds (file lands) but V0.4.0 has no consumer. `claude --bg` sessions are one-shot, not long-lived tmux. Recommended replacement: write briefing to `.claude/agents/<role>.md` body, or design a watch-trigger role.

## V0.4.1 still owes

- `workflow_overrides.json` hot-read
- `signal/<role>_<sid>` SIGSTOP/SIGCONT/SIGINT
- `stop_signal/<role>_<sid>` soft-stop
- inbox-as-spawn-stdin (let V0.3.x inbox writes become next-spawn briefing)

## Test plan

- [x] `cargo test --test orchestrator_thin_test -- t21_ t22_ t23_ t24_ t08_gate_override` → 5/5 pass
- [x] User-reported scenario: `echo '{"role":"explorer"}' > .ccteam/spawn_requests/x.json` → orchestrator spawns within next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)