### PR TITLE
docs(v0-6-0): Epic 重构 + Codex Option B + 不造 IM 轮子

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,70 @@
 # ccteam
 
-> **Autonomous multi-agent orchestrator built on Claude Code.** Declare a `workflow.yaml` — ccteam schedules `claude --bg` sessions per role, watches artifact directories for triggers, and asks for your input only when agents deadlock.
+> **在 Claude session 里一句话召唤 AI 团队 — 接进你的 IM,跨设备 24/7 替你干活。**
 
-## Quick start
+![demo](docs/v0-6-0/demos/30s-tg-bot-team.gif)
+
+> _GIF wave 2 ship 后填_
+
+## 5 分钟上手
 
 ```bash
-# Install (per machine)
-ccteam doctor --install-all           # skill + MCP + meta-agent
-
-# New project
-cd ~/projects/my-app && ccteam init   # writes .ccteam/workflow.yaml + .claude/agents/explorer.md
-ccteam start                          # daemon + web UI on http://localhost:7331
+# 0. 先装 Claude Code:https://code.claude.com/docs/install
+# 1. 起 Claude session
+claude
+# 2. 在 session 里装 ccteam plugin
+/plugin install ccteam
+# 3. 一次性绑你的 IM(TG / Slack / Discord 任选)
+/ccteam-im-setup
+# 4. 起第一个 AI 助理(自然语言对话起 bot)
+/ccteam-creator "做个 TG 私聊助理 bot,帮我管邮件"
 ```
 
-Edit `.ccteam/workflow.yaml` to declare your agent topology:
+→ 详 [quickstart](docs/quickstart.md)(5 步收到 bot 第一条 IM 回话)。
 
-```yaml
-name: my-app-loop
-budget:
-  max_cost_usd_per_24h: 5.00          # auto-disable if exceeded
-agents:
-  planner:
-    trigger: manual                   # explicit spawn only
-    executor: claude
-  builder:
-    trigger: watch:.ccteam/plans/     # spawn on new file in dir
-    parallelism: 2                    # up to 2 concurrent sessions
-  reviewer:
-    trigger: gate                     # wait for trigger_gate MCP call
-```
+## 5 种用法,任你挑
 
-Each role has a system prompt at `.claude/agents/<role>.md` (Anthropic agent spec — name / description / tools / model / color frontmatter + body).
+| 用法 | 一句话场景 | 怎么起 |
+|---|---|---|
+| **Solo Sidekick** | Claude 写代码时临时召唤一个帮手 | `/ccteam <自然语言>` |
+| **Team Sprint** | 几小时冲一波,3-5 agent 并行 | `/ccteam-team 3 "<task>"` |
+| **Overnight Builder** | 丢任务睡觉去,长跑几小时到几天 | `/ccteam-creator "夜里跑 …"` |
+| **Pocket Assistant** ⭐ | 手机 IM 私聊一个 AI 助理 | `/ccteam-creator "做个 TG 助理"` |
+| **IM Squad** | IM 群里多个 bot 互相 @ 协作 | `/ccteam-creator "做个 TG 多 bot 团队"` |
 
-## Architecture
+⭐ **V0.6 旗舰场景。Pocket Assistant + IM Squad 让 AI 团队跨进你的 IM**,跨设备 24/7 替你干活 — 这是 ccteam 跟 ChatGPT / Cursor / Devin 的关键差异:bot 跑在**你电脑上**,能动你的文件 / 跑你的命令 / 看你的代码,手机只是入口。
 
-Three layers ([`docs/tech-design.md §2.1`](docs/tech-design.md)):
+## 三种跟 ccteam 对话的方式
 
-```
-L0  user           — chat with meta-agent OR edit workflow.yaml directly
-L1  meta-agent     — singleton claude session + 17 mcp__ccteam__* tools
-L2  ccteam daemon  — Rust orchestrator, ArtifactWatcher, progress.jsonl SoT
-L3  project agents — `claude --bg --agent <role>` per workflow.yaml role
-                     (Codex executor uses tmux)
-```
+- 🟢 **Claude session 内**:`/ccteam <自然语言>` 总入口(发啥都行)
+- 🟢 **IM 端**:私聊 bot 或群里 `@ccteam <NL admin>`
+- 🟡 **Web 仪表板**:`http://localhost:7331`(只看不操作)
 
-**No prompt injection** — agent behavior lives in `.claude/agents/<role>.md`. **No tmux long-sessions for Claude** — each spawn is a fresh `claude --bg` job, context resets cleanly. **All state in `progress.jsonl`** — 7 canonical workflow events, single source of truth.
+> 你**不需要**学一堆 CLI 命令,也**不需要**写任何 yaml 配置。所有 setup 都通过 Claude session 对话生成。
 
-5 canonical orchestration patterns ([`docs/orchestration-patterns.md`](docs/orchestration-patterns.md)) — Chaining / Routing / Parallelization / Orchestrator-Worker / Evaluator-Optimizer — all map to workflow.yaml + agent.md combinations.
+## 文档
 
-## What it gives you
-
-| Pain | ccteam answer |
+| 想干什么 | 读这个 |
 |---|---|
-| AI helper still asks me to project-manage | meta-agent dispatches; you supervise |
-| Multi-agent topology is brittle | workflow.yaml + ArtifactWatcher; hot-reload on edit |
-| Bug fixes loop forever | hard 3-strike escalation, then notify user |
-| Run-aways blow my budget | per-project `max_cost_usd_per_24h` auto-disable |
-| Daemon ungraceful shutdown loses state | F86 cancel token + 30s timeout fallback |
-| Stale `~/.claude/jobs/<id>/` accumulates | F85 GC at daemon startup + `doctor --gc-claude-jobs` |
-| Want to delete a project | `ccteam remove <slug>` with active-session red-line refusal |
-
-## Web UI
-
-`ccteam start` launches a SPA on `http://<host>:7331` (token auth on non-loopback). Four panels per workflow:
-
-- **WorkflowView** — agent cards with running / queued / cost + SSE live updates
-- **Artifact Queue** — pending files per watch dir + oldest age
-- **Events Timeline** — `progress.jsonl` tail with event-type colors
-- **Failure Inspector** — click errored agent → live tail of `~/.claude/jobs/<id>/output.log`
-- **Cost Sparkline** — 24h / 7d trend
-
-## Commands
-
-13 user-facing (see `ccteam --help`):
-
-```
-init   start  stop  new  ls  status  show  remove
-doctor web    team  session
-```
-
-8 internal (meta-agent / MCP / hooks):
-```
-ccteam internal hook | mcp-serve | spawn | send | peek | attach | progress | resume
-```
-
-Plus `ccteam-control` skill (loaded via `ccteam doctor --install-skill`) gives natural-language wrappers in any Claude Code session.
+| 5 分钟跑通第一个 bot | [docs/quickstart.md](docs/quickstart.md) |
+| 完整 5 种 preset 使用手册 | [docs/user-manual.md](docs/user-manual.md) |
+| 抄一份现成的 use case | [docs/recipes.md](docs/recipes.md) |
+| 出错查不到 | [docs/troubleshooting.md](docs/troubleshooting.md) |
+| 高级定制 / Codex 集成 | [docs/advanced/](docs/advanced/) |
+| 看代码 / 改 ccteam | [docs/architecture/](docs/architecture/) |
 
 ## Status
 
-- **V0.4.6 shipped** (2026-05-16) — 11 findings F81-F91 (project lifecycle / workflow hot-reload / budget cap / graceful shutdown / cost SoT / Web panels / CLI slimming)
-- **755 passing / 1 known port-bind flake** in `cargo test --workspace`
-- **V1.0.0 goals** ([`docs/requirements.md §14-15`](docs/requirements.md)):
-  1. Run autonomously ≥7 days on real 20-100k LOC projects (token maxxing)
-  2. Extend to non-coding domains (research / content ops / investment analysis)
+**V0.6.0 蓄势中**(2026-05 立项)— Epic A 5 min 起第一个 IM bot · Epic B bot 在 IM 像真人助理 · Epic C 中文用户能用(铺底)。详 [docs/v0-6-0/README.md](docs/v0-6-0/README.md)。
 
-Pre-v1.0 = development stage — breaking changes welcome, no migration debt ([`CLAUDE.md §五.3`](CLAUDE.md)).
-
-## Documentation
-
-Full index: [`docs/README.md`](docs/README.md).
-
-| Doc | Use case |
-|---|---|
-| [`docs/v0-4-6/user-manual.md`](docs/v0-4-6/user-manual.md) | end-user command reference |
-| [`docs/orchestration-patterns.md`](docs/orchestration-patterns.md) | designing workflow.yaml topologies (5 patterns + split philosophy) |
-| [`docs/tech-design.md`](docs/tech-design.md) | architecture SoT |
-| [`docs/interfaces.md`](docs/interfaces.md) | protocol reference (YAML / JSON / CLI / hooks) |
-| [`docs/requirements.md`](docs/requirements.md) | 15 pain points (13 user + 2 V1.0.0 ultimate) |
-| [`CLAUDE.md`](CLAUDE.md) | implementation rules (consumed by Claude Code) |
-
-## Contributing
-
-ccteam is developed using Claude Code under the worktree-per-task pattern.
-
-```bash
-git worktree add -b feat/your-thing /tmp/ccteam-feature origin/main
-# read CLAUDE.md + docs/README.md before changing code
-cargo test --workspace --locked   # must stay green
-cargo clippy --workspace --all-targets   # no new warnings
-```
-
-Every PR maps to: a pain point in `requirements.md` + a section in `tech-design.md` + a F-finding in `dev-coupling-audit.md` (if applicable).
-
-Docs / agent prompts in Chinese (working language); commit messages + PR descriptions in English.
+**V0.5.1 in production**(2026-05 ship)— 升级 V0.6 **0 用户操作**:工具名 / skill 入口 / workflow.yaml 全兼容。
 
 ## License
 
-See [`LICENSE`](LICENSE).
+详 [LICENSE](LICENSE)。
 
-## Acknowledgments
+## 致谢
 
-- [Claude Code](https://code.claude.com/) — the runtime
-- [Anthropic *Building Effective Agents*](https://www.anthropic.com/engineering/building-effective-agents) — the 5-pattern taxonomy
+- [Claude Code](https://code.claude.com/) — 运行时
+- [openhuman/channels](https://github.com/openhuman/channels) — 14+ IM 平台 Rust 抽象
+- Anthropic *Building Effective Agents* — 5 编排模式 taxonomy

--- a/docs/advanced/customize-workflow.md
+++ b/docs/advanced/customize-workflow.md
@@ -1,0 +1,230 @@
+# 自定义 workflow.yaml(高级用户 / contributor)
+
+> **先读这条**:绝大多数用户**不该编辑 `workflow.yaml`**。默认 UX 是 Claude session 内 `/ccteam` slash — `ccteam-creator` skill 走 NL 对话推断 mode、选 persona、生成 yaml(全程不见文件名)。直接 vim yaml 仅在 (1) 写 contributor PR、(2) skill 不支持的 advanced 字段、(3) debug 时合理。
+>
+> 本文用内部术语(`HarnessAdapter` / `ThreadEvent` / serde tagged enum)— 假设你愿读 Rust 源码。
+
+## 一、决策表
+
+| 诉求 | 路径 |
+|---|---|
+| 起新项目 / 新 bot | `/ccteam-creator` skill |
+| 改 tone / guardrail / 语言 | 改 `.claude/agents/<role>.md` 正文,不动 yaml |
+| 加 reviewer / critic | `/ccteam-creator` 重跑(中断式)|
+| 改 budget cap | `/ccteam-control set-budget` |
+| **加新 mode / vendor / trigger** | **vim yaml**(本文)|
+| **写 V0.7+ 新 preset PR** | **vim yaml + 加 template**(本文)|
+
+## 二、workflow.yaml 完整 schema(V0.6)
+
+位置:`<project>/.ccteam/workflow.yaml`(F83 canonical;旧 `<project>/workflow.yaml` 仅 fallback)。
+
+```yaml
+version: "0.6"                       # 必;迁移时 doctor 警告
+mode: chat                           # 必,{ in_proc | bg | chat }(serde tagged enum)
+                                     # 决定 HarnessAdapter 路径 + mode-specific 字段集
+enabled: true                        # F82,default true
+
+budgets:                             # F107 + F112 vendor 拆分
+  claude:
+    max_cost_usd_per_24h: 5.00       # 撞顶 → budget_exceeded + auto-disable
+    max_agent_spawns_per_hour: 100
+    max_tokens_per_turn: 200000      # chat 必填,防 100k history 烧穿
+    max_cost_per_hour: 1.50          # spike 防,F84 24h cap 不够
+  codex:
+    max_cost_usd_per_24h: 2.00
+    max_tokens_per_turn: 100000
+
+agents:
+  - role: helpful-bot                # 必,匹配 .claude/agents/<role>.md
+    vendor: claude                   # default claude;{ claude | codex }(严格小写枚举)
+    model: opus-4-7                  # vendor-specific(claude:opus-4-7|sonnet-4-7|haiku;codex:o4|o4-mini)
+    trigger: manual                  # { manual | watch:<path> }(V0.6.0 仅这两类)
+    parallelism: 1                   # 仅 watch 有意义;manual 强制 1
+    timeout: 30m
+    on_timeout: escalate             # { escalate | retry | skip }
+    max_spawn_depth: 5               # F112 recursion bomb guard;default 5
+    # mode: chat 专用字段(其他 mode 写了 ignore + serde warn)
+    bot_name: "@helpful_assistant"   # IM handle(F109);default 从 F112 agent_naming 池取
+    hop_limit: 3                     # bot-to-bot @ 链路上限(R6);default 3
+    compact_every_turns: 50          # default 50,0 = 禁
+    compact_every_tokens: 100000     # 双触发,default 100k
+
+artifact_dirs:                       # mode: bg 专用;mode: chat 完全忽略
+  - .ccteam/fix-requests/
+
+im_channels:                         # mode: chat 专用;F109 openhuman/channels
+  - kind: telegram                   # { telegram | slack | discord | email | lark | ... (V0.7+ feature) }
+    credentials_ref: default         # ~/.ccteam/im/credentials.json 内 key
+    chat_kind: dm                    # { dm | group }
+    acl:                             # production must-have
+      allow_user_ids: [12345]
+      rate_limit_per_user: "10/h"
+```
+
+**不许写** `prompt:` / `system_prompt:` / `messages:` — 红线(`tech-design.md §3.3.3`);agent 行为住 `.claude/agents/<role>.md`。
+
+## 三、5 preset 的 yaml diff(从 ccteam-creator 默认产物出发)
+
+`ccteam-creator` 模板在 `crates/ccteam-core/src/templates/workflow_templates/{pocket,squad,sprint,builder,solo}.yaml`(F114)。
+
+### Pocket → IM Squad(单 bot → 多 bot 群组)
+
+```diff
+ agents:
+   - role: helpful-bot
++  - role: critic-bot
++    vendor: codex                    # F112 §D auto-critic
++    bot_name: "@critic_newton"       # 自动从 agent_naming 池
+ im_channels:
+   - kind: telegram
++    chat_kind: group
+```
+
+### Pocket → Solo Sidekick(chat → in_proc)
+
+```diff
+-mode: chat
++mode: in_proc
+ agents:
+   - role: helpful-bot
+-    bot_name: "@helpful_assistant"
+-    hop_limit: 3
+-im_channels: ...                     # 整段删
+```
+
+### Pocket → Overnight Builder(chat → bg)
+
+```diff
+-mode: chat
++mode: bg
+ agents:
+   - role: builder
+     trigger: watch:.ccteam/inbox/
+     parallelism: 3
++artifact_dirs: [.ccteam/inbox/, .ccteam/done/]
+-im_channels: ...                     # 整段删
+```
+
+### 加 Codex critic(任意 preset)
+
+```diff
+ agents:
+   - role: main
+     vendor: claude
++  - role: critic
++    vendor: codex
++    model: o4-mini
++    trigger: watch:.ccteam/main-output/
+```
+
+`/ccteam doctor --check-codex` 验装 + auth;缺则报错,不静默 fallback。
+
+## 四、`.claude/agents/<role>.md` frontmatter(V0.6 加 `vendor`)
+
+```markdown
+---
+name: helpful-bot                    # 必,匹配 workflow.yaml::agents.role
+description: 中文技术助手,Claude Code best practices 范围内答问
+tools: [Read, Grep, Edit, Bash]      # Claude Code subagent 白名单;漏写 = 用不上
+model: opus-4-7
+vendor: claude                       # V0.6 新;与 workflow.yaml::vendor 必须一致(doctor warn)
+tone: 礼貌、技术准、不啰嗦
+guardrails:
+  - 拒绝 rm -rf / curl 管道 sudo 类高危命令
+---
+
+# System Prompt 正文(LLM 自读)
+你是一个中文技术助手 ...
+```
+
+**坑**:`vendor: codex` 时 `tools:` 字段静默 ignored(Codex 自有 tool surface),但仍要写以保 schema valid。
+
+## 五、自定义 persona(从 prefab 改)
+
+prefab 在 `skills/ccteam-creator/personas/<name>/`(F114),目录结构:
+
+```
+personas/tech-assistant-zh/
+├── agent.md.tmpl                    # .claude/agents/<role>.md 模板,{{role}} {{tone_overrides}} 插槽
+├── meta.toml                        # { tags, supported_modes, recommended_vendor, language }
+└── README.md
+```
+
+加新 prefab:
+
+```bash
+cp -r skills/ccteam-creator/personas/tech-assistant-zh \
+      skills/ccteam-creator/personas/my-custom-bot
+vim skills/ccteam-creator/personas/my-custom-bot/{agent.md.tmpl,meta.toml}
+# 不需要改 Rust — skill 启动扫 personas/* 自动 pick
+```
+
+**用户自定义 persona 不入 V0.6.0**(F114 §不在范围)— 本节是 contributor 加内置 prefab 路径;V0.7+ 才支持 user-defined。
+
+## 六、Trigger 类型(V0.6.0 仅 2 类)
+
+| Trigger | 语义 | 并发 |
+|---|---|---|
+| `manual` | `mcp__ct__workflow_spawn_agent` / chat user 触发 | 强制 1 |
+| `watch:<path>` | inotify(Linux) / fsevents(macOS),**项目相对路径** | `parallelism` 上限内并发 |
+
+旧 `schedule` / `gate` 在 V0.6 schema error(no shim,CLAUDE.md §五);`ccteam doctor --migrate-workflow` 自动 rewrite。
+
+## 七、Handoff 模板自定义(F115)
+
+每 stage / fix-loop iteration 完,hook prompt 当前 agent 落 `.ccteam/handoffs/<workflow-slug>/stage-<N>-<role>.md`(10-30 行);后续 spawn prompt 自动 `{{include_prev_handoffs}}` 注入。
+
+默认模板 `crates/ccteam-core/src/templates/handoff.md.tmpl`:
+
+```markdown
+# Stage {{stage_n}}: {{stage_name}}
+**Decided**: {{#bullets}}
+**Rejected**: {{#bullets}}
+**Risks**: {{#bullets}}
+**Files changed**: {{#files_with_why}}
+**Remaining**: {{#bullets}}
+```
+
+自定义:仓内 fork 此模板,改 `crates/ccteam-core/src/handoff.rs::HANDOFF_TEMPLATE` 常量。**workflow.yaml 不暴露模板路径** — 全项目共享一个 template;per-project 不同走 PR 改源。
+
+## 八、`ccteam new --no-interactive`(绕过 skill dialogue)
+
+```bash
+ccteam new my-bots \
+  --no-interactive \
+  --mode chat \
+  --preset pocket \                  # { pocket | squad | sprint | builder | solo }
+  --persona tech-assistant-zh \
+  --vendor claude \
+  --with-codex-critic \              # 等价 ccteam-creator Phase 2 自动 critic
+  --im-platform telegram \
+  --skip-im-setup                    # token 已落 ~/.ccteam/im/credentials.json
+
+vim ~/projects/my-bots/.ccteam/workflow.yaml
+ccteam start my-bots
+```
+
+**用途**:CI e2e probe / ansible / nix 自动化 / 反复迭代新 preset 时。**不**调 `/ccteam-im-setup`(token 必须已存);**不**走 mode-inferrer LLM 兜底(rule miss 直接报错)。
+
+## 九、常见陷阱
+
+1. **yaml 缩进** — list item 用 `-` + 2 空格;tab `serde_yaml` 直接 reject。
+2. **`mode` 是 serde tagged enum** — 改 mode 必须**同时**改 mode-specific 字段。`mode: bg` 留 `bot_name`/`hop_limit` → 静默 ignore;`mode: chat` 漏 `im_channels` → schema error,daemon 不起。
+3. **`vendor` 严格小写枚举** — `vendor: openai` ✗ / `vendor: anthropic` ✗;只 `{ claude | codex }`。
+4. **`vendor` agent.md vs workflow.yaml 不一致** — doctor warn 不 error;运行时**按 workflow.yaml 走**,agent.md 字段静默 ignore。
+5. **`watch:<path>` 是项目相对路径**(F78 修过)— `watch:/abs/path` schema error。
+6. **`tools:` 列 `mcp__ct__*` 无效** — 该工具组给 meta-agent;普通 bot 无 permission。F111 反向 `CCTEAM_DISABLE_TOOLS` 才是禁用入口。
+7. **`max_spawn_depth: 0` ≠ 无限,是禁 spawn** — 想"无限"删字段走 default 5,或 `u32::MAX`。
+8. **`compact_every_tokens` 不含 cached input** — cumulative input + output,**不算** cached(F108 实现细节)。
+9. **Trait 接口契约不能突破** — yaml schema 只是 `HarnessAdapter` trait 的 surface 投影;trait 不支持的字段(eg. mode 1 in_proc 写 `im_channels`)加了也是死字段。改 yaml 不能让 `submit_turn` 跳过 `start_thread`、不能让 `events()` 无 `ThreadStarted`。
+
+## 十、看实际跑的是什么
+
+```bash
+/ccteam-control show-workflow <slug>          # 推荐,渲染 yaml + 注释
+cat ~/projects/<team>-<slug>/.ccteam/workflow.yaml
+tail -f ~/projects/<team>-<slug>/.ccteam/progress.jsonl | jq 'select(.event=="agent_spawn") | {role, vendor, mode}'
+```
+
+任何 yaml 改动 daemon **不需重启**(F82 热加载);下次 spawn 即生效。**已在跑的 thread 不受影响**(R3 永不主动 kill);要应用到现有 chat bot,显式 `/ccteam-control restart-bot <role>`。

--- a/docs/advanced/multi-llm-codex.md
+++ b/docs/advanced/multi-llm-codex.md
@@ -1,0 +1,273 @@
+# Multi-LLM with Codex — Advanced Guide
+
+> **Audience**:已用过 V0.5.x ccteam,想理解 V0.6.0 引入的 Codex 集成怎么工作 + 怎么定制 / 双 vendor workflow 调优 / cross-vendor 限制的高级用户。新手不必读这篇 — Codex 在默认场景下对你**完全透明**。
+>
+> **Source of truth**:`docs/v0-6-0/{README,prd}.md` §F107 / F108 / F112。本文是消化版,优先以 prd 为准。
+
+---
+
+## 1. Codex 在 V0.6.0 的定位:advanced 隐藏开关
+
+ccteam 的"低门槛 / Claude-Code-native UX"原则要求**用户从不直接选 vendor**。Codex 不是 first-class user-facing executor,而是**在 4 个明显占优场景静默接入**;其他场景默认全 Claude。
+
+#### 4 个用户可见场景
+
+| 场景 | 入口(用户面)| Codex 角色 | degrade |
+|---|---|---|---|
+| **A. Parallel voting** | `/ccteam-advise <hard question>` skill | Claude + Codex 同 prompt 并发跑 advisor,合成 verdict | codex 缺 / quota → 静默 Claude-only,**不报错** |
+| **B. Auto-critic** | `ccteam-creator` skill phase 内 | 当 role ∈ {critic, reviewer, architect, code-reviewer} 且 codex 可用 → 自动赋 `vendor: codex`(yaml 内部) | codex 不可用 → 全 Claude,yaml 不写 vendor 字段 |
+| **C. Quota fallback** | `~/.ccteam/preferences.toml` `fallback.on_claude_quota = "codex"` | Claude 报 quota / 5xx → 同 turn 重试 Codex 一次 | 默认 off;meta-agent 在用户抱怨 quota 时主动提议 opt-in |
+| **D. `/ccteam-team` second-opinion** | `/ccteam-team N "task ..."` skill | in-proc team 自动加 1 个 Codex critic teammate(if codex 可用) | codex 不可用 → 全 Claude,team size 不变 |
+
+**所有其他场景**(qa-loop / autonomous-orchestrator / chat-bot / 通用 executor / planner / fixer)默认 Claude。Codex 不出场。
+
+---
+
+## 2. 什么时候用 Codex / Claude / 混用
+
+V0.6.0 ccteam-creator skill 内部按下表自动决策。手编 `workflow.yaml` 的高级用户可参考:
+
+| 场景 | 推荐 vendor | 理由 |
+|---|---|---|
+| 长链 reasoning(architect / planner / hard debug)| **Codex** o-series / gpt-5.2-codex | `reasoning_output_tokens` 单独计费,长 CoT 强项;sandbox 默认严格 |
+| 编辑大量代码(executor / fixer / multi-file edit)| **Claude** Opus 4.x / Sonnet | tool use 稳定性 + ephemeral 1h cache 显著省 token |
+| 长跑 chat bot(mode 3)| **Claude** | `claude -p --resume` stream-json + cache hit turn 2 起,V0.6.0 Codex chat 走 V0.7 |
+| Multi-advisor 投票(同 prompt 多视角)| **混合** | Claude + Codex 各跑一次,合成"双方同意 / 冲突 + 选谁"— 见场景 A |
+| 严格 sandbox + approval workflow | **Codex** | sandbox + approval_policy 是 first-class config;Claude 只能靠 hook 模拟 |
+| Critic / code-reviewer / architect role | **Codex**(自动)| 长链 reasoning 强,二阶意见更有价值 |
+| Anthropic-only 合规客户 | **Claude only** | doctor 不 nag 不装 codex |
+| OpenAI Enterprise 合规客户 | **Codex first** | 反向同上;workflow.yaml 模板可 default vendor=codex |
+
+---
+
+## 3. Prerequisites
+
+仅当用户开启场景 A/B/C/D 任一时必需:
+
+```bash
+codex --version    # ≥ 0.45(`--experimental-json` API 稳定 baseline)
+codex login        # ChatGPT plan / API key / device code 任选(Codex 4 路 auth)
+codex account      # 探活,确认 auth ok
+```
+
+`~/.codex/config.toml` 推荐 preset(`ccteam doctor --install-codex-profile` 自动落):
+
+```toml
+[profiles.ccteam-default]
+sandbox = "workspace-write"      # 写权限限 repo 内
+approval_policy = "on-failure"   # 默认信任,失败再问
+model = "gpt-5.2-codex"
+model_reasoning_effort = "medium"
+```
+
+ccteam 内部跑 codex 用 `--profile ccteam-default` 引这套;**用户不必手编 sandbox/approval 字段**。
+
+---
+
+## 4. `ccteam doctor` 检 Codex
+
+默认 doctor 不强求 codex(全 Claude workflow 不 nag)。显式查:
+
+```bash
+ccteam doctor --check-codex-version    # 报告 binary 版本 / 是否 ≥0.45
+ccteam doctor --check-codex-auth       # codex account 探活
+ccteam doctor --install-codex-profile  # 落 ~/.codex/config.toml [profiles.ccteam-default]
+```
+
+doctor 输出语义:
+
+```
+[ok]   claude --version: 2.0.x
+[ok]   codex --version: 0.45.x         ← --check-codex-version
+[ok]   codex auth: user@example.com    ← --check-codex-auth
+[ok]   ~/.codex/config.toml profile ccteam-default present
+[info] workflow.yaml: 2/5 agent vendor=codex (auto-assigned by ccteam-creator)
+```
+
+workflow 含 `vendor: codex` 但 codex auth 缺 → **启动前**报错,不等到 spawn 才挂(F112 验收 §4)。
+
+---
+
+## 5. 手动启用 Codex preferences
+
+`~/.ccteam/preferences.toml` 是 advanced 偏好文件,**不让用户直接 vim**;走 meta-agent 或 skill 命令:
+
+```
+# 在 Claude session 里
+/ccteam prefs fallback.on_claude_quota codex
+/ccteam prefs default.critic_vendor codex
+/ccteam prefs codex.profile ccteam-default
+```
+
+写入后:
+
+```toml
+# ~/.ccteam/preferences.toml(skill 生成,不要手编)
+[fallback]
+on_claude_quota = "codex"        # 场景 C 启用
+
+[default]
+critic_vendor = "codex"          # 场景 B 强制(默认 = auto-detect)
+
+[codex]
+profile = "ccteam-default"       # codex --profile flag 用此名
+```
+
+**preferences 是 user-global**(`~/.ccteam/`),不进 git,不污染项目。
+
+---
+
+## 6. `workflow.yaml` `vendor:` 字段(advanced)
+
+`workflow.yaml` 由 `ccteam-creator` skill 自动生成,vendor 字段系统写。**advanced 用户**可手编(承认你愿意维护 yaml):
+
+```yaml
+version: 0.6
+mode: bg
+agents:
+  - role: planner
+    vendor: claude                   # claude | codex | auto
+    model: opus-4-7
+
+  - role: critic
+    vendor: codex                    # 用 Codex o-series 长链 reasoning
+    model: gpt-5.2-codex
+    codex_sandbox: read-only         # 只 vendor=codex 适用
+    codex_approval: never            # critic 只读,无 approval
+    codex_reasoning_effort: high
+
+  - role: executor
+    vendor: claude
+    codex_sandbox:                   # 写了 schema validate 报错(vendor 不匹配)
+```
+
+#### 字段说明
+
+| 字段 | vendor | 默认 | 取值 |
+|---|---|---|---|
+| `vendor` | both | `claude` | `claude | codex | auto`(`auto` = ccteam-creator 决策) |
+| `model` | both | vendor 默认 | vendor-specific 名 |
+| `codex_sandbox` | codex only | `workspace-write` | `read-only | workspace-write | danger-full-access` |
+| `codex_approval` | codex only | `on-failure` | `untrusted | on-failure | on-request | never` |
+| `codex_reasoning_effort` | codex only | `medium` | `low | medium | high` |
+
+`codex_*` 字段在 `vendor: claude` 下出现 → schema validate 报错(明确错误,不静默忽略)。
+
+---
+
+## 7. Cost 透明 — 双 pricing table
+
+#### 内部架构
+
+| crate / file | 用途 |
+|---|---|
+| `crates/ccteam-cost/pricing/anthropic.toml` | Claude 各 tier 定价(`opus-4-7` / `sonnet-4-5` / `haiku-4-5`),含 `cache_creation_input_tokens` / `cache_read_input_tokens` 写入价 + 命中价 |
+| `crates/ccteam-cost/pricing/openai.toml` | Codex 各 tier 定价(`gpt-5.2-codex` / `o3` / `o3-mini`),含 `reasoning_output_tokens` 单独计费 |
+| `crates/ccteam-cost/src/budget.rs` | `UnifiedTokenUsage` enum + per-vendor budget cap |
+
+`UnifiedTokenUsage`(详 prd F107 §D)是 superset,容两边字段;`progress.jsonl::agent_done.usage` 序列化此结构。
+
+#### Per-vendor budget cap
+
+```yaml
+# workflow.yaml(系统生成,user 不见)
+budgets:
+  claude:
+    max_cost_usd_per_24h: 5.0
+  codex:
+    max_cost_usd_per_24h: 2.0
+```
+
+**触底行为**:任一 vendor 触底 → workflow 整体 `enabled: false`(F84 红线),emit `vendor_budget_exhausted { vendor }` event;**不**自动切另一 vendor(避免行为漂移)。
+
+#### 用户面展示(MCP `workflow_show_cost`)
+
+```
+$ /mcp ccteam workflow show-cost
+Total: $1.50 / day
+  claude: $1.00 (Opus 4.7 main x 3 hour, Sonnet critic x 30min)
+  codex:  $0.50 (o3-mini critic x 1 hour, reasoning 30% of cost)
+```
+
+聚合数 + 分 vendor 详情,user 看 1 行;web UI 同模式渲染。
+
+---
+
+## 8. AGENTS.md vs CLAUDE.md
+
+| 文件 | Vendor | 内容 |
+|---|---|---|
+| `<repo>/CLAUDE.md` | Claude | Claude Code 项目级指令(已有) |
+| `<repo>/AGENTS.md` | Codex | Codex 项目级指令(本身格式与 CLAUDE.md 同) |
+
+**ccteam init** 落 `AGENTS.md` 作 POSIX symlink → `CLAUDE.md`:
+
+```bash
+ln -s CLAUDE.md AGENTS.md         # ccteam init 默认行为(Linux / macOS)
+```
+
+Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sync-agents-md.sh`)。doctor 检测 drift,落 finding。
+
+**用户改 CLAUDE.md 自动反映到 AGENTS.md**(symlink),Codex bot 看到同一份项目规则。R8 红线(跨项目记忆走官方接口)扩到 "两边官方路径,ccteam 不写第三份"。
+
+---
+
+## 9. Cross-vendor 限制(物理事实)
+
+| 跨 vendor 场景 | 可行性 | 原因 |
+|---|---|---|
+| **模式 1 in-proc team(同 parent session)** | ✗ **永远不可能** | Anthropic 官方 `TeamCreate` 文档明示 "workers are Claude sessions";Codex 同理只能 spawn Codex 子 thread。**没有任何技术路径**让一个 Claude session 把 Codex 作 in-proc teammate。详 prd CC9 |
+| **模式 2 bg sessions 跨 vendor** | ✓ | ccteam orchestrator 是外置中转;`.ccteam/inbox/*.md` 触发 fresh `claude --bg` / `codex exec`;`progress.jsonl::agent_done.vendor` 字段区分 |
+| **模式 3 chat bots 跨 vendor**(同 TG 群)| V0.7+ | V0.6.0 chat mode 锁 Claude(F108);Codex chat 需 F112 wave 3 `CodexAppServerAdapter` |
+| **Auto-fallback Claude↔Codex**(同任务自动切)| ⚠ opt-in only | 场景 C,默认 off;两边 system prompt 不同 + sandbox 不同 + cost model 不同,**自动切换会让 debug 极难找根因** — 用户显式开 |
+
+#### Cross-vendor 桥协议(mode 2 跨 vendor 时)
+
+- **SendMessage**:走 orchestrator(写 `.ccteam/inbox/<recipient>/msg-*.md`);**不**直接传 Claude `SendMessage` tool call 给 Codex
+- **cost 聚合**:`UnifiedTokenUsage` + 双 pricing,progress event `cost_update` 带 `vendor`
+- **observability**:`progress.jsonl::*.vendor` 必填,web UI 按 vendor 着色 + 分组
+- **memory 隔离**:`~/.claude/CLAUDE.md` 给 Claude bot,`~/.codex/AGENTS.md` 给 Codex bot,**ccteam 不混写**(同 §8 symlink 策略)
+
+---
+
+## 10. 5 编排 × 3 执行 × 2 vendor 矩阵(Codex 列摘要)
+
+详细矩阵在 `docs/orchestration-patterns.md` §五。Codex 列(对照 Claude 列)摘要:
+
+| Cell | Codex 列 | 注 |
+|---|---|---|
+| Chaining × mode 1 × Codex | ⚠ | Codex 原生 `spawn_agent` 但 ccteam-team skill 是 Claude session-local — 跨 vendor in-proc 不可行(CC9) |
+| Chaining × mode 2 × Codex | ✓ | `codex exec` artifact-driven,行为对齐 Claude |
+| Chaining × mode 3 × Codex | ✗(V0.6.0) | 需 `CodexAppServerAdapter`,F112 wave 3 |
+| Routing × all × Codex | ⚠ | Codex routing config-driven(role.toml 选模型),跟 Claude SKILL.md prompt-driven routing **不等价**;用户面统一走 `ccteam-creator` 自动选,内部 routing 各管各 |
+| Parallel-vote × mode 1 × Codex | ✓ | 场景 A `/ccteam-advise` 头条用例 |
+| Parallel-segment × mode 2 × mixed | ✓ | git worktree per agent,vendor 标在 progress event |
+| Orchestrator-Worker × mode 3 × Codex | ✗(V0.6.0) | 同 chaining mode 3 |
+| Evaluator-Optimizer × mode 2 × Codex | ✓ | critic 角色自动接 Codex(场景 B) |
+| Evaluator-Optimizer × mode 1 × mixed | ✗ | 同 CC9 |
+| **In-proc 跨 vendor 任意 cell** | ✗ **永远** | 物理不可能 |
+
+**总计 30 cell 状态**:✓ 11 / ⚠ 2 / ✗ 4(mode 1 跨 vendor 全 ✗,共 5 cell;mode 3 Codex 单 vendor V0.6.0 共 5 cell ✗ 等 Wave 3);其余 V0.6.0 不展开。
+
+---
+
+## 11. 常见陷阱
+
+| 陷阱 | 症状 | 解 |
+|---|---|---|
+| **Codex sandbox 默认 read-only** | bot 想写文件失败 "permission denied",静默 | workflow.yaml 显式 `codex_sandbox: workspace-write`;Claude 的 `--dangerously-skip-permissions` **无 Codex 等价** — 必须配 sandbox + approval=never 才同效果 |
+| **`reasoning_output_tokens` 单独计费** | `gpt-5.2-codex` o-series 跑 fix-loop 3 次 bill 看起来比 Claude 贵 3x | `medium` reasoning effort 已是默认;`high` 只在 architect role 用,不在 executor;监控 `progress.jsonl::*.usage.reasoning_output_tokens` 比 input/output 还大就是 effort 配错 |
+| **AGENTS.md 不读 → bot 行为漂移** | Codex bot 不知道项目规则,Claude bot 知道 | doctor 检测 `<repo>/AGENTS.md` 存在且 symlink 到 CLAUDE.md;CI 加 trufflehog 扫 AGENTS.md / CLAUDE.md drift |
+| **Codex CLI 形态漂移激进** | `codex exec` 升级后 flag 改、`--experimental-json` API 变 | `CCTEAM_CODEX_BIN` env override(同 `CCTEAM_CLAUDE_BIN`);prd pin `codex >= 0.45`,V0.6.x 任何 codex breaking 升 ccteam patch 版兜底 |
+| **OpenAI auth 比 Anthropic 复杂** | `codex login` 4 路(ChatGPT plan / API key / device code / access token)首次失败率高 | doctor 强制 `codex account` 探活;workflow.yaml validate `vendor: codex` 但 auth 缺 → 启动前 abort |
+| **session-id 命名空间冲突** | Claude bot 和 Codex bot 同 workflow,session-id 文件互覆盖 | 内部路径 `~/.ccteam/im/<workflow>/<bot>/<vendor>/session-id` 强制 vendor 段;此 path V0.6.0 已固化(prd F112) |
+| **cross-vendor in-proc 期望** | 用户问"为啥 `/ccteam-team` 不能起 Claude + Codex 混合 in-proc 队伍" | 解释 CC9 物理限制:跨进程通过 mode 2 `.ccteam/inbox/` 桥可实现近似效果,但 in-proc(同 session)永不可能 |
+
+---
+
+## See also
+
+- `docs/v0-6-0/prd.md` §F107 / F108 / F112 — 完整 finding 设计
+- `docs/orchestration-patterns.md` §五 — 5 拓扑 × 3 执行模式适用矩阵全表
+- `docs/v0-6-0/README.md` §4.3 — Codex 4 用户可见场景的 UX 决策记录
+- `CLAUDE.md` §三 红线表 — R3 / R4 / R6 / R8 在模式 × vendor 下的措辞

--- a/docs/advanced/presets-reference.md
+++ b/docs/advanced/presets-reference.md
@@ -1,0 +1,306 @@
+# Presets Reference — 5 preset 内部映射
+
+> **Audience**:已经用过 [quickstart](../quickstart.md) 和 [recipes](../recipes.md) 的 power user / contributor。本文档展示 5 个 user-facing preset 在内部映射到哪些 execution mode / orchestration pattern / yaml schema,以及每字段的 default。日常使用者不需要看本文档 — `ccteam-creator` skill 自动生成所有这些字段。
+>
+> **关系到的内部文档**:
+> - `docs/tech-design.md` §2.1(`HarnessAdapter` trait,5 方法)
+> - `docs/architecture/orchestration-patterns.md` §一(5 编排模式 × 3 执行模式 × 2 vendor = 30 cell)
+> - `docs/interfaces.md`(`workflow.yaml` schema 权威)
+
+---
+
+## 一、5 preset 内部映射总表
+
+| Preset | 执行模式 | 主要编排模式 | spawn 原语 | 默认 vendor | 默认 cost cap |
+|---|---|---|---|---|---|
+| **Solo Sidekick** | mode 1 in-proc | Routing(单 agent)| `Task(subagent_type=...)` | Claude | parent session 共享 |
+| **Team Sprint** | mode 1 in-proc | Orchestrator-Worker(+ optional Codex critic) | `Task(subagent_type=..., team_name=..., name=...)` × N | Claude + auto-critic Codex | parent session 共享 |
+| **Overnight Builder** | mode 2 bg artifact-driven | Chaining + Evaluator-Optimizer 内圈 | `claude --bg --agent <role>` per spawn | Claude + auto-reviewer Codex | `max_cost_usd_per_24h: 5.0` |
+| **Pocket Assistant** | mode 3 chat (DM) | Routing(单 bot)| `claude -p --resume <sid> --input-format stream-json` | Claude(Codex critic 隐式 second-opinion 可开) | `max_cost_usd_per_24h: 1.0` |
+| **IM Squad** | mode 3 chat (group + bot-to-bot @) | Orchestrator-Worker + Routing(@-mention)| 同上,N 个 long-running session | Claude(per-bot vendor 可异)| `max_cost_usd_per_24h: 2.0` |
+
+trait 层:全部走 `HarnessAdapter::{start_thread, submit_turn, events, resume_thread, close_thread}` 5 方法;`vendor: AgentVendor { Claude, Codex }` enum 决定具体 adapter(`ClaudeBgAdapter` / `ClaudeStreamJsonAdapter` / `CodexExecAdapter` / `CodexAppServerAdapter`)。
+
+---
+
+## 二、Solo Sidekick 内部 schema
+
+User entry:`/ccteam-team 1 "task"` 或 `/ccteam <NL>` 推断单人小事 → 实际是单 `Task` call,**不写 yaml**。
+
+无 `.ccteam/workflow.yaml` 落盘(parent Claude session 内瞬时,session 关即丢)。配置在 skill prompt 内。
+
+---
+
+## 三、Team Sprint 内部 schema
+
+User entry:`/ccteam-team N "task"` 或 `/ccteam-team N:executor "task"` 显式指定 worker 类型。
+
+`.ccteam/workflow.yaml`(由 `ccteam-creator` 生成):
+
+```yaml
+version: 0.6
+mode: in_proc                          # 内部枚举,user 不见
+preset: team_sprint
+agents:
+  - role: lead
+    spawn: implicit                    # 即 parent session
+  - role: executor
+    parallelism: 3                     # user 指定的 N
+    vendor: claude                     # default
+  - role: critic
+    vendor: codex                      # auto-detect:codex binary in PATH + auth ok → 自动设置
+    optional: true                     # 没装 codex 则跳过此 agent
+
+triggers:
+  - kind: manual                       # user `go` 触发
+    target: lead
+
+budgets:
+  parent_session_inherit: true         # 不单独 cap,跟 parent context
+```
+
+`vendor: codex` 自动设置规则:`ccteam-creator` skill `Phase 3` 检测 (a) `which codex` 成功 (b) `codex auth status` ok (c) role name ∈ {critic, reviewer, code-reviewer, security-reviewer, architect}。三条全满足才设置。
+
+---
+
+## 四、Overnight Builder 内部 schema
+
+User entry:`/ccteam-creator "夜跑 X"` 推断 timeline = long-running + presence = unattended → mode 2。
+
+`.ccteam/workflow.yaml`:
+
+```yaml
+version: 0.6
+mode: bg                               # 内部枚举,user 不见
+preset: overnight_builder
+agents:
+  - role: test-runner
+    vendor: claude
+    spawn_command: claude --bg --agent test-runner
+    triggers:
+      - kind: artifact_received
+        watch: .ccteam/inbox/test/
+      - kind: cron
+        schedule: "0 22 * * *"        # 22:00 dispatch
+  - role: fixer
+    vendor: claude
+    triggers:
+      - kind: artifact_received
+        watch: .ccteam/outbox/test-fail/
+  - role: releaser
+    vendor: claude
+    triggers:
+      - kind: artifact_received
+        watch: .ccteam/outbox/test-pass/
+  - role: reviewer
+    vendor: codex                      # auto-critic
+    optional: true
+    triggers:
+      - kind: artifact_received
+        watch: .ccteam/outbox/fix/
+
+budgets:
+  claude:
+    max_cost_usd_per_24h: 5.0
+  codex:
+    max_cost_usd_per_24h: 2.0
+
+fix_loop:
+  max_attempts: 3                      # 撞 3 次必 escalate(R6 红线)
+  on_max_exceeded: escalate            # 写 escalation event,通过 IM 推用户
+
+notification:
+  channel: ~/.ccteam/im/credentials.json   # 走 /ccteam-im-setup 落地的 token
+  on_events: [escalation, workflow_done, budget_exceeded]
+```
+
+trigger 类型详 `docs/interfaces.md` §3:
+- `artifact_received { watch: <dir> }` — inotify 监听目录新文件
+- `cron { schedule: <spec> }` — 时刻触发
+- `manual` — user 在 Claude session 里手动 `/ccteam-control trigger <agent>`
+- `workflow_event { kind: <event> }` — 监听 progress.jsonl 业务事件
+
+---
+
+## 五、Pocket Assistant 内部 schema
+
+User entry:`/ccteam-creator "TG 私聊助手"` 推断 presence = "IM 私聊" → mode 3 chat DM。
+
+`.ccteam/workflow.yaml`:
+
+```yaml
+version: 0.6
+mode: chat                             # 内部枚举,user 不见
+preset: pocket_assistant
+im:
+  channel_id_path: ~/.ccteam-im/channels/<slug>.json    # 内部 ref,user 不见
+  transport: openhuman                                   # default;可 official-telegram override
+agents:
+  - role: helpful-bot
+    persona: tech_helper_zh            # personas/tech_helper/zh/ 目录预填
+    vendor: claude
+    spawn_command: claude -p --resume <sid?> --input-format stream-json
+    bot_name: auto                     # 从 agent_naming.rs 50 nickname 池取
+    compact_every_turns: 50            # default
+    hop_limit: 3                       # bot-to-bot @ 上限(R6 红线扩展)
+    second_opinion:
+      enabled: auto                    # 检测 codex available → 启用
+      vendor: codex
+      trigger: on_uncertain            # bot 自己判断"我不太确定" → 跑 Codex critic
+
+budgets:
+  claude:
+    max_cost_usd_per_24h: 1.0
+  codex:
+    max_cost_usd_per_24h: 0.5
+
+session_id_persist: ~/.ccteam/im/<slug>/<bot>/session-id
+turns_jsonl: <project>/.ccteam/chat/<bot>/turns.jsonl    # ccteam-owned conversation SoT
+```
+
+`turns_jsonl` 格式(每 turn 一行):
+
+```jsonl
+{"turn_id":"...","ts":"...","user":"...","assistant":"...","usage":{"input_tokens":...,"output_tokens":...,"cache_read_input_tokens":...},"tool_calls":[...],"vendor":"claude"}
+```
+
+`session_id_persist` 文件丢失 / Anthropic 内部 jsonl 改格式 → fail-open + 从 `turns_jsonl` last-N turn 重建 conversation(详 F118)。
+
+---
+
+## 六、IM Squad 内部 schema
+
+User entry:`/ccteam-creator "TG 群组 N 个 bot"` 推断 presence = "IM 群多 bot" → mode 3 chat group。
+
+`.ccteam/workflow.yaml`:
+
+```yaml
+version: 0.6
+mode: chat
+preset: im_squad
+im:
+  channel_id_path: ~/.ccteam-im/channels/<slug>.json
+  transport: openhuman
+  group_mode: true                     # 群组 + bot-to-bot @ 路由
+agents:
+  - role: helpful-bot
+    persona: tech_helper_zh
+    bot_name: newton                   # 从 nickname 池取(或 user 指定)
+    hop_limit: 3                       # 同上
+    vendor: claude
+  - role: critic-bot
+    persona: code_critic_zh
+    bot_name: curie
+    hop_limit: 3
+    vendor: codex                      # auto-critic 路径自动设置
+    optional: true
+
+bot_to_bot:
+  routing: at_mention                  # @ critic-bot 才进入 critic 处理
+  max_hop_per_chain: 3                 # 与 hop_limit 一致;不允许 bot 链超 3 跳
+  hop_escalate_to: user                # 撞 limit → @ user 介入
+
+budgets:
+  claude:
+    max_cost_usd_per_24h: 2.0
+  codex:
+    max_cost_usd_per_24h: 1.0
+```
+
+`bot_to_bot.routing` 选项:
+- `at_mention` — 只有显式 @ 才转发(默认)
+- `keyword` — agent prompt 内置关键词触发(进阶,V0.7+)
+- `pubsub` — 任何 bot 发言所有其他 bot 都看到(危险,V0.7+ 仅小群组)
+
+`hop_escalate_to`:`user` / `lead` / `none`(撞 limit 自动停)
+
+---
+
+## 七、跨 preset 通用字段
+
+下列字段所有 preset 共享(`#[serde(default)]`):
+
+| 字段 | 类型 | default | 说明 |
+|---|---|---|---|
+| `version` | str | "0.6" | yaml schema 版本 |
+| `vendor` | enum | `claude` | `claude` / `codex`;per-agent 可异 |
+| `budgets.<vendor>.max_cost_usd_per_24h` | f64 | preset-specific | 触顶 ccteam 自动 stop + IM 通知 |
+| `fix_loop.max_attempts` | u32 | 3 | R6 红线,绝不静默重置 |
+| `fix_loop.on_max_exceeded` | enum | `escalate` | `escalate` / `accept`(后者仅 dev 测试) |
+| `agent.optional` | bool | `false` | 缺依赖(vendor binary 没装等)→ 跳过该 agent 而非 abort |
+| `agent.max_spawn_depth` | u32 | 5 | recursion bomb guard(借 Codex `agent_max_depth`)|
+
+---
+
+## 八、IM transport 选项
+
+`im.transport` 字段:
+
+| 值 | 形态 | provider 支持(V0.6.0) |
+|---|---|---|
+| `openhuman`(default)| `ccteam-imd` daemon + `openhuman/channels` crate | Telegram / Slack / Discord(V0.6.0);Lark / DingTalk / QQ feature gate(V0.7 启用) |
+| `official-telegram` | `claude --channels plugin:telegram@claude-plugins-official` | Telegram only |
+
+切换走 `/ccteam-im-setup --transport <name>`,不让用户编辑 yaml。两 path 互斥(同 bot token 不可同时绑两条)。
+
+---
+
+## 九、Override 例子
+
+`ccteam-creator` 生成的 yaml 是默认值,power user 可手改。改完 `/ccteam-control reload <slug>` 触发 hot-reload(部分字段)或 cold-reload(影响 topology 的字段)。
+
+### 例 1:Pocket Assistant 切换 second-opinion 关闭
+
+```yaml
+# 原 auto
+second_opinion:
+  enabled: auto
+# 改为强制关
+second_opinion:
+  enabled: false
+```
+
+### 例 2:Overnight Builder 加 security-reviewer 阶段
+
+```yaml
+agents:
+  # ... 原 4 agent ...
+  - role: security-reviewer
+    vendor: codex
+    triggers:
+      - kind: artifact_received
+        watch: .ccteam/outbox/release/   # release 后再过一次 security
+```
+
+### 例 3:IM Squad 给某 bot 单独提预算
+
+```yaml
+budgets:
+  claude:
+    max_cost_usd_per_24h: 5.0          # 群里聊得多
+  codex:
+    max_cost_usd_per_24h: 2.0
+agents:
+  - role: critic-bot
+    budget_override:                    # 单 bot override
+      claude.max_cost_usd_per_24h: 0.5  # critic 只拿小份额
+```
+
+### 例 4:同一 preset 切默认 vendor
+
+```yaml
+agents:
+  - role: helpful-bot
+    vendor: codex                       # 整 bot 跑 codex 而非 claude(罕见;通常自动 detect 路径不到这里)
+```
+
+---
+
+## 十、相关文档
+
+- 用户面入门:[quickstart.md](../quickstart.md)
+- 8 个 ready 配方:[recipes.md](../recipes.md)
+- 5 preset 用户文档:[user-manual.md](../user-manual.md)
+- 自定义改造:[advanced/customize-workflow.md](customize-workflow.md)
+- Codex 集成深拆:[advanced/multi-llm-codex.md](multi-llm-codex.md)
+- 架构权威:`docs/tech-design.md` + `docs/interfaces.md` + `docs/architecture/orchestration-patterns.md`(V0.6.0 重组后路径)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,120 @@
+# Quickstart — 5 分钟在 TG 收到你第一个 AI 助理的回话
+
+> 本文档单一目标:从 0 到 **你手机 TG 收到 bot 第一条回话**,5 步,5 分钟。
+>
+> 卡住任何一步?跳到 [troubleshooting.md](troubleshooting.md) 搜对应章节。
+
+## 你需要
+
+- Claude Code(`claude` CLI),装好登好。没装看 [code.claude.com/docs/install](https://code.claude.com/docs/install)。
+- Telegram 账号 + 手机装 Telegram app。macOS / Linux 主机(Windows 走 WSL2)。
+
+---
+
+## Step 1 — 装 ccteam plugin(30 秒)
+
+任意 terminal 起 Claude session:
+
+```bash
+$ claude
+```
+
+在 session 里输入:
+
+```
+/plugin install ccteam
+```
+
+预期输出:
+
+```
+✓ Installed ccteam@0.6.0
+  • 5 slash commands registered: /ccteam, /ccteam-team, /ccteam-creator, /ccteam-control, /ccteam-im-setup
+  • mcp__ccteam__* tools available
+```
+
+→ 卡了?见 [troubleshooting.md](troubleshooting.md) "plugin install 失败"。
+
+---
+
+## Step 2 — 绑定你的 TG bot(2 分钟)
+
+```
+/ccteam-im-setup
+```
+
+向导引导你:浏览器自动开 [@BotFather](https://t.me/BotFather) → 发 `/newbot` → 起名(如 `my_helper_bot`)→ 复制 token 粘回 Claude → 向导在 TG 监听 30 秒,你随便发条 `hi`,它自动抓 `chat_id`。
+
+预期结束:
+
+```
+✓ Telegram bot 已绑定:@my_helper_bot
+✓ chat_id 抓到:123456789
+✓ Daemon ccteam-imd 已起
+现在可以跟 @my_helper_bot 私聊:https://t.me/my_helper_bot
+```
+
+→ 卡了?见 [troubleshooting.md](troubleshooting.md) "TG token 拿不到 / chat_id 抓不到"。
+
+---
+
+## Step 3 — 让 ccteam 做一个 Pocket Assistant(1 分钟)
+
+```
+/ccteam-creator "做个 TG 私聊助理 bot,帮我每天读邮件 + 看 GitHub PR + 早 7 点发摘要"
+```
+
+ccteam-creator 自动判定是 **Pocket Assistant** preset,问 2-3 个问题:
+
+```
+Creator: persona 模板?推荐 "Personal Workflow Assistant"(中文)
+         其他选项:Technical Helper / Writing Coach / Translator / Study Buddy
+You:     用 Personal Workflow Assistant
+
+Creator: 24h cost cap?建议 $2 起步(用得多再调)
+You:     $2
+
+Creator: 计划:Preset = Pocket Assistant · Persona = Personal Workflow Assistant(中文)
+         · IM = TG @my_helper_bot(私聊)· cap = $2/24h。回 "go" 起。
+You:     go
+```
+
+预期:
+
+```
+✓ Workflow created: helper-bot
+✓ Bot @my_helper_bot is now live
+✓ Web dashboard: http://localhost:7331/p/helper-bot
+```
+
+---
+
+## Step 4 — 去 TG 私聊它(30 秒)
+
+打开 Telegram,搜 `@my_helper_bot`(你 Step 2 起的名字),点 Start。
+
+发条消息:
+
+```
+你好,你能帮我做啥?
+```
+
+预期:几秒内收到 bot 自我介绍 + 列能力清单。
+
+🎉 **完成。你的第一个 AI 助理已经在 TG 里跑起来了。**
+
+---
+
+## Step 5 — 跨设备试试(可选)
+
+笔记本继续开着,掏手机走开,继续在 TG 跟 bot 聊。bot 仍然回。bot 跑在**你电脑上**(能动文件 / 跑命令),手机只是入口 — 这是跟 ChatGPT app 拉开差异的关键。
+
+---
+
+## 接下来读什么
+
+- 想跑别的 use case?→ [recipes.md](recipes.md)(代码审查 bot / 翻译 bot / 日报助手等 10 个现成模板)
+- 想了解全部 5 种用法?→ [user-manual.md](user-manual.md)
+- 想给 bot 换 persona / 加能力?→ [user-manual.md](user-manual.md) §2.4 Pocket Assistant
+- 装 Codex 让两个 LLM 互审?→ [advanced/multi-llm-codex.md](advanced/multi-llm-codex.md)
+- 出错?→ [troubleshooting.md](troubleshooting.md)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,495 @@
+# Recipes — 8 个 ready-to-go 配方
+
+> 这是一份"照菜单点"的快速起手册。每个配方告诉你 **一句话怎么起、起出来是啥、每天大约花多少钱**。
+>
+> 所有起步命令都在 Claude session 里跑 — 一句 `/ccteam <自然语言>`,剩下的 `ccteam-creator` 帮你搞定:agent 行为、IM 连接、Codex critic、预算上限,统统不用你写配置。
+>
+> **前置一次性**:
+> 1. 装好 ccteam:`/plugin install ccteam` + `ccteam doctor`
+> 2. 想要 IM bot?先跑一次 `/ccteam-im-setup` 绑定 TG / Slack token(2-3 分钟,后续所有配方都自动复用这个 token)
+> 3. 想要 Codex critic?在终端跑过 `codex auth` 就行(可选 — 没装 ccteam 自动跳过 critic 那一档,只用 Claude)
+>
+> **看完想改?** 每个配方最后有 [进阶定制](advanced/customize-workflow.md) 链接。改名字、换 persona、调 IM 平台、加更多 bot — 都在那本手册。
+
+---
+
+## 配方 1 — 个人代码助手(TG 私聊)
+
+### 场景
+
+> "我想在 Telegram 私聊里随时问个技术问题,通勤路上、卧床都能用。最好支持中文。"
+
+### 适合谁
+
+独立开发者 / 学生 / 任何想"把 Claude 装进口袋"的人。
+
+### 起步
+
+在 Claude session 里:
+
+```
+/ccteam 做个 Telegram 私聊技术助手,中文回答
+```
+
+ccteam-creator 会问你 2-3 个 follow-up(用什么名字 / 回答风格偏正式还是随意),然后回:
+
+```
+PROJECT PLAN
+============
+Type:           Pocket Assistant(TG 私聊)
+Bot:            @code_helper(persona: 技术助手 中文版)
+Codex critic:   自动启用(检测到 codex auth)
+预计 cost/day:  ~$0.4(Claude 主对话 + Codex 偶尔挑刺)
+
+Reply 'go' 启动,或改 persona / 平台 / 语言。
+```
+
+回 `go`,30 秒后 ccteam 告诉你"在 TG 找 @code_helper 私聊试试"。
+
+### 生成什么(你不用编辑)
+
+- 一个 helpful-bot agent,中文技术助手 persona
+- TG bot 注册(走你已经绑定的 token)
+- Claude Opus 作主回答 + Codex 自动当 critic(检测到才启用,没装就纯 Claude)
+- 每日预算 $1 上限,触顶 ccteam 自己 escalate 告诉你
+
+### 预期 cost
+
+- 轻度日用(20-30 条问答 / 天):**$0.3-0.6 / day**
+- 重度日用(100+ 条 / 天):**$1-2 / day**
+
+### 想改?
+
+[进阶定制 — 换 persona / 切英文 / 加额外 critic](advanced/customize-workflow.md#pocket-assistant)
+
+---
+
+## 配方 2 — 写作 critic 群
+
+### 场景
+
+> "我写文章 / 邮件 / 文案的时候想丢进群里,让两个 AI 帮我看 — 一个挑文笔,一个挑结构。"
+
+### 适合谁
+
+写作者 / 内容创作者 / 营销 / 任何需要"先放一边晾一下再回头看"的写作场景。
+
+### 起步
+
+先在 TG 创个群,把你的两个 bot 拉进去。然后在 Claude session:
+
+```
+/ccteam 做个 TG 群组写作 critic 双 bot:一个挑文笔风格,一个挑结构逻辑
+```
+
+ccteam-creator 推断:这是 IM 群组多 bot 互动场景。生成:
+
+```
+PROJECT PLAN
+============
+Type:           IM Squad(TG 群组双 bot)
+Bots:           @style_critic(文笔 / 风格 / 用词)
+                @structure_critic(结构 / 论证 / 逻辑)
+互动模式:        你 @ 它们,它们会 @ 对方协同;最多 3 轮自动止住
+Codex critic:   不启用(都是 critic 角色,不需要 critic 的 critic)
+预计 cost/day:  ~$0.8(看文章长度;一篇千字稿 ~$0.05)
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+```
+你 → 群里发文章草稿
+你 → @style_critic 帮我看看文笔
+@style_critic → 5 处建议 + @structure_critic 这段结构你怎么看
+@structure_critic → 回应 + 给出修订建议
+```
+
+### 生成什么
+
+- 两个 agent,style-critic + structure-critic,各自 persona 已预填
+- TG 群组 webhook
+- bot 互相 @ 链路:最多 3 轮自动停(防止两个 bot 无限互相回应)
+- 没有 Codex critic 自动接入(critic 角色不需要 second-opinion critic)
+
+### 预期 cost
+
+- 每天审 1-3 篇短稿:**$0.3-1 / day**
+- 长稿(5k+ 字):每篇 **$0.1-0.3**
+
+### 想改?
+
+[进阶定制 — 换成单 bot / 加第三个 bot / 改 prompt 风格](advanced/customize-workflow.md#im-squad)
+
+---
+
+## 配方 3 — 夜跑 qa-loop
+
+### 场景
+
+> "我下班丢一个 bug fix 任务,睡一觉醒来看到结果。要 test 跑通才停,撞到 3 次失败必须告诉我。"
+
+### 适合谁
+
+任何"白天 review、晚上跑"的人。需要质量 gate 的长任务都吃这套。
+
+### 起步
+
+```
+/ccteam 做个夜跑 qa-loop:test → fix → release,失败 3 次必须叫醒我
+```
+
+ccteam-creator 推断:长跑、用户不在场、有质量 gate → Overnight Builder。
+
+```
+PROJECT PLAN
+============
+Type:           Overnight Builder(后台长跑)
+Pipeline:       test 跑测试 → fix 修复失败 → release 打 tag
+Codex critic:   自动启用(review 角色)— 每次 fix 后让 Codex 二审
+失败上限:        3 次;撞到 ccteam 停手 + 发 TG 私信通知你
+预计 cost/day:  ~$2-5(看任务复杂度;一晚 8 小时 ~$3)
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+```
+你 → 把任务说清楚,go
+ccteam → 起 daemon,你关电脑去睡
+夜里 → ccteam 跑 test,fail 就 fix,通过就 release tag
+撞 3 次失败 → 停手 + TG @你 "卡在 X 模块,需要人审一下"
+通过 → TG @你 "已 release,见 PR https://..."
+```
+
+### 生成什么
+
+- test-runner agent + fix-er agent + release-er agent
+- 任务文件接力:test 输出 → fix 读 → 修完触发 release
+- Codex critic 自动接入 fix 一关(走"自动当 reviewer"路径)
+- IM 通知:成功 / 失败都通过你绑定的 TG 推一条
+
+### 预期 cost
+
+- 简单 task(改 5-10 行,跑 1-2 轮)**$0.5-1.5 / 晚**
+- 中等 task(几个模块,3-5 轮)**$2-5 / 晚**
+- 大 task(整 feature,~10 轮)**$5-10 / 晚**
+- 撞预算上限 ccteam 自动停 — 不会跑出天价账单
+
+### 想改?
+
+[进阶定制 — 调失败上限 / 换 critic / 加 security-review 一关](advanced/customize-workflow.md#overnight-builder)
+
+---
+
+## 配方 4 — GitHub issue triage 助理
+
+### 场景
+
+> "我有个开源项目,issue 越积越多。想要个助手帮我分类、贴标签、给优先级建议,有空我再回复人类。"
+
+### 适合谁
+
+开源维护者 / 内部工具 owner / 任何需要"先归类再处理"的 issue 接收方。
+
+### 起步
+
+前置:`gh auth login` 装好 GitHub CLI;或者装 GitHub MCP server(`/plugin install github`)。
+
+```
+/ccteam 做个 GitHub issue triage 助理,接到新 issue 自动分类贴标签,有困难的留给我
+```
+
+ccteam-creator:
+
+```
+PROJECT PLAN
+============
+Type:           Pocket Assistant + GitHub MCP
+Bot:            @triage_helper(persona: 项目监工)
+接入:            GitHub MCP(detected: ✓)
+触发:            GitHub webhook → 你电脑 ngrok → ccteam → bot 处理
+分类规则:        bug / feature / question / docs / dup
+拿不准时:        TG 私信你,等你裁决
+预计 cost/day:  ~$0.2-1(取决于 issue 流量)
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+- 新 issue 进 GitHub → bot 自动读 issue body → 贴 1-3 个 label + 回一句中性的"thanks for reporting"
+- 拿不准的(比如 "这是 bug 还是 feature?")→ bot TG 私信你 + 选项 a/b/c,你回一个数字它就给 issue 操作下去
+
+### 生成什么
+
+- triage-helper agent 接 GitHub MCP 工具
+- TG bot 走你绑定的 token(私信模式)
+- 内置分类 prompt 模板;你可以在 [进阶定制](advanced/customize-workflow.md#github-triage) 里改
+
+### 预期 cost
+
+- 小项目(5-10 issue / 周):**~$0.5 / 周**
+- 中项目(50 issue / 周):**~$3 / 周**
+- 撞预算上限 ccteam 自动停
+
+### 想改?
+
+[进阶定制 — 接 Linear / Jira / 自定义 label 规则](advanced/customize-workflow.md#github-triage)
+
+---
+
+## 配方 5 — 学习辅导 bot
+
+### 场景
+
+> "我在学一门新东西(算法 / 第二语言 / 某框架),想要一个能耐心解释、出题、纠错的 bot 陪我练。"
+
+### 适合谁
+
+学生 / 自学者 / 任何"每天 30 分钟刷一下"场景。
+
+### 起步
+
+```
+/ccteam 做个中文学习辅导 bot,我每天练 30 分钟算法题
+```
+
+ccteam-creator 推断:Pocket Assistant + 学习辅导 persona + 中文。
+
+```
+PROJECT PLAN
+============
+Type:           Pocket Assistant(TG 私聊)
+Bot:            @algo_tutor(persona: 学习辅导 中文版)
+风格:            苏格拉底式提问 + 提示而不直接给答案 + 复盘
+Codex critic:   不启用(教学场景不需要 second-opinion)
+预计 cost/day:  ~$0.3-0.8(30 分钟 / 天)
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+```
+你 → "今天讲讲二叉搜索"
+bot → 出 3 题,从 easy 到 hard,你做完它逐题点评 + 标重点 + 一周末出复盘
+```
+
+### 生成什么
+
+- algo-tutor agent,内置学习辅导 persona(中文版)
+- 不接 critic(教学不需要)
+- 不接 Codex(节省预算)
+
+### 预期 cost
+
+- 30 分钟 / 天:**~$0.5 / day**
+- 1 小时 / 天:**~$1 / day**
+
+### 想改?
+
+[进阶定制 — 换学习领域 / 切英文 / 改风格](advanced/customize-workflow.md#tutor)
+
+---
+
+## 配方 6 — 翻译团队
+
+### 场景
+
+> "我有一批英文文档要翻成中文,想要 3 个 bot 接力:翻译、母语审、风格统一。"
+
+### 适合谁
+
+技术写作者 / 本地化 / 任何"先初翻再多轮校对"的翻译场景。
+
+### 起步
+
+```
+/ccteam 做个 TG 群组翻译团队三 bot:translator 初翻、reviewer 母语审、style 风格统一
+```
+
+ccteam-creator:
+
+```
+PROJECT PLAN
+============
+Type:           IM Squad(TG 群组三 bot 接力)
+Bots:           @translator(persona: 翻译 中文)
+                @native_reviewer(persona: 翻译 中文 — 母语审视角)
+                @style_critic(persona: 写作助手 中文 — 风格统一)
+流程:            你贴英文 → translator 初翻 → reviewer 审 → style 统一 → 输出 final
+Codex critic:   不启用
+预计 cost/day:  千字 ~$0.05;每天 5 千字 ~$0.25
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+```
+你 → 群里贴英文段落
+@translator → 初翻
+@native_reviewer → 改 5-10 处不顺口
+@style_critic → 统一用词术语
+final 输出 → 你点 reaction 表示接受 / 让某个 bot 重做一段
+```
+
+### 生成什么
+
+- 三 bot,各自 persona 中文预填
+- 接力顺序:translator → reviewer → style;每 bot 处理完自动 @ 下一棒
+- 不接 Codex(翻译质量靠多 bot 接力,不需 second-opinion vendor)
+
+### 预期 cost
+
+- 5 千字 / 天:**~$0.25 / day**
+- 5 万字 / 天:**~$2.5 / day**
+
+### 想改?
+
+[进阶定制 — 反向翻译 / 加 SEO 关键词 review / 多语种](advanced/customize-workflow.md#translation-team)
+
+---
+
+## 配方 7 — 代码 review 集(with Codex)
+
+### 场景
+
+> "我要写一个 feature,过程中希望 Claude 做主力,Codex 当 critic 经常二审。一句话起一个临时 5 人小组。"
+
+### 适合谁
+
+任何"我要 V0.6.0 一上来就玩 Codex 集成"的早期采用者;严肃多模块改动场景。
+
+### 起步
+
+```
+/ccteam-team 5 "实现 feature X,要 Codex critic 严审"
+```
+
+或 `/ccteam` 总入口:
+
+```
+/ccteam 起 5 人临时小组实现 feature X,Codex 当 critic
+```
+
+ccteam-team(或 creator)推断:Team Sprint + Codex auto-critic。
+
+```
+TEAM PLAN
+=========
+Type:           Team Sprint(几小时冲一波)
+Workers:        5 agents(executor × 3 + reviewer + critic)
+Critic vendor:  Codex(检测到 codex auth)
+策略:            Claude 干主力,每个 PR-size 改动 Codex 二审;失败 3 次升级你
+预计 cost:      ~$2-8(看 feature 规模;一个普通 feature 约 4 小时 $5)
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+```
+go → ccteam 起 team,5 个 worker 各跑一块
+你 → 在 Claude session 内 watch SendMessage 流,或 /ccteam-control show-progress
+完成 → 各 worker SendMessage 报告 + critic verdict
+```
+
+### 生成什么
+
+- 5 个 in-proc Task agent(`Task(subagent_type=...)`)
+- critic worker `vendor: codex` 自动设置(用户不见 yaml)
+- Codex 写 verdict 文件 `.ccteam/verdicts/<task>.json`,Claude 主 session 读后决策接受 / 改
+
+### 预期 cost
+
+- 短任务(1 小时,500 行改)**~$1-2**
+- 中任务(4 小时,2k 行改)**~$5-8**
+- 大任务(全天,10k 行)**~$15-25**
+
+### 想改?
+
+[进阶定制 — 切 critic vendor / 调 team size / 接更多 reviewer 角色](advanced/customize-workflow.md#team-sprint-with-codex)
+
+---
+
+## 配方 8 — 项目监工(混合)
+
+### 场景
+
+> "我有个长期项目,想要白天用 IM 私聊跟它聊进展,夜里它自己跑测试 + 修 bug,撞墙就喊我。"
+
+### 适合谁
+
+solo 创业者 / 业余维护项目 / 需要 "24/7 替身" 场景。
+
+### 起步
+
+```
+/ccteam 做个项目监工:白天 TG 私聊汇报进展,夜里自动跑测试和修 bug,撞墙叫我
+```
+
+ccteam-creator 推断:**混合** — Overnight Builder 跑长任务 + Pocket Assistant 收发 IM。
+
+```
+PROJECT PLAN
+============
+Type:           Pocket Assistant + Overnight Builder(混合配方,V0.6.0 验证项)
+Bot:            @project_lead(persona: 项目监工 中文版)
+白天角色:        TG 私聊回答进度问题、收新需求、整理 backlog
+夜里角色:        跑 test → fix bug → 生成晨报
+撞 3 次失败:     TG @你 + 暂停夜跑等你裁决
+Codex critic:   自动启用(夜里 review 角色)
+预计 cost/day:  ~$3-8(白天聊 + 夜里 8h 长跑)
+
+Reply 'go' 启动。
+```
+
+### 用法
+
+```
+白天 9-18 点:
+  你 → TG @project_lead "今天进度怎样?"
+  bot → 列 backlog 状态 + 昨夜测试摘要 + 推荐今天 priority
+  你 → "把 X 加到夜里任务"
+  bot → 记入 backlog
+
+夜里 22:00 - 早 8:00:
+  bot 自动跑 test → fix → release 循环
+  早晨给你 TG 推一条 "昨夜过 3 个 PR,1 个卡 X 模块求救"
+```
+
+### 生成什么
+
+- project-lead agent(白天 IM 端);test/fix/release 三个夜跑 worker(后台端)
+- 共享同一个项目目录 + 同一份运行状态
+- Codex critic 接夜跑 review 路径
+- IM 通知频道 = 你绑定的 TG bot
+
+### 预期 cost
+
+- 白天 30 分钟 IM + 夜里 8 小时长跑:**~$5 / day**
+- 撞 budget 自动停 + 通知你
+
+### 想改?
+
+[进阶定制 — 调白天 / 夜里时段 / 改通知策略 / 加多人协作](advanced/customize-workflow.md#hybrid-project-lead)
+
+---
+
+## 看完想自己捣鼓?
+
+每个配方都是 `ccteam-creator` 帮你生成的 `.ccteam/workflow.yaml` + `.claude/agents/*.md`。你 95% 时间不需要看这些文件 — 改东西在 Claude session 里一句话就行:
+
+```
+/ccteam-control add-agent translator-to-french
+/ccteam-control change-budget 2.0
+/ccteam-control switch-persona "更正式的口吻"
+```
+
+但如果你是 power user 想真的看 yaml 内部长什么样、各字段默认值是啥 → [advanced/presets-reference.md](advanced/presets-reference.md) 有完整 schema。
+
+如果你想接的平台 / 流程没在上面 8 个配方里 → 直接 `/ccteam <描述你要什么>`,ccteam-creator 会尽力推断。推断不出来时会回 fallback 问你 a/b/c/d 选项。

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,283 @@
+# ccteam 故障排查手册
+
+> V0.6.0 起。主入口都在 Claude session 内:`/ccteam-doctor`(诊断)、`/ccteam-control`(运行时)、`/ccteam-creator`(新建项目)、`/ccteam-team`(临时 team)、`/ccteam-im-setup`(TG 配置)。**先跑 `/ccteam-doctor` —— 80% 卡点它自动检出**;还卡再查本手册。
+>
+> 进阶 fix path:`docs/v0-6-0/prd.md` 找 F-finding,`docs/claude-code-tool-surface.md` 看平台原语,`docs/orchestration-patterns.md` 看拓扑选择。
+
+---
+
+## A. 安装 / 初始化(15 条)
+
+### A1. `/ccteam-doctor` 报 "claude CLI not found"
+**原因**:系统 PATH 里没有 `claude` 可执行文件,或刚装好但当前 shell 没 reload。
+**修复**:1) 终端 `which claude` 确认;2) 没装就 `npm i -g @anthropic-ai/claude-code`;3) 装了找不到就 `hash -r` 或重启 Claude session。
+**相关**:A2(版本过低)。
+
+### A2. `/ccteam-doctor` 报 "claude version too old, need ≥ 2.1.139"
+**原因**:V0.6.0 依赖 agent-view / `--bg` 等新特性,旧版没有。
+**修复**:`claude update` 升 stable → 重启 Claude session → 重跑 `/ccteam-doctor`。
+**相关**:A1。
+
+### A3. `/plugin install ccteam@claude-plugins-official` 失败
+**原因**:网络 / GitHub rate-limit / 已装同名 plugin 冲突。
+**修复**:1) `/plugin list` 看是否同名 → `/plugin remove ccteam` 重装;2) 走代理 / 国内镜像;3) 仍失败:手动 `git clone` 到 `~/.claude/plugins/marketplaces/`。
+**相关**:A4 / A5。
+
+### A4. `/mcp` 列表里没 `mcp__ct__*` 工具
+**原因**:MCP 没注册到 `.mcp.json` 或 `~/.claude.json`,或 plugin 装完没 reload。
+**修复**:1) `/ccteam-doctor --install-mcp`;2) `/reload-mcp` 或重启 Claude session;3) 项目级 `.mcp.json` 残缺 → 删后重 `/ccteam-doctor --install-mcp`。
+**相关**:D1。
+
+### A5. `~/.claude.json` 损坏,Claude 一启动就崩
+**原因**:手改错 JSON / 编辑器加 BOM / 半截 plugin install 写垃圾。
+**修复**:1) `cp ~/.claude.json ~/.claude.json.bak`;2) `jq . ~/.claude.json` 看哪行错;3) 实在修不了删掉重启 Claude(会生空 stub,要重登录)。
+**相关**:A3。
+
+### A6. `/ccteam-doctor` 报 "supervisor not running"
+**原因**:Claude Code 后台 supervisor(管 `--bg` session 的常驻进程)没启或被杀。
+**修复**:1) 终端 `claude agents` —— 打开 agent view 时 supervisor 自启;2) 仍失败 `pkill -f "claude.*daemon"` 后再开。
+**相关**:B1。
+
+### A7. `/ccteam-creator` 起新项目报 "Team already exists"
+**原因**:上次新建留下的 `~/.claude/teams/<name>/` 残留,或 `~/projects/<slug>/` 已存在。
+**修复**:1) 重选另一个 slug;2) 想用同名:手动 `rm -rf ~/.claude/teams/<name> ~/projects/<slug>` 后重起。
+**相关**:`docs/v0-5-1/` troubleshoot 同类。
+
+### A8. 跟 BotFather 要 TG bot token 拿不到
+**原因**:TG 没注册 / @BotFather 没回 / 超出 20 bot 上限。
+**修复**:1) TG 搜 `@BotFather` 发 `/newbot`;2) 没回信先发 `/start`;3) 超 20 用 `/mybots` 删旧的。
+**相关**:A9 / A10。
+
+### A9. 拿到 token 但不知道 chat_id
+**原因**:bot 加群后必须有人 @ 它一次,bot 才能拿到 chat_id。
+**修复**:1) 群里 `@your_bot hi`;2) Claude session 里 `/ccteam-im-setup`,它读 bot 最近消息列出 chat_id;3) 选一个绑到 workflow.yaml 的 env。
+**相关**:A8。
+
+### A10. `/ccteam-im-setup` 报 "token invalid"
+**原因**:复制粘贴带空格 / 引号 / 换行,或 token 被 BotFather revoke 过。
+**修复**:1) @BotFather → `/mybots` → 选 bot → "API Token" 重新复制;2) 粘贴时确保单行无空格;3) 仍失败 BotFather `/revoke` 重生成。
+**相关**:A8。
+
+### A11. 想跑 `ccteam new ...` shell 命令,提示 command not found
+**原因**:V0.6.0 推荐**不走 shell**,所有创建在 Claude session 里 `/ccteam-creator` 完成。
+**修复**:在 Claude session 内 `/ccteam-creator`,跟向导走完即可。**不需要装 ccteam 二进制**。
+**相关**:A3。
+
+### A12. 项目 `.mcp.json` 跟其他 MCP server 冲突
+**原因**:你装了 `serena` / `omc` 等同时注册项目级 `.mcp.json`,合并后字段互踩。
+**修复**:1) `/ccteam-doctor` 自动合并不覆盖;2) 手查 `.mcp.json` 里 `mcpServers.ct` 是否齐全;3) 仍冲突:`ct` 仅 user-global 注册,其他保留项目级。
+**相关**:A4。
+
+### A13. 跨设备 — 一台机器装了在另一台没有
+**原因**:`~/.claude/plugins/` 和 `~/.claude.json` 不在 git 范围。
+**修复**:1) 新机器重跑 `/plugin install ccteam@claude-plugins-official`;2) workflow.yaml 入项目 git 共享;3) bot token 走 env,**不入 git**。
+**相关**:C3。
+
+### A14. WSL 行为怪
+**原因**:WSL 文件系统 watch 偶尔丢事件;Windows 路径 ≠ Linux 路径。
+**修复**:1) 项目放 WSL 的 `~` 下而非 `/mnt/c/`;2) 用 WSL 原生 npm 装 claude,别走 Windows npm。
+**相关**:A1。
+
+### A15. macOS Gatekeeper 拦 codex 二进制
+**原因**:从 GitHub Releases 下载的 codex 没签名。
+**修复**:System Settings → Privacy → "Allow anyway";或 `brew install --cask codex`(已签)。
+**相关**:E1。
+
+---
+
+## B. 聊天运行时(15 条)
+
+### B1. TG 群 @bot 后 bot 完全不回
+**原因**:3 种:bot 进程崩 / token 失效 / 网络不通。
+**修复**:1) `/ccteam-control show-bots` 看每个 bot 状态;2) status "stopped" → `/ccteam-control restart-bot <name>`;3) "running 但不回" → 看 B10。
+**相关**:A6 / B10。
+
+### B2. bot 回了但内容像"失忆了"
+**原因**:bot 对话历史被清(compact / new session)或平台升级后旧会话失效。
+**修复**:1) `/ccteam-control show-bot <name>` 看 "memory reset" 时间;2) 这是正常,告诉 bot 上下文重新讲;3) 想少触发:看 B6。
+**相关**:B6 / B11 / D2。
+
+### B3. bot 回得超慢(>30s)
+**原因**:模型本身慢(Opus)/ 上文太长缓存未命中 / 后端限流。
+**修复**:1) `/ccteam-control show-bot <name>` 看 last_turn_latency;2) workflow.yaml 切到 sonnet;3) 强制 compact:`/ccteam-control bot-compact <name>`。
+**相关**:B6 / C4。
+
+### B4. 群里两个 bot 互 @ 卡死循环
+**原因**:bot-to-bot 链超过 hop_limit(默认 3)之前没拦。
+**修复**:1) ccteam 第 3 跳自动 escalate;2) workflow.yaml 调低 `hop_limit: 2`;3) 立即打断:群里发 `@your_bot stop`。
+**相关**:B5。
+
+### B5. escalate 后没人提醒我
+**原因**:默认 escalation 只写 ccteam 内部日志,不主动推 TG。
+**修复**:1) workflow.yaml 加 `on_hop_escalate: notify_tg`;2) `/ccteam-control show-escalations` 看全列表。
+**相关**:B4。
+
+### B6. 想让 bot 记得更多 / 更少历史
+**原因**:默认 50 turn 触发自动 compact,可调。
+**修复**:workflow.yaml 改 `agents.<role>.compact_every_turns: 100`(多记)或 `: 20`(少记,省钱)。
+**相关**:C4 / C9。
+
+### B7. 编辑过 / reply 引用的 TG 消息 bot 看不到
+**原因**:TG bridge V0.6.0 只处理 plain text 新消息。
+**修复**:编辑后重新 @bot 一次;reply quote 不传入,需在新消息复述要点。
+**相关**:B8。
+
+### B8. bot 看不到图片 / 文件
+**原因**:V0.6.0 mode 3 只支持 text;富媒体延 V0.7.x。
+**修复**:1) 图片 OCR 后粘贴文字;2) 文件放服务器 + URL 让 bot fetch。
+**相关**:`docs/v0-6-0/prd.md` F109 不在范围。
+
+### B9. bot 在 DM(私聊)里不回
+**原因**:V0.6.0 mode 3 只支持 group chat,DM 是 V0.6.1。
+**修复**:把 bot 加群后 @ 它;DM 场景等 V0.6.1。
+**相关**:`docs/v0-6-0/prd.md` F109。
+
+### B10. bot 突然回乱码 / 内部错误
+**原因**:模型 API 抽风(rate limit / overload / 内容审核)。
+**修复**:1) 等 30s 再试;2) `/ccteam-control show-bot <name>` 看 last_error;3) 持续报错 → 看 C2。
+**相关**:B3 / C2。
+
+### B11. 想让 bot 完全忘记重来
+**原因**:希望 bot fresh 起。
+**修复**:`/ccteam-control bot-new-session <name>`,下一句开始全新上下文。
+**相关**:B2 / B6。
+
+### B12. 多 bot 同名 / 串号
+**原因**:workflow.yaml 两个 role 用同 `bot_name`,或同 TG bot 注册到多 workflow。
+**修复**:1) `/ccteam-control show-bots` 看冲突;2) workflow.yaml 改名;3) 一个 TG bot 只能属一个 workflow。
+**相关**:A8。
+
+### B13. bot 回复夹了 `<thinking>` / 内部标记
+**原因**:模型未屏蔽 thinking 段,或 system prompt 没拦。
+**修复**:1) 通常 ccteam 自动剥;漏的请报 issue;2) workflow.yaml 加 `strip_thinking: true`。
+**相关**:`docs/v0-6-0/prd.md` F108。
+
+### B14. 群里多人同时 @bot,谁先谁后
+**原因**:bot 单 session 串行处理 turn。
+**修复**:1) 默认 FIFO;2) 想真并发:workflow.yaml 拆多 role 各起 session,@ 分别 routing。
+**相关**:B3 / `docs/orchestration-patterns.md` §3 Parallelization。
+
+### B15. bot idle 时偶尔自己开口
+**原因**:没装 schedule trigger / 平台内部 retry 串出。
+**修复**:1) `/ccteam-control show-bot <name>` 看 last_event;2) 若 retry:平台兜底,不动;3) schedule 触发但你没要:workflow.yaml 删 `trigger: schedule`。
+**相关**:C7。
+
+---
+
+## C. 成本 / 配额(10 条)
+
+### C1. 24h budget 触底,bot 全停
+**原因**:F84 红线 — workflow 24h cost 撞 `max_cost_usd_per_24h`。
+**修复**:1) `/ccteam-control show-cost` 看哪个 role 烧得多;2) workflow.yaml 调高 budget 或换便宜模型;3) 等 24h reset 自动恢复。
+**相关**:C5 / C7。
+
+### C2. Claude 报 "rate_limit" / "billing_error"
+**原因**:你的 Anthropic 账号月度额度触顶 / 信用卡过期。
+**修复**:1) https://console.anthropic.com 查 usage / billing;2) ccteam 自动 retry,持续 fail 会 emit `budget_exceeded`;3) 加额度或换 API key。
+**相关**:E2 codex auth。
+
+### C3. `/ccteam-control show-cost` 数字跟 console 对不上
+**原因**:ccteam 按 turn token × 单价累计;console 算 billing cycle。短期 5-15% 偏差正常。
+**修复**:长期偏差大(>30%)才查;通常 console 是权威。
+**相关**:C1。
+
+### C4. 同 workflow 两次跑 cost 差 10×
+**原因**:通常 prompt cache 命中 vs 不命中(cache hit 约 10% 价)。
+**修复**:1) workflow.yaml `use_cache: true`(默认 on);2) 短间隔重跑命中率高;3) 跨日 cache TTL 失效正常。
+**相关**:B6 / C8。
+
+### C5. 想给单个 bot 设硬上限,不动整个 workflow
+**原因**:V0.6.0 cost cap 默认 workflow 级。
+**修复**:1) workflow.yaml `agents.<role>.max_cost_usd_per_day: 5`(per-role);2) 平台层附加 `--max-budget-usd` 硬终止兜底。
+**相关**:C1。
+
+### C6. Codex 跟 Claude cost 字段对不上
+**原因**:Codex 用 token usage 报告,Claude 用 Anthropic billing API,精度不同。
+**修复**:`/ccteam-control show-cost --vendor codex` 单独看;两 vendor 不直接加和,各算各。
+**相关**:E5。
+
+### C7. schedule-trigger 的 role 把 budget 烧光
+**原因**:`trigger: schedule` 每 N 分钟跑一次,没 cap 容易爆。
+**修复**:1) workflow.yaml `interval: 30m` 拉长;2) 该 role 加 `max_cost_usd_per_day`;3) 暂停 `/ccteam-control pause <slug>`。
+**相关**:C1 / C5。
+
+### C8. Cache 不命中,prompt token 暴涨
+**原因**:system prompt 含动态字段(时间戳 / cwd)每次都变。
+**修复**:V0.6.0 默认带 `--exclude-dynamic-system-prompt-sections`;若仍不命中,workflow.yaml 别在 system prompt 里塞 "今天日期" 这类。
+**相关**:C4 / `docs/claude-code-best-practices.md` §6.2。
+
+### C9. compact 完反而更贵了
+**原因**:`/compact` 本身要一次 model call,短期成本高但后续 turn 省。
+**修复**:1) 只在历史 >5k token 时调 `/ccteam-control bot-compact`;2) workflow.yaml `compact_every_turns` 调高减少触发。
+**相关**:B6 / C4。
+
+### C10. 想完全 dry-run 不花钱
+**原因**:验证 workflow 而不调真实模型。
+**修复**:1) `/ccteam-control dry-run <slug>` — 只校验 yaml + 列将 spawn 的 role,不调 model;2) 单 bot:`CCTEAM_DRY_RUN=1` env。
+**相关**:`docs/v0-6-0/dev-plan.md` validation 节。
+
+---
+
+## D. Claude Code 平台层(5 条)
+
+### D1. `/mcp` 显示 `ct` server "disconnected"
+**原因**:`mcp-serve` 子进程没起或被 kill;`.mcp.json` 路径不对。
+**修复**:1) 重启 Claude session 通常自愈;2) `/ccteam-doctor --install-mcp` 重写注册;3) `claude --debug "mcp"` 看启动错误。
+**相关**:A4。
+
+### D2. `claude -p --resume <sid>` 报 "session not found"
+**原因**:session id 失效(平台升级 / 用户清过 `~/.claude/projects/`)。
+**修复**:1) ccteam 自动起新 session 并 emit `chat_session_reset`;2) 历史聊天不可恢复,告知 bot 重讲 context。
+**相关**:B2。
+
+### D3. 自定义 `.claude/agents/<role>.md` 不生效
+**原因**:agent 文件只在 session 启动时扫一次;新加文件需重 spawn。
+**修复**:1) `/ccteam-control restart-bot <name>` 重 spawn;2) frontmatter 有 yaml 错会被静默忽略 — `/ccteam-doctor` 会 lint。
+**相关**:`docs/claude-code-tool-surface.md` §1.2.4。
+
+### D4. PreToolUse / PostToolUse hook 不 fire
+**原因**:`.claude/settings.json` 里 hook 路径错或脚本没 +x。
+**修复**:1) `chmod +x .claude/hooks/*.sh`;2) `claude --debug "hooks"` 看 fire 痕迹;3) `--bare` mode 下 hook 全跳。
+**相关**:`docs/claude-code-best-practices.md` §4.5。
+
+### D5. `/<skill>` 没出现在补全
+**原因**:`~/.claude/skills/` 目录是 session 启动后建的,监听没挂上。
+**修复**:1) 关掉 Claude session 重开;2) `/reload-plugins`(tmux-attached session 可用);3) 仍不见 → `/plugin list` 检查 ccteam plugin 状态。
+**相关**:A3 / `docs/claude-code-tool-surface.md` §1.2.4。
+
+---
+
+## E. Codex 集成(V0.6.0 引入,5 条)
+
+### E1. workflow.yaml 标 `vendor: codex` 但 spawn 报 "codex not found"
+**原因**:Codex CLI 没装在 PATH。
+**修复**:1) `npm i -g @openai/codex` 或 `brew install --cask codex`;2) `/ccteam-doctor` 自动检测并降级用 claude;3) 想坚持 codex:装完重启 Claude session。
+**相关**:E2 / A15。
+
+### E2. codex auth 缺 / 过期
+**原因**:`codex login` 没跑过,或 OAuth token 过期。
+**修复**:终端 `codex login`,按提示 OAuth;`/ccteam-doctor --check-codex` 验证。
+**相关**:E1。
+
+### E3. codex 报 "sandbox denied"
+**原因**:codex 默认 `--sandbox read-only`,不允许写文件。
+**修复**:1) workflow.yaml `agents.<role>.codex_sandbox: workspace-write`;2) 危险场景才用 `danger-full-access`,且仅在容器里。
+**相关**:`docs/v0-6-0/prd.md` Codex sandbox 表。
+
+### E4. codex 比 claude 慢 3-5×
+**原因**:Codex 默认走 OpenAI Responses API,首 token 延迟比 Anthropic 高;且 V0.6.0 还没接 Codex 的 prompt cache。
+**修复**:1) 高频对话场景用 claude;2) batch 任务可接受;3) 等 V0.6.x 优化 codex cache。
+**相关**:B3。
+
+### E5. 同 workflow 混 Claude+Codex,cost 报告分裂
+**原因**:两 vendor 计费单位、token 价格不同,V0.6.0 不合算。
+**修复**:`/ccteam-control show-cost --vendor claude` 和 `--vendor codex` 分别看;workflow 总额按各自 budget 独立 cap。
+**相关**:C6。
+
+---
+
+## 仍未解决?
+
+1. 在 Claude session 跑 `/ccteam-doctor --full` 收集所有诊断信息
+2. 仍卡:把诊断输出贴 GitHub issue,或 ccteam 用户群 @ 维护者
+3. 进阶 fix:`docs/v0-6-0/prd.md` 找对应 F-finding;`docs/claude-code-tool-surface.md` 看平台原语;`docs/dev-coupling-audit.md` 看历史已修类似问题

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,0 +1,290 @@
+# ccteam User Manual
+
+> ccteam 让你**用一句中文/英文召唤一个 AI 团队**,跑在你电脑上、接进你的 IM。本手册带你跑通 5 种典型场景,5 分钟见效。
+>
+> **零 yaml,零 CLI 命令记忆,零术语**。你只需要会用 Claude Code session 输入 slash 命令 + 自然语言。
+
+---
+
+## §1 ccteam 是什么
+
+ccteam = "在 Claude session 里召唤一个 AI 团队,长跑 + 跨设备 + 接进 IM"。
+
+对比同类工具:
+
+| 工具 | ccteam 的差异 |
+|---|---|
+| ChatGPT app / Claude.ai web | ccteam 能动你电脑(读文件、改代码、跑命令);它们不能。 |
+| Cursor / Cline / Aider | ccteam 不锁在 IDE,在 IM / 终端 / web 都能用,跨设备。 |
+| OMC / Devin | ccteam 长跑 + 接进多平台 IM,关电脑也继续跑。 |
+
+### 三种跟 ccteam 对话的入口
+
+| 入口 | 用啥 | 啥时用 |
+|---|---|---|
+| 🟢 Claude session 内 | `/ccteam <NL>` 总入口 或 5 个 sub-slash | 已开着 Claude,顺手做事 |
+| 🟢 IM(TG / Slack / Discord)| 私聊 bot,或群里 `@ccteam <NL>` | 离电脑,手机想跟 AI 互动 |
+| 🟡 Web 仪表板 | 浏览器开 `http://localhost:7331` | 想看图监控,不"操作" |
+
+> **不需要打开新 terminal 跑命令**。所有功能都通过 Claude session slash + NL + IM 触发。
+
+---
+
+## §2 5 种用法(preset)
+
+每种用法 = "一个 ccteam 团队的预设配方"。你只挑场景,不挑实现细节。
+
+### §2.1 Solo Sidekick — 写代码时临时召唤一个帮手
+
+**啥时用**:你在 Claude 写代码,临时需要个独立 agent 干 1 个小事(读完整个 `src/` 总结、扫漏洞、跑数据分析),不想污染主 session 上下文。
+
+**怎么起**:
+
+```
+/ccteam <你的请求>
+# 例:/ccteam 扫一下 src/ 找所有 TODO 注释,列成 markdown 表
+```
+
+ccteam 总 dispatcher 判定是 Solo Sidekick,自动跑一个 sub-agent,结果回当前 session。
+
+**例 session**:
+
+```
+You:    /ccteam 扫一下 src/ 找所有 TODO 注释
+Claude: 召唤 sidekick(工具:Read/Glob/Grep)...
+        [1 分钟后]
+        Found 17 TODOs across 8 files:
+        | File | Line | Note |
+        ...
+```
+
+**Cost 估**:每次 ≈ $0.01-0.05(中小型仓库)。
+
+---
+
+### §2.2 Team Sprint — 几小时冲一波
+
+**啥时用**:你有一个 1-3 小时能干完的任务,要 3-5 个 agent 协作(fix 一批 TS error、分模块并行 refactor、多视角 review 设计)。
+
+**怎么起**:
+
+```
+/ccteam-team <N> "<task>"
+# 例:/ccteam-team 3 "fix all TypeScript errors in src/"
+# 例:/ccteam-team 5:reviewer "review the new auth design"
+```
+
+Team Sprint 会起 N 个 teammate(role 你指或 ccteam 自决)+ 一个 lead 调度,当前 Claude session 看实时通信。
+
+**例 session**:
+
+```
+You:    /ccteam-team 3 "fix all TypeScript errors in src/"
+Claude: TEAM PLAN
+        =========
+        Team name: ts-fix-team
+        Proposed teammates:
+          1. fixer-a (sonnet, blue)   — src/auth/, src/api/
+          2. fixer-b (sonnet, green)  — src/ui/, src/utils/
+          3. reviewer (sonnet, yellow) — verify all fixes
+        回 'go' 起。
+You:    go
+[3 个 teammate 并行跑,通信尽收眼底]
+```
+
+**Cost 估**:1 小时 sprint ≈ $1-3。
+
+---
+
+### §2.3 Overnight Builder — 丢任务睡觉去
+
+**啥时用**:任务需长跑几小时到几天(全栈搭一个 todo app、夜里 test→fix→test 循环、跨周做依赖升级)。
+
+**怎么起**:
+
+```
+/ccteam-creator "夜里给我跑 qa-loop:测试失败自动 fix,每 fix 一轮 commit,直到 24h 或 cost cap"
+```
+
+ccteam-creator 进入对话向导,自动判断是 Overnight Builder,问你:
+- 24h cost cap 多少 $
+- 失败 N 次后是否中途叫醒你(TG 推送)
+
+确认后起长跑 daemon,关电脑(笔记本合盖,daemon 后台继续)早上你看摘要。
+
+**例 session**(简化):
+
+```
+You:    /ccteam-creator "夜里跑 qa-loop,$5 cap,撞 3 次失败叫醒我"
+Creator: 计划:
+         - Preset: Overnight Builder
+         - Loop: test → fix → test(max 5 轮 / 4 小时)
+         - 24h cost cap: $5
+         - 失败叫醒:TG @你
+         回 "go"。
+You:    go
+[第二天早 TG]
+@you 完成 ✓:5 测试修复,$1.82,详 http://localhost:7331/p/qa-loop
+```
+
+**Cost 估**:1 晚 ≈ $1-5(自动 cap 兜底)。
+
+---
+
+### §2.4 Pocket Assistant — 手机 IM 私聊一个 AI 助理 ⭐
+
+**啥时用**:你想要一个**随时随地在手机上找它说话**的 AI 助理。它能读你电脑文件、跑命令、做长期记事、定期推送。
+
+**怎么起**(第一次):
+
+```
+/ccteam-im-setup                                          # 一次性绑 TG bot
+/ccteam-creator "做个 TG 私聊助理 bot:管邮件 + 早 7 点推 GitHub PR 摘要"
+```
+
+→ 详 [quickstart.md](quickstart.md)。
+
+起完之后,打开 TG,搜你的 bot,私聊。bot 跑在你电脑(合盖也继续),手机只是入口。
+
+**例 session**(在 TG):
+
+```
+You:   今天 GitHub 上有什么新 PR?
+Bot:   找到 3 个新 PR:
+       1. #1234 feat(auth): SSO support(@alice)— 大改,建议你看
+       2. #1235 docs: typo fix(@bob)— 小改
+       3. #1236 fix(api): rate limit edge(@you)— 你自己开的
+       回 "1" / "2" / "3" 我帮你打开摘要;回 "diff 1" 看 1 号 diff。
+```
+
+**换 persona / 加能力**(随时,任意 Claude session):
+
+```
+/ccteam-control change-persona helper-bot "改成英文 + 更幽默"
+/ccteam-control add-tool helper-bot "scan ~/Downloads for new PDFs and summarize"
+```
+
+**Cost 估**:轻度使用 ≈ $0.5-2 / 天。
+
+---
+
+### §2.5 IM Squad — IM 群里多个 bot 互相 @ 协作
+
+**啥时用**:你想搞个 "AI 圆桌会"。一个 TG 群,2-5 个 bot 各持职责(架构师 + 评审 + 文档 + 测试),你 @ 任一 bot 开局,bot 间 @ 对方协作,在群里给你共识。
+
+**怎么起**:
+
+```
+/ccteam-creator "做个 TG 多 bot 团队:架构师 + 评审员 + 写手,讨论我贴进去的设计文档"
+```
+
+Creator 自动:
+- 起一个 Telegram 群(或让你加进自己的群)
+- 4-5 个 bot 各持 persona
+- 配 bot-to-bot @ 路由
+- 限 3 层 @ 链路(防 ping-pong 循环)
+
+**例 session**(在 TG 群):
+
+```
+You:        @arch_bot 看下我贴的 API 设计 [paste...]
+arch_bot:   @reviewer_bot 你怎么看 v3 endpoint 设计?
+reviewer:   @writer_bot 我建议改回 v2,文档需要 ...
+writer_bot: 已起草文档,贴 PR 链接 → #1240
+            @you 共识达成,请你拍板
+```
+
+**Cost 估**:1 次 30 分钟 round-table ≈ $0.3-1。
+
+---
+
+## §3 怎么跟 ccteam 对话(三种入口详解)
+
+### §3.1 在 Claude session 内
+
+总入口 `/ccteam <NL>` 是万能的 — 发啥都行,它路由到对应 sub-skill。
+
+直接跳过 router 也行,5 个 sub-slash:
+
+| Slash | 干啥 |
+|---|---|
+| `/ccteam-team <N> "<task>"` | 起临时 team(Team Sprint)|
+| `/ccteam-creator "<NL>"` | 起新 workflow / 改现有 workflow |
+| `/ccteam-control <subcmd>` | 管已有 workflow(暂停 / 恢复 / 查 cost / 改 persona)|
+| `/ccteam-im-setup` | 一次性绑 IM token(TG / Slack / Discord)|
+| `/ccteam-advise "<hard question>"` | Claude + Codex 并行二答案(仅装了 Codex 才出来)|
+
+### §3.2 在 IM 端
+
+**私聊你的 bot**:直接说话,bot 走 Pocket Assistant 模式。
+
+**群里跟 ccteam 总管对话**:发 `@ccteam <NL>`(NL admin),它走 meta-agent 路由:
+
+```
+@ccteam pause helper-bot           # 暂停某个 bot
+@ccteam resume helper-bot          # 恢复
+@ccteam list bots                  # 列所有跑着的 bot
+@ccteam cost today                 # 今日 cost
+@ccteam stop everything            # 紧急停所有
+```
+
+### §3.3 Web 仪表板
+
+浏览器开 `http://localhost:7331`,看:
+- 所有 workflow 实时状态
+- 每个 bot 的对话历史
+- 24h cost 趋势图
+- 失败 / 告警列表
+
+Web **只看不操作**。所有控制走 Claude session slash 或 IM。
+
+---
+
+## §4 Cost 透明
+
+ccteam 默认每个 workflow 有 24h cost cap(creator 起项目时问你)。
+
+**实时查看**:
+
+```
+/ccteam-control show-cost                       # 所有 workflow 今日 cost
+/ccteam-control show-cost helper-bot --days 7   # 单 workflow,7 天
+```
+
+或 IM 端:`@ccteam cost today`。
+
+**读输出**:
+
+```
+Workflow         Today    24h cap   7d trend   Status
+helper-bot       $0.83    $2.00     ↗ +12%     OK
+qa-loop          $4.12    $5.00     ↘ -3%      ⚠ 82% of cap
+```
+
+撞 90% → 自动 TG 推送提醒;撞 100% → 自动暂停 workflow(不会偷偷烧钱)。
+
+---
+
+## §5 从 V0.5 升级到 V0.6 — 0 用户操作
+
+V0.6 升级**完全无感**:
+
+- 你的 V0.5 项目配置继续跑 — 兼容,**0 文件修改**。
+- MCP 工具名字 `mcp__ccteam__*` **全保留** — V0.5 muscle memory 0 破坏。
+- V0.5 的 `/ccteam-team` / `/ccteam-control` / `/ccteam-creator` slash 行为兼容。
+- **新加**:`/ccteam` 总入口、`/ccteam-im-setup`(绑 IM)、`/ccteam-advise`(双 LLM 投票)。
+
+**唯一新选**:想试 Pocket Assistant / IM Squad?跑一次 `/ccteam-im-setup` 绑 TG token 就行。
+
+---
+
+## §6 接下来去哪
+
+| 想干什么 | 读这个 |
+|---|---|
+| 5 分钟跑通第一个 bot | [quickstart.md](quickstart.md) |
+| 抄一份现成 use case | [recipes.md](recipes.md) |
+| 改默认 persona / 加 MCP 工具 / 自定义 workflow | [advanced/customize-workflow.md](advanced/customize-workflow.md) |
+| 装 Codex 让两个 LLM 互审 | [advanced/multi-llm-codex.md](advanced/multi-llm-codex.md) |
+| 出错查不到 | [troubleshooting.md](troubleshooting.md) |
+| 看代码 / 改 ccteam | [architecture/](architecture/) |

--- a/docs/v0-6-0/README.md
+++ b/docs/v0-6-0/README.md
@@ -1,114 +1,300 @@
-# V0.6.0 — 三执行模式定型 + 模式 3 (chat / IM) 落地 + MCP 优化
+# V0.6.0 — 从开发者元工具到产品可用 AI 团队
 
-> **立项主线**:把"ccteam 是 Claude Code 之上的编排层"这句话**显式拆成三种执行模式**,每种锚到 Claude Code 一个执行原语;红线按模式重新 scope;模式 3(chat / IM bot)是本版新落地能力;MCP 顺带按 OMC 借鉴优化。
+> **立项主线**(转 product 视角的 3 Epic):
+> - **Epic A — 5 min 起第一个 IM bot**(Pocket Assistant preset,V0.6 旗舰场景)
+> - **Epic B — bot 在 IM 里像真人助理**(rich media / 错误回流 / session 恢复 / NL admin)
+> - **Epic C — 中文用户能用**(铺底:lift `openhuman/channels` 14+ IM 平台抽象 → V0.7 国内 IM 专项零成本启动)
 >
-> **不立项**:任何会破坏现有模式 2(artifact-driven workflow)行为的改动。Wave 1 trait 抽离要求 `cargo test --workspace` 数字**完全持平**,不得退步。
+> **一句 value prop**:在 Claude session 里**一句话**召唤 AI 团队 — 接进你的 IM,跨设备 24/7 替你干活。
 >
-> **doc-first 原则**:本 PR 只 land `docs/v0-6-0/`(README + PRD + dev-plan),代码改动按 3 个 wave 跟进 PR。
+> **硬约束**(memory: `feedback_low_friction_claude_code_native`):用户禁止写复杂 yaml / 学多 ccteam CLI 命令;主 UX 入口 = Claude session 内 skill + slash + MCP tool。`ccteam` CLI 退守 install / health / system admin。
+>
+> **5 团队 review 收敛**(architect / cc-expert / pm / researcher / codex-expert)详 V0.6.0 review session;本文档为 synthesize 后的最终立项。
 
 ---
 
-## 一、三执行模式定型(本版核心)
+## 一、Epic 主线(替代上版 F-finding 顶层结构)
 
-ccteam 在 Claude Code 之上提供三种 agent 执行模式,**锚到 Claude Code 三种执行原语**:
+### Epic A — 5 min 起第一个 IM bot
 
-| 模式 | 直观场景 | spawn 原语 | input 面 | output 面 | context 生命周期 |
-|---|---|---|---|---|---|
-| **1. in-proc team** | CC 插件 / skill,一句话起临时 team(`/ccteam-team "fix TS errors"`)| `Task(subagent_type=…)` | tool args | tool result | parent session 内,死则同死 |
-| **2. bg sessions** | 长跑自动化工作流(qa-loop:test→fix→release)| `claude --bg --agent <role>` | `.ccteam/inbox/*.md`(artifact)| `progress.jsonl` + state.json | **每次 spawn fresh 1M context** |
-| **3. tmux sessions** | 随叫随到 chat agent team(TG 群里多 bot,@ 召唤,bot 间互 @)| 长跑 `claude`(交互模式,常驻 tmux pane)| `tmux send-keys`(含 `/new` `/compact`)| `~/.claude/projects/<…>/<session-id>.jsonl`(Anthropic 官方 session 格式)| `/new` 重置 / `/compact` 摘要,**在线管理** |
+**目标**:**普通用户在 5 分钟内**完成"打开 Claude session → 在 TG 收到 bot 第一条回话"的全过程。
 
-每模式自带的 control plane / cost model 详 `prd.md §F106`。
+衡量指标:
+- 步数 ≤ 5(对比当前 PRD 14 步)
+- 0 行 yaml 编辑(全部 skill dialogue 自动生成)
+- 0 个用户面新概念(mode 1/2/3 / hop_limit / compact_every_turns 全藏)
+- 第一个 wow ≤ 5 分钟
 
----
+实施手段:
+- F113 `/ccteam` 总入口 slash dispatcher + 5 sub-skill(Solo / Team / Overnight / Pocket / Squad)
+- F114 `ccteam-creator` 复活 + NL 自动 mode 推断
+- F117 `/ccteam-im-setup` 一次性 onboarding(TG token / Lark token 一次绑定,后续 chat workflow 自动复用)
+- F109 lift `claude-plugins-official/telegram`(零代码 TG 路径)+ `openhuman/channels` Rust crate(14+ IM 多平台)
 
-## 二、红线按模式重新 scope(配套改动)
+### Epic B — bot 像真人助理
 
-现有 7 条红线大多写于 V0.1-V0.4 的模式 2 语境,V0.6 显式标注每条**适用哪些模式**:
+**目标**:用户在 IM 里跟 bot 互动**感觉像真人**(对比"AI 客服式僵硬体验")。
 
-| 红线 | 当前措辞 | 模式 1 | 模式 2 | 模式 3 |
-|---|---|---|---|---|
-| 文件系统是控制平面 | 全局 | N/A(in-proc)| **输入 + 输出都是** | **输出 SoT 是**(session jsonl);输入是 send-keys |
-| `progress.jsonl` 唯一 state SoT | 全局 | N/A | **是**(SoT)| **业务事件 SoT**;对话原文走 session jsonl,**不重抄** |
-| 每次 spawn = fresh 1M context | 全局 | parent session,无 spawn | **守** | **不适用** — chat 场景就是要复用,显式 `/compact` `/new` 管理 |
-| 不解析 tmux 输出 | 全局 | N/A | **守** | **守** — 读 session jsonl 替代,**不 scrape pane** |
-| 永不主动 kill 长 session | 全局 | N/A | **守**(F84 budget cap 唯一例外)| **守** + `/compact` `/new` 是合法状态操作,非 kill |
-| fix-loop 3 次必 escalate | 全局 | parent 自决 | **守** | **守** + bot-to-bot @ ping-pong **hop_limit 同等 escalate** |
-| `ccteam-core` 零 team 名字面量 | 全局 | **守** | **守** | **守** |
+衡量指标:
+- DM + group + bot-to-bot @ 全场景支持(V0.6.0 完整 IM Squad 体验)
+- 错误回流 IM(bot 自己开口说"我刚失忆了 / 撞 budget cap / 配置坏了",不让用户去翻 log)
+- session 失效后 last-N turn 回放(F115 handoff 机制延伸)
+- rich media(图片 / 文件)传递
+- Codex 自动当 critic / second-opinion(用户不感知,F112 §C-D)
 
-详 PRD §F106。
+实施手段:
+- F108 模式 3 走 **Agent SDK / `claude -p --resume <sid>` + stream-json**(弃 tmux send-keys)+ **JSON-mailbox-trigger**(OMC `tmux-comm.ts` 模式)
+- F112 Codex 集成 Option B 完整(`CodexExecAdapter` + `CodexAppServerAdapter` + `vendor: AgentVendor` enum)
+- F115 `.ccteam/handoffs/<workflow>/<stage>.md` 决策摘要机制(researcher R4#3)
+- F116 `ccteam-imd` 独立 supervisor daemon binary(borrowed OMC `reply-listener.ts` 模式)
+- F118 chat session 失效 last-N turn 重建(基于 progress.jsonl + ccteam-owned `<project>/.ccteam/chat/<bot>/turns.jsonl`)
 
----
+### Epic C — 中文用户能用(V0.6.0 铺底,V0.7 专项)
 
-## 三、模式 3 是本版的新落地
+**目标**:V0.6.0 ship 时**架构准备就绪**让 V0.7 国内 IM(WeChat / 飞书 / DingTalk / QQ)零成本接入。
 
-模式 1 已由 V0.5.0 `ccteam-team` skill 落地;模式 2 是 V0.4.x → V0.5.x 主线。**模式 3 之前没有**。
+**V0.6.0 范围(铺底)**:
+- F109 lift `openhuman/channels` Rust crate 时**带全 14+ provider 模块**(Lark / DingTalk / QQ 等都已实现),只用 `--feature` 门控编译;V0.7 启用对应 feature 即可
+- 中文文档先行(`docs/quickstart.md` / `user-manual.md` 中文版默认,英文翻译跟随)
+- bot persona 预设库含**中文 prefab**(技术助手 / 写作 / 翻译 / 学习辅导 5 个中文 persona)
 
-落地范围:
-- `ExecutionAdapter` trait 抽出(F107) — 现有 `BgSpawner` 改造对接,**行为零变化**。模式 3 / 模式 1 复用此 trait
-- `TmuxInteractiveAdapter`(F108) — 长跑 `claude` 进程 + send-keys 输入 + session jsonl tail 输出
-- `ccteam-im-bridge` crate(F109) — 第一个目标 IM 是 Telegram(`tgbot` crate 已成熟);Slack / Discord / IRC 留 trait 扩展点
-
-**用户视角**:
-```
-$ ccteam new my-tg-bots --mode chat                # 新模式
-$ vim .ccteam/workflow.yaml                        # 声明 bot roster + IM channel binding
-$ ccteam start my-tg-bots
-# 然后 TG 群里 @bot-name "..." → bot 在 tmux 里 long-running claude session 处理 → 回 TG
-# bot-to-bot @ 自动路由
-```
-
-模式 3 **不复用模式 2 的 inbox watcher**(那是 fresh-context 触发,模式 3 是 stdin 喂)。但**复用** progress.jsonl(业务事件)/ MCP 控制面(user 远程看哪个 bot 在干嘛)/ web UI(panel 加 Chat View tab)。
+**V0.7 范围(不在本版)**:
+- 国内 IM 平台启用(WeChat 个人灰路径 + 飞书 + DingTalk + QQ)
+- 国内云部署文档(走 ngrok / cloudflared 替代)
 
 ---
 
-## 四、MCP 优化(顺带)
+## 二、5 个用户面 preset(替代"3 mode + 5 pattern"内部概念)
 
-借鉴 OMC `mcp__t__*` / `mcp__team__*` 模式,**单 server + 子前缀**重组:
+用户**只选 preset**,不直接选 mode / pattern。每 preset = 默认 surface × pattern × persona 组合配方,由 `ccteam-creator` skill 在 dialogue 中自动推断:
 
-| 改动 | 现状 | V0.6.0 后 |
-|---|---|---|
-| Server name | `ccteam` | `ct`(节省 4 字符 × 17 工具 × N session)|
-| Tool 命名 | `mcp__ccteam__ls` `mcp__ccteam__spawn_agent` 平铺 | `mcp__ct__workflow_ls` `mcp__ct__workflow_spawn_agent` `mcp__ct__chat_send_input`(子前缀)|
-| 选择性禁用 | 无,17 工具全发布 | `CCTEAM_DISABLE_TOOLS=chat_*,screenshot` env-driven |
-| 项目级注册 | 只 `~/.claude.json`(user-global)| `ccteam init` 落项目 `.mcp.json`;user-global 保留作 fallback |
-
-**Breaking**:`mcp__ccteam__*` → `mcp__ct__*`。pre-v1.0 不留 alias(CLAUDE.md §五:no backwards-compat shim)。meta-agent / `ccteam-control` skill / 测试同步改。
-
----
-
-## 五、Findings 索引
-
-| F | 主题 | 性质 | Wave |
+| Preset | 一句话场景 | hello world | 内部映射 |
 |---|---|---|---|
-| F106 | 三执行模式定型 + 红线按模式 scope 重写 | 纯文档 | 跟随各 wave |
-| F107 | `ExecutionAdapter` trait 抽离 + `BgSpawner` 改造对接 | 重构(零行为变化)| Wave 1 |
-| F108 | `TmuxInteractiveAdapter` 实现(模式 3 执行 runtime)| 新增 | Wave 2 |
-| F109 | `ccteam-im-bridge` crate(模式 3 IM 触发源,TG 起步)| 新增 | Wave 2 |
-| F110 | MCP namespace `ccteam` → `ct` + 子前缀工具命名 | Breaking | Wave 3 |
-| F111 | MCP 工具粒度配置(`CCTEAM_DISABLE_TOOLS` + 项目级 `.mcp.json`)| 新增 | Wave 3 |
+| **Solo Sidekick** | 在 Claude 里临时召唤一个帮手干小事 | V0.5 已有(`Task` 工具)| in-proc / single agent |
+| **Team Sprint** | 几小时冲一波,3-5 agent 并行干一件事 | `/ccteam-team 3 "task"`(V0.5 已有)| in-proc / Orchestrator-Worker |
+| **Overnight Builder** | 丢个任务睡觉去,长跑几小时到几天 | `/ccteam-creator "夜里跑 qa-loop"` | bg / Chaining + Refine |
+| **Pocket Assistant**(V0.6 旗舰)| 手机 IM 私聊一个 AI 助理 | `/ccteam-creator "做个 TG 助理 bot"` | chat (DM) / Routing |
+| **IM Squad** | IM 群里多个 bot 互相 @ 协作 | `/ccteam-creator "做个 TG 多 bot 团队"` | chat (group + bot-to-bot) / Orchestrator-Worker |
+
+---
+
+## 三、用户面入口(全部 Claude session 内,0 ccteam CLI)
+
+```
+/ccteam <NL>                          # 总入口 NL dispatcher(F113)→ 路由到下方
+/ccteam-team <NL>                     # 起临时 team(V0.5 已有,扩展 vote mode + Codex 自动)
+/ccteam-creator <NL>                  # NL 对话起 workflow(V0.5 砍掉,V0.6 复活 + auto mode)
+/ccteam-control <NL>                  # 项目状态查看 / 暂停 / 恢复(V0.5 已有)
+/ccteam-im-setup                      # TG / Lark / Slack 一次性 token 绑定 onboarding
+/ccteam-advise <hard question>        # Codex + Claude 并行 advisor(vote 模式,F112)
+```
+
+IM 端:
+```
+TG bot 群里:@ccteam pause helpful-bot          # NL admin,im-bridge 走 meta-agent NL 路由
+TG bot 群里:@ccteam list bots                  # 同上
+TG bot DM:                                     # 直接跟 bot 对话(F112 模式 3 DM)
+```
+
+`ccteam` CLI 仅保留 admin:
+```
+ccteam doctor                          # 健康检查 + 一次性安装
+ccteam daemon {start|stop|status}      # 系统级 daemon 管理
+```
+其他 `ccteam new` / `ccteam start <slug>` / `ccteam internal *` 等命令仍存在(Rust binary 内),但 **user-manual.md 不教**,只在 troubleshooting / advanced 出现。
+
+---
+
+## 四、核心架构改动(转 product-ready)
+
+### 4.1 ExecutionAdapter trait 对齐 Codex `ThreadManager`(F107)
+
+弃 PRD 上版的 "新建 `ExecutionAdapter` trait + 三 LifecycleOp enum"。改为**扩展现有 `HarnessAdapter` trait**(`crates/ccteam-core/src/harness.rs:75` V0.4.0 已落)+ **对齐 Codex `ThreadManager::{submit, next_event}`**:
+
+```rust
+pub trait HarnessAdapter: Send + Sync {
+    async fn start_thread(&self, spec: &AgentSpec, ctx: &SpawnCtx) -> Result<ThreadHandle>;
+    async fn submit_turn(&self, h: &ThreadHandle, input: TurnInput) -> Result<TurnId>;
+    fn events(&self, h: &ThreadHandle) -> BoxStream<'static, ThreadEvent>;
+    async fn resume_thread(&self, persistent_id: &str) -> Result<ThreadHandle>;
+    async fn close_thread(&self, h: &ThreadHandle) -> Result<()>;
+}
+
+pub enum TurnInput {
+    UserText(String),
+    Artifact(PathBuf),                // bg mode inbox
+    SystemDirective(String),          // /compact /new /clear 退化为特殊 turn
+    Image(PathBuf),                   // rich media
+}
+
+pub struct SessionHandle {
+    pub vendor: AgentVendor,           // Claude | Codex
+    pub mode: ExecutionMode,           // InProc | Bg | Chat
+    pub identity: String,
+}
+```
+
+`/compact /new /clear` 不再是独立 `LifecycleOp` enum,而是 `TurnInput::SystemDirective("compact")` 特殊 turn — adapter 内部翻译为 backend-specific 操作(Claude → `/compact` slash;Codex → `compact_remote` API)。**统一 mode 2 + mode 3 = "all chat is a turn sequence"**。
+
+### 4.2 模式 3 执行路径:Agent SDK / `claude -p --resume`(F108 重写)
+
+弃 PRD 上版的 "tmux send-keys + session jsonl tail"。改为:
+- **input** 面:`claude -p --resume <sid> --input-format stream-json --output-format stream-json` stdin pipe(Anthropic 官方文档化路径)+ **JSON-mailbox-trigger 模式**(写 `<.ccteam/im/<bot>/inbox/msg-<ts>.md>` + 一个短 send-keys "read your mailbox" 触发,OMC `tmux-comm.ts` 抄)
+- **output** 面:stream-json events 流(`stream_event` / `system/init` / `system/api_retry` 全部官方文档化 schema)
+- **lifecycle** 操作:Agent SDK `compact` API 直接调,弃 `/compact` slash 命令模拟
+- **tmux 退居** dev-time attach 调试入口,**不**作 production 控制平面
+
+### 4.3 Codex 集成 Option B 完整(F112)
+
+`vendor: AgentVendor { Claude, Codex }` 作 trait 一等公民。新增 adapter:
+- `CodexExecAdapter`(模式 2 codex,走 `codex exec --json`)
+- `CodexAppServerAdapter`(模式 3 codex,走 `codex app-server` UDS JSON-RPC v2)
+- 复用 Codex `agent_max_depth` recursion guard
+- 复用 Codex 50+ scientist nickname 池子作 bot_name 自动生成(`agent_naming.rs`)
+- 借鉴 Codex `AgentPath` 层次树作 hop_limit 红线实现
+
+cost 双 pricing table:`crates/ccteam-cost/pricing/{anthropic,openai}.toml`;`budgets.claude.max_cost_usd_per_24h` / `budgets.codex.max_cost_usd_per_24h` 各管各的。
+
+**Codex 用户面 4 个可见场景**(其他全自动):
+- A. `/ccteam-advise <hard question>` parallel voting(Claude + Codex 并行,合成显示)
+- B. Auto-critic:用户起 critic / reviewer / architect role 时,如装 codex + auth ok → 自动赋 vendor: codex(`ccteam-creator` 内部决策,user 不见 yaml 字段)
+- C. Claude quota 触顶 opt-in fallback(默认 off,prefs 启用)
+- D. `/ccteam-team` 内置 Codex critic teammate(if available)
+
+### 4.4 IM bridge:**lift,不造**(F109 重写)
+
+**核心 directive**:不自造 channels 轮子。
+
+**统一 transport = `openhuman/channels` Rust crate**(14+ IM 平台:Telegram / Slack / Discord / Lark / DingTalk / QQ / Signal / iMessage / Matrix / WhatsApp / Email / IRC / Mattermost / Web)。`Channel` trait + `SendMessage` + `ChannelMessage` 抽象在 `traits.rs:5-60`;每 provider 走 Cargo feature gate;event bus + supervisor pattern 已实现。
+
+```
+ccteam-imd(独立 daemon binary,V0.6.0 F116)
+├── 依赖 openhuman/channels(Rust crate,统一 trait)
+│   ├── feature=telegram  # V0.6.0
+│   ├── feature=slack     # V0.6.0
+│   ├── feature=discord   # V0.6.0
+│   ├── feature=lark      # V0.7
+│   ├── feature=dingtalk  # V0.7
+│   ├── feature=qq        # V0.7
+│   └── ...
+├── bot-to-bot @ routing / hop_limit / mailbox 协调 / NL admin / @ccteam 解析
+│   (ccteam-imd 一处实现,跨所有 IM 平台统一)
+└── HarnessAdapter trait 调用(F107)— 把 inbound 消息翻译成 turn input
+```
+
+**`claude-plugins-official/telegram` 留作 backup**(用户 directive):
+- 默认 V0.6.0 走 openhuman / `ccteam-imd`;`/ccteam-im-setup` 默认 transport = `openhuman/telegram`
+- 用户偏好 Anthropic 全栈 / openhuman bug fallback:`/ccteam-im-setup --transport official-telegram` 切官方 MCP 路径(`claude --channels plugin:telegram@claude-plugins-official`)
+- 两 path 互斥(避免同 bot token 双重 webhook 竞争);切换走 onboarding skill,不让用户编辑配置
+
+**架构收益**(为啥统一比"TG 官方 + 其他 openhuman"好):
+- bot-to-bot @ routing / hop_limit / `@ccteam` NL admin / mailbox 协调 **一处实现**,跨所有 IM 平台一致
+- V0.7 国内 IM 启用零代码(只 cargo feature 切换 + token onboarding 测试)
+- 单一 daemon(`ccteam-imd`)替代"ccteam daemon + Anthropic 官方 TG MCP server"双进程
+- TG 特定逻辑(pairing/allowlist)若 openhuman/telegram 暂缺,ccteam-imd 上层补,**不分两套实现**
+
+### 4.5 F110 MCP namespace rename 取消
+
+**收 review 反馈**:`mcp__ccteam__*` → `mcp__ct__*` 节省 4 字符是 dev-cost 优化,**对 V0.5 用户是肌肉记忆破坏**;`ct` 1 年后用户记不住代表啥。**保留** `mcp__ccteam__*` namespace;F110 只保留 "**子前缀分组**" 部分:`mcp__ccteam__workflow_ls` / `mcp__ccteam__chat_send_input` 等。
+
+### 4.6 F111 + F114 等其他改进
 
 详 `prd.md`。
 
 ---
 
-## 六、不在本版
+## 五、红线按"模式 × vendor"双轴 scope 重写(F106 重写)
 
-- 模式 3 跨 session chat memory 重建(session-id 失效时,从 progress.jsonl 重放业务事件作 system prompt) — 延 V0.6.1
-- IM bridge 多平台扩展(Slack / Discord) — 延 V0.7.x;V0.6.0 只落 TG + trait
-- V0.5.x 延期 F98(plan-approval↔outbox 联动)— 见 `docs/v0-5-0/prd.md` 末段,本版仍不动
-- mcp `ct` 之外的拆 server(多 server / standalone server)— 见决策记录 §七,本版不拆
+原 V0.6.0 红线只按模式 scope。Codex 加入后必须按 vendor 也 scope:
+
+| 红线 | 模式 1 in-proc | 模式 2 bg | 模式 3 chat |
+|---|---|---|---|
+| R1 文件系统是控制平面 | — | **Claude+Codex 同**(artifact)| Claude: stream-json + ccteam-owned `turns.jsonl`;Codex: app-server UDS + `turns.jsonl` |
+| R2 progress.jsonl 唯一 state SoT | — | **守(双 vendor)** | **业务事件 SoT 守**;对话原文走 ccteam-owned `turns.jsonl`(取代依赖 Anthropic 内部 `~/.claude/projects/`)|
+| R3 每次 spawn = fresh 1M context | — | **Claude 守;Codex `codex exec resume <tid>` 实现可复用,trait 决定,用户不见** | **不适用** — chat 复用 context 是 feature |
+| R4 不解析 tmux 输出 | — | 守 | 守 — 读 stream-json + `turns.jsonl`,**不 scrape pane** |
+| R5 永不主动 kill 长 session | 守 | 守(`--max-budget-usd` 平台兜底替代 F84 强制 kill)| 守 + `/compact /new` 是合法 turn,非 kill |
+| R6 fix-loop 3 次必 escalate | 守 | 守 | 守 + **AgentPath depth limit**(借 Codex AgentRegistry 实现)替代平铺 fix_counts 红线 |
+| R7 `ccteam-core` 零 team 名字面量 | 守 | 守 | 守 |
+| R8 跨项目记忆走官方接口 | **Claude: `~/.claude/CLAUDE.md`** / **Codex: `~/.codex/AGENTS.md`**;`ccteam init` 落 AGENTS.md → CLAUDE.md POSIX symlink | 同上 | 同上 |
+| R9 新建项目走 `<projects_root>/<team>-<slug>/` | — | 守 | 守 |
 
 ---
 
-## 七、决策记录(为什么这么做)
+## 六、Findings 索引(F106-F118,Epic 下的实施手段)
 
-| 决策 | 选项 A | 选项 B | 选了 | 理由 |
+| F | 主题 | 性质 | Epic | Wave |
 |---|---|---|---|---|
-| 模式 3 执行 runtime | `claude --resume` + stream-json 长跑 | Agent SDK adapter 进程内 agent loop | **A** | 跟现有 tmux pane plumbing 顺,Claude Code 全栈(skills / hooks / MCP)零损耗 |
-| 模式 3 input 面 | send-keys | stdin pipe(`--input-format stream-json`)| **send-keys** | 复用 tmux 已有基础设施;stdin 模式将来可加 |
-| 模式 3 output 面 | parse session jsonl | parse tmux capture-pane | **session jsonl** | 守"不解析 tmux 输出"红线;Anthropic 官方格式比 ANSI 文本稳定 |
-| MCP server 拆 | 单 server `ct` + 子前缀 | 拆 2 server(`ct` + `ct_chat`)| **单 server** | `.mcp.json` 单条目;`CCTEAM_DISABLE_TOOLS` 抵消 tool list 长度风险 |
-| MCP namespace 长度 | `t`(1 字母)| `ct`(2 字母)| **`ct`** | `t` 容易撞别人(OMC 已占);`ct` 是"ccteam"缩 |
-| Breaking vs alias | 留 `ccteam__*` alias 一版 | 直接 breaking | **直接 breaking** | pre-v1.0 + CLAUDE.md §五 no shim |
-| 模式 3 落地深度 | trait + adapter stub | trait + adapter + TG bridge 全栈 | **全栈** | trait + 一个真实 adapter 才能验证 trait 设计;TG 是最低复杂度 IM 选择 |
+| F106 | 红线按"模式 × vendor"双轴 scope 重写 | 文档 | A/B/C | 跟随 |
+| F107 | 扩展 `HarnessAdapter` 对齐 Codex `ThreadManager`;5 方法 trait + vendor enum | 重构 | B | 1 |
+| F108 | 模式 3 走 `claude -p --resume` + stream-json + JSON-mailbox-trigger(弃 tmux send-keys)| 新增 | B | 2 |
+| F109 | IM bridge 统一 `openhuman/channels` Rust crate(主路径,14+ IM 平台);`claude-plugins-official/telegram` 作 backup | 新增 | A/C | 2 |
+| ~~F110~~ | ~~MCP namespace ccteam → ct rename~~ | **取消** | — | — |
+| F111 | MCP 工具子前缀 + group disable env + 项目级 `.mcp.json` | 改进 | A | 3 |
+| F112 | Codex 集成 Option B 完整:trait + 2 adapter + 双 pricing + 4 用户场景 | 新增 | B | 2 |
+| F113 | `/ccteam` 总入口 NL dispatcher slash + 5 sub-skill | 新增 | A | 1-2 |
+| F114 | `ccteam-creator` 复活 + NL 自动 mode 推断 + persona 预设库 | 新增 | A | 2 |
+| F115 | `.ccteam/handoffs/<workflow>/<stage>.md` 决策摘要机制 | 新增 | B | 2 |
+| F116 | `ccteam-imd` 独立 supervisor daemon binary(borrowed OMC `reply-listener.ts`)| 新增 | A/B | 2 |
+| F117 | `/ccteam-im-setup` 一次性 IM token onboarding skill | 新增 | A | 2 |
+| F118 | chat session 失效 last-N turn 重建(ccteam-owned `turns.jsonl` SoT)| 新增 | B | 3 |
+
+---
+
+## 七、文档套件(本版产物)
+
+PM 提议的 5 用户面文档全部产出:
+
+```
+ccteam/
+├── README.md                              ≤80 行 [V0.6.0 REWRITE,产品 pitch + 5 行 install + link]
+└── docs/
+    ├── quickstart.md                      ≤120 行 [V0.6.0 NEW,Pocket Assistant 场景 5-step]
+    ├── user-manual.md                     ≤300 行 [V0.6.0 REWRITE V0.5,5 preset 各一节]
+    ├── recipes.md                         ≤500 行 [V0.6.0 NEW,8-10 ready preset 模板]
+    ├── troubleshooting.md                 ≤400 行 [V0.6.0 NEW,50+ 故障条目]
+    ├── advanced/                          [V0.6.0 NEW]
+    │   ├── customize-workflow.md
+    │   ├── multi-llm-codex.md             [Codex 集成手册]
+    │   └── presets-reference.md
+    ├── v0-6-0/                            [本 PR dev 归档,ship 后冻结]
+    │   ├── README.md(本文件)
+    │   ├── prd.md
+    │   ├── dev-plan.md
+    │   └── host-probe.md(wave 4 验证产物)
+    └── architecture/(重组,纯 dev docs)
+```
+
+**用户面 13 项内部术语永久从用户面文档清出**(详 PM PM11):mode 1/2/3、progress.jsonl、send-keys、session jsonl tail、ExecutionAdapter、fix_count、escalation event、hop_limit、compact_every_turns、F-number、`mcp__ccteam__chat_session_reset_force`、`cleanup_on_stop: leave-running`、5 编排 × 3 执行矩阵。
+
+---
+
+## 八、不在本版
+
+- **国内 IM 启用**(WeChat / 飞书 / DingTalk / QQ)— V0.7 专项;V0.6.0 铺底使 V0.7 几乎零成本
+- **chat memory 跨设备同步**(`<project>/.ccteam/chat/<bot>/turns.jsonl` 已是 SoT,但跨机同步走 git / rsync / 云盘是 V0.7 工具支持)
+- **6 号编排模式 HITL / Approval Gating**(researcher R10 提)— V0.6.1 立项 F119
+- **monorepo-aware `.mcp.json`**(researcher R6#4 提)— V0.7+
+- **`ccteam migrate-from claude` 反向 import**(codex-expert CX6#5 提)— V0.7+
+- **V0.5.x 延期 F98**(plan-approval↔outbox 联动)— 与 F119 合并 V0.6.1
+
+---
+
+## 九、决策记录修订(对上版 README §七)
+
+| 决策 | 上版选 | 本版改 | 理由 |
+|---|---|---|---|
+| 模式 3 execution runtime | tmux send-keys(A)| **Agent SDK / `claude -p --resume` + stream-json(B)** | cc-expert WebFetch 验证 session jsonl 路径 0 文档化;architect "internal-not-API";researcher OMC mailbox-trigger 模式更稳 |
+| 模式 3 input 面 | send-keys | **stream-json stdin pipe + JSON-mailbox-trigger 组合** | send-keys 仅传短 trigger("read your mailbox"),内容写 mailbox 文件;0 escape 雷区 |
+| 模式 3 output 面 | parse session jsonl(Anthropic internal)| **stream-json 官方 schema + ccteam-owned `turns.jsonl`** | A5 architect:ccteam-owned SoT 让 R1/R2 红线在模式 3 真正站住 |
+| MCP namespace rename | breaking `ccteam` → `ct` | **取消;保 `ccteam` namespace,只加子前缀** | PM + cc-expert + codex-expert 共识 + 用户低门槛 override:rename 用户净损失 |
+| F109 IM bridge 自造 | tokio task + `tgbot` crate | **统一 `openhuman/channels` Rust crate(全 14+ IM 含 Telegram);`claude-plugins-official/telegram` 作 backup transport** | 用户 directive:不造轮子;统一 transport 一处实现 bot-to-bot routing;V0.7 国内 IM 零代码启用 |
+| Codex 集成深度 | Option A(模式 2 only)| **Option B(完整:trait + 2 adapter + 双 pricing + 4 用户场景)** | 用户拍板;不集成 V0.6.0 ship 后被定义为"只支持 Claude 的小众工具"(researcher R9 表)|
+| user surface 主入口 | `ccteam` CLI 命令 | **Claude session 内 `/ccteam-*` slash + meta-agent NL + MCP tool** | 用户硬约束:"低门槛 + Claude-Code-native UX";13 lock decisions L2 |
+| 用户面概念 | mode 1/2/3 + 5 编排 + 4 trigger + N MCP 工具 = 8+ 概念 | **5 preset(用户只选 preset)+ `/ccteam` 一个总入口 slash** | architect A9 + PM PM10 8→2-axis 压缩;用户低门槛 override |
+| DM vs group | group 优先,DM 延 V0.6.1 | **DM + group + bot-to-bot @ 全起 V0.6.0** | 用户拍板:R6#1 完整 IM Squad 体验是 V0.6.0 锁定卖点 |
+| 5 用户文档 | docs/v0-x-y/ 内 user-manual.md | **5 份文档独立 docs/ 根 + advanced/ + v0-6-0/(dev archive)分离** | PM PM11 |
+
+---
+
+详 `prd.md`(Epic 详细需求 + 12 finding 实施)+ `dev-plan.md`(4 wave 修订)。

--- a/docs/v0-6-0/README.md
+++ b/docs/v0-6-0/README.md
@@ -1,0 +1,114 @@
+# V0.6.0 — 三执行模式定型 + 模式 3 (chat / IM) 落地 + MCP 优化
+
+> **立项主线**:把"ccteam 是 Claude Code 之上的编排层"这句话**显式拆成三种执行模式**,每种锚到 Claude Code 一个执行原语;红线按模式重新 scope;模式 3(chat / IM bot)是本版新落地能力;MCP 顺带按 OMC 借鉴优化。
+>
+> **不立项**:任何会破坏现有模式 2(artifact-driven workflow)行为的改动。Wave 1 trait 抽离要求 `cargo test --workspace` 数字**完全持平**,不得退步。
+>
+> **doc-first 原则**:本 PR 只 land `docs/v0-6-0/`(README + PRD + dev-plan),代码改动按 3 个 wave 跟进 PR。
+
+---
+
+## 一、三执行模式定型(本版核心)
+
+ccteam 在 Claude Code 之上提供三种 agent 执行模式,**锚到 Claude Code 三种执行原语**:
+
+| 模式 | 直观场景 | spawn 原语 | input 面 | output 面 | context 生命周期 |
+|---|---|---|---|---|---|
+| **1. in-proc team** | CC 插件 / skill,一句话起临时 team(`/ccteam-team "fix TS errors"`)| `Task(subagent_type=…)` | tool args | tool result | parent session 内,死则同死 |
+| **2. bg sessions** | 长跑自动化工作流(qa-loop:test→fix→release)| `claude --bg --agent <role>` | `.ccteam/inbox/*.md`(artifact)| `progress.jsonl` + state.json | **每次 spawn fresh 1M context** |
+| **3. tmux sessions** | 随叫随到 chat agent team(TG 群里多 bot,@ 召唤,bot 间互 @)| 长跑 `claude`(交互模式,常驻 tmux pane)| `tmux send-keys`(含 `/new` `/compact`)| `~/.claude/projects/<…>/<session-id>.jsonl`(Anthropic 官方 session 格式)| `/new` 重置 / `/compact` 摘要,**在线管理** |
+
+每模式自带的 control plane / cost model 详 `prd.md §F106`。
+
+---
+
+## 二、红线按模式重新 scope(配套改动)
+
+现有 7 条红线大多写于 V0.1-V0.4 的模式 2 语境,V0.6 显式标注每条**适用哪些模式**:
+
+| 红线 | 当前措辞 | 模式 1 | 模式 2 | 模式 3 |
+|---|---|---|---|---|
+| 文件系统是控制平面 | 全局 | N/A(in-proc)| **输入 + 输出都是** | **输出 SoT 是**(session jsonl);输入是 send-keys |
+| `progress.jsonl` 唯一 state SoT | 全局 | N/A | **是**(SoT)| **业务事件 SoT**;对话原文走 session jsonl,**不重抄** |
+| 每次 spawn = fresh 1M context | 全局 | parent session,无 spawn | **守** | **不适用** — chat 场景就是要复用,显式 `/compact` `/new` 管理 |
+| 不解析 tmux 输出 | 全局 | N/A | **守** | **守** — 读 session jsonl 替代,**不 scrape pane** |
+| 永不主动 kill 长 session | 全局 | N/A | **守**(F84 budget cap 唯一例外)| **守** + `/compact` `/new` 是合法状态操作,非 kill |
+| fix-loop 3 次必 escalate | 全局 | parent 自决 | **守** | **守** + bot-to-bot @ ping-pong **hop_limit 同等 escalate** |
+| `ccteam-core` 零 team 名字面量 | 全局 | **守** | **守** | **守** |
+
+详 PRD §F106。
+
+---
+
+## 三、模式 3 是本版的新落地
+
+模式 1 已由 V0.5.0 `ccteam-team` skill 落地;模式 2 是 V0.4.x → V0.5.x 主线。**模式 3 之前没有**。
+
+落地范围:
+- `ExecutionAdapter` trait 抽出(F107) — 现有 `BgSpawner` 改造对接,**行为零变化**。模式 3 / 模式 1 复用此 trait
+- `TmuxInteractiveAdapter`(F108) — 长跑 `claude` 进程 + send-keys 输入 + session jsonl tail 输出
+- `ccteam-im-bridge` crate(F109) — 第一个目标 IM 是 Telegram(`tgbot` crate 已成熟);Slack / Discord / IRC 留 trait 扩展点
+
+**用户视角**:
+```
+$ ccteam new my-tg-bots --mode chat                # 新模式
+$ vim .ccteam/workflow.yaml                        # 声明 bot roster + IM channel binding
+$ ccteam start my-tg-bots
+# 然后 TG 群里 @bot-name "..." → bot 在 tmux 里 long-running claude session 处理 → 回 TG
+# bot-to-bot @ 自动路由
+```
+
+模式 3 **不复用模式 2 的 inbox watcher**(那是 fresh-context 触发,模式 3 是 stdin 喂)。但**复用** progress.jsonl(业务事件)/ MCP 控制面(user 远程看哪个 bot 在干嘛)/ web UI(panel 加 Chat View tab)。
+
+---
+
+## 四、MCP 优化(顺带)
+
+借鉴 OMC `mcp__t__*` / `mcp__team__*` 模式,**单 server + 子前缀**重组:
+
+| 改动 | 现状 | V0.6.0 后 |
+|---|---|---|
+| Server name | `ccteam` | `ct`(节省 4 字符 × 17 工具 × N session)|
+| Tool 命名 | `mcp__ccteam__ls` `mcp__ccteam__spawn_agent` 平铺 | `mcp__ct__workflow_ls` `mcp__ct__workflow_spawn_agent` `mcp__ct__chat_send_input`(子前缀)|
+| 选择性禁用 | 无,17 工具全发布 | `CCTEAM_DISABLE_TOOLS=chat_*,screenshot` env-driven |
+| 项目级注册 | 只 `~/.claude.json`(user-global)| `ccteam init` 落项目 `.mcp.json`;user-global 保留作 fallback |
+
+**Breaking**:`mcp__ccteam__*` → `mcp__ct__*`。pre-v1.0 不留 alias(CLAUDE.md §五:no backwards-compat shim)。meta-agent / `ccteam-control` skill / 测试同步改。
+
+---
+
+## 五、Findings 索引
+
+| F | 主题 | 性质 | Wave |
+|---|---|---|---|
+| F106 | 三执行模式定型 + 红线按模式 scope 重写 | 纯文档 | 跟随各 wave |
+| F107 | `ExecutionAdapter` trait 抽离 + `BgSpawner` 改造对接 | 重构(零行为变化)| Wave 1 |
+| F108 | `TmuxInteractiveAdapter` 实现(模式 3 执行 runtime)| 新增 | Wave 2 |
+| F109 | `ccteam-im-bridge` crate(模式 3 IM 触发源,TG 起步)| 新增 | Wave 2 |
+| F110 | MCP namespace `ccteam` → `ct` + 子前缀工具命名 | Breaking | Wave 3 |
+| F111 | MCP 工具粒度配置(`CCTEAM_DISABLE_TOOLS` + 项目级 `.mcp.json`)| 新增 | Wave 3 |
+
+详 `prd.md`。
+
+---
+
+## 六、不在本版
+
+- 模式 3 跨 session chat memory 重建(session-id 失效时,从 progress.jsonl 重放业务事件作 system prompt) — 延 V0.6.1
+- IM bridge 多平台扩展(Slack / Discord) — 延 V0.7.x;V0.6.0 只落 TG + trait
+- V0.5.x 延期 F98(plan-approval↔outbox 联动)— 见 `docs/v0-5-0/prd.md` 末段,本版仍不动
+- mcp `ct` 之外的拆 server(多 server / standalone server)— 见决策记录 §七,本版不拆
+
+---
+
+## 七、决策记录(为什么这么做)
+
+| 决策 | 选项 A | 选项 B | 选了 | 理由 |
+|---|---|---|---|---|
+| 模式 3 执行 runtime | `claude --resume` + stream-json 长跑 | Agent SDK adapter 进程内 agent loop | **A** | 跟现有 tmux pane plumbing 顺,Claude Code 全栈(skills / hooks / MCP)零损耗 |
+| 模式 3 input 面 | send-keys | stdin pipe(`--input-format stream-json`)| **send-keys** | 复用 tmux 已有基础设施;stdin 模式将来可加 |
+| 模式 3 output 面 | parse session jsonl | parse tmux capture-pane | **session jsonl** | 守"不解析 tmux 输出"红线;Anthropic 官方格式比 ANSI 文本稳定 |
+| MCP server 拆 | 单 server `ct` + 子前缀 | 拆 2 server(`ct` + `ct_chat`)| **单 server** | `.mcp.json` 单条目;`CCTEAM_DISABLE_TOOLS` 抵消 tool list 长度风险 |
+| MCP namespace 长度 | `t`(1 字母)| `ct`(2 字母)| **`ct`** | `t` 容易撞别人(OMC 已占);`ct` 是"ccteam"缩 |
+| Breaking vs alias | 留 `ccteam__*` alias 一版 | 直接 breaking | **直接 breaking** | pre-v1.0 + CLAUDE.md §五 no shim |
+| 模式 3 落地深度 | trait + adapter stub | trait + adapter + TG bridge 全栈 | **全栈** | trait + 一个真实 adapter 才能验证 trait 设计;TG 是最低复杂度 IM 选择 |

--- a/docs/v0-6-0/dev-plan.md
+++ b/docs/v0-6-0/dev-plan.md
@@ -1,218 +1,266 @@
 # V0.6.0 — dev-plan
 
-**Wave 顺序** — trait 抽离打地基(零行为变化)→ 模式 3 落地(本版主菜)→ MCP 优化(顺带,独立)。每 wave 单独 PR + 单独 baseline 校验。
+**4 wave**(按 Epic 组织,F-finding 是实施手段):
 
-| Wave | 内容 | F | 占比 | 并行度 |
-|---|---|---|---|---|
-| Wave 1 | `ExecutionAdapter` trait 抽离 + `BgSpawnAdapter` 改造 — 零行为变化 | F107 | 20% | 单 subagent,2-3 天 |
-| Wave 2 | `TmuxInteractiveAdapter` + `ccteam-im-bridge` crate — 模式 3 落地 | F108 + F109 | 55% | 2 subagent 并行,5-7 天 |
-| Wave 3 | MCP namespace + 子前缀 + `CCTEAM_DISABLE_TOOLS` + 项目级 `.mcp.json` | F110 + F111 | 15% | 单 subagent,2-3 天 |
-| Wave 4 | 文档同步(F106 落 tech-design / orchestration-patterns / CLAUDE.md)+ host E2E + ship | F106 + 集成 | 10% | 主 session,2 天 |
+| Wave | 内容 | F | 占比 | 工期 | 并行度 |
+|---|---|---|---|---|---|
+| Wave 0 | **doc-first**:land 本 PRD + README + dev-plan + 5 用户面文档 + advanced 文档 | F106 + 文档套件 | 5% | 1 天(本 PR) | 主 session + 5 teammate 并行 |
+| Wave 1 | **架构基石**:F107 HarnessAdapter trait 扩展(对齐 Codex ThreadManager)+ F113 `/ccteam` dispatcher skill 雏形 + F111 MCP 子前缀 | F107 + F113 + F111 | 20% | 3-4 天 | 2 subagent 并行 |
+| Wave 2 | **Epic A + B 主菜**:F108 ClaudeStreamJsonAdapter + F109 ccteam-imd(统一 openhuman)+ F114 ccteam-creator 复活 + F117 ccteam-im-setup + F115 handoff + F116 supervisor + F118 session recovery | F108 + F109 + F114 + F115 + F116 + F117 + F118 | 50% | 8-10 天 | 4 subagent 并行 |
+| Wave 3 | **Codex 完整集成**:F112 CodexExecAdapter + CodexAppServerAdapter + 4 用户场景 + 双 pricing | F112 | 18% | 4-5 天 | 2 subagent 并行 |
+| Wave 4 | **集成 + host E2E + ship**:全链路 5 preset host probe + 文档 polish + version bump | F106 集成部分 | 7% | 2 天 | 主 session |
 
-总:T+11-15 天。baseline 942/1 → 预计 ~975/1(新增 ~33 测试:trait 4 + tmux 8 + im-bridge 6 + mcp disable 5 + project mcp.json 4 + 集成 ~6)。
+总:T+18-22 天(对比上版 PRD 11-15 天)。Baseline 942/1 → 预计 ~1010/1(新增 ~68 测试)。
 
 ---
 
 ## Wave 0 — 立项 PR(本 PR)
 
-**只 land 文档**:
-- `docs/v0-6-0/README.md`
-- `docs/v0-6-0/prd.md`(本文件兄弟)
-- `docs/v0-6-0/dev-plan.md`(本文件)
+**只 land 文档** — 12 个文件:
 
-**不动**任何代码 / 测试 / `CLAUDE.md`(version bump 走 wave 4)。
-
-**估工**:已完成(本 session)。
-
----
-
-## Wave 1 — `ExecutionAdapter` trait 抽离(F107)
-
-**目标**:抽 trait + 改造现有 BgSpawner,行为零变化,`cargo test --workspace` 数字持平 942/1。
-
-### 关键文件
-
-| 文件 | 改动类型 | 说明 |
+| 文件 | 行数估 | 写者 |
 |---|---|---|
-| `crates/ccteam-core/src/execution/mod.rs` | 新 | trait + 类型定义 |
-| `crates/ccteam-core/src/execution/bg.rs` | 新(迁移)| `BgSpawnAdapter` impl;迁移自现 `spawn.rs` / `claude_job.rs` |
-| `crates/ccteam-core/src/orchestrator.rs` | 改 | 持 `Arc<dyn ExecutionAdapter>`;主循环走 trait |
-| `crates/ccteam-core/src/lib.rs` | 改 | re-export `execution::*` |
-| `crates/ccteam-cli/src/commands.rs` | 改 | spawn / send / pause / resume 全改走 trait |
-| `crates/ccteam-cli/src/mcp_serve.rs` | 改 | tool handler 走 trait(为 wave 3 chat tool 铺路) |
-| `crates/ccteam-core/tests/execution_trait_test.rs` | 新 | 4 trait 行为测试 |
+| `docs/v0-6-0/README.md` | ~250 | 主 session(已写) |
+| `docs/v0-6-0/prd.md` | ~800 | 主 session(已写) |
+| `docs/v0-6-0/dev-plan.md`(本文件)| ~280 | 主 session |
+| `README.md`(repo 根 重写)| ≤80 | PM teammate |
+| `docs/quickstart.md`(新) | ≤120 | PM teammate |
+| `docs/user-manual.md`(重写 V0.5)| ≤300 | PM teammate |
+| `docs/recipes.md`(新) | ≤500 | researcher teammate |
+| `docs/troubleshooting.md`(新)| ≤400 | cc-expert teammate |
+| `docs/advanced/customize-workflow.md`(新) | ~200 | architect teammate |
+| `docs/advanced/multi-llm-codex.md`(新)| ~250 | codex-expert teammate |
+| `docs/advanced/presets-reference.md`(新)| ~200 | researcher teammate |
+
+**5 teammate 并行派单**(主 session 写完核心 3 + 调度):
+1. PM → `README.md` + `quickstart.md` + `user-manual.md`(产品 voice 一致)
+2. researcher → `recipes.md` + `advanced/presets-reference.md`(横向对比经验)
+3. cc-expert → `troubleshooting.md`(故障 + 平台依赖知识)
+4. architect → `advanced/customize-workflow.md`(高级 yaml 编辑指南)
+5. codex-expert → `advanced/multi-llm-codex.md`(Codex 集成手册)
+
+**估工**:1 天(主 session 已完 3 核心 + 调度;teammate 各 0.5-1 工时并行)
+
+---
+
+## Wave 1 — 架构基石(F107 + F113 + F111)
+
+**目标**:trait 抽离 + skill dispatcher 框架 + MCP 子前缀。零行为变化(baseline 942/1 持平)。
+
+### Subagent A:F107 HarnessAdapter trait 扩展
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/harness.rs` | trait 加 `start_thread / submit_turn / events / resume_thread / close_thread` 5 方法 + `TurnInput` / `ThreadEvent` / `SessionHandle` / `AgentVendor` / `ExecutionMode` 类型 |
+| `crates/ccteam-core/src/execution/claude_bg.rs`(新,迁移自 spawn.rs)| `ClaudeBgAdapter` impl trait — 行为完全等价旧 `spawn_session` |
+| `crates/ccteam-core/src/execution/codex_exec.rs`(新)| `CodexExecAdapter` skeleton impl(stub 测 trait 设计,Wave 3 详填)|
+| `crates/ccteam-core/src/orchestrator.rs` | 主循环改 ThreadHandle / ThreadEvent 分发 |
+| `crates/ccteam-cost/src/lib.rs`(新)| `UnifiedTokenUsage` + 双 pricing table |
+| `crates/ccteam-cost/pricing/{anthropic,openai}.toml`(新)| 双 pricing |
+| `crates/ccteam-core/tests/harness_trait_test.rs`(扩)| 4-6 trait 行为测试 |
+
+**估工**:2 subagent 协作 3-4 天。
+
+### Subagent B:F113 + F111
+
+| 文件 | 改动 |
+|---|---|
+| `skills/ccteam/SKILL.md`(新)| ~150 行 dispatcher skill body |
+| `crates/ccteam-cli/src/mcp_serve.rs` | tool name 加子前缀;`CCTEAM_DISABLE_TOOLS` 改 group enum |
+| `crates/ccteam-cli/src/mcp_chat_tools.rs`(新)| chat_* 5 工具 stub(Wave 2 接 F108)|
+| `crates/ccteam-cli/src/mcp_advise_tools.rs`(新)| advise_* 2 工具 stub(Wave 3 接 F112)|
+| `crates/ccteam-cli/tests/mcp_subprefix_test.rs`(新)| 4 测试 |
+
+**估工**:1 subagent 2 天。
 
 ### Stub agreement(开 wave 前定)
 
-trait 签名锁定(PRD §F107 接口)。**任何后续 wave 不许改 trait 签名**(改 = wave 1 没收敛,回炉)。
-
-### 实施步骤
-
-1. 写 trait + 类型 + 单测,先 `cargo build` 通过 — 0.5 天
-2. 抽 `BgSpawnAdapter`,迁移 `spawn_session` 主路径 — 1 天
-3. orchestrator 主循环替换 — 0.5 天
-4. CLI / MCP 路径替换 — 0.5 天
-5. 跑 `cargo test --workspace`,fix 退步 — 0.5 天
+trait 签名锁定(PRD §F107 接口)— wave 2/3 不许改 signature(改 = wave 1 没收敛回炉)。
 
 ### 验收
 
-- `cargo test --workspace --locked --no-fail-fast`: ≥942 通过,1 失败(同 baseline,不变)
+- `cargo test --workspace`: ≥942 通过(baseline 持平)
 - clippy: 0 errors, ≤18 warnings
-- `grep -rn "Command::new(\"claude\")" crates/ccteam-core` 命中**仅在** `execution/bg.rs`
-- host probe:V0.5.1 跑过的 dex-ui workflow.yaml 行为完全一致(progress.jsonl event 序列 diff = 0)
-
-### 风险 / 应对
-
-| 风险 | 应对 |
-|---|---|
-| trait 设计不够泛化,wave 2 发现要改签名 | wave 1 PR 包含 1 个"mock chat adapter" 测试(只为验证签名能容纳,不实现真功能) |
-| BgSpawner 迁移漏掉 edge case(restart / cancel race)| 复跑现有 `crates/ccteam-core/tests/bg_spawner_test.rs` 等全套现测试,严格 0 退步 |
-| orchestrator 主循环动到了红线 | code review 严守:`grep -n "fix_count\|escalate\|budget"` 在 orchestrator.rs 改动行数 ≤ 5 |
+- `grep -rn "Command::new(\"claude\")" crates/ccteam-core` 命中**仅在** `execution/claude_bg.rs`
+- `grep -rn "trait HarnessAdapter" crates/ccteam-core/src/harness.rs` ≥1(扩展不新建)
+- `grep -rn "mcp__ccteam__" crates/ccteam-cli/src/` 命中 ≥17(server name 不变)
 
 ---
 
-## Wave 2 — 模式 3 落地(F108 + F109)
+## Wave 2 — Epic A + B 主菜(F108 + F109 + F114 + F115 + F116 + F117 + F118)
 
-**目标**:`TmuxInteractiveAdapter` impl + `ccteam-im-bridge` crate + workflow.yaml `mode: chat`;host TG 实测多轮 chat 跑通。
+**目标**:Epic A 5min IM bot 跑通(host probe TG hello world);Epic B chat 完整 IM Squad + handoff + session recovery。
 
-### 并行拆分(2 subagent)
+### 4 subagent 并行拆
 
-#### Subagent A:F108 `TmuxInteractiveAdapter` + 配套 schema
+#### Subagent A:F108 ClaudeStreamJsonAdapter + F118 session recovery
 
 | 文件 | 改动 |
 |---|---|
-| `crates/ccteam-core/src/execution/tmux_interactive.rs` | 新,~600 行 |
-| `crates/ccteam-core/src/execution/session_jsonl_tail.rs` | 新,~300 行 |
-| `crates/ccteam-core/src/execution/send_keys.rs` | 新,~200 行 + fuzzing test |
-| `crates/ccteam-core/src/workflow_schema.rs` | 加 `mode: chat` 枚举 + 字段 |
+| `crates/ccteam-core/src/execution/claude_stream_json.rs`(新)| `ClaudeStreamJsonAdapter` impl,~400 行 |
+| `crates/ccteam-core/src/execution/mailbox.rs`(新)| JSON-mailbox-trigger 读写,~150 行 |
+| `crates/ccteam-core/src/execution/turns_jsonl.rs`(新)| ccteam-owned chat history SoT,~200 行 |
+| `crates/ccteam-core/src/execution/session_recovery.rs`(新,F118)| last-N turn 重建逻辑 |
+| `crates/ccteam-core/src/workflow_schema.rs` | `mode: chat` schema 字段 `#[serde(default)]` 收紧 |
 | `crates/ccteam-core/src/progress_event.rs` | 加 4 chat_* event 类型 |
-| `crates/ccteam-core/tests/tmux_interactive_test.rs` | 新,8 测试 |
+| `crates/ccteam-core/tests/claude_stream_json_test.rs`(新)| 8 测试 |
 
 **估工**:3-4 天。
 
-#### Subagent B:F109 `ccteam-im-bridge` crate
+#### Subagent B:F109 ccteam-imd + F116 supervisor
 
 | 文件 | 改动 |
 |---|---|
-| `crates/ccteam-im-bridge/Cargo.toml` | 新 crate |
-| `crates/ccteam-im-bridge/src/lib.rs` | 新,trait + types |
-| `crates/ccteam-im-bridge/src/telegram.rs` | 新,teloxide impl |
-| `crates/ccteam-im-bridge/src/router.rs` | 新,@-mention parse + 路由 |
-| `crates/ccteam-im-bridge/src/hop_tracker.rs` | 新,R6 hop_limit |
-| `crates/ccteam-im-bridge/src/session_link.rs` | 新,TG user ↔ bot session 持久化 |
-| `crates/ccteam-cli/src/commands.rs::start` | chat mode 检测 → spawn bridge |
-| `crates/ccteam-cli/src/main.rs` | 加 `internal im-bridge` 子命令 |
-| `Cargo.toml`(workspace 根)| 加 member |
-| `crates/ccteam-im-bridge/tests/router_test.rs` | 新,6 测试 |
-| `crates/ccteam-im-bridge/tests/dep_graph_test.rs` | 新,守 core 不依赖 teloxide |
+| `crates/ccteam-imd/Cargo.toml`(新)| deps openhuman + feature gate;ccteam-core trait dep |
+| `crates/ccteam-imd/src/main.rs`(新)| daemon 入口 |
+| `crates/ccteam-imd/src/{supervisor,inbound,outbound,router,hop_tracker,nl_admin,credentials,sanitize,rate_limit,acl}.rs`(新)| 6 模块 ~1500 行 |
+| `crates/ccteam-imd/systemd/ccteam-imd.service`(新)| Linux systemd unit |
+| `Cargo.toml`(workspace)| 加 member + openhuman dep |
+| `crates/ccteam-imd/tests/router_test.rs`(新)| 6 测试 |
+| `crates/ccteam-imd/tests/dep_graph_test.rs`(新)| 守 ccteam-core 0 openhuman dep |
+| `crates/ccteam-cli/src/commands.rs::daemon_start` | chat workflow 检测 → spawn ccteam-imd |
 
 **估工**:3-4 天。
 
-### Stub agreement(开 wave 前定)
+#### Subagent C:F114 ccteam-creator + F117 ccteam-im-setup
 
-A 给 B 提供的 stub:
-- `ExecutionAdapter::send_input(handle, Input::User { ... })` signature 确认(F107 wave 1 已固化)
-- `ObservedEvent::ChatTurn` 字段:`{ speaker: Speaker, content: String, ts: SystemTime, raw_jsonl_offset: u64 }`
-- session-id 持久化路径:`~/.ccteam/im/<workflow_slug>/<bot_name>/session-id`
-
-A 不依赖 B(可在 mock IM 输入下独立测试)。
-B 不依赖 A 真实(用 mock ExecutionAdapter 单测 router / hop_tracker)。
-
-### Wave 2 集成节点(并行结束后)
-
-1. workflow.yaml fixture(`crates/ccteam-core/tests/fixtures/chat-2-bot.yaml`)
-2. 集成测试:mock IM 输入 → TmuxInteractive(用 echo 替代 `claude` 二进制,`CCTEAM_CLAUDE_BIN` env 覆盖)→ assert progress.jsonl 含 `chat_turn` event
-3. host TG probe(开发者 own TG bot token):双 bot 群组 @ 链式互动,实测 prompt cache hit + hop_limit 触发
-
-### 验收
-
-- `cargo test --workspace`: ≥970 通过
-- TG host probe pass(有视频 / log 留存放进 `docs/v0-6-0/host-probe.md`,主 session 写)
-- `cargo tree -p ccteam-core | grep teloxide` 命中 0
-- `claude --resume` cache hit:turn 2 起 transcript jsonl 的 `cache_read_input_tokens > 0`
-
-### 风险 / 应对
-
-| 风险 | 应对 |
+| 文件 | 改动 |
 |---|---|
-| `claude --resume` 在新 Claude Code 版本失效 | feature-gate 检测:`ccteam doctor --check-claude` 测试 resume 能力,失败则报错让用户升 |
-| send-keys 在 unicode / emoji 输入 corrupt pane | fuzzing test 200 sample;`tmux send-keys -l`(literal mode)覆盖 risky 字符 |
-| session jsonl 格式 Anthropic 改 | session_jsonl_tail 用 `#[serde(other)]` + 容错 parse;格式变化 graceful 退化为 turn-count-only(失对话细节,不失业务事件) |
-| teloxide breaking upgrade | pin 0.13.x;每月 dependabot scan |
-| TG bot token 被仓库泄露 | 红线:`workflow.yaml` 只写 env var **名字**,token 必须从环境拿;CI 加 trufflehog 扫 |
+| `skills/ccteam-creator/SKILL.md`(复活 + 重写)| ~400 行 |
+| `skills/ccteam-creator/personas/<10 prefab>`(新)| 5-10 个 prefab persona(每个 zh + en 版)|
+| `skills/ccteam-im-setup/SKILL.md`(新)| ~200 行 onboarding dialog |
+| `crates/ccteam-core/src/templates/workflow_templates/`(新)| 5 个 workflow.yaml 模板(对应 5 preset) |
+| `crates/ccteam-core/src/mode_inferrer.rs`(新)| NL → mode 推断(rule-based + LLM 兜底)|
+| `crates/ccteam-core/src/agent_naming.rs`(新)| 50 scientist nickname 池 |
+| `crates/ccteam-imd/src/onboarding.rs`(新)| getMe + getUpdates auto-detect chat_id |
+| `skills/ccteam-creator/tests/`(新)| persona / mode_inferrer 测试 |
 
----
+**估工**:3 天。
 
-## Wave 3 — MCP 优化(F110 + F111)
+#### Subagent D:F115 handoff
 
-**目标**:server rename + 子前缀 + disable env + 项目级 `.mcp.json`。
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/handoff.rs`(新)| handoff hook trigger + markdown 模板 |
+| `crates/ccteam-core/src/orchestrator.rs` | `stage_done` event 触发 handoff prompt 注入 |
+| `crates/ccteam-core/src/spawn_brief.rs` | spawn prompt 模板加 `{{include_prev_handoffs}}` |
+| `crates/ccteam-core/tests/handoff_test.rs`(新)| 4 测试 |
 
-### 文件清单
-
-详 PRD §F110 + §F111。
-
-### 实施步骤(单 subagent)
-
-1. mcp_serve.rs server name + tool registry 重命名 — 0.5 天
-2. 新 `mcp_chat_tools.rs`(5 工具)注册 — 0.5 天
-3. CCTEAM_DISABLE_TOOLS env + glob 过滤 — 0.5 天
-4. `ccteam init` 落项目 `.mcp.json` + merge 逻辑 — 0.5 天
-5. skill `SKILL.md` + meta-agent template 全文 replace — 0.5 天
-6. 测试新增 + host probe — 0.5 天
-
-**估工**:2-3 天。
+**估工**:1.5 天。
 
 ### Stub agreement
 
-- F110 tool name 表(PRD §F110 完整表)在 wave 3 启动前再次确认(给 user 最后一次反悔机会)
-- F111 disable glob 语义:short name 不含 prefix,`workflow_*` / `chat_*` / exact name 都支持
+- A 给 B/C:`HarnessAdapter::submit_turn(TurnInput::UserText)` signature 确认(Wave 1 已 lock)
+- B 给 C:`ccteam-imd::register_bot(workflow_slug, vendor, role)` 接口
+- C 给 B:`workflow_templates/chat.yaml` template format(bot_roster 字段)
+- D 不依赖其他
+
+### Wave 2 集成节点(并行结束后)
+
+1. workflow.yaml fixture(`crates/ccteam-core/tests/fixtures/chat-pocket-assistant.yaml` + `chat-im-squad.yaml`)
+2. 集成测试:mock IM 输入 → ccteam-imd → ClaudeStreamJsonAdapter(`CCTEAM_CLAUDE_BIN` env 覆盖)→ assert progress.jsonl 含 `chat_turn` event
+3. **host TG probe**(开发者 own TG bot token + chat_id 走 `/ccteam-im-setup`):
+   - Pocket Assistant DM hello world(目标:5 min 内 wow)
+   - IM Squad group + bot-to-bot @ + hop_limit 触发
+   - session recovery:删 Anthropic session jsonl → bot 在 IM 主动通知重建
+   - `@ccteam pause helpful-bot` NL admin
+4. **video / GIF**:30s 录屏 user 5min hello world,放 `docs/v0-6-0/demos/30s-tg-bot-team.gif`
 
 ### 验收
 
-- `~/.claude.json` 含 `"ct"` server,**无** `"ccteam"` server
-- `/mcp` 列表 22 工具按 workflow_/chat_ 分组(Claude Code 不强制分组渲染,但工具名前缀让 user 一眼看到归属)
-- `CCTEAM_DISABLE_TOOLS=chat_*` 后 tool list 17 工具(模式 2-only 用户场景)
-- `ccteam init` 新项目自动生成 `.mcp.json`,既有项目 merge 不破坏
-- meta-agent / `ccteam-control` skill 跑过 V0.5.1 全部 host probe
-
-### 风险 / 应对
-
-| 风险 | 应对 |
-|---|---|
-| 用户 V0.5 session 中调用旧名字 → method-not-found | Claude 看到错误自然重试新名字;skill SKILL.md 升级文档显著标"V0.6.0 breaking" |
-| `.mcp.json` 跟用户已有 OMC / serena 等 server 冲突 | merge 逻辑保留其他 server,只加 `ct`;ct 已存在则跳过 |
-| 项目级 `.mcp.json` 进 git,泄露 / 团队成员强制配 | doctor 输出明确提示"`.mcp.json` 推荐 commit,但 `CCTEAM_DISABLE_TOOLS` 个人偏好别写进去 — 用 shell rc" |
+- `cargo test --workspace`: ≥980 通过
+- TG host probe pass(视频 + log 留存 `docs/v0-6-0/host-probe.md`)
+- `cargo tree -p ccteam-core | grep -E "openhuman|teloxide|tgbot"` 命中 0
+- ccteam-imd crash 重启 ≤2s,无丢 turn
+- `claude -p --resume` cache hit:turn 2 起 `cache_read_input_tokens > 0`
+- backup transport 切换(`/ccteam-im-setup --transport official-telegram`)生效
+- NL admin `@ccteam pause` 在 TG 群中工作
 
 ---
 
-## Wave 4 — 文档同步 + host E2E + ship(F106 + 集成)
+## Wave 3 — Codex 完整集成(F112)
 
-**目标**:三模式 + 红线表正式 land tier-1 文档;主 session 跑完整 host E2E;`workspace.package.version` bump → V0.6.0;ship。
+**目标**:Codex Option B 完整落地。4 用户场景全跑通。30 cell 矩阵中 Codex 列 ✓ 11 + ⚠ 2 / ✗ 4(mode 1 跨 vendor)host probe 验。
+
+### 2 subagent 并行拆
+
+#### Subagent A:F112 CodexExecAdapter + CodexAppServerAdapter
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/execution/codex_exec.rs` | 从 Wave 1 stub 填完整 impl,~400 行 |
+| `crates/ccteam-core/src/execution/codex_app_server.rs`(新)| `CodexAppServerAdapter` impl(走 UDS JSON-RPC v2)~600 行 |
+| `crates/ccteam-core/src/execution/codex_jsonrpc.rs`(新)| `rmcp` client 复用 or 自造 thin client |
+| `crates/ccteam-cli/src/commands.rs::run_doctor` | `--check-codex-version` + `--check-codex-auth` |
+| `crates/ccteam-cost/src/budget.rs` | per-vendor budget caps |
+| `crates/ccteam-core/tests/codex_exec_test.rs`(新)| 6 测试 |
+| `crates/ccteam-core/tests/codex_app_server_test.rs`(新)| 5 测试 |
+
+**估工**:3-4 天。
+
+#### Subagent B:F112 4 用户场景 skill
+
+| 文件 | 改动 |
+|---|---|
+| `skills/ccteam-advise/SKILL.md`(新)| ~100 行 parallel voting skill |
+| `skills/ccteam-creator/SKILL.md` | Phase 2 加 auto-critic 路径(检测 codex binary + auth → critic role 自动 `vendor: codex`)|
+| `skills/ccteam-team/SKILL.md` | 加 "Codex critic teammate(if available)" 路径 |
+| `crates/ccteam-core/src/preferences.rs`(新)| `~/.ccteam/preferences.toml` 读写(fallback.on_claude_quota = "codex|off")|
+| `crates/ccteam-cli/src/commands.rs::prefs_*` | `ccteam prefs <key> <value>` admin CLI(opt-in)|
+| `skills/tests/`(新)| skill dialogue test |
+
+**估工**:2 天。
+
+### Wave 3 集成节点
+
+1. host probe(开发者装 codex + auth):
+   - `/ccteam-advise "what's the best approach to X"` → Claude + Codex 并行 → 合成 verdict
+   - `ccteam-creator` task 含 "review" → critic role 自动 `vendor: codex`(progress.jsonl 记 `vendor: codex`)
+   - Codex `agent_max_depth` 递归保护:链 5 层后 escalate
+2. cost 双 vendor 聚合验证:`ccteam-control show-cost` 显示聚合 + 分 vendor
+3. 模式 3 codex(`CodexAppServerAdapter`)host probe:`codex app-server` UDS thread/start + turn/start + 流式 items
+4. backup transport + Codex 混合场景验证
+
+### 验收
+
+- `cargo test --workspace`: ≥1010 通过
+- Codex host probe pass
+- 30 cell 矩阵 host probe(关键 ⚠/✗ cell 至少 mock test;✓ cell 至少 1 host)
+
+---
+
+## Wave 4 — 集成 + host E2E + ship(F106 集成 + 文档 polish)
 
 ### 任务
 
 1. **F106 文档落地**(主 session):
-   - `CLAUDE.md` §一表格 version → 0.6.0,baseline 数字回填(wave 1/2/3 ship 后实测)
-   - `CLAUDE.md` §三红线表加"模式"列
-   - `docs/tech-design.md` §2.1(或 §0)三模式定义表 + 红线 × 模式矩阵 + `ExecutionAdapter` trait section
-   - `docs/orchestration-patterns.md` §一 5×3 适用矩阵
-   - `docs/interfaces.md` MCP 工具表 + workflow.yaml `mode: chat` schema
-   - `docs/dev-coupling-audit.md` 加 F106-F111
+   - `CLAUDE.md` §一 version → 0.6.0;baseline 数字回填;§三红线表加 vendor 列(模式 × vendor 双轴)
+   - `docs/tech-design.md` §0 + §2.1 + §3.3 改动 land
+   - `docs/architecture/orchestration-patterns.md` §一加 30 cell 矩阵
+   - `docs/interfaces.md` MCP 子前缀 + workflow.yaml schema + handoff format
+   - `docs/dev-coupling-audit.md` F106-F118 各 1 条
 
-2. **`docs/v0-6-0/user-manual.md`**:chat mode 教程(从 `ccteam init --mode chat` 到 TG @ bot 跑通,~150 行)
+2. **5 preset 全链路 host E2E**:
+   - Solo Sidekick(V0.5 既有,verify 不退步)
+   - Team Sprint(V0.5 既有,verify 不退步 + 加 Codex critic 测试)
+   - Overnight Builder(mode 2 既有 + 加 Codex critic role)
+   - Pocket Assistant(Wave 2 落,完整 5min hello world)
+   - IM Squad(Wave 2 落,完整 group + bot-to-bot @ + hop_limit)
 
-3. **host E2E**:
-   - 现 V0.5.1 host E2E 全部复跑(模式 2 不退步)
-   - 新 mode-3 E2E:启 chat workflow + TG 真实 bot + 多 bot 链式 @ + hop_limit + `/compact` 触发
+3. **5 demo GIF**(每 preset 30s 录屏)放 `docs/v0-6-0/demos/`;README + quickstart 头条引用
 
-4. **commit + tag**:`vX.Y.Z:` 前缀,`workspace.package.version = "0.6.0"`,git tag `v0.6.0`
+4. **commit + tag**:`v0.6.0:` 前缀,`workspace.package.version = "0.6.0"`,git tag `v0.6.0`
 
 ### 验收
 
-- `cargo test --workspace --locked --no-fail-fast`: ≥975 / 1
-- clippy: 0 errors, ≤18 warnings
-- host E2E 全过
-- 文档 self-consistency:`grep -rn "每次 spawn.*fresh"` 全仓命中处都有 `[模式 2]` 标记 / EOL dir / 删除
+- `cargo test --workspace --locked --no-fail-fast`: ≥1010 / 1
+- clippy: 0 errors, ≤18 warnings(允许减少)
+- 5 host E2E 全过(每个 5 preset 一个 GIF + 一个 host-probe.md 段落)
+- 文档 self-consistency:
+  - `grep -rn "每次 spawn.*fresh"` 全仓命中处都标 [模式 2 / Claude vendor];EOL dir 内不动
+  - `grep -rn "mcp__ccteam__chat_" crates/ skills/ docs/` 命中 ≥5(子前缀工具命名生效)
+  - `grep -rn "send-keys" crates/ccteam-core/src/execution/` 命中 0(tmux send-keys 路径已弃)
+  - `grep -rn "mode 1\|mode 2\|mode 3" docs/{quickstart,user-manual,recipes,troubleshooting,README}.md` 命中 0(用户面 0 内部术语)
 
 ---
 
@@ -222,6 +270,22 @@ B 不依赖 A 真实(用 mock ExecutionAdapter 单测 router / hop_tracker)。
 
 1. **现有模式 2 行为不退步** — 任何 wave PR 都跑现 V0.5.1 host E2E,fail 即 block
 2. **trait 签名 wave 1 后冻结** — wave 2/3 改 signature 必须打回 wave 1 重做
-3. **`ccteam-core` 不依赖 IM SDK** — `cargo tree -p ccteam-core | grep -i "telox\|slack\|discord"` 命中 0
-4. **测试 fixture 不依赖真 Claude binary / 真 TG** — `CCTEAM_CLAUDE_BIN` / `CCTEAM_TG_BOT_API_URL` env 覆盖 + mock server
+3. **`ccteam-core` 不依赖 openhuman / IM SDK** — `cargo tree -p ccteam-core | grep -E "openhuman|teloxide|slack|discord|tgbot"` 命中 0
+4. **测试 fixture 不依赖真 binary**:`CCTEAM_CLAUDE_BIN` / `CCTEAM_CODEX_BIN` env 覆盖;TG / Slack 用 mock server
 5. **每 wave PR 描述**带:`requirements.md` 痛点 link + `prd.md` F-finding link + `dev-coupling-audit.md` 条目;**测试 baseline 数字** before/after
+6. **用户面文档**(README / quickstart / user-manual / recipes / troubleshooting)13 项内部术语 0 命中(grep 守红线)
+7. **vendor 双轴**:任何新 finding / 新代码加入,都答"Claude / Codex 各自如何?";只覆盖 Claude 不算完成
+
+---
+
+## 范围回滚 / 紧急 ship plan
+
+如 Wave 2 host probe 发现重大平台不可控(如 Anthropic 改 `claude -p --resume` 协议),fallback 顺序:
+
+1. **保 Epic A 完整 ship**(`ccteam-creator` skill + Pocket Assistant + 单 vendor Claude):优先级 1
+2. **Epic B 砍 IM Squad,只保 DM**:Epic B 完整体验降级,V0.6.1 补 group + bot-to-bot
+3. **Epic C 砍** persona 中文版,等 V0.7:Epic C 影响国际化但不阻塞 ship
+4. **F112 Codex 砍到 Option A 最小**(mode 2 codex only):若 Codex app-server UDS 协议变,Wave 3 紧急降级
+5. **F108 紧急回退 tmux send-keys**:若 Agent SDK / `claude -p --resume` 不可用,F108 走原 PRD tmux 路径(技术债,但保 ship)— 标记 V0.6.1 必偿还
+
+任何 fallback 触发 → PR 描述明示 + `docs/v0-6-0/host-probe.md` 详记 + `dev-coupling-audit.md` 加 F-finding 入下版必清单。

--- a/docs/v0-6-0/dev-plan.md
+++ b/docs/v0-6-0/dev-plan.md
@@ -1,0 +1,227 @@
+# V0.6.0 — dev-plan
+
+**Wave 顺序** — trait 抽离打地基(零行为变化)→ 模式 3 落地(本版主菜)→ MCP 优化(顺带,独立)。每 wave 单独 PR + 单独 baseline 校验。
+
+| Wave | 内容 | F | 占比 | 并行度 |
+|---|---|---|---|---|
+| Wave 1 | `ExecutionAdapter` trait 抽离 + `BgSpawnAdapter` 改造 — 零行为变化 | F107 | 20% | 单 subagent,2-3 天 |
+| Wave 2 | `TmuxInteractiveAdapter` + `ccteam-im-bridge` crate — 模式 3 落地 | F108 + F109 | 55% | 2 subagent 并行,5-7 天 |
+| Wave 3 | MCP namespace + 子前缀 + `CCTEAM_DISABLE_TOOLS` + 项目级 `.mcp.json` | F110 + F111 | 15% | 单 subagent,2-3 天 |
+| Wave 4 | 文档同步(F106 落 tech-design / orchestration-patterns / CLAUDE.md)+ host E2E + ship | F106 + 集成 | 10% | 主 session,2 天 |
+
+总:T+11-15 天。baseline 942/1 → 预计 ~975/1(新增 ~33 测试:trait 4 + tmux 8 + im-bridge 6 + mcp disable 5 + project mcp.json 4 + 集成 ~6)。
+
+---
+
+## Wave 0 — 立项 PR(本 PR)
+
+**只 land 文档**:
+- `docs/v0-6-0/README.md`
+- `docs/v0-6-0/prd.md`(本文件兄弟)
+- `docs/v0-6-0/dev-plan.md`(本文件)
+
+**不动**任何代码 / 测试 / `CLAUDE.md`(version bump 走 wave 4)。
+
+**估工**:已完成(本 session)。
+
+---
+
+## Wave 1 — `ExecutionAdapter` trait 抽离(F107)
+
+**目标**:抽 trait + 改造现有 BgSpawner,行为零变化,`cargo test --workspace` 数字持平 942/1。
+
+### 关键文件
+
+| 文件 | 改动类型 | 说明 |
+|---|---|---|
+| `crates/ccteam-core/src/execution/mod.rs` | 新 | trait + 类型定义 |
+| `crates/ccteam-core/src/execution/bg.rs` | 新(迁移)| `BgSpawnAdapter` impl;迁移自现 `spawn.rs` / `claude_job.rs` |
+| `crates/ccteam-core/src/orchestrator.rs` | 改 | 持 `Arc<dyn ExecutionAdapter>`;主循环走 trait |
+| `crates/ccteam-core/src/lib.rs` | 改 | re-export `execution::*` |
+| `crates/ccteam-cli/src/commands.rs` | 改 | spawn / send / pause / resume 全改走 trait |
+| `crates/ccteam-cli/src/mcp_serve.rs` | 改 | tool handler 走 trait(为 wave 3 chat tool 铺路) |
+| `crates/ccteam-core/tests/execution_trait_test.rs` | 新 | 4 trait 行为测试 |
+
+### Stub agreement(开 wave 前定)
+
+trait 签名锁定(PRD §F107 接口)。**任何后续 wave 不许改 trait 签名**(改 = wave 1 没收敛,回炉)。
+
+### 实施步骤
+
+1. 写 trait + 类型 + 单测,先 `cargo build` 通过 — 0.5 天
+2. 抽 `BgSpawnAdapter`,迁移 `spawn_session` 主路径 — 1 天
+3. orchestrator 主循环替换 — 0.5 天
+4. CLI / MCP 路径替换 — 0.5 天
+5. 跑 `cargo test --workspace`,fix 退步 — 0.5 天
+
+### 验收
+
+- `cargo test --workspace --locked --no-fail-fast`: ≥942 通过,1 失败(同 baseline,不变)
+- clippy: 0 errors, ≤18 warnings
+- `grep -rn "Command::new(\"claude\")" crates/ccteam-core` 命中**仅在** `execution/bg.rs`
+- host probe:V0.5.1 跑过的 dex-ui workflow.yaml 行为完全一致(progress.jsonl event 序列 diff = 0)
+
+### 风险 / 应对
+
+| 风险 | 应对 |
+|---|---|
+| trait 设计不够泛化,wave 2 发现要改签名 | wave 1 PR 包含 1 个"mock chat adapter" 测试(只为验证签名能容纳,不实现真功能) |
+| BgSpawner 迁移漏掉 edge case(restart / cancel race)| 复跑现有 `crates/ccteam-core/tests/bg_spawner_test.rs` 等全套现测试,严格 0 退步 |
+| orchestrator 主循环动到了红线 | code review 严守:`grep -n "fix_count\|escalate\|budget"` 在 orchestrator.rs 改动行数 ≤ 5 |
+
+---
+
+## Wave 2 — 模式 3 落地(F108 + F109)
+
+**目标**:`TmuxInteractiveAdapter` impl + `ccteam-im-bridge` crate + workflow.yaml `mode: chat`;host TG 实测多轮 chat 跑通。
+
+### 并行拆分(2 subagent)
+
+#### Subagent A:F108 `TmuxInteractiveAdapter` + 配套 schema
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/execution/tmux_interactive.rs` | 新,~600 行 |
+| `crates/ccteam-core/src/execution/session_jsonl_tail.rs` | 新,~300 行 |
+| `crates/ccteam-core/src/execution/send_keys.rs` | 新,~200 行 + fuzzing test |
+| `crates/ccteam-core/src/workflow_schema.rs` | 加 `mode: chat` 枚举 + 字段 |
+| `crates/ccteam-core/src/progress_event.rs` | 加 4 chat_* event 类型 |
+| `crates/ccteam-core/tests/tmux_interactive_test.rs` | 新,8 测试 |
+
+**估工**:3-4 天。
+
+#### Subagent B:F109 `ccteam-im-bridge` crate
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-im-bridge/Cargo.toml` | 新 crate |
+| `crates/ccteam-im-bridge/src/lib.rs` | 新,trait + types |
+| `crates/ccteam-im-bridge/src/telegram.rs` | 新,teloxide impl |
+| `crates/ccteam-im-bridge/src/router.rs` | 新,@-mention parse + 路由 |
+| `crates/ccteam-im-bridge/src/hop_tracker.rs` | 新,R6 hop_limit |
+| `crates/ccteam-im-bridge/src/session_link.rs` | 新,TG user ↔ bot session 持久化 |
+| `crates/ccteam-cli/src/commands.rs::start` | chat mode 检测 → spawn bridge |
+| `crates/ccteam-cli/src/main.rs` | 加 `internal im-bridge` 子命令 |
+| `Cargo.toml`(workspace 根)| 加 member |
+| `crates/ccteam-im-bridge/tests/router_test.rs` | 新,6 测试 |
+| `crates/ccteam-im-bridge/tests/dep_graph_test.rs` | 新,守 core 不依赖 teloxide |
+
+**估工**:3-4 天。
+
+### Stub agreement(开 wave 前定)
+
+A 给 B 提供的 stub:
+- `ExecutionAdapter::send_input(handle, Input::User { ... })` signature 确认(F107 wave 1 已固化)
+- `ObservedEvent::ChatTurn` 字段:`{ speaker: Speaker, content: String, ts: SystemTime, raw_jsonl_offset: u64 }`
+- session-id 持久化路径:`~/.ccteam/im/<workflow_slug>/<bot_name>/session-id`
+
+A 不依赖 B(可在 mock IM 输入下独立测试)。
+B 不依赖 A 真实(用 mock ExecutionAdapter 单测 router / hop_tracker)。
+
+### Wave 2 集成节点(并行结束后)
+
+1. workflow.yaml fixture(`crates/ccteam-core/tests/fixtures/chat-2-bot.yaml`)
+2. 集成测试:mock IM 输入 → TmuxInteractive(用 echo 替代 `claude` 二进制,`CCTEAM_CLAUDE_BIN` env 覆盖)→ assert progress.jsonl 含 `chat_turn` event
+3. host TG probe(开发者 own TG bot token):双 bot 群组 @ 链式互动,实测 prompt cache hit + hop_limit 触发
+
+### 验收
+
+- `cargo test --workspace`: ≥970 通过
+- TG host probe pass(有视频 / log 留存放进 `docs/v0-6-0/host-probe.md`,主 session 写)
+- `cargo tree -p ccteam-core | grep teloxide` 命中 0
+- `claude --resume` cache hit:turn 2 起 transcript jsonl 的 `cache_read_input_tokens > 0`
+
+### 风险 / 应对
+
+| 风险 | 应对 |
+|---|---|
+| `claude --resume` 在新 Claude Code 版本失效 | feature-gate 检测:`ccteam doctor --check-claude` 测试 resume 能力,失败则报错让用户升 |
+| send-keys 在 unicode / emoji 输入 corrupt pane | fuzzing test 200 sample;`tmux send-keys -l`(literal mode)覆盖 risky 字符 |
+| session jsonl 格式 Anthropic 改 | session_jsonl_tail 用 `#[serde(other)]` + 容错 parse;格式变化 graceful 退化为 turn-count-only(失对话细节,不失业务事件) |
+| teloxide breaking upgrade | pin 0.13.x;每月 dependabot scan |
+| TG bot token 被仓库泄露 | 红线:`workflow.yaml` 只写 env var **名字**,token 必须从环境拿;CI 加 trufflehog 扫 |
+
+---
+
+## Wave 3 — MCP 优化(F110 + F111)
+
+**目标**:server rename + 子前缀 + disable env + 项目级 `.mcp.json`。
+
+### 文件清单
+
+详 PRD §F110 + §F111。
+
+### 实施步骤(单 subagent)
+
+1. mcp_serve.rs server name + tool registry 重命名 — 0.5 天
+2. 新 `mcp_chat_tools.rs`(5 工具)注册 — 0.5 天
+3. CCTEAM_DISABLE_TOOLS env + glob 过滤 — 0.5 天
+4. `ccteam init` 落项目 `.mcp.json` + merge 逻辑 — 0.5 天
+5. skill `SKILL.md` + meta-agent template 全文 replace — 0.5 天
+6. 测试新增 + host probe — 0.5 天
+
+**估工**:2-3 天。
+
+### Stub agreement
+
+- F110 tool name 表(PRD §F110 完整表)在 wave 3 启动前再次确认(给 user 最后一次反悔机会)
+- F111 disable glob 语义:short name 不含 prefix,`workflow_*` / `chat_*` / exact name 都支持
+
+### 验收
+
+- `~/.claude.json` 含 `"ct"` server,**无** `"ccteam"` server
+- `/mcp` 列表 22 工具按 workflow_/chat_ 分组(Claude Code 不强制分组渲染,但工具名前缀让 user 一眼看到归属)
+- `CCTEAM_DISABLE_TOOLS=chat_*` 后 tool list 17 工具(模式 2-only 用户场景)
+- `ccteam init` 新项目自动生成 `.mcp.json`,既有项目 merge 不破坏
+- meta-agent / `ccteam-control` skill 跑过 V0.5.1 全部 host probe
+
+### 风险 / 应对
+
+| 风险 | 应对 |
+|---|---|
+| 用户 V0.5 session 中调用旧名字 → method-not-found | Claude 看到错误自然重试新名字;skill SKILL.md 升级文档显著标"V0.6.0 breaking" |
+| `.mcp.json` 跟用户已有 OMC / serena 等 server 冲突 | merge 逻辑保留其他 server,只加 `ct`;ct 已存在则跳过 |
+| 项目级 `.mcp.json` 进 git,泄露 / 团队成员强制配 | doctor 输出明确提示"`.mcp.json` 推荐 commit,但 `CCTEAM_DISABLE_TOOLS` 个人偏好别写进去 — 用 shell rc" |
+
+---
+
+## Wave 4 — 文档同步 + host E2E + ship(F106 + 集成)
+
+**目标**:三模式 + 红线表正式 land tier-1 文档;主 session 跑完整 host E2E;`workspace.package.version` bump → V0.6.0;ship。
+
+### 任务
+
+1. **F106 文档落地**(主 session):
+   - `CLAUDE.md` §一表格 version → 0.6.0,baseline 数字回填(wave 1/2/3 ship 后实测)
+   - `CLAUDE.md` §三红线表加"模式"列
+   - `docs/tech-design.md` §2.1(或 §0)三模式定义表 + 红线 × 模式矩阵 + `ExecutionAdapter` trait section
+   - `docs/orchestration-patterns.md` §一 5×3 适用矩阵
+   - `docs/interfaces.md` MCP 工具表 + workflow.yaml `mode: chat` schema
+   - `docs/dev-coupling-audit.md` 加 F106-F111
+
+2. **`docs/v0-6-0/user-manual.md`**:chat mode 教程(从 `ccteam init --mode chat` 到 TG @ bot 跑通,~150 行)
+
+3. **host E2E**:
+   - 现 V0.5.1 host E2E 全部复跑(模式 2 不退步)
+   - 新 mode-3 E2E:启 chat workflow + TG 真实 bot + 多 bot 链式 @ + hop_limit + `/compact` 触发
+
+4. **commit + tag**:`vX.Y.Z:` 前缀,`workspace.package.version = "0.6.0"`,git tag `v0.6.0`
+
+### 验收
+
+- `cargo test --workspace --locked --no-fail-fast`: ≥975 / 1
+- clippy: 0 errors, ≤18 warnings
+- host E2E 全过
+- 文档 self-consistency:`grep -rn "每次 spawn.*fresh"` 全仓命中处都有 `[模式 2]` 标记 / EOL dir / 删除
+
+---
+
+## Cross-wave invariants
+
+整个 V0.6.0 周期守:
+
+1. **现有模式 2 行为不退步** — 任何 wave PR 都跑现 V0.5.1 host E2E,fail 即 block
+2. **trait 签名 wave 1 后冻结** — wave 2/3 改 signature 必须打回 wave 1 重做
+3. **`ccteam-core` 不依赖 IM SDK** — `cargo tree -p ccteam-core | grep -i "telox\|slack\|discord"` 命中 0
+4. **测试 fixture 不依赖真 Claude binary / 真 TG** — `CCTEAM_CLAUDE_BIN` / `CCTEAM_TG_BOT_API_URL` env 覆盖 + mock server
+5. **每 wave PR 描述**带:`requirements.md` 痛点 link + `prd.md` F-finding link + `dev-coupling-audit.md` 条目;**测试 baseline 数字** before/after

--- a/docs/v0-6-0/prd.md
+++ b/docs/v0-6-0/prd.md
@@ -1,0 +1,558 @@
+# V0.6.0 — PRD
+
+6 个 finding。F106 是架构原则文档,定义本版基调;F107 重构准备(零行为变化);F108 + F109 模式 3 落地;F110 + F111 MCP 优化。
+
+> **本 PR 范围**:只 land 本 PRD + `README.md` + `dev-plan.md`。代码改动**全部走后续 wave PR**,以便每 wave 单独 review + 跑 baseline。
+
+---
+
+## F106 — 三执行模式定型 + 红线按模式 scope 重写
+
+### 痛点
+
+CLAUDE.md 现有红线"每次 spawn = 全新 1M context"、"文件系统是控制平面"、"progress.jsonl 唯一 state SoT" 等,**全部默认了一种执行模型**(`claude --bg` 任务式 spawn,artifact-driven)。当 V0.5.0 落了 `ccteam-team` skill(in-process Task 模式)、V0.6.0 要落 chat/IM bot(tmux 长跑模式)时,这些红线**部分不适用 / 含义需要细分**。
+
+具体冲突:
+- in-proc team(模式 1)没有 file-system 控制平面,但红线写"是控制平面"
+- chat bot(模式 3)就是要复用 context,但红线写"每次 spawn fresh"
+- chat bot 输出来自 `~/.claude/projects/<…>/<session-id>.jsonl` 而非 progress.jsonl,但红线写"progress.jsonl 唯一 SoT"
+
+不澄清的后果:后续 PR 作者要么误读红线限制实现、要么实现后跟现有红线表面冲突、要么把红线悄悄改弱。
+
+### 需求
+
+把三模式 + 红线适用矩阵显式写进 tier-1 文档(`tech-design.md` + `CLAUDE.md`),让任何 PR 作者一眼看到自己的改动落在哪个模式 + 守哪些红线。
+
+#### 三模式定义表(权威版)
+
+| 维度 | 模式 1: in-proc team | 模式 2: bg sessions | 模式 3: tmux sessions |
+|---|---|---|---|
+| **直观场景** | CC 插件 / skill 起临时 team | 长跑自动化 workflow | 随叫随到 chat bot / IM agent |
+| **触发** | 用户在 Claude session 内 `/ccteam-team "..."` | `ccteam start <slug>` daemon 起 + ArtifactWatcher 触发 | IM webhook(TG / Slack)→ bridge → send-keys |
+| **spawn 原语** | `Task(subagent_type=…)` | `claude --bg --agent <role>` | 长跑 `claude`(交互模式)+ `tmux send-keys` |
+| **进程模型** | parent Claude session 内 N teammate(同进程)| 每 spawn 一个独立 Claude job 进程,run-to-completion | 每 bot 一个常驻 tmux pane,内含长跑 `claude` 进程 |
+| **input 面** | tool args(`Task` 的 `prompt`)| `.ccteam/inbox/msg-<ts>-NNN.md` 文件 | `tmux send-keys -t <pane> "<text>" Enter`(含 `/new` `/compact` `/clear`)|
+| **output 面** | tool result(返回值)| `progress.jsonl` 业务事件 + `state.json` cost | `~/.claude/projects/<encoded-path>/<session-id>.jsonl` tail(Anthropic 官方 session 格式)|
+| **context 生命周期** | parent session window,死则同死 | **每次 spawn fresh 1M**,无 `--resume` | **长跑复用**;`/compact` 摘要 / `/new` 重置 / `/clear` 清,**在线管理** |
+| **cost model** | shares parent context budget | 每 spawn 重 tokenize 全 prompt,无 cache 命中 | warm cache(turn 2 起 cache hit),`/compact` 重置 baseline |
+| **可观测性** | parent Claude 自看 SendMessage | progress.jsonl + web UI | progress.jsonl(业务事件)+ session jsonl(对话原文)+ web UI 加 Chat View |
+| **状态恢复** | 不适用(session 死即丢)| progress.jsonl + 文件 SoT 完整可重建 | session-id 持久化(`~/.ccteam/im/<bot>/session-id`),失效则重启 + 重放 last-N(F108 §恢复)|
+| **跨设备** | ✗(锁在 parent session)| ✓(daemon 在哪跑,在哪看)| ✓(IM 是 location-agnostic)|
+
+#### 红线 × 模式适用矩阵(改 `tech-design.md` §0 + `CLAUDE.md` §三)
+
+| # | 红线 | 模式 1 | 模式 2 | 模式 3 | 细则 |
+|---|---|:-:|:-:|:-:|---|
+| R1 | 文件系统是控制平面 | — | ✓ | ⚠ | 模式 3 **输出**是文件(session jsonl);**输入**是 send-keys,**不是文件**。措辞改为"输出 SoT 是文件" |
+| R2 | progress.jsonl 唯一 state SoT | — | ✓ | ⚠ | 模式 3:progress.jsonl 是**业务事件 SoT**(@-routed / compact / hop-escalate),对话原文在 session jsonl。两个 SoT **不重叠**,各管一半 |
+| R3 | 每次 spawn = fresh 1M context | — | ✓ | ✗ | 模式 3 显式**不适用**。chat 场景 context 复用是 feature,通过 `/compact` `/new` 管理 |
+| R4 | 不解析 tmux 输出 | — | ✓ | ✓ | 模式 3 **守**。读 session jsonl(Anthropic 官方格式)替代 tmux capture-pane |
+| R5 | 永不主动 kill 长 session | ✓ | ✓(F84 budget cap 唯一例外)| ✓ | 模式 3:`/compact` `/new` 是**合法状态操作**,不算 kill |
+| R6 | fix-loop 3 次必 escalate | ✓ | ✓ | ✓ + 新增 | 模式 3 加 bot-to-bot @ ping-pong **hop_limit**(默认 3,workflow.yaml 可配),撞 limit 同等 escalate |
+| R7 | `ccteam-core` 零 team 名字面量 | ✓ | ✓ | ✓ | 全模式守 |
+| R8 | 跨项目记忆走官方接口 | ✓ | ✓ | ✓ | 模式 3 的 IM 用户身份 ≠ ccteam memory,不污染 `~/.claude/CLAUDE.md` |
+| R9 | 新建项目走 `<projects_root>/<team>-<slug>/` | — | ✓ | ✓ | 模式 3 `ccteam new --mode chat <slug>` 仍走此 layout;bot per project |
+
+(— = 模式不涉及该红线场景)
+
+### 验收
+
+1. `docs/tech-design.md` §0(开篇红线表)按上表重写,每红线标 `[模式 1/2/3]` 适用
+2. `CLAUDE.md` §三红线表加"模式"列(精简版,详 link 到 tech-design)
+3. `docs/orchestration-patterns.md` §一加"模式 × 拓扑模式"对应表(哪个执行模式适合哪种 orchestration topology)
+4. `docs/v0-6-0/README.md` 三模式表是唯一权威源,其他文档引用 link 回 README
+5. PR 描述带 `grep -rn "每次 spawn.*fresh"` 全仓比对:所有命中处或加 [模式 2] 标记、或删
+
+### 不在范围
+
+- 不动现有 V0.4-V0.5 prd / dev-plan(EOL 版本归档不动,CLAUDE.md §五原则)
+- 不删任何红线,只 scope 和细则化
+- 不引入新红线(模式 3 hop_limit 是 R6 的扩展,不是新条)
+
+---
+
+## F107 — `ExecutionAdapter` trait 抽离 + `BgSpawner` 改造对接
+
+### 痛点
+
+现有 `crates/ccteam-core/src/orchestrator.rs` + `bg_spawner.rs`(实际文件名待验,可能在 `spawn.rs` / `claude_job.rs`)直接以 `claude --bg --agent` 为唯一 spawn 路径。模式 3 要塞 `claude`(交互模式)长跑 + send-keys input + session jsonl tail output,**没法在现有路径里加 if/else**,会污染 orchestrator 主循环。
+
+需要在 ccteam-core 抽出一个 `ExecutionAdapter` trait,把"如何 spawn / 如何送 input / 如何观察 output / 如何 lifecycle 操作"抽象掉。`BgSpawner` 重命名为 `BgSpawnAdapter` 实现 trait,**行为零变化**。F108 再加 `TmuxInteractiveAdapter`,F109 的 im-bridge 通过 trait 用。
+
+### 需求
+
+#### trait 接口
+
+```rust
+// crates/ccteam-core/src/execution/mod.rs(新)
+pub trait ExecutionAdapter: Send + Sync {
+    /// spawn 一个新 agent session;返回 handle 用于后续 input/observe/lifecycle 操作
+    fn spawn(&self, role: &str, ctx: SpawnContext) -> Result<SessionHandle>;
+
+    /// 投递一条 input message 到 session
+    /// 模式 2:写 .ccteam/inbox/msg-*.md
+    /// 模式 3:tmux send-keys
+    fn send_input(&self, handle: &SessionHandle, input: Input) -> Result<()>;
+
+    /// 流式观察 session 输出(driver 侧 await)
+    /// 模式 2:tail progress.jsonl 业务事件
+    /// 模式 3:tail session jsonl + emit ChatTurn
+    fn observe(&self, handle: &SessionHandle) -> BoxStream<'static, ObservedEvent>;
+
+    /// session 生命周期操作(模式 3 主用)
+    fn lifecycle(&self, handle: &SessionHandle, op: LifecycleOp) -> Result<()>;
+}
+
+pub struct SpawnContext {
+    pub workflow_slug: String,
+    pub agent_md_path: PathBuf,
+    pub env: Vec<(String, String)>,
+    pub mode_specific: ModeSpecificCtx,  // 区分 mode 2 / mode 3 必要字段
+}
+
+pub enum Input {
+    User { content: String },          // chat 场景的 user 输入
+    SlashCommand { name: String, args: Vec<String> },
+    InboxMarkdown { body: String },    // 模式 2 现有 path
+}
+
+pub enum LifecycleOp {
+    Compact,                            // 模式 3:/compact
+    NewSession,                         // 模式 3:/new
+    Clear,                              // 模式 3:/clear
+    Close,                              // 全模式
+}
+
+pub enum ObservedEvent {
+    BusinessEvent(ProgressEvent),       // mode 2 主路径
+    ChatTurn { speaker: Speaker, content: String, ts: SystemTime },  // mode 3 主路径
+    LifecycleAck { op: LifecycleOp, ok: bool },
+    Closed { reason: String },
+}
+
+pub struct SessionHandle {
+    pub mode: ExecutionMode,
+    pub identity: String,               // mode 2: jobs/<id>;mode 3: tmux pane + session-id
+    pub spawned_at: SystemTime,
+}
+
+pub enum ExecutionMode { InProc, Bg, TmuxInteractive }
+```
+
+#### `BgSpawnAdapter` 改造点
+
+| 现在 | 改后 |
+|---|---|
+| `orchestrator.rs` 直接 `Command::new("claude").arg("--bg")...` | 通过 trait `bg_adapter.spawn(...)` |
+| ArtifactWatcher 发现 inbox 文件 → 现 `spawn_session(...)` | trait `bg_adapter.send_input(handle, Input::InboxMarkdown {..})` |
+| progress.jsonl tail 现 ad-hoc | trait `bg_adapter.observe(handle)` 返流 |
+| pause/resume/cancel 现 `cancel_token` 直接 | trait `bg_adapter.lifecycle(handle, LifecycleOp::Close)` |
+
+**关键不变量**:重构后 `cargo test --workspace` 全部测试通过,数字跟 V0.5.1 baseline(942/1)持平。**这是 wave 1 唯一硬验收**。
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/execution/mod.rs`(新)| trait 定义 + 共享类型(SpawnContext / Input / LifecycleOp / ObservedEvent / SessionHandle / ExecutionMode)|
+| `crates/ccteam-core/src/execution/bg.rs`(新,迁移自现 spawn 路径)| `BgSpawnAdapter` impl ExecutionAdapter;包装现 spawn_session / state.json watch / progress.jsonl tail |
+| `crates/ccteam-core/src/orchestrator.rs` | 主循环改 `Arc<dyn ExecutionAdapter>`;路径分支 `match mode { Bg => bg_adapter, TmuxInteractive => tmux_adapter, ... }` |
+| `crates/ccteam-cli/src/commands.rs` | spawn / send / pause / resume 路径改走 trait |
+| `crates/ccteam-core/tests/execution_trait_test.rs`(新)| 4 测试:trait 对象动态分发 / BgSpawnAdapter 路径全 happy path / lifecycle Close 等价旧 cancel / observe 流退出条件 |
+
+### 验收
+
+1. `cargo test --workspace --locked --no-fail-fast` 通过数 ≥942(允许 +新增 trait 测试,**禁止减少**);失败数仅 1(已有 ccteam-web flake,**新增不允许**)
+2. clippy 0 errors + ≤18 warnings(允许减少,禁止新增)
+3. `grep -rn "Command::new(\"claude\")" crates/ccteam-core` 命中**仅在** `execution/bg.rs`,主 orchestrator 零命中
+4. `grep -rn "execution::ExecutionAdapter" crates/ ` ≥3 命中(core + cli + 测试)
+5. host probe:V0.5.1 跑过的 dex-ui workflow.yaml 在 V0.6.0 wave-1 二进制下行为完全一致(progress.jsonl event 序列 diff = 0)
+
+### 不在范围
+
+- 不实现 `TmuxInteractiveAdapter`(F108)
+- 不实现 `InProcTeamAdapter`(在 F107 trait 设计完后,V0.5.0 `ccteam-team` skill 是否能 trait 化是 V0.6.1 议题,V0.6.0 不强求 — skill 是 in-Claude-session 逻辑,本来就不在 ccteam-core 里跑)
+- 不改 MCP / CLI 用户面接口(纯内部重构)
+
+---
+
+## F108 — `TmuxInteractiveAdapter`(模式 3 执行 runtime)
+
+### 痛点
+
+模式 3 chat bot 需要长跑 Claude session 复用 context(不复用 → 每轮重 tokenize 全历史,N 轮 5k 历史成本 O(N²),无 prompt cache 命中)。现有 `claude --bg` 是 run-to-completion,出口即死,不能多轮。
+
+Claude Code 本身支持 `claude --resume <session-id> --input-format stream-json --output-format stream-json`,可以长跑 + stream I/O。但 ccteam 现有红线"不解析 tmux 输出"指向**不用 capture-pane**,所以要找到既能 stdin-style 控制又不 scrape pane 的路径。
+
+**结论**(详 README §七 决策记录):
+- **input** 走 `tmux send-keys`(tmux pane 已有,plumbing 现成)
+- **output** 走 `~/.claude/projects/<encoded-path>/<session-id>.jsonl` tail(Anthropic 官方 session 格式,稳定可解析)
+- pane 内跑 `claude --resume <session-id>` 长跑,session-id 由 adapter 持久化
+
+### 需求
+
+#### `TmuxInteractiveAdapter` 行为
+
+```
+spawn(role, ctx):
+  1. 决定 bot identity:slug = ctx.workflow_slug + role + bot-name
+  2. 检查 ~/.ccteam/im/<slug>/session-id:
+     - 存在 → claude --resume <id> 在 tmux pane 启动
+     - 不存在 → claude(新 session)在 tmux pane 启动,捕获新 session-id 写文件
+  3. agent_md_path 通过 Claude Code subagent resolver(项目 .claude/agents/ → ~/.claude/agents/)
+  4. 返回 SessionHandle{ mode: TmuxInteractive, identity: <pane-id>+<session-id> }
+
+send_input(handle, Input::User { content }):
+  tmux send-keys -t <pane> -- "<escape(content)>" Enter
+  (escape:换行用 send-keys Enter 分段;backtick / $ 用 -l 字面量模式)
+
+send_input(handle, Input::SlashCommand { name, args }):
+  tmux send-keys -t <pane> -- "/<name> <args>" Enter
+
+observe(handle) -> Stream<ObservedEvent>:
+  inotify watch ~/.claude/projects/<…>/<session-id>.jsonl
+  parse 增量 line(每 line 一条 Anthropic SDK event)
+  → ChatTurn { speaker: Assistant, content: ... }(filter user/system)
+  → 检测 lifecycle ack(/compact 完毕 / /new 后新 session-id 出现)
+  → 文件被 Anthropic 重命名(/new 触发)→ 重新 watch 新 session-id
+
+lifecycle(handle, op):
+  Compact -> send-keys "/compact" Enter
+  NewSession -> send-keys "/new" Enter;监 ~/.claude/projects/<…>/ 新 jsonl 出现 → 更新 session-id 持久化
+  Clear -> send-keys "/clear" Enter
+  Close -> send-keys C-c C-c + tmux kill-pane;session-id 文件保留(下次 spawn 可 resume)
+```
+
+#### workflow.yaml `mode: chat` schema(新)
+
+```yaml
+version: 0.6
+mode: chat                              # 新枚举值,触发 TmuxInteractiveAdapter
+agents:
+  - role: helpful-bot
+    bot_name: "@helpful_bot"            # IM 暴露的 handle(F109 用)
+    compact_every_turns: 50             # 累计 turn 数达到则自动 /compact
+    new_on_topic_shift: false           # 暂留 false(主题检测下版)
+    hop_limit: 3                        # bot-to-bot @ 链路上限(R6 红线)
+    model: opus-4-7                     # 同现有
+  - role: critic-bot
+    bot_name: "@critic_bot"
+    compact_every_turns: 100
+    hop_limit: 3
+im_channels:                            # F109 用
+  - kind: telegram
+    chat_id_env: TG_CHAT_ID
+    bot_token_env: TG_BOT_TOKEN
+```
+
+#### session-id 失效恢复
+
+session-id 失效场景:Claude Code 升级后 session 文件格式 incompat、用户 `rm -rf ~/.claude/projects/`、磁盘 fsck 丢文件。
+
+V0.6.0 策略:**fail-open + 业务事件可见**
+- 检测 `claude --resume <id>` 退出码非 0 → adapter 启用 fresh `claude`,新 session-id 持久化
+- emit progress 事件 `chat_session_reset { bot, old_session_id, reason }`(让用户 web UI / TG 知道 bot "失忆"了)
+- **不**自动重放历史(那是 V0.6.1 议题)
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/execution/tmux_interactive.rs`(新)| `TmuxInteractiveAdapter` impl,~600 行 |
+| `crates/ccteam-core/src/execution/session_jsonl_tail.rs`(新)| inotify watch + 增量 jsonl parse;复用 V0.5.0 F92 transcript_scanner 的 mtime+length memoize 思路 |
+| `crates/ccteam-core/src/execution/send_keys.rs`(新)| tmux send-keys 安全 escape;**带 fuzzing test**(任意 unicode + ANSI 控制字符 输入不 corrupt pane)|
+| `crates/ccteam-core/src/workflow_schema.rs`(改)| 加 `mode: chat` 枚举值 + `bot_name` / `compact_every_turns` / `new_on_topic_shift` / `hop_limit` 字段;serde tagged enum 区分 artifact-driven vs agent-team vs chat |
+| `crates/ccteam-core/src/progress_event.rs`(改)| 加 4 新 event 类型:`chat_turn` / `chat_session_reset` / `chat_compact_done` / `chat_hop_escalate` |
+| `crates/ccteam-core/tests/tmux_interactive_test.rs`(新)| 8 测试:spawn 新 session / spawn resume 已存 session / send_input escape edge case / observe 流增量 / lifecycle compact / lifecycle new(session-id 更新)/ session-id 失效 fallback / fuzzing send-keys |
+
+### 验收
+
+1. host probe:跑 chat workflow,bot 多轮 @ 后 `claude --resume` 实测 prompt cache hit ≥turn 2(从 transcript usage 字段读 cache_read_input_tokens > 0)
+2. `/compact` 触发后,后续 turn 的 input_tokens 显著下降(<前一个 turn 的 1/3,具体阈值 manual probe)
+3. session-id 失效 mock test:删 session jsonl → spawn 退化为 fresh,emit `chat_session_reset`
+4. send-keys fuzzing 200 sample 输入,无 pane corruption(pane 内 `claude` 进程仍 alive)
+5. `cargo test --workspace --locked --no-fail-fast` baseline 数字增长(预计 +10 测试)
+
+### 不在范围
+
+- **跨 session memory 重建** — session-id 丢了不重放,V0.6.1 议题
+- **主题漂移检测自动 `/new`**(`new_on_topic_shift: true` 暂留 false 不实现) — V0.6.2 议题
+- **stdin pipe 替代 send-keys** — 决策选 send-keys,V0.6.x 不切
+
+---
+
+## F109 — `ccteam-im-bridge` crate(模式 3 IM 触发源,Telegram 起步)
+
+### 痛点
+
+模式 3 的触发源不是 ArtifactWatcher(文件触发),而是 IM webhook(`@bot_name "..."` 来自 TG / Slack)。这是一个独立的 trigger 通道,职责清晰:**把 IM 消息翻译成 `ExecutionAdapter::send_input` 调用,并把 `observe()` 出来的 ChatTurn 翻译回 IM post**。
+
+放新 crate 而不是塞 ccteam-core 的理由:
+- IM SDK(`teloxide` / TG bot crate)是大依赖,不该污染 core
+- 多 IM 平台扩展点天然走插件式 crate(`ccteam-im-bridge-telegram` / `ccteam-im-bridge-slack` / ...)
+- 独立 crate 边界 + `cargo tree` 测试守住:core 永不依赖 IM SDK
+
+### 需求
+
+#### Crate 结构
+
+```
+crates/ccteam-im-bridge/
+├── Cargo.toml                       # 依赖:ccteam-core(读 workflow.yaml),teloxide(TG)
+├── src/
+│   ├── lib.rs                       # 总入口 trait ImBridge
+│   ├── telegram.rs                  # TgBridge impl
+│   ├── router.rs                    # bot-to-bot @ 路由(本 crate 内,不入 core)
+│   ├── hop_tracker.rs               # R6 hop_limit 计数 + escalate
+│   └── session_link.rs              # IM user ↔ bot session-id 映射
+└── tests/...
+```
+
+#### trait `ImBridge`
+
+```rust
+pub trait ImBridge: Send + Sync {
+    /// 启动 webhook / long-poll;阻塞循环
+    async fn run(&self, ctx: BridgeContext) -> Result<()>;
+}
+
+pub struct BridgeContext {
+    pub adapter: Arc<dyn ExecutionAdapter>,            // F107 trait
+    pub workflow_slug: String,
+    pub bot_roster: Vec<BotConfig>,                    // workflow.yaml `agents:` 解析
+    pub progress_writer: ProgressWriter,               // emit chat_* event
+}
+```
+
+#### TG 实现关键路径
+
+```
+TG @helpful_bot "explain X":
+  1. teloxide 收 message,parse @mention
+  2. session_link.lookup(tg_chat_id, "@helpful_bot") -> bot SessionHandle
+     - 不存在 → adapter.spawn(role="helpful-bot", ctx) → 存映射
+  3. adapter.send_input(handle, Input::User { content: "explain X" })
+  4. await adapter.observe(handle).take_while(|e| !is_turn_end(e))
+  5. assistant content → teloxide.send_message(tg_chat_id, content)
+  6. progress_writer.emit(ChatTurn { bot, ts, ... })
+
+assistant content 含 "@critic_bot 看下":
+  1. router.parse_mentions(content) -> ["@critic_bot"]
+  2. hop_tracker.check(tg_chat_id, current_chain) -> ok | escalate
+     - escalate → progress_writer.emit(ChatHopEscalate { chain, limit })
+       + teloxide 回 "@user 该话题 bot 间已链 3 轮,人工介入"
+  3. ok → 递归:adapter.send_input(critic_handle, Input::User {..})
+  4. critic 输出 → 同样 teloxide post 到 TG(以 critic_bot 身份)
+```
+
+#### CLI 集成
+
+```bash
+ccteam start <chat-slug>              # 现有 daemon 起;chat mode 检测后额外起 im-bridge
+                                       # bridge 进程是 daemon 的 child,daemon stop 时 graceful 关
+ccteam internal im-bridge <slug>      # 单独起 bridge(调试用,daemon 不启)
+```
+
+实施:`ccteam-cli::start` 检测 workflow.yaml `mode: chat` → 注册 `ccteam-core` daemon hook:启动后 spawn `ccteam-im-bridge` 进程 + tokio task。bridge 通过 `ExecutionAdapter` trait 操作 adapter,**不直接 import `TmuxInteractiveAdapter`**(松耦合)。
+
+#### env / secrets
+
+TG bot token / chat ID 不入 `workflow.yaml`(R8 红线 + 安全),只声明 env 变量名(`bot_token_env: TG_BOT_TOKEN`),token 在 `ccteam start` 启动环境拿。
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-im-bridge/Cargo.toml`(新)| 依赖 ccteam-core(workflow.yaml 解析)+ teloxide 0.13(只在 telegram feature 下)+ tokio + anyhow |
+| `crates/ccteam-im-bridge/src/lib.rs` 等(新)| 上述结构 |
+| `crates/ccteam-cli/src/commands.rs::start` | 检测 `mode: chat` → spawn bridge |
+| `crates/ccteam-cli/src/main.rs::internal` | 加 `im-bridge <slug>` 子命令 |
+| `Cargo.toml`(workspace 根)| 加 member `crates/ccteam-im-bridge` |
+| `crates/ccteam-im-bridge/tests/router_test.rs`(新)| mention parse / hop_limit / escalate 触发 |
+| `crates/ccteam-im-bridge/tests/dep_graph_test.rs`(新)| `cargo tree -p ccteam-core` 不能包含 teloxide(松耦合红线)|
+
+### 验收
+
+1. host probe(需 TG 账号):TG 群里 `@helpful_bot 你好` → bot 回应 → emit `chat_turn` event;`@helpful_bot @critic_bot "review my plan"` → 双 bot 链式回应,emit 2 个 `chat_turn`
+2. hop_limit 测试:mock bot-to-bot 链 4 轮 → 第 4 轮 escalate,TG 收人工介入消息
+3. session_link 持久化:bridge 重启后,同一 TG user 继续 @ 同一 bot,bot 仍是同 session-id(prompt cache 仍命中)
+4. dep_graph_test 通过:`ccteam-core` 不引 teloxide
+5. `ccteam start <chat-slug>` 不阻塞 mode 2 现有 workflow(混合 mode 项目 — 一个 daemon 同时跑 artifact + chat;V0.6.0 不要求,但不能 break)
+
+### 不在范围
+
+- Slack / Discord / IRC bridge — V0.7.x;V0.6.0 只 trait + TG 一个实现,trait 必须足够泛化
+- 富媒体(图片 / 文件 / voice)— TG 消息只 text + reply markup,V0.6.x 不扩
+- DM(私聊)scope — V0.6.0 只支持 group chat;DM 是 V0.6.1
+- IM webhook reverse proxy / public URL 自动注册 — 用户自行 ngrok / cloudflared
+
+---
+
+## F110 — MCP namespace `ccteam` → `ct` + 子前缀工具命名
+
+### 痛点
+
+现有 17 MCP 工具命名 `mcp__ccteam__<verb>`,prefix `ccteam` 占 6 字符 / `mcp__ccteam__` 占 11 字符。每次 Claude session 启动 / tool list 拉取 / Claude 调用 / 错误返回都吃这个 prefix。考虑 tool list 在 session 启动 prompt 里出现一次(~17 行 × 字符数)+ 每次 tool call assistant message 出现一次(每次 ~30 token),长期摊销有意义。
+
+OMC 用单字母 `t` 作 namespace 已验证可行。ccteam 选 2 字母 `ct`(safer than `t`, 避撞)。
+
+同时模式 3 加 6+ 新工具(send_chat_input / chat_lifecycle / observe_session / bot_roster 等),全部继续平铺 + 单一前缀会让 17 → 23 工具列表更难定位。**单 server + 子前缀**(`workflow_ls` / `chat_send_input`)更清晰。
+
+### 需求
+
+#### 新命名(全表)
+
+| 现 | 新 |
+|---|---|
+| `mcp__ccteam__ls` | `mcp__ct__workflow_ls` |
+| `mcp__ccteam__show` | `mcp__ct__workflow_show` |
+| `mcp__ccteam__peek` | `mcp__ct__workflow_peek` |
+| `mcp__ccteam__progress` | `mcp__ct__workflow_progress` |
+| `mcp__ccteam__new` | `mcp__ct__workflow_new` |
+| `mcp__ccteam__pause` | `mcp__ct__workflow_pause` |
+| `mcp__ccteam__resume` | `mcp__ct__workflow_resume` |
+| `mcp__ccteam__send_to_session` | `mcp__ct__workflow_send_to_session` |
+| `mcp__ccteam__inject_decision` | `mcp__ct__workflow_inject_decision` |
+| `mcp__ccteam__screenshot` | `mcp__ct__workflow_screenshot` |
+| `mcp__ccteam__spawn_agent` | `mcp__ct__workflow_spawn_agent` |
+| `mcp__ccteam__stop_agent` | `mcp__ct__workflow_stop_agent` |
+| `mcp__ccteam__observe_agents` | `mcp__ct__workflow_observe_agents` |
+| `mcp__ccteam__signal` | `mcp__ct__workflow_signal` |
+| `mcp__ccteam__set_parallelism` | `mcp__ct__workflow_set_parallelism` |
+| `mcp__ccteam__trigger_gate` | `mcp__ct__workflow_trigger_gate` |
+| `mcp__ccteam__get_artifact_summary` | `mcp__ct__workflow_get_artifact_summary` |
+| **(新)** | `mcp__ct__chat_send_input` |
+| **(新)** | `mcp__ct__chat_lifecycle`(compact / new / clear / close)|
+| **(新)** | `mcp__ct__chat_observe_session`(返当前 jsonl tail snapshot)|
+| **(新)** | `mcp__ct__chat_bot_roster`(列当前 chat workflow 所有 bot + 状态)|
+| **(新)** | `mcp__ct__chat_session_reset_force`(管理员强制 `/new`,emit reset 事件)|
+
+#### Breaking 策略
+
+CLAUDE.md §五:no backwards-compat shim。**直接 rename**,不留 `mcp__ccteam__*` alias 一版。同步改:
+1. `ccteam-control` skill `SKILL.md` capability index(全 17 行替换 + 加 5 新行)
+2. meta-agent prompt 全文 replace
+3. `crates/ccteam-cli/src/mcp_serve.rs` + `mcp_workflow_tools.rs` 注册名字
+4. test fixture / snapshot 同步
+
+升级体验:用户跑 `ccteam doctor --install-mcp` 重新写 `~/.claude.json` + `/reload-mcp`。旧 session 的 tool call 用错名字 → MCP server 返 method-not-found,Claude 自动重试新名(LLM 看到错误能改)。损失低。
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-cli/src/mcp_serve.rs` | server name `"ccteam"` → `"ct"`;tool registration 加 `workflow_` 前缀 |
+| `crates/ccteam-cli/src/mcp_workflow_tools.rs` | 同上,7 工具加前缀 |
+| `crates/ccteam-cli/src/mcp_chat_tools.rs`(新)| 5 chat 工具注册(F108 + F109 业务调用)|
+| `skills/ccteam-control/SKILL.md` | capability index 表整体重写 |
+| `crates/ccteam-cli/src/commands.rs::install_meta_agent` | meta-agent prompt template 全文 replace |
+| `crates/ccteam-cli/tests/mcp_protocol_test.rs`(改名 / 新)| tool name 全更新 |
+
+### 验收
+
+1. `ccteam doctor --install-mcp` 写入的 `~/.claude.json` 含 `"mcpServers": { "ct": {...} }`(无 `"ccteam"` 键)
+2. `mcp__ct__workflow_ls` 等所有工具在 `/mcp` 列表里出现,名字正确
+3. `grep -rn "mcp__ccteam__" crates/ skills/ docs/v0-5-0/ docs/v0-5-1/` 命中**仅**老版本归档 dir(EOL 不动);`crates/` 和 `skills/` 命中 0
+4. host probe:V0.5.1 跑过的 meta-agent 工作流(read project,inject_decision)在 V0.6.0 全部用新名字跑通
+
+### 不在范围
+
+- 不留 `ccteam` server 别名(breaking is OK)
+- 不动 OMC / claude-mem 等外部 MCP 命名
+
+---
+
+## F111 — MCP 工具粒度配置(`CCTEAM_DISABLE_TOOLS` + 项目级 `.mcp.json`)
+
+### 痛点
+
+V0.6.0 后 MCP 工具总数 22(17 现 + 5 chat),全部发布到每个 Claude session 的 tool list:
+- 每 session 启动 prompt 含 22 工具 schema(每个 ~50 token),~1100 token 固定开销
+- 用户只用模式 2 → chat_* 5 工具白占空间;反之亦然
+- 一些工具(`workflow_screenshot` 渲染图片成本高,`workflow_set_parallelism` 危险操作)用户想禁
+
+OMC `OMC_DISABLE_TOOLS` env-driven 提供了精确控制范本。
+
+同时:现 MCP 注册路径只 `~/.claude.json`(user-global,所有 Claude session 都看到 ccteam MCP)。项目级 `.mcp.json` 更可移植:`git clone` 后任何 Claude session 在该项目根自动拿到 ccteam MCP,无需 doctor 安装。
+
+### 需求
+
+#### `CCTEAM_DISABLE_TOOLS` env
+
+```bash
+# 一律 glob 匹配 tool short name(不含 mcp__ct__ 前缀)
+export CCTEAM_DISABLE_TOOLS="chat_*"                     # 用户只跑模式 2
+export CCTEAM_DISABLE_TOOLS="workflow_screenshot,workflow_set_parallelism"
+export CCTEAM_DISABLE_TOOLS="chat_*,workflow_screenshot"  # 组合
+```
+
+`ccteam mcp-serve` 启动时读环境变量,过滤 `tools/list` 返回。被禁工具被 call 时返 method-not-found。
+
+#### 项目级 `.mcp.json` 自动生成
+
+`ccteam init` 落项目 `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "ct": {
+      "command": "ccteam",
+      "args": ["mcp-serve"],
+      "env": {
+        "CCTEAM_PROJECT_ROOT": "${workspaceFolder}",
+        "CCTEAM_DISABLE_TOOLS": ""
+      }
+    }
+  }
+}
+```
+
+Claude Code 在项目根启动时自动 merge `.mcp.json` + `~/.claude.json`(项目级覆盖 user-global)。
+
+`ccteam doctor --install-mcp` 仍写 `~/.claude.json`(保 user-global fallback,任意 cwd 都能用);但**优先**推荐项目级。doctor 提示语调整:"推荐 `ccteam init` 落项目 `.mcp.json`,本命令是 user-global 后备。"
+
+#### `.mcp.json` 已存在的合并
+
+`ccteam init` 检测 `.mcp.json` 已存在:
+- 含 `ct` 键 → 跳过,告知用户已存在
+- 不含 `ct` 键 → merge `ct` 键进去,保留其他 MCP server 不动
+- JSON 损坏 → 报错 abort(不覆盖用户文件)
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-cli/src/mcp_serve.rs` | 启动读 `CCTEAM_DISABLE_TOOLS`,glob 过滤 `tools/list` + `tools/call` |
+| `crates/ccteam-cli/src/commands.rs::init` | 调 `write_project_mcp_json(<project_root>)`,merge 逻辑 |
+| `crates/ccteam-cli/src/commands.rs::run_doctor` | `--install-mcp` 输出加项目级推荐 |
+| `crates/ccteam-cli/tests/mcp_disable_test.rs`(新)| 5 测试:single tool disable / glob disable / disable 全部 chat_* / 被禁工具 call 返错 / 无 env 行为不变 |
+| `crates/ccteam-cli/tests/project_mcp_json_test.rs`(新)| 4 测试:全新 .mcp.json / 合并已有 / ct 键已存在跳过 / 损坏 JSON abort |
+
+### 验收
+
+1. `CCTEAM_DISABLE_TOOLS=chat_* ccteam mcp-serve` 启动后,`tools/list` 不含 chat_* 5 工具
+2. `ccteam init` 在空目录落 `.mcp.json`,内容含 `ct` server 注册
+3. `ccteam init` 在已有 `.mcp.json`(含其他 server)的目录运行,merge 后其他 server 保留
+4. host probe:VS Code Claude Code extension 在 `ccteam init` 后的项目里启动,`/mcp` 显示 `ct` 已连接(无需 `--install-mcp`)
+5. 同一 user 同时用 `~/.claude.json` 全局 ct + 项目 `.mcp.json` ct,无冲突(Claude Code 项目级覆盖)
+
+### 不在范围
+
+- 不实现工具类别分组(只 glob)
+- 不做 `.mcp.json` GUI 编辑器
+- 不替代 doctor --install-mcp(保留作 user-global 入口)
+
+---
+
+## 文档影响清单
+
+| 文档 | 改动 |
+|---|---|
+| `CLAUDE.md` §一(当前状态表)| Workspace version → 0.6.0;baseline 数字 wave 3 ship 后回填 |
+| `CLAUDE.md` §三红线 | 加"模式"列(精简);link 到 tech-design 详 |
+| `docs/tech-design.md` §0(若存在)/ §2.1 | 三模式定义表 + 红线 × 模式矩阵;`ExecutionAdapter` trait 接口 |
+| `docs/orchestration-patterns.md` §一 | 5 拓扑模式 × 3 执行模式适用矩阵 |
+| `docs/interfaces.md` | MCP 工具名全表更新;workflow.yaml `mode: chat` schema 加入 |
+| `docs/dev-coupling-audit.md` | F106-F111 各一条 finding 简述 |
+| `docs/claude-code-best-practices.md` | 加一节"用 send-keys + session jsonl 实现长跑 agent"(模式 3 落地经验) |
+| `docs/v0-6-0/user-manual.md`(新)| chat mode 用户使用指南(TG bot 起步教程)|

--- a/docs/v0-6-0/prd.md
+++ b/docs/v0-6-0/prd.md
@@ -1,558 +1,896 @@
 # V0.6.0 — PRD
 
-6 个 finding。F106 是架构原则文档,定义本版基调;F107 重构准备(零行为变化);F108 + F109 模式 3 落地;F110 + F111 MCP 优化。
+**12 个 finding(F106-F118,F110 取消)**,按 3 Epic 组织:Epic A "5 min IM bot" / Epic B "bot 像真人助理" / Epic C "中文用户能用"。详 `README.md`。
 
-> **本 PR 范围**:只 land 本 PRD + `README.md` + `dev-plan.md`。代码改动**全部走后续 wave PR**,以便每 wave 单独 review + 跑 baseline。
-
----
-
-## F106 — 三执行模式定型 + 红线按模式 scope 重写
-
-### 痛点
-
-CLAUDE.md 现有红线"每次 spawn = 全新 1M context"、"文件系统是控制平面"、"progress.jsonl 唯一 state SoT" 等,**全部默认了一种执行模型**(`claude --bg` 任务式 spawn,artifact-driven)。当 V0.5.0 落了 `ccteam-team` skill(in-process Task 模式)、V0.6.0 要落 chat/IM bot(tmux 长跑模式)时,这些红线**部分不适用 / 含义需要细分**。
-
-具体冲突:
-- in-proc team(模式 1)没有 file-system 控制平面,但红线写"是控制平面"
-- chat bot(模式 3)就是要复用 context,但红线写"每次 spawn fresh"
-- chat bot 输出来自 `~/.claude/projects/<…>/<session-id>.jsonl` 而非 progress.jsonl,但红线写"progress.jsonl 唯一 SoT"
-
-不澄清的后果:后续 PR 作者要么误读红线限制实现、要么实现后跟现有红线表面冲突、要么把红线悄悄改弱。
-
-### 需求
-
-把三模式 + 红线适用矩阵显式写进 tier-1 文档(`tech-design.md` + `CLAUDE.md`),让任何 PR 作者一眼看到自己的改动落在哪个模式 + 守哪些红线。
-
-#### 三模式定义表(权威版)
-
-| 维度 | 模式 1: in-proc team | 模式 2: bg sessions | 模式 3: tmux sessions |
-|---|---|---|---|
-| **直观场景** | CC 插件 / skill 起临时 team | 长跑自动化 workflow | 随叫随到 chat bot / IM agent |
-| **触发** | 用户在 Claude session 内 `/ccteam-team "..."` | `ccteam start <slug>` daemon 起 + ArtifactWatcher 触发 | IM webhook(TG / Slack)→ bridge → send-keys |
-| **spawn 原语** | `Task(subagent_type=…)` | `claude --bg --agent <role>` | 长跑 `claude`(交互模式)+ `tmux send-keys` |
-| **进程模型** | parent Claude session 内 N teammate(同进程)| 每 spawn 一个独立 Claude job 进程,run-to-completion | 每 bot 一个常驻 tmux pane,内含长跑 `claude` 进程 |
-| **input 面** | tool args(`Task` 的 `prompt`)| `.ccteam/inbox/msg-<ts>-NNN.md` 文件 | `tmux send-keys -t <pane> "<text>" Enter`(含 `/new` `/compact` `/clear`)|
-| **output 面** | tool result(返回值)| `progress.jsonl` 业务事件 + `state.json` cost | `~/.claude/projects/<encoded-path>/<session-id>.jsonl` tail(Anthropic 官方 session 格式)|
-| **context 生命周期** | parent session window,死则同死 | **每次 spawn fresh 1M**,无 `--resume` | **长跑复用**;`/compact` 摘要 / `/new` 重置 / `/clear` 清,**在线管理** |
-| **cost model** | shares parent context budget | 每 spawn 重 tokenize 全 prompt,无 cache 命中 | warm cache(turn 2 起 cache hit),`/compact` 重置 baseline |
-| **可观测性** | parent Claude 自看 SendMessage | progress.jsonl + web UI | progress.jsonl(业务事件)+ session jsonl(对话原文)+ web UI 加 Chat View |
-| **状态恢复** | 不适用(session 死即丢)| progress.jsonl + 文件 SoT 完整可重建 | session-id 持久化(`~/.ccteam/im/<bot>/session-id`),失效则重启 + 重放 last-N(F108 §恢复)|
-| **跨设备** | ✗(锁在 parent session)| ✓(daemon 在哪跑,在哪看)| ✓(IM 是 location-agnostic)|
-
-#### 红线 × 模式适用矩阵(改 `tech-design.md` §0 + `CLAUDE.md` §三)
-
-| # | 红线 | 模式 1 | 模式 2 | 模式 3 | 细则 |
-|---|---|:-:|:-:|:-:|---|
-| R1 | 文件系统是控制平面 | — | ✓ | ⚠ | 模式 3 **输出**是文件(session jsonl);**输入**是 send-keys,**不是文件**。措辞改为"输出 SoT 是文件" |
-| R2 | progress.jsonl 唯一 state SoT | — | ✓ | ⚠ | 模式 3:progress.jsonl 是**业务事件 SoT**(@-routed / compact / hop-escalate),对话原文在 session jsonl。两个 SoT **不重叠**,各管一半 |
-| R3 | 每次 spawn = fresh 1M context | — | ✓ | ✗ | 模式 3 显式**不适用**。chat 场景 context 复用是 feature,通过 `/compact` `/new` 管理 |
-| R4 | 不解析 tmux 输出 | — | ✓ | ✓ | 模式 3 **守**。读 session jsonl(Anthropic 官方格式)替代 tmux capture-pane |
-| R5 | 永不主动 kill 长 session | ✓ | ✓(F84 budget cap 唯一例外)| ✓ | 模式 3:`/compact` `/new` 是**合法状态操作**,不算 kill |
-| R6 | fix-loop 3 次必 escalate | ✓ | ✓ | ✓ + 新增 | 模式 3 加 bot-to-bot @ ping-pong **hop_limit**(默认 3,workflow.yaml 可配),撞 limit 同等 escalate |
-| R7 | `ccteam-core` 零 team 名字面量 | ✓ | ✓ | ✓ | 全模式守 |
-| R8 | 跨项目记忆走官方接口 | ✓ | ✓ | ✓ | 模式 3 的 IM 用户身份 ≠ ccteam memory,不污染 `~/.claude/CLAUDE.md` |
-| R9 | 新建项目走 `<projects_root>/<team>-<slug>/` | — | ✓ | ✓ | 模式 3 `ccteam new --mode chat <slug>` 仍走此 layout;bot per project |
-
-(— = 模式不涉及该红线场景)
-
-### 验收
-
-1. `docs/tech-design.md` §0(开篇红线表)按上表重写,每红线标 `[模式 1/2/3]` 适用
-2. `CLAUDE.md` §三红线表加"模式"列(精简版,详 link 到 tech-design)
-3. `docs/orchestration-patterns.md` §一加"模式 × 拓扑模式"对应表(哪个执行模式适合哪种 orchestration topology)
-4. `docs/v0-6-0/README.md` 三模式表是唯一权威源,其他文档引用 link 回 README
-5. PR 描述带 `grep -rn "每次 spawn.*fresh"` 全仓比对:所有命中处或加 [模式 2] 标记、或删
-
-### 不在范围
-
-- 不动现有 V0.4-V0.5 prd / dev-plan(EOL 版本归档不动,CLAUDE.md §五原则)
-- 不删任何红线,只 scope 和细则化
-- 不引入新红线(模式 3 hop_limit 是 R6 的扩展,不是新条)
+> **本 PR 范围**:只 land 本 PRD + `README.md` + `dev-plan.md` + 5 用户面文档(`docs/quickstart.md` / `user-manual.md` / `recipes.md` / `troubleshooting.md` / `advanced/*`)。代码改动**全部走后续 wave PR**。
 
 ---
 
-## F107 — `ExecutionAdapter` trait 抽离 + `BgSpawner` 改造对接
+## EPIC A — 5 min 起第一个 IM bot
 
-### 痛点
+**Epic 验收**:普通用户(非 ccteam 开发者)在 5 分钟内完成:打开 Claude session → `/ccteam <NL>` 起 Pocket Assistant → 在 TG 收到 bot 第一条回话。**0 行 yaml 编辑;0 个新用户面概念**。
 
-现有 `crates/ccteam-core/src/orchestrator.rs` + `bg_spawner.rs`(实际文件名待验,可能在 `spawn.rs` / `claude_job.rs`)直接以 `claude --bg --agent` 为唯一 spawn 路径。模式 3 要塞 `claude`(交互模式)长跑 + send-keys input + session jsonl tail output,**没法在现有路径里加 if/else**,会污染 orchestrator 主循环。
+下属 finding:F113 / F114 / F117 / F109(Epic A 部分)/ F111 / F106(Epic A 部分)。
 
-需要在 ccteam-core 抽出一个 `ExecutionAdapter` trait,把"如何 spawn / 如何送 input / 如何观察 output / 如何 lifecycle 操作"抽象掉。`BgSpawner` 重命名为 `BgSpawnAdapter` 实现 trait,**行为零变化**。F108 再加 `TmuxInteractiveAdapter`,F109 的 im-bridge 通过 trait 用。
+---
 
-### 需求
+### F113 — `/ccteam` 总入口 NL dispatcher + 5 sub-skill
 
-#### trait 接口
+#### 痛点
 
-```rust
-// crates/ccteam-core/src/execution/mod.rs(新)
-pub trait ExecutionAdapter: Send + Sync {
-    /// spawn 一个新 agent session;返回 handle 用于后续 input/observe/lifecycle 操作
-    fn spawn(&self, role: &str, ctx: SpawnContext) -> Result<SessionHandle>;
+V0.5.0 已经把 5 skill 砍到 3(`ccteam-team` / `ccteam-control` / `ccteam-creator`),但用户仍要记多个 slash 名。普通用户期望"一个总入口,我说人话,系统决定调啥"。OMC `README:231` "No commands to memorize, just describe what you want" 已经市场验证。
 
-    /// 投递一条 input message 到 session
-    /// 模式 2:写 .ccteam/inbox/msg-*.md
-    /// 模式 3:tmux send-keys
-    fn send_input(&self, handle: &SessionHandle, input: Input) -> Result<()>;
+#### 需求
 
-    /// 流式观察 session 输出(driver 侧 await)
-    /// 模式 2:tail progress.jsonl 业务事件
-    /// 模式 3:tail session jsonl + emit ChatTurn
-    fn observe(&self, handle: &SessionHandle) -> BoxStream<'static, ObservedEvent>;
+新建 `skills/ccteam/SKILL.md`(总入口):
 
-    /// session 生命周期操作(模式 3 主用)
-    fn lifecycle(&self, handle: &SessionHandle, op: LifecycleOp) -> Result<()>;
-}
-
-pub struct SpawnContext {
-    pub workflow_slug: String,
-    pub agent_md_path: PathBuf,
-    pub env: Vec<(String, String)>,
-    pub mode_specific: ModeSpecificCtx,  // 区分 mode 2 / mode 3 必要字段
-}
-
-pub enum Input {
-    User { content: String },          // chat 场景的 user 输入
-    SlashCommand { name: String, args: Vec<String> },
-    InboxMarkdown { body: String },    // 模式 2 现有 path
-}
-
-pub enum LifecycleOp {
-    Compact,                            // 模式 3:/compact
-    NewSession,                         // 模式 3:/new
-    Clear,                              // 模式 3:/clear
-    Close,                              // 全模式
-}
-
-pub enum ObservedEvent {
-    BusinessEvent(ProgressEvent),       // mode 2 主路径
-    ChatTurn { speaker: Speaker, content: String, ts: SystemTime },  // mode 3 主路径
-    LifecycleAck { op: LifecycleOp, ok: bool },
-    Closed { reason: String },
-}
-
-pub struct SessionHandle {
-    pub mode: ExecutionMode,
-    pub identity: String,               // mode 2: jobs/<id>;mode 3: tmux pane + session-id
-    pub spawned_at: SystemTime,
-}
-
-pub enum ExecutionMode { InProc, Bg, TmuxInteractive }
+```
+/ccteam <NL>
 ```
 
-#### `BgSpawnAdapter` 改造点
+skill body 是一个 NL dispatcher:
+1. parse 用户意图(意图分类:start-team / monitor / configure-im / advise / create-workflow / status / debug)
+2. 路由到下方 5 sub-skill 之一,自动透传用户 NL
+3. 失败时 fallback "我没听懂,你想:(a)起一个 team 干活 / (b)做个 IM bot 助理 / (c)看 ccteam 状态 / (d)其他 — 请选或重新描述"
 
-| 现在 | 改后 |
-|---|---|
-| `orchestrator.rs` 直接 `Command::new("claude").arg("--bg")...` | 通过 trait `bg_adapter.spawn(...)` |
-| ArtifactWatcher 发现 inbox 文件 → 现 `spawn_session(...)` | trait `bg_adapter.send_input(handle, Input::InboxMarkdown {..})` |
-| progress.jsonl tail 现 ad-hoc | trait `bg_adapter.observe(handle)` 返流 |
-| pause/resume/cancel 现 `cancel_token` 直接 | trait `bg_adapter.lifecycle(handle, LifecycleOp::Close)` |
-
-**关键不变量**:重构后 `cargo test --workspace` 全部测试通过,数字跟 V0.5.1 baseline(942/1)持平。**这是 wave 1 唯一硬验收**。
+sub-skill 仍保留(高级用户 deep-link):
+- `/ccteam-team <NL>` — 起临时 team(V0.5 已有,V0.6 加 vote mode + Codex auto-critic 路径)
+- `/ccteam-creator <NL>` — NL 对话起 workflow(V0.5 砍掉,V0.6 复活 + auto mode 推断)
+- `/ccteam-control <NL>` — 项目状态查看 / 暂停 / 恢复(V0.5 已有)
+- `/ccteam-im-setup` — IM token 一次性 onboarding(V0.6 NEW,详 F117)
+- `/ccteam-advise <hard question>` — Codex + Claude 并行 advisor 投票(V0.6 NEW,详 F112 §A)
 
 #### 文件清单
 
 | 文件 | 改动 |
 |---|---|
-| `crates/ccteam-core/src/execution/mod.rs`(新)| trait 定义 + 共享类型(SpawnContext / Input / LifecycleOp / ObservedEvent / SessionHandle / ExecutionMode)|
-| `crates/ccteam-core/src/execution/bg.rs`(新,迁移自现 spawn 路径)| `BgSpawnAdapter` impl ExecutionAdapter;包装现 spawn_session / state.json watch / progress.jsonl tail |
-| `crates/ccteam-core/src/orchestrator.rs` | 主循环改 `Arc<dyn ExecutionAdapter>`;路径分支 `match mode { Bg => bg_adapter, TmuxInteractive => tmux_adapter, ... }` |
-| `crates/ccteam-cli/src/commands.rs` | spawn / send / pause / resume 路径改走 trait |
-| `crates/ccteam-core/tests/execution_trait_test.rs`(新)| 4 测试:trait 对象动态分发 / BgSpawnAdapter 路径全 happy path / lifecycle Close 等价旧 cancel / observe 流退出条件 |
+| `skills/ccteam/SKILL.md`(新)| ~150 行 dispatcher;前 30 行 LLM 意图分类 prompt + 后 120 行 5 sub-skill 调用模板 |
+| `skills/ccteam-creator/SKILL.md`(复活)| V0.5.0 砍掉,V0.6 重写 — auto mode 推断 + persona 预设库(详 F114)|
+| `skills/ccteam-im-setup/SKILL.md`(新)| ~200 行 onboarding dialog(详 F117)|
+| `skills/ccteam-advise/SKILL.md`(新)| ~100 行 Codex + Claude parallel advisor 模式 |
+| `crates/ccteam-cli/src/commands.rs::run_doctor` | `--install-skill all` 装 5 skill(总入口 + 4 sub);保留 single-skill flag |
 
-### 验收
+#### 验收
 
-1. `cargo test --workspace --locked --no-fail-fast` 通过数 ≥942(允许 +新增 trait 测试,**禁止减少**);失败数仅 1(已有 ccteam-web flake,**新增不允许**)
-2. clippy 0 errors + ≤18 warnings(允许减少,禁止新增)
-3. `grep -rn "Command::new(\"claude\")" crates/ccteam-core` 命中**仅在** `execution/bg.rs`,主 orchestrator 零命中
-4. `grep -rn "execution::ExecutionAdapter" crates/ ` ≥3 命中(core + cli + 测试)
-5. host probe:V0.5.1 跑过的 dex-ui workflow.yaml 在 V0.6.0 wave-1 二进制下行为完全一致(progress.jsonl event 序列 diff = 0)
+1. 用户 `cd && claude` 后第一次输入 `/ccteam "我想做个 TG 助理 bot"` → 自动路由到 `/ccteam-creator` → 启动 Pocket Assistant 配方 + 自动 IM onboarding
+2. `/ccteam "fix all TS errors"` → 自动路由 `/ccteam-team 3:executor` 立刻起 team
+3. `/ccteam "我哪些项目还活着"` → 自动路由 `/ccteam-control ls`
+4. NL 失败 fallback → "我没听懂,(a)/(b)/(c)/(d)" 4 选项;用户选 → 路由
+5. `host probe`:5 个 sub-skill 各 1 host test,intent classification accuracy ≥90%(基于 50 个 sample query)
 
-### 不在范围
+#### 不在范围
 
-- 不实现 `TmuxInteractiveAdapter`(F108)
-- 不实现 `InProcTeamAdapter`(在 F107 trait 设计完后,V0.5.0 `ccteam-team` skill 是否能 trait 化是 V0.6.1 议题,V0.6.0 不强求 — skill 是 in-Claude-session 逻辑,本来就不在 ccteam-core 里跑)
-- 不改 MCP / CLI 用户面接口(纯内部重构)
+- 不做 voice / 多模态 input(V0.7+)
+- 不做 skill 自定义注册(用户不能 `/ccteam-add-skill`,固定 5 sub)
 
 ---
 
-## F108 — `TmuxInteractiveAdapter`(模式 3 执行 runtime)
+### F114 — `ccteam-creator` 复活 + NL 自动 mode 推断 + persona 预设库
 
-### 痛点
+#### 痛点
 
-模式 3 chat bot 需要长跑 Claude session 复用 context(不复用 → 每轮重 tokenize 全历史,N 轮 5k 历史成本 O(N²),无 prompt cache 命中)。现有 `claude --bg` 是 run-to-completion,出口即死,不能多轮。
+V0.5.0 F100 把 `ccteam-creator` skill 砍掉(5→3 skill),代价是用户**没有 dialogue path 起新项目**。模式 3 chat 加入后必须有:用户说"做个 TG 助理 bot",skill 走 NL dialogue 自动:
+- 推断 mode(chat / bg / in-proc)
+- 生成 workflow.yaml(用户不可见)
+- 选 bot persona 模板(预设库挑)
+- 调 `/ccteam-im-setup`(如果是 chat)
+- 调 `ccteam init` 内部接口(daemon-internal,用户不见)
+- 落 `.claude/agents/<role>.md` agent 定义
 
-Claude Code 本身支持 `claude --resume <session-id> --input-format stream-json --output-format stream-json`,可以长跑 + stream I/O。但 ccteam 现有红线"不解析 tmux 输出"指向**不用 capture-pane**,所以要找到既能 stdin-style 控制又不 scrape pane 的路径。
+#### 需求
 
-**结论**(详 README §七 决策记录):
-- **input** 走 `tmux send-keys`(tmux pane 已有,plumbing 现成)
-- **output** 走 `~/.claude/projects/<encoded-path>/<session-id>.jsonl` tail(Anthropic 官方 session 格式,稳定可解析)
-- pane 内跑 `claude --resume <session-id>` 长跑,session-id 由 adapter 持久化
+`skills/ccteam-creator/SKILL.md`(~400 行):
 
-### 需求
+**Phase 1: Intent classification**(从用户 NL 提取):
+- task type(coding / writing / research / support / scheduling / monitoring / chat-assistant / multi-bot-team / qa-loop / ...)
+- presence(用户全程在 / 偶尔回来看 / 关上电脑跑 / IM 私聊 / IM 群)
+- timeline(一次性 / 长跑几小时 / 长跑 24/7)
 
-#### `TmuxInteractiveAdapter` 行为
+**Phase 2: Mode 推断**(规则:见 [架构 doc Mode 推断决策树](../architecture/mode-inference.md)):
+- presence = "全程在" + timeline = "一次性" → in-proc team(Solo Sidekick / Team Sprint)
+- presence = "关上电脑跑" + timeline = "长跑" → bg artifact-driven(Overnight Builder)
+- presence = "IM 私聊" → chat DM(Pocket Assistant)
+- presence = "IM 群多 bot" → chat group(IM Squad)
 
+**Phase 3: Persona 预设库匹配**(5-10 个内置 prefab):
+- 技术助手(中英 2 版本)
+- 写作助手(中英 2 版本)
+- 项目经理 / 监工
+- 客服 / 翻译
+- 学习辅导
+- 心理咨询(谨慎,默认 off)
+- 代码 critic / reviewer(自动接 Codex if available)
+- 翻译 / 摘要
+- 群组协调员
+
+每 persona = `.claude/agents/<role>.md` + `tone` / `guardrails` / `tools` frontmatter 全部预填。
+
+**Phase 4: 输出 TEAM/PROJECT PLAN**(plan-first,严格不立刻 spawn):
 ```
-spawn(role, ctx):
-  1. 决定 bot identity:slug = ctx.workflow_slug + role + bot-name
-  2. 检查 ~/.ccteam/im/<slug>/session-id:
-     - 存在 → claude --resume <id> 在 tmux pane 启动
-     - 不存在 → claude(新 session)在 tmux pane 启动,捕获新 session-id 写文件
-  3. agent_md_path 通过 Claude Code subagent resolver(项目 .claude/agents/ → ~/.claude/agents/)
-  4. 返回 SessionHandle{ mode: TmuxInteractive, identity: <pane-id>+<session-id> }
+PROJECT PLAN
+============
+Type: Pocket Assistant (private TG bot)
+Bot: @helpful_assistant(persona: 技术助手 中文版)
+Codex critic: 自动启用(检测到 codex binary + auth)
+IM:Telegram via openhuman/channels(已 onboarded:✓)
+预计 cost / day: ~$0.5 (Claude main + Codex critic ratio)
 
-send_input(handle, Input::User { content }):
-  tmux send-keys -t <pane> -- "<escape(content)>" Enter
-  (escape:换行用 send-keys Enter 分段;backtick / $ 用 -l 字面量模式)
-
-send_input(handle, Input::SlashCommand { name, args }):
-  tmux send-keys -t <pane> -- "/<name> <args>" Enter
-
-observe(handle) -> Stream<ObservedEvent>:
-  inotify watch ~/.claude/projects/<…>/<session-id>.jsonl
-  parse 增量 line(每 line 一条 Anthropic SDK event)
-  → ChatTurn { speaker: Assistant, content: ... }(filter user/system)
-  → 检测 lifecycle ack(/compact 完毕 / /new 后新 session-id 出现)
-  → 文件被 Anthropic 重命名(/new 触发)→ 重新 watch 新 session-id
-
-lifecycle(handle, op):
-  Compact -> send-keys "/compact" Enter
-  NewSession -> send-keys "/new" Enter;监 ~/.claude/projects/<…>/ 新 jsonl 出现 → 更新 session-id 持久化
-  Clear -> send-keys "/clear" Enter
-  Close -> send-keys C-c C-c + tmux kill-pane;session-id 文件保留(下次 spawn 可 resume)
-```
-
-#### workflow.yaml `mode: chat` schema(新)
-
-```yaml
-version: 0.6
-mode: chat                              # 新枚举值,触发 TmuxInteractiveAdapter
-agents:
-  - role: helpful-bot
-    bot_name: "@helpful_bot"            # IM 暴露的 handle(F109 用)
-    compact_every_turns: 50             # 累计 turn 数达到则自动 /compact
-    new_on_topic_shift: false           # 暂留 false(主题检测下版)
-    hop_limit: 3                        # bot-to-bot @ 链路上限(R6 红线)
-    model: opus-4-7                     # 同现有
-  - role: critic-bot
-    bot_name: "@critic_bot"
-    compact_every_turns: 100
-    hop_limit: 3
-im_channels:                            # F109 用
-  - kind: telegram
-    chat_id_env: TG_CHAT_ID
-    bot_token_env: TG_BOT_TOKEN
+Reply 'go' 起,或描述要改的(persona / IM platform / language)。
 ```
 
-#### session-id 失效恢复
-
-session-id 失效场景:Claude Code 升级后 session 文件格式 incompat、用户 `rm -rf ~/.claude/projects/`、磁盘 fsck 丢文件。
-
-V0.6.0 策略:**fail-open + 业务事件可见**
-- 检测 `claude --resume <id>` 退出码非 0 → adapter 启用 fresh `claude`,新 session-id 持久化
-- emit progress 事件 `chat_session_reset { bot, old_session_id, reason }`(让用户 web UI / TG 知道 bot "失忆"了)
-- **不**自动重放历史(那是 V0.6.1 议题)
+**Phase 5: On 'go' execute**:
+- 调内部 API 生成 `.ccteam/workflow.yaml`(用户不可见;`/ccteam-control show-workflow` 高级 user 可看)
+- 调 `ccteam daemon` 起 chat workflow
+- 通知 IM bridge 注册 bot
+- 回 user "好了,在 TG 找 @helpful_assistant 私聊试试"
 
 #### 文件清单
 
 | 文件 | 改动 |
 |---|---|
-| `crates/ccteam-core/src/execution/tmux_interactive.rs`(新)| `TmuxInteractiveAdapter` impl,~600 行 |
-| `crates/ccteam-core/src/execution/session_jsonl_tail.rs`(新)| inotify watch + 增量 jsonl parse;复用 V0.5.0 F92 transcript_scanner 的 mtime+length memoize 思路 |
-| `crates/ccteam-core/src/execution/send_keys.rs`(新)| tmux send-keys 安全 escape;**带 fuzzing test**(任意 unicode + ANSI 控制字符 输入不 corrupt pane)|
-| `crates/ccteam-core/src/workflow_schema.rs`(改)| 加 `mode: chat` 枚举值 + `bot_name` / `compact_every_turns` / `new_on_topic_shift` / `hop_limit` 字段;serde tagged enum 区分 artifact-driven vs agent-team vs chat |
-| `crates/ccteam-core/src/progress_event.rs`(改)| 加 4 新 event 类型:`chat_turn` / `chat_session_reset` / `chat_compact_done` / `chat_hop_escalate` |
-| `crates/ccteam-core/tests/tmux_interactive_test.rs`(新)| 8 测试:spawn 新 session / spawn resume 已存 session / send_input escape edge case / observe 流增量 / lifecycle compact / lifecycle new(session-id 更新)/ session-id 失效 fallback / fuzzing send-keys |
+| `skills/ccteam-creator/SKILL.md`(复活 + 重写)| ~400 行 |
+| `skills/ccteam-creator/personas/`(新目录)| 5-10 个 prefab persona 文件(每个含 `.claude/agents/<role>.md` 模板 + tone + guardrails)|
+| `crates/ccteam-core/src/templates/workflow_templates/`(新)| 5 个 workflow.yaml 模板(对应 5 preset)|
+| `crates/ccteam-core/src/mode_inferrer.rs`(新)| NL → mode 推断逻辑(rule-based + LLM 兜底)|
 
-### 验收
+#### 验收
 
-1. host probe:跑 chat workflow,bot 多轮 @ 后 `claude --resume` 实测 prompt cache hit ≥turn 2(从 transcript usage 字段读 cache_read_input_tokens > 0)
-2. `/compact` 触发后,后续 turn 的 input_tokens 显著下降(<前一个 turn 的 1/3,具体阈值 manual probe)
-3. session-id 失效 mock test:删 session jsonl → spawn 退化为 fresh,emit `chat_session_reset`
-4. send-keys fuzzing 200 sample 输入,无 pane corruption(pane 内 `claude` 进程仍 alive)
-5. `cargo test --workspace --locked --no-fail-fast` baseline 数字增长(预计 +10 测试)
+1. 50 个 sample NL query → mode 推断 accuracy ≥85%(host probe 验)
+2. 5 preset 各跑通 `ccteam-creator` 全 dialogue → workflow.yaml + agent.md + daemon 启动一站式完成
+3. user 看不到 yaml 字段名 / persona file 路径(技术细节藏在 skill body 内)
+4. user 可中途打断 "等等,改成中文 persona / 加个 critic" → skill 回 Phase 2 / 3 重选
 
-### 不在范围
+#### 不在范围
 
-- **跨 session memory 重建** — session-id 丢了不重放,V0.6.1 议题
-- **主题漂移检测自动 `/new`**(`new_on_topic_shift: true` 暂留 false 不实现) — V0.6.2 议题
-- **stdin pipe 替代 send-keys** — 决策选 send-keys,V0.6.x 不切
+- 不做 user-defined 自定义 persona(用户写 markdown)— V0.7+
+- 不做 persona marketplace 拉取(V0.8+)
 
 ---
 
-## F109 — `ccteam-im-bridge` crate(模式 3 IM 触发源,Telegram 起步)
+### F117 — `/ccteam-im-setup` 一次性 IM token onboarding
 
-### 痛点
+#### 痛点
 
-模式 3 的触发源不是 ArtifactWatcher(文件触发),而是 IM webhook(`@bot_name "..."` 来自 TG / Slack)。这是一个独立的 trigger 通道,职责清晰:**把 IM 消息翻译成 `ExecutionAdapter::send_input` 调用,并把 `observe()` 出来的 ChatTurn 翻译回 IM post**。
+PM PM3 量化:模式 3 hello world 14 步,其中 5 个高危卡点 — TG @BotFather 注册 + 拿 chat_id + 设 env var 是前 3 个。普通用户 80% 在这里放弃。
 
-放新 crate 而不是塞 ccteam-core 的理由:
-- IM SDK(`teloxide` / TG bot crate)是大依赖,不该污染 core
-- 多 IM 平台扩展点天然走插件式 crate(`ccteam-im-bridge-telegram` / `ccteam-im-bridge-slack` / ...)
-- 独立 crate 边界 + `cargo tree` 测试守住:core 永不依赖 IM SDK
+需要:**一个 skill,user 在 Claude session 内 `/ccteam-im-setup`,5 句话内拿到 token + 验证 + 永久绑定**。后续任何 chat workflow 自动用 token,user 不再碰。
 
-### 需求
+#### 需求
 
-#### Crate 结构
+`skills/ccteam-im-setup/SKILL.md`(~200 行):
 
+**Step 1: Platform 选择**
 ```
-crates/ccteam-im-bridge/
-├── Cargo.toml                       # 依赖:ccteam-core(读 workflow.yaml),teloxide(TG)
-├── src/
-│   ├── lib.rs                       # 总入口 trait ImBridge
-│   ├── telegram.rs                  # TgBridge impl
-│   ├── router.rs                    # bot-to-bot @ 路由(本 crate 内,不入 core)
-│   ├── hop_tracker.rs               # R6 hop_limit 计数 + escalate
-│   └── session_link.rs              # IM user ↔ bot session-id 映射
-└── tests/...
+$ /ccteam-im-setup
+> 你要绑定哪个 IM 平台?
+  1. Telegram
+  2. Slack
+  3. Discord
+  4. (V0.7) Lark / DingTalk / WeChat
 ```
 
-#### trait `ImBridge`
+**Step 2: 平台特定 onboarding**(平台脚本化,自动化能省的全自动):
 
-```rust
-pub trait ImBridge: Send + Sync {
-    /// 启动 webhook / long-poll;阻塞循环
-    async fn run(&self, ctx: BridgeContext) -> Result<()>;
-}
+TG path:
+- 系统打印浏览器可点开 URL:`https://t.me/BotFather`
+- 系统说"打开后发 `/newbot`,起个名字,@BotFather 会给你一段 token"
+- user 粘贴 token → skill 验证 token(`getMe` API call)→ 成功显示 bot username
+- skill 提示"现在用手机 TG app 私聊一下这个 bot 发 'hello' — 我帮你拿 chat_id"
+- skill long-poll Telegram getUpdates → 捕获 chat_id → 验证 → 落地
 
-pub struct BridgeContext {
-    pub adapter: Arc<dyn ExecutionAdapter>,            // F107 trait
-    pub workflow_slug: String,
-    pub bot_roster: Vec<BotConfig>,                    // workflow.yaml `agents:` 解析
-    pub progress_writer: ProgressWriter,               // emit chat_* event
-}
+Slack path:用 https://api.slack.com/apps + bot token + Socket Mode 验证流(skill 文档化每一步)
+
+**Step 3: token 持久化**
+- 写 `~/.ccteam/im/credentials.json` 0600 权限
+- **不写 env var**(用户不学 .bashrc)
+- **不入 workflow.yaml**(R8 红线 + 安全)
+
+**Step 4: backup transport 切换**(用户 directive)
+- 默认 transport = `openhuman` (统一路径)
+- 用户可 `/ccteam-im-setup --transport official-telegram` 切官方 Anthropic MCP 路径(用户偏好"全 Anthropic 栈"或 openhuman bug)
+- 切换后状态写 `~/.ccteam/im/transport.toml`,后续所有 chat workflow 使用新 transport
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `skills/ccteam-im-setup/SKILL.md`(新)| ~200 行 |
+| `crates/ccteam-imd/src/onboarding.rs`(新)| getMe + getUpdates auto-detect chat_id |
+| `crates/ccteam-imd/src/credentials.rs`(新)| `~/.ccteam/im/credentials.json` 0600 读写 |
+
+#### 验收
+
+1. 新用户 TG path 端到端:3-5 分钟拿到 bot 第一条回话(包含 BotFather 跳转 + 测试 chat_id)
+2. token 落地 `~/.ccteam/im/credentials.json` 0600;`ls -la` 显示正确权限
+3. backup transport 切换:`/ccteam-im-setup --transport official-telegram` 后,下一个 chat workflow 起 bot 走官方 `claude --channels plugin:telegram@claude-plugins-official`
+4. 出错友好提示:`token` 错 / `chat_id` 拿不到 / network → 中文 / 英文 解释 + 修复指南
+5. user 不学 env var / BotFather command 名 / chat_id 格式 — skill 全程引导
+
+#### 不在范围
+
+- 不做 OAuth flow(只 token-based)
+- 不做 webhook 公网 URL 自动 setup(用户自行 ngrok / cloudflared,文档教)
+- 不做 multi-account(一 bot per platform)
+
+---
+
+### F111 — MCP 工具粒度配置 + 项目级 `.mcp.json`(改进版,F110 取消)
+
+#### 痛点
+
+V0.6.0 后 MCP 工具总数 ≥22(17 现 + 5 chat + Codex 集成扩);默认全发到每 session tool list,context 预算占大。
+
+但 V0.6.0 **取消** 上版 F110 ccteam → ct rename(理由详 README §4.5)。**保留** F110 的"子前缀分组"+ F111 的 disable env + 项目级 `.mcp.json`。
+
+#### 需求
+
+**A. MCP 工具子前缀(保留 F110 中此部分)**
+
+```
+mcp__ccteam__workflow_ls
+mcp__ccteam__workflow_show
+mcp__ccteam__workflow_send_to_session
+mcp__ccteam__chat_send_input
+mcp__ccteam__chat_lifecycle
+...
 ```
 
-#### TG 实现关键路径
+server name **仍是** `ccteam`(不动 V0.5 用户肌肉记忆);子前缀让用户在 `/mcp` 列表一眼看清归属(workflow / chat / advise 等)。
 
-```
-TG @helpful_bot "explain X":
-  1. teloxide 收 message,parse @mention
-  2. session_link.lookup(tg_chat_id, "@helpful_bot") -> bot SessionHandle
-     - 不存在 → adapter.spawn(role="helpful-bot", ctx) → 存映射
-  3. adapter.send_input(handle, Input::User { content: "explain X" })
-  4. await adapter.observe(handle).take_while(|e| !is_turn_end(e))
-  5. assistant content → teloxide.send_message(tg_chat_id, content)
-  6. progress_writer.emit(ChatTurn { bot, ts, ... })
+**B. `CCTEAM_DISABLE_TOOLS` 改 group-name 枚举**(researcher R4#5)
 
-assistant content 含 "@critic_bot 看下":
-  1. router.parse_mentions(content) -> ["@critic_bot"]
-  2. hop_tracker.check(tg_chat_id, current_chain) -> ok | escalate
-     - escalate → progress_writer.emit(ChatHopEscalate { chain, limit })
-       + teloxide 回 "@user 该话题 bot 间已链 3 轮,人工介入"
-  3. ok → 递归:adapter.send_input(critic_handle, Input::User {..})
-  4. critic 输出 → 同样 teloxide post 到 TG(以 critic_bot 身份)
-```
-
-#### CLI 集成
+弃 glob 模式 `chat_*,screenshot`。改 enum group:
 
 ```bash
-ccteam start <chat-slug>              # 现有 daemon 起;chat mode 检测后额外起 im-bridge
-                                       # bridge 进程是 daemon 的 child,daemon stop 时 graceful 关
-ccteam internal im-bridge <slug>      # 单独起 bridge(调试用,daemon 不启)
+export CCTEAM_DISABLE_TOOLS="chat,screenshot,parallelism"
 ```
 
-实施:`ccteam-cli::start` 检测 workflow.yaml `mode: chat` → 注册 `ccteam-core` daemon hook:启动后 spawn `ccteam-im-bridge` 进程 + tokio task。bridge 通过 `ExecutionAdapter` trait 操作 adapter,**不直接 import `TmuxInteractiveAdapter`**(松耦合)。
+支持 group:`workflow` / `chat` / `advise` / `screenshot` / `parallelism` / `admin`。`DISABLE_TOOLS_GROUP_MAP: HashMap<&str, ToolCategory>` 在 ccteam-cli 内维护。
 
-#### env / secrets
+**C. 项目级 `.mcp.json` 自动生成**
 
-TG bot token / chat ID 不入 `workflow.yaml`(R8 红线 + 安全),只声明 env 变量名(`bot_token_env: TG_BOT_TOKEN`),token 在 `ccteam start` 启动环境拿。
-
-#### 文件清单
-
-| 文件 | 改动 |
-|---|---|
-| `crates/ccteam-im-bridge/Cargo.toml`(新)| 依赖 ccteam-core(workflow.yaml 解析)+ teloxide 0.13(只在 telegram feature 下)+ tokio + anyhow |
-| `crates/ccteam-im-bridge/src/lib.rs` 等(新)| 上述结构 |
-| `crates/ccteam-cli/src/commands.rs::start` | 检测 `mode: chat` → spawn bridge |
-| `crates/ccteam-cli/src/main.rs::internal` | 加 `im-bridge <slug>` 子命令 |
-| `Cargo.toml`(workspace 根)| 加 member `crates/ccteam-im-bridge` |
-| `crates/ccteam-im-bridge/tests/router_test.rs`(新)| mention parse / hop_limit / escalate 触发 |
-| `crates/ccteam-im-bridge/tests/dep_graph_test.rs`(新)| `cargo tree -p ccteam-core` 不能包含 teloxide(松耦合红线)|
-
-### 验收
-
-1. host probe(需 TG 账号):TG 群里 `@helpful_bot 你好` → bot 回应 → emit `chat_turn` event;`@helpful_bot @critic_bot "review my plan"` → 双 bot 链式回应,emit 2 个 `chat_turn`
-2. hop_limit 测试:mock bot-to-bot 链 4 轮 → 第 4 轮 escalate,TG 收人工介入消息
-3. session_link 持久化:bridge 重启后,同一 TG user 继续 @ 同一 bot,bot 仍是同 session-id(prompt cache 仍命中)
-4. dep_graph_test 通过:`ccteam-core` 不引 teloxide
-5. `ccteam start <chat-slug>` 不阻塞 mode 2 现有 workflow(混合 mode 项目 — 一个 daemon 同时跑 artifact + chat;V0.6.0 不要求,但不能 break)
-
-### 不在范围
-
-- Slack / Discord / IRC bridge — V0.7.x;V0.6.0 只 trait + TG 一个实现,trait 必须足够泛化
-- 富媒体(图片 / 文件 / voice)— TG 消息只 text + reply markup,V0.6.x 不扩
-- DM(私聊)scope — V0.6.0 只支持 group chat;DM 是 V0.6.1
-- IM webhook reverse proxy / public URL 自动注册 — 用户自行 ngrok / cloudflared
-
----
-
-## F110 — MCP namespace `ccteam` → `ct` + 子前缀工具命名
-
-### 痛点
-
-现有 17 MCP 工具命名 `mcp__ccteam__<verb>`,prefix `ccteam` 占 6 字符 / `mcp__ccteam__` 占 11 字符。每次 Claude session 启动 / tool list 拉取 / Claude 调用 / 错误返回都吃这个 prefix。考虑 tool list 在 session 启动 prompt 里出现一次(~17 行 × 字符数)+ 每次 tool call assistant message 出现一次(每次 ~30 token),长期摊销有意义。
-
-OMC 用单字母 `t` 作 namespace 已验证可行。ccteam 选 2 字母 `ct`(safer than `t`, 避撞)。
-
-同时模式 3 加 6+ 新工具(send_chat_input / chat_lifecycle / observe_session / bot_roster 等),全部继续平铺 + 单一前缀会让 17 → 23 工具列表更难定位。**单 server + 子前缀**(`workflow_ls` / `chat_send_input`)更清晰。
-
-### 需求
-
-#### 新命名(全表)
-
-| 现 | 新 |
-|---|---|
-| `mcp__ccteam__ls` | `mcp__ct__workflow_ls` |
-| `mcp__ccteam__show` | `mcp__ct__workflow_show` |
-| `mcp__ccteam__peek` | `mcp__ct__workflow_peek` |
-| `mcp__ccteam__progress` | `mcp__ct__workflow_progress` |
-| `mcp__ccteam__new` | `mcp__ct__workflow_new` |
-| `mcp__ccteam__pause` | `mcp__ct__workflow_pause` |
-| `mcp__ccteam__resume` | `mcp__ct__workflow_resume` |
-| `mcp__ccteam__send_to_session` | `mcp__ct__workflow_send_to_session` |
-| `mcp__ccteam__inject_decision` | `mcp__ct__workflow_inject_decision` |
-| `mcp__ccteam__screenshot` | `mcp__ct__workflow_screenshot` |
-| `mcp__ccteam__spawn_agent` | `mcp__ct__workflow_spawn_agent` |
-| `mcp__ccteam__stop_agent` | `mcp__ct__workflow_stop_agent` |
-| `mcp__ccteam__observe_agents` | `mcp__ct__workflow_observe_agents` |
-| `mcp__ccteam__signal` | `mcp__ct__workflow_signal` |
-| `mcp__ccteam__set_parallelism` | `mcp__ct__workflow_set_parallelism` |
-| `mcp__ccteam__trigger_gate` | `mcp__ct__workflow_trigger_gate` |
-| `mcp__ccteam__get_artifact_summary` | `mcp__ct__workflow_get_artifact_summary` |
-| **(新)** | `mcp__ct__chat_send_input` |
-| **(新)** | `mcp__ct__chat_lifecycle`(compact / new / clear / close)|
-| **(新)** | `mcp__ct__chat_observe_session`(返当前 jsonl tail snapshot)|
-| **(新)** | `mcp__ct__chat_bot_roster`(列当前 chat workflow 所有 bot + 状态)|
-| **(新)** | `mcp__ct__chat_session_reset_force`(管理员强制 `/new`,emit reset 事件)|
-
-#### Breaking 策略
-
-CLAUDE.md §五:no backwards-compat shim。**直接 rename**,不留 `mcp__ccteam__*` alias 一版。同步改:
-1. `ccteam-control` skill `SKILL.md` capability index(全 17 行替换 + 加 5 新行)
-2. meta-agent prompt 全文 replace
-3. `crates/ccteam-cli/src/mcp_serve.rs` + `mcp_workflow_tools.rs` 注册名字
-4. test fixture / snapshot 同步
-
-升级体验:用户跑 `ccteam doctor --install-mcp` 重新写 `~/.claude.json` + `/reload-mcp`。旧 session 的 tool call 用错名字 → MCP server 返 method-not-found,Claude 自动重试新名(LLM 看到错误能改)。损失低。
-
-#### 文件清单
-
-| 文件 | 改动 |
-|---|---|
-| `crates/ccteam-cli/src/mcp_serve.rs` | server name `"ccteam"` → `"ct"`;tool registration 加 `workflow_` 前缀 |
-| `crates/ccteam-cli/src/mcp_workflow_tools.rs` | 同上,7 工具加前缀 |
-| `crates/ccteam-cli/src/mcp_chat_tools.rs`(新)| 5 chat 工具注册(F108 + F109 业务调用)|
-| `skills/ccteam-control/SKILL.md` | capability index 表整体重写 |
-| `crates/ccteam-cli/src/commands.rs::install_meta_agent` | meta-agent prompt template 全文 replace |
-| `crates/ccteam-cli/tests/mcp_protocol_test.rs`(改名 / 新)| tool name 全更新 |
-
-### 验收
-
-1. `ccteam doctor --install-mcp` 写入的 `~/.claude.json` 含 `"mcpServers": { "ct": {...} }`(无 `"ccteam"` 键)
-2. `mcp__ct__workflow_ls` 等所有工具在 `/mcp` 列表里出现,名字正确
-3. `grep -rn "mcp__ccteam__" crates/ skills/ docs/v0-5-0/ docs/v0-5-1/` 命中**仅**老版本归档 dir(EOL 不动);`crates/` 和 `skills/` 命中 0
-4. host probe:V0.5.1 跑过的 meta-agent 工作流(read project,inject_decision)在 V0.6.0 全部用新名字跑通
-
-### 不在范围
-
-- 不留 `ccteam` server 别名(breaking is OK)
-- 不动 OMC / claude-mem 等外部 MCP 命名
-
----
-
-## F111 — MCP 工具粒度配置(`CCTEAM_DISABLE_TOOLS` + 项目级 `.mcp.json`)
-
-### 痛点
-
-V0.6.0 后 MCP 工具总数 22(17 现 + 5 chat),全部发布到每个 Claude session 的 tool list:
-- 每 session 启动 prompt 含 22 工具 schema(每个 ~50 token),~1100 token 固定开销
-- 用户只用模式 2 → chat_* 5 工具白占空间;反之亦然
-- 一些工具(`workflow_screenshot` 渲染图片成本高,`workflow_set_parallelism` 危险操作)用户想禁
-
-OMC `OMC_DISABLE_TOOLS` env-driven 提供了精确控制范本。
-
-同时:现 MCP 注册路径只 `~/.claude.json`(user-global,所有 Claude session 都看到 ccteam MCP)。项目级 `.mcp.json` 更可移植:`git clone` 后任何 Claude session 在该项目根自动拿到 ccteam MCP,无需 doctor 安装。
-
-### 需求
-
-#### `CCTEAM_DISABLE_TOOLS` env
-
-```bash
-# 一律 glob 匹配 tool short name(不含 mcp__ct__ 前缀)
-export CCTEAM_DISABLE_TOOLS="chat_*"                     # 用户只跑模式 2
-export CCTEAM_DISABLE_TOOLS="workflow_screenshot,workflow_set_parallelism"
-export CCTEAM_DISABLE_TOOLS="chat_*,workflow_screenshot"  # 组合
-```
-
-`ccteam mcp-serve` 启动时读环境变量,过滤 `tools/list` 返回。被禁工具被 call 时返 method-not-found。
-
-#### 项目级 `.mcp.json` 自动生成
-
-`ccteam init` 落项目 `.mcp.json`:
+`ccteam-creator` skill `Phase 5: execute` 落项目 `.mcp.json`(merge 已有 `.mcp.json` 而非覆盖):
 
 ```json
 {
   "mcpServers": {
-    "ct": {
+    "ccteam": {
       "command": "ccteam",
       "args": ["mcp-serve"],
       "env": {
-        "CCTEAM_PROJECT_ROOT": "${workspaceFolder}",
-        "CCTEAM_DISABLE_TOOLS": ""
+        "CCTEAM_PROJECT_ROOT": "${workspaceFolder}"
       }
     }
   }
 }
 ```
 
-Claude Code 在项目根启动时自动 merge `.mcp.json` + `~/.claude.json`(项目级覆盖 user-global)。
-
-`ccteam doctor --install-mcp` 仍写 `~/.claude.json`(保 user-global fallback,任意 cwd 都能用);但**优先**推荐项目级。doctor 提示语调整:"推荐 `ccteam init` 落项目 `.mcp.json`,本命令是 user-global 后备。"
-
-#### `.mcp.json` 已存在的合并
-
-`ccteam init` 检测 `.mcp.json` 已存在:
-- 含 `ct` 键 → 跳过,告知用户已存在
-- 不含 `ct` 键 → merge `ct` 键进去,保留其他 MCP server 不动
-- JSON 损坏 → 报错 abort(不覆盖用户文件)
+`ccteam doctor --install-mcp` 保留(`~/.claude.json` user-global fallback)。
 
 #### 文件清单
 
 | 文件 | 改动 |
 |---|---|
-| `crates/ccteam-cli/src/mcp_serve.rs` | 启动读 `CCTEAM_DISABLE_TOOLS`,glob 过滤 `tools/list` + `tools/call` |
-| `crates/ccteam-cli/src/commands.rs::init` | 调 `write_project_mcp_json(<project_root>)`,merge 逻辑 |
-| `crates/ccteam-cli/src/commands.rs::run_doctor` | `--install-mcp` 输出加项目级推荐 |
-| `crates/ccteam-cli/tests/mcp_disable_test.rs`(新)| 5 测试:single tool disable / glob disable / disable 全部 chat_* / 被禁工具 call 返错 / 无 env 行为不变 |
-| `crates/ccteam-cli/tests/project_mcp_json_test.rs`(新)| 4 测试:全新 .mcp.json / 合并已有 / ct 键已存在跳过 / 损坏 JSON abort |
+| `crates/ccteam-cli/src/mcp_serve.rs` | tool registration 加子前缀;读 `CCTEAM_DISABLE_TOOLS` group enum |
+| `crates/ccteam-cli/src/mcp_chat_tools.rs`(新)| chat_* 5 工具注册 |
+| `crates/ccteam-cli/src/mcp_advise_tools.rs`(新)| advise_* 2 工具(F112)|
+| `crates/ccteam-core/src/templates/project_mcp_json.rs`(新)| `.mcp.json` 生成 + merge 逻辑 |
 
-### 验收
+#### 验收
 
-1. `CCTEAM_DISABLE_TOOLS=chat_* ccteam mcp-serve` 启动后,`tools/list` 不含 chat_* 5 工具
-2. `ccteam init` 在空目录落 `.mcp.json`,内容含 `ct` server 注册
-3. `ccteam init` 在已有 `.mcp.json`(含其他 server)的目录运行,merge 后其他 server 保留
-4. host probe:VS Code Claude Code extension 在 `ccteam init` 后的项目里启动,`/mcp` 显示 `ct` 已连接(无需 `--install-mcp`)
-5. 同一 user 同时用 `~/.claude.json` 全局 ct + 项目 `.mcp.json` ct,无冲突(Claude Code 项目级覆盖)
+1. `ccteam` server name 不变,V0.5 用户配置零 break
+2. `mcp__ccteam__workflow_ls` `mcp__ccteam__chat_send_input` 等所有工具按子前缀出现
+3. `CCTEAM_DISABLE_TOOLS=chat,screenshot` → tool list 仅含 workflow_* + advise_*
+4. `ccteam-creator` 起新 chat workflow → 项目目录有 `.mcp.json` 含 ccteam server 注册
 
-### 不在范围
+#### 不在范围
 
-- 不实现工具类别分组(只 glob)
-- 不做 `.mcp.json` GUI 编辑器
-- 不替代 doctor --install-mcp(保留作 user-global 入口)
+- 不做工具类别 GUI 编辑器
+- 不取代 `doctor --install-mcp`(保留作 user-global fallback)
 
 ---
 
-## 文档影响清单
+## EPIC B — bot 在 IM 里像真人助理
+
+**Epic 验收**:用户在 TG bot 跑通 hello world 后,**连续 3 天的高频日常使用**中体验"像真人"(对比 "AI 客服式僵硬"):
+- DM + group + bot-to-bot @ 完整 IM Squad
+- 错误回流 IM(bot 自己开口说错误,不让用户去翻 log)
+- session 失效后 last-N turn 回放(bot 不"失忆灾难")
+- rich media(图片 / 文件)传递
+- Codex 自动当 critic / second-opinion(用户不感知)
+
+下属 finding:F107 / F108 / F112 / F115 / F116 / F118 / F109(Epic B 部分)。
+
+---
+
+### F107 — 扩展 `HarnessAdapter` 对齐 Codex `ThreadManager`(架构基石,Wave 1 完成)
+
+#### 痛点
+
+V0.6.0 PRD 上版提"新建 `ExecutionAdapter` trait",但 `crates/ccteam-core/src/harness.rs:75` V0.4.0 F61/F62 已落 `HarnessAdapter` trait + `Executor::{Claude, Codex}` enum + orchestrator HashMap dispatch。**新建 trait = 重复抽象**。
+
+同时:Codex 已经把"长跑 multi-agent"协议做完(`ThreadManager::{submit, next_event}` + `ThreadEvent` enum;`AgentPath` 层次树;`InterAgentCommunication { trigger_turn: bool }` 语义)。ccteam V0.6.0 应**对齐**而非自创。
+
+#### 需求
+
+**A. 扩展现有 `HarnessAdapter` trait**(5 方法,对齐 Codex `ThreadManager`):
+
+```rust
+// crates/ccteam-core/src/harness.rs(扩展)
+pub trait HarnessAdapter: Send + Sync {
+    /// thread = 一次会话生命周期(bg one-shot 也是一 thread,只跑一 turn)
+    async fn start_thread(&self, spec: &AgentSpec, ctx: &SpawnCtx) -> Result<ThreadHandle>;
+
+    /// 在已存 thread 上启动一个 turn(给 user input / artifact / system msg)
+    async fn submit_turn(&self, h: &ThreadHandle, input: TurnInput) -> Result<TurnId>;
+
+    /// 订阅 thread 上所有 event 流(turn boundaries + items)
+    fn events(&self, h: &ThreadHandle) -> BoxStream<'static, ThreadEvent>;
+
+    /// 恢复已存 thread(session-id 持久化路径)
+    async fn resume_thread(&self, persistent_id: &str) -> Result<ThreadHandle>;
+
+    /// 终结 thread
+    async fn close_thread(&self, h: &ThreadHandle) -> Result<()>;
+}
+
+pub enum TurnInput {
+    UserText(String),
+    Artifact(PathBuf),             // mode 2 inbox 文件
+    SystemDirective(String),       // /compact /new /clear 退化为特殊 turn
+    Image(PathBuf),                // rich media(Epic B)
+    ToolResult { ... },            // external resolver 回 agent
+}
+
+pub enum ThreadEvent {
+    ThreadStarted { thread_id: String },
+    TurnStarted { turn_id: String },
+    TurnCompleted { turn_id: String, usage: UnifiedTokenUsage },
+    TurnFailed { turn_id: String, err: ThreadErrorEvent },
+    ItemStarted { item: ThreadItem },
+    ItemUpdated { item: ThreadItem },
+    ItemCompleted { item: ThreadItem },
+    Error(ThreadErrorEvent),
+}
+
+pub struct SessionHandle {
+    pub vendor: AgentVendor,        // Claude | Codex
+    pub mode: ExecutionMode,        // InProc | Bg | Chat
+    pub identity: String,
+}
+
+pub enum AgentVendor { Claude, Codex }
+pub enum ExecutionMode { InProc, Bg, Chat }
+```
+
+**B. 现有 Claude `BgSpawner` 改造为 `ClaudeBgAdapter` impl trait**(零行为变化,baseline 942/1 持平)。
+
+**C. 现有 Codex tmux 路径(若存在,V0.4.0 F62)改造为 `CodexExecAdapter` impl trait**;模式 3 Codex(`CodexAppServerAdapter`)推 Wave 3。
+
+**D. `UnifiedTokenUsage` 收 vendor 差异**:
+
+```rust
+pub struct UnifiedTokenUsage {
+    pub input_tokens: u64,
+    pub cached_input_tokens: u64,       // both vendors
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: Option<u64>,   // Anthropic 1h ephemeral cache 写入
+    pub reasoning_output_tokens: Option<u64>,        // Codex o-series CoT
+}
+```
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/harness.rs` | 扩展 trait 加 5 方法 + 类型 |
+| `crates/ccteam-core/src/execution/claude_bg.rs`(新,迁移自 spawn.rs)| `ClaudeBgAdapter` impl |
+| `crates/ccteam-core/src/execution/codex_exec.rs`(新)| `CodexExecAdapter` impl(走 `codex exec --json`) |
+| `crates/ccteam-core/src/orchestrator.rs` | trait 主循环改 ThreadHandle / TurnInput / ThreadEvent |
+| `crates/ccteam-cost/src/lib.rs`(新或重构 `cost_summary.rs`)| `UnifiedTokenUsage` + 双 pricing table |
+| `crates/ccteam-cost/pricing/anthropic.toml`(新)| Anthropic 定价 |
+| `crates/ccteam-cost/pricing/openai.toml`(新)| OpenAI 定价 |
+| `crates/ccteam-core/tests/harness_trait_test.rs`(扩)| 4-6 trait 行为测试 |
+
+#### 验收
+
+1. `cargo test --workspace`: ≥942 通过(baseline 持平,允许 +新 trait 测试)
+2. `grep -rn "trait HarnessAdapter" crates/ccteam-core/src/harness.rs` ≥1(扩展不新建)
+3. `grep -rn "trait ExecutionAdapter" crates/` 0 命中(不新建 trait)
+4. host probe:V0.5.1 跑过的 dex-ui workflow 在 V0.6.0 wave-1 zero behavior change(progress.jsonl event sequence diff = 0)
+5. cost 计算双 vendor:Claude + Codex 同 workflow 跑,`progress.jsonl::agent_done.cost_usd` 各自从对应 pricing table 算 ±5% 准确
+
+#### 不在范围
+
+- 不实现 `ClaudeStreamJsonAdapter`(F108) / `CodexAppServerAdapter`(F112)— Wave 2/3
+- 不改 MCP / CLI 用户面接口(纯内部重构)
+
+---
+
+### F108 — 模式 3 走 Agent SDK / `claude -p --resume` + JSON-mailbox-trigger(弃 tmux send-keys)
+
+#### 痛点
+
+V0.6.0 PRD 上版 F108 用 tmux send-keys + session jsonl tail 实现模式 3:
+- input 面 send-keys 喂 TUI long-running `claude` — **未文档化**,cc-expert WebFetch 验全 6 篇 Claude Code 官方文档零命中
+- output 面 `~/.claude/projects/<...>/<sid>.jsonl` — **未文档化**(Anthropic 内部 logging 文件)
+- `/compact /new /clear` 副作用监听 — 无 stable contract
+
+3 方独立给出 **"路径错误,改 Agent SDK / `claude -p --resume`"** 建议:cc-expert WebFetch + architect "internal-not-API" + researcher OMC `tmux-comm.ts` mailbox-trigger 模式。
+
+#### 需求
+
+**A. 模式 3 input/output 平面切到 Anthropic 官方文档化路径**:
+
+```
+input  = stdin pipe + `claude -p --resume <sid> --input-format stream-json`
+         (Anthropic Agent SDK + cli-reference 全文档化)
+output = stream-json events 流(stream_event / system/init / system/api_retry 全官方 schema)
+```
+
+**B. JSON-mailbox-trigger 模式**(researcher R4#1,OMC `tmux-comm.ts` lift):
+
+stdin pipe 直接传 user content 仍有 quoting / escape 边界(尤其 multi-line / code block / unicode emoji)。借鉴 OMC:
+
+```
+1. ccteam-imd 收到 IM 消息:
+2. 写文件 <project>/.ccteam/im/<bot>/inbox/msg-<ts>-<seq>.md(完整 user content)
+3. stdin 给 claude 进程发短 trigger:"read mailbox: msg-<ts>-<seq>"
+4. claude 在 turn 内调内置 Read 工具读文件,**避免 stdin escape 雷区**
+```
+
+这样 user content 走文件传(0 escape 问题),trigger 走 stdin(短,确定性强)。**Fuzz test 范围缩小 90%**。
+
+**C. ccteam-owned `<project>/.ccteam/chat/<bot>/turns.jsonl` 作 conversation SoT**(architect A5#5):
+
+不依赖 `~/.claude/projects/<...>/<sid>.jsonl`(Anthropic 内部)。ccteam 自己写一份 conversation 历史 jsonl,每 turn 一行:
+
+```jsonl
+{"turn_id":"...","ts":"...","user":"...","assistant":"...","usage":{...},"tool_calls":[...],"vendor":"claude"}
+```
+
+session-id 失效 / Anthropic 改格式 / 磁盘 fsck 丢文件 → 从 `turns.jsonl` 重建 conversation(F118 详),**不再是失忆灾难**。
+
+**D. `ClaudeStreamJsonAdapter` impl `HarnessAdapter` trait**:
+
+```rust
+// crates/ccteam-core/src/execution/claude_stream_json.rs
+impl HarnessAdapter for ClaudeStreamJsonAdapter {
+    async fn start_thread(&self, spec, ctx) -> Result<ThreadHandle> {
+        // spawn `claude -p --resume <sid?> --input-format stream-json --output-format stream-json`
+        // stdin pipe + stdout/stderr pipe
+        // 返回 SessionHandle { vendor: Claude, mode: Chat, identity: pid+sid }
+    }
+
+    async fn submit_turn(&self, h, input) -> Result<TurnId> {
+        let mailbox_path = write_to_mailbox(&h, &input)?;
+        let trigger = format!("read mailbox: {}", mailbox_path.file_name());
+        self.send_stdin_line(h, &trigger).await?;
+        Ok(TurnId::new())
+    }
+
+    fn events(&self, h) -> BoxStream<'static, ThreadEvent> {
+        // tail stdout stream-json events,翻译成 ThreadEvent
+        // 同时 append to <project>/.ccteam/chat/<bot>/turns.jsonl
+    }
+
+    async fn close_thread(&self, h) -> Result<()> {
+        self.send_stdin_eof(h).await?;
+        // 进程退出;session-id 写持久化 ~/.ccteam/im/<bot>/session-id
+    }
+}
+```
+
+#### `workflow.yaml mode: chat` schema(收紧版,藏字段)
+
+```yaml
+version: 0.6
+mode: chat
+agents:
+  - role: helpful-bot
+    # bot_name, compact_every_turns, hop_limit 全部 Rust default,user 不见
+```
+
+所有 advanced 字段 `#[serde(default)]`;`ccteam-creator` skill 自动写,用户从不 vim。
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/execution/claude_stream_json.rs`(新)| ~400 行(替代上版 1100 行的 tmux_interactive.rs) |
+| `crates/ccteam-core/src/execution/mailbox.rs`(新)| JSON-mailbox-trigger 读写 |
+| `crates/ccteam-core/src/execution/turns_jsonl.rs`(新)| ccteam-owned chat history SoT |
+| `crates/ccteam-core/src/workflow_schema.rs` | `mode: chat` schema 字段全 `serde(default)` 收紧 |
+| `crates/ccteam-core/src/progress_event.rs` | 加 4 chat_* event 类型(turn / reset / compact_done / hop_escalate)|
+| `crates/ccteam-core/tests/claude_stream_json_test.rs`(新)| 6 测试 |
+
+#### 验收
+
+1. host probe:多轮 chat session,turn 2 起 prompt cache hit(transcript `cache_read_input_tokens > 0`)
+2. `/compact` 触发后,后续 turn input_tokens 显著下降 < 前 turn 1/3
+3. session-id 失效 mock test:删 Anthropic `~/.claude/projects/...` → 从 `turns.jsonl` 重建 conversation,无丢失
+4. JSON-mailbox-trigger:200 sample unicode / emoji / multi-line / code-block input,0 pane corruption / 0 escape error
+5. `cargo test`: baseline +6 通过
+
+#### 不在范围
+
+- 模式 3 Codex 路径(`CodexAppServerAdapter`)— F112 Wave 3
+- bot-to-bot @ 链路细节 — F109 详
+
+---
+
+### F109 — IM bridge 统一 `openhuman/channels` + `ccteam-imd` 独立 daemon(用户 directive 不造轮子)
+
+#### 痛点
+
+V0.6.0 PRD 上版 F109 自造 `ccteam-im-bridge` crate(tokio task + teloxide TG 实现 + Slack/Discord 留 trait 扩展点)— 约 1000 行 Rust。用户 directive:**不造轮子**;同时 architect / researcher 共识:im-bridge 应该是独立 supervisor daemon(借 OMC `reply-listener.ts` 模式)而非 tokio task。
+
+#### 需求
+
+**A. 统一 transport = `openhuman/channels` Rust crate**
+
+`openhuman/channels` 已实现 14+ IM 平台(traits.rs:5-60 `Channel` + `SendMessage` + `ChannelMessage` 抽象):
+- V0.6.0 启用 feature:`telegram` / `slack` / `discord` / `email`
+- V0.7 启用 feature:`lark` / `dingtalk` / `qq` / `wechat`(灰)/ `signal` / `imessage` / `matrix` / `whatsapp` / `irc` / `mattermost`
+
+实施:`crates/ccteam-imd/Cargo.toml` 引 `openhuman` 作 dep + feature gate;0 自己写 IM transport 代码。
+
+**B. `ccteam-imd` 独立 supervisor daemon binary**(borrowed OMC `reply-listener.ts` 模式)
+
+```
+crates/ccteam-imd/
+├── Cargo.toml                        # deps: openhuman/channels, ccteam-core (trait only)
+├── src/
+│   ├── main.rs                       # daemon 入口
+│   ├── supervisor.rs                 # per-bot child process supervisor
+│   ├── inbound.rs                    # openhuman::Channel inbound → HarnessAdapter::submit_turn
+│   ├── outbound.rs                   # ThreadEvent → openhuman::Channel send_message
+│   ├── router.rs                     # bot-to-bot @ routing
+│   ├── hop_tracker.rs                # 借 Codex AgentPath 模式
+│   ├── nl_admin.rs                   # @ccteam <NL admin> → MCP tool call
+│   ├── credentials.rs                # ~/.ccteam/im/credentials.json 0600 读写
+│   ├── sanitize.rs                   # OMC reply-listener 两层 sanitize(backtick/$()/${}/control/bidi)
+│   ├── rate_limit.rs                 # per-user token bucket
+│   └── acl.rs                        # workflow.yaml im_acl 允许列表
+├── systemd/ccteam-imd.service        # Linux systemd unit
+└── tests/...
+```
+
+**C. `claude-plugins-official/telegram` 作 backup transport**(用户 directive)
+
+默认 transport:`openhuman/telegram` 走 `ccteam-imd`。
+用户 `/ccteam-im-setup --transport official-telegram` 切官方 Anthropic MCP 路径(`claude --channels plugin:telegram@claude-plugins-official`)。
+
+两 path 互斥(避免同 bot token 双重 webhook 竞争);切换走 onboarding skill 状态文件 `~/.ccteam/im/transport.toml`。
+
+**D. bot-to-bot @ routing + hop_limit**(IM Squad 完整体验)
+
+借 Codex `AgentPath` 模式(researcher R11.A,codex-expert CX6#1):
+- 每 bot turn 启动时获得 path(`/root/turn-1`)
+- bot 输出 `@critic_bot` → router 解析 → 给 critic 新 turn,path = `/root/turn-1/turn-2`
+- path depth ≥ `hop_limit`(默认 3,workflow.yaml `agents.<role>.hop_limit` 可覆盖)→ escalate 给 user("该话题 bot 间已链 3 轮,请人工介入"+ TG 自动 @ user)
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-imd/`(新 crate,~6 模块)| 详上 |
+| `Cargo.toml`(workspace 根)| 加 member;加 dep openhuman `{ version = "0.x", features = [...] }` |
+| `crates/ccteam-imd/tests/router_test.rs`(新)| 6 测试 |
+| `crates/ccteam-imd/tests/dep_graph_test.rs`(新)| 守 ccteam-core 不依赖 openhuman / teloxide / slack_morphism / serenity |
+| `crates/ccteam-cli/src/commands.rs::daemon_start` | 检测 chat workflow 存在 → spawn ccteam-imd child process |
+
+#### 验收
+
+1. TG host probe(开发者 own TG bot token + chat_id 走 `/ccteam-im-setup`):
+   - DM hello world 跑通(`@helpful_bot hi` → 回复)
+   - Group + bot-to-bot @:`@helpful_bot review my plan` → `@critic_bot` chain → critic 回 → 合成最终回
+   - hop_limit:mock bot-to-bot 链 4 轮 → 第 4 轮 escalate,TG 收人工介入消息
+2. `cargo tree -p ccteam-core | grep -E "openhuman|teloxide|slack"` 命中 0
+3. `ccteam-imd` crash 自动重启:`kill -9` daemon → systemd / s6 / supervisor 拉起 → 状态恢复无丢失 turn
+4. backup transport 切换:`/ccteam-im-setup --transport official-telegram` 后,新 chat workflow 走官方 MCP 路径
+5. NL admin:TG 群里 `@ccteam pause helpful-bot` → bot 暂停;`@ccteam list` → 回 bot 列表
+
+#### 不在范围
+
+- 国内 IM 平台(`lark` / `dingtalk` / `wechat` / `qq`)— V0.7;V0.6.0 cargo feature gate **预留**但不启用
+- DM 跨设备 sync — V0.7+
+- IM webhook 公网 URL 自动 setup — 用户自行 ngrok / cloudflared
+
+---
+
+### F112 — Codex 集成 Option B 完整
+
+#### 痛点 + 设计
+
+详 README §4.3。Codex 用户面 4 个可见场景 + 内部架构 vendor 一等公民。
+
+#### 需求
+
+**A. trait `vendor: AgentVendor` 字段**(F107 已 cover)
+
+**B. `CodexExecAdapter` impl(模式 2 codex)**
+
+```rust
+// crates/ccteam-core/src/execution/codex_exec.rs
+impl HarnessAdapter for CodexExecAdapter {
+    async fn start_thread(...) -> ThreadHandle {
+        // spawn `codex exec --json --config sandbox=<...> --config approval=<...>`
+        // stdout JSONL stream of ThreadEvent::ThreadStarted, TurnStarted, ...
+    }
+    async fn submit_turn(...) -> TurnId {
+        // stdin write input (Codex stdin 接一次性 prompt)
+    }
+    fn events(...) -> Stream<ThreadEvent> {
+        // tail stdout JSONL → ThreadEvent
+    }
+    async fn resume_thread(persistent_id) -> ThreadHandle {
+        // spawn `codex resume <UUID>` 或 `codex resume --last`
+    }
+    async fn close_thread(...) {
+        // kill process; sessions/<rollout>.jsonl 留存
+    }
+}
+```
+
+**C. `CodexAppServerAdapter` impl(模式 3 codex,Wave 3)**
+
+```rust
+impl HarnessAdapter for CodexAppServerAdapter {
+    async fn start_thread(...) -> ThreadHandle {
+        // 检测 codex app-server 是否已起,若否:`codex app-server --listen unix:///tmp/...`
+        // UDS 上 JSON-RPC `initialize` + `thread/start` → 拿 thread-id
+    }
+    async fn submit_turn(...) -> TurnId {
+        // UDS JSON-RPC `turn/start { threadId, input: [...] }`
+    }
+    fn events(...) -> Stream<ThreadEvent> {
+        // UDS 推送 `item/started`, `item/agentMessage/delta`, `turn/completed`
+    }
+}
+```
+
+**D. 4 用户可见场景**(详 README §4.3 A/B/C/D)
+
+- A. `/ccteam-advise <hard question>` parallel voting skill(`skills/ccteam-advise/SKILL.md`)— Codex + Claude 并行 advisor,合成显示
+- B. Auto-critic in `ccteam-creator`:用户起 critic / reviewer / architect role 时,如装 codex + auth ok → 自动赋 `vendor: codex`(用户不见 yaml)
+- C. Claude quota 触顶 opt-in fallback:`~/.ccteam/preferences.toml` `fallback.on_claude_quota = "codex"` 默认 off
+- D. `/ccteam-team` 内置 Codex critic teammate(`/ccteam-team N "task with critic"` if codex available)
+
+**E. 双 pricing table**(F107 已 cover):`crates/ccteam-cost/pricing/{anthropic,openai}.toml`
+
+**F. budget 按 vendor 拆**:
+
+```toml
+# workflow.yaml(系统生成,user 不见)
+budgets.claude.max_cost_usd_per_24h = 5.0
+budgets.codex.max_cost_usd_per_24h = 2.0
+```
+
+UI 展示给 user 只 1 个聚合数(`/ccteam-control show-cost`);内部分 vendor。
+
+**G. `agent_max_depth` recursion bomb guard**(借 Codex)
+
+`HarnessAdapter` trait 内置 default impl,任何 adapter 都 enforce `max_spawn_depth: u32`(默认 5)。撞 limit → escalate event(同 fix-loop 红线 R6)。
+
+**H. agent_naming 池**(借 Codex 50+ scientist nicknames)
+
+`crates/ccteam-core/src/agent_naming.rs`:bot_name 默认从池子取(Newton / Curie / Einstein / Turing / Feynman / ...),user 不起名;`ccteam-creator` skill `Phase 3` 可让用户自定义。
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/execution/codex_exec.rs`(新)| `CodexExecAdapter` ~400 行 |
+| `crates/ccteam-core/src/execution/codex_app_server.rs`(新,Wave 3)| `CodexAppServerAdapter` ~600 行 |
+| `crates/ccteam-core/src/agent_naming.rs`(新)| 50 nickname 池 |
+| `crates/ccteam-cli/src/commands.rs::run_doctor` | `--check-codex-version` + `--check-codex-auth` |
+| `crates/ccteam-cost/src/budget.rs` | per-vendor budget caps |
+| `crates/ccteam-cost/pricing/{anthropic,openai}.toml`(新)| 双 pricing |
+| `skills/ccteam-advise/SKILL.md`(新)| ~100 行 parallel voting skill |
+| `crates/ccteam-cli/tests/codex_exec_test.rs`(新)| 5 测试 |
+
+#### 验收
+
+1. host probe(开发者装 codex):
+   - `/ccteam-advise "what's the best approach to X"` → Claude + Codex 并行 → 合成 verdict
+   - `ccteam-creator` 起 workflow,task 含 "review" → critic role 自动选 codex(`progress.jsonl` 记录 `vendor: codex`)
+   - Codex `agent_max_depth` 递归保护:bot spawn bot spawn bot 链 5 层后触 escalate
+2. cost 双 vendor 聚合:Claude $1 + Codex $0.5 → `ccteam-control show-cost` 显示 "$1.5(详:claude $1 / codex $0.5)"
+3. bot_name 自动 Newton / Curie / 不 collide:`/ccteam-team 3` 起 3 个 worker,name 都从池子取且不重复
+4. doctor 检测:codex 缺 → `vendor: codex` 的 agent 报"装 codex 或切 Claude";不 nag 已经全 claude 的 workflow
+
+#### 不在范围
+
+- Anthropic / OpenAI 之外的 vendor(Gemini / DeepSeek / Qwen)— V0.7+
+- cross-vendor in-proc team(物理不可能,详 CC9)— 永不
+- Auto-fallback(Codex / Claude 互切)— C 场景 opt-in,不默认
+
+---
+
+### F115 — `.ccteam/handoffs/<workflow>/<stage>.md` 决策摘要机制
+
+#### 痛点
+
+ccteam 5 拓扑模式(chaining / orchestrator-worker / evaluator-optimizer 等)间的"为什么这么决定"丢失。current progress.jsonl 只记业务事件不记 rationale。fix-loop 撞 3 次撞错原因看不到上一轮决策 trace;wave 间跨 session 重启 lead 不知道前任做了啥。
+
+OMC `.omc/handoffs/<stage>.md` 已经验证(`skills/team/SKILL.md` 1040 行解释机制)。borrow。
+
+#### 需求
+
+每个 stage / wave / fix-loop iteration 完成时,触发 hook **prompt 当前 agent 写一份 10-20 行 markdown 落盘**:
+
+```markdown
+<!-- .ccteam/handoffs/<workflow-slug>/stage-<N>-<role>.md -->
+# Stage N: <Stage Name>
+
+**Decided**: 
+- ...
+
+**Rejected**:
+- ...
+
+**Risks**:
+- ...
+
+**Files changed**:
+- `path/to/foo.rs` — what + why
+
+**Remaining**:
+- ...
+```
+
+后续 stage / fix-loop iteration spawn prompt **自动 include** 前序 stage 的 handoff markdown(`{{include_prev_handoffs}}` template directive)。
+
+#### 文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `crates/ccteam-core/src/handoff.rs`(新)| handoff hook trigger 逻辑 + markdown 模板 |
+| `crates/ccteam-core/src/orchestrator.rs` | 在 `stage_done` event 触发 handoff prompt 注入 |
+| `crates/ccteam-core/src/spawn_brief.rs` | spawn prompt 模板加 `{{include_prev_handoffs}}` |
+| `crates/ccteam-core/tests/handoff_test.rs`(新)| 4 测试 |
+
+#### 验收
+
+1. workflow 跑 3 stage → `<project>/.ccteam/handoffs/<slug>/stage-{1,2,3}-<role>.md` 3 个文件生成,每文件 10-30 行
+2. fix-loop 撞 2 次后,第 3 次 spawn prompt 含前 2 次 handoff(同 file glob)
+3. fix-loop 3 次 escalate 时,user 看到 web UI 或 IM 展示最近 handoff(回答 "why did it loop")
+
+#### 不在范围
+
+- 不做 handoff 自动摘要(全 agent 写)
+- 不做 handoff 跨 workflow share(每 workflow 独立目录)
+
+---
+
+### F116 — `ccteam-imd` 独立 daemon binary(F109 子 finding)
+
+#### 痛点 + 设计
+
+详 F109 §B。
+
+#### 必须验收
+
+- daemon crash 自动重启(systemd / s6 / Mac launchd)
+- 0600 secret state(`~/.ccteam/im/credentials.json`)
+- env allowlist(daemon spawn 子进程 PATH / HOME / USER / TMUX,**不传 ANTHROPIC_API_KEY / TELEGRAM_BOT_TOKEN**)
+- 两层 sanitize(OMC `sanitizeReplyInput` + `sanitizeForTmux` lift)
+- per-user rate limit(默认 10/min)
+- workflow.yaml `chat_acl: { allow_user_ids: [...] }`(可选,允许列表)
+
+---
+
+### F118 — chat session 失效 last-N turn 重建
+
+#### 痛点 + 设计
+
+详 F108 §C。
+
+`turns.jsonl` 失效场景下 ccteam 不再"fail-open + 沉默丢失"。当 `~/.claude/projects/...<sid>.jsonl` 失效:
+- 从 `<project>/.ccteam/chat/<bot>/turns.jsonl` 读最后 N(配置)turn
+- 重新拉起 `claude` 进程(fresh `claude -p`,无 `--resume`)
+- 把 last-N turn 作 system prompt 注入(`<conversation_history>...</conversation_history>` block)
+- emit `chat_session_reset_with_recovery` event
+- bot 在 IM 主动发"我刚做了一次小检修,记忆已经从 `turns.jsonl` 恢复;有什么需要继续的?"
+
+#### 验收
+
+1. mock test:删 Anthropic session jsonl 文件 → `turns.jsonl` 重建后 bot 第一句话能正确引用上一轮对话
+2. last-N 默认 20 turn;workflow.yaml `agents.<role>.recover_last_n_turns` 可覆盖
+3. emit event 进 progress.jsonl,web UI 红色 banner 显示 "bot 失忆重建"
+
+---
+
+## EPIC C — 中文用户能用(V0.6.0 铺底)
+
+**Epic 验收**:V0.6.0 ship 时**架构准备就绪**让 V0.7 国内 IM 零成本接入;中文文档先行;persona 库含中文。
+
+下属 finding:F109(Epic C 部分 — openhuman feature gate 含国内 IM)+ F114(persona 含中文)+ 文档套件中文版默认。
+
+---
+
+### F109 Epic C 部分:openhuman feature gate 含国内 IM
+
+V0.6.0 cargo feature 配置:
+
+```toml
+# crates/ccteam-imd/Cargo.toml
+[features]
+default = ["telegram", "slack", "discord"]
+intl = ["telegram", "slack", "discord", "email", "irc"]
+china = ["lark", "dingtalk", "qq", "wechat"]  # V0.7 启用,V0.6.0 预留 cargo feature 名
+all = ["intl", "china", "signal", "imessage", "matrix", "whatsapp"]
+
+telegram = ["openhuman/telegram"]
+slack = ["openhuman/slack"]
+discord = ["openhuman/discord"]
+lark = ["openhuman/lark"]
+dingtalk = ["openhuman/dingtalk"]
+qq = ["openhuman/qq"]
+wechat = ["openhuman/wechat"]
+# ...
+```
+
+V0.6.0 binary 编译时 `--features default`;V0.7 加 `--features china` 即启用所有国内 IM,**零 ccteam 代码改动**(只 `/ccteam-im-setup` skill 加 4 个 platform option + 4 个 host probe 验证)。
+
+---
+
+### F114 Epic C 部分:persona 预设库含中文 prefab
+
+`skills/ccteam-creator/personas/` 内置:
+
+| Persona | 中文版 | 英文版 |
+|---|---|---|
+| 技术助手 / Code Helper | ✓ | ✓ |
+| 写作助手 / Writing Assistant | ✓ | ✓ |
+| 翻译 / Translator(双向)| ✓ | ✓ |
+| 学习辅导 / Tutor | ✓ | ✓ |
+| 项目监工 / Project Lead | ✓ | ✓ |
+| 客服 / Customer Support | ✓ | ✓ |
+| 心理咨询 / Therapist(谨慎)| ✓ | ✓ |
+| 代码 critic / reviewer | ✓ | ✓ |
+
+每 persona = `personas/<name>/{en,zh}/{role.md,tone.md,guardrails.md}` 三文件。`ccteam-creator` skill `Phase 3` 按用户 NL 语言自动选 zh / en 版本。
+
+---
+
+### 文档套件中文版默认
+
+详 README §七。`docs/` 根 5 用户面文档(quickstart / user-manual / recipes / troubleshooting / README)中文版**默认**,英文翻译版按需(命名约定:`<doc>.en.md`)。
+
+理由:用户画像主要为中文独立开发者(`docs/requirements.md` §用户画像)。英文用户社区国际化在 V0.8 专项(`docs/i18n/`)。
+
+---
+
+## F106 — 红线按"模式 × vendor"双轴 scope 重写
+
+详 README §五矩阵表。改 `docs/tech-design.md` §0 + `CLAUDE.md` §三红线表。
+
+#### 文件影响
+
+| 文件 | 改动 |
+|---|---|
+| `docs/tech-design.md` §0 | 红线表加 vendor 列(Claude / Codex)|
+| `CLAUDE.md` §三 | 红线表加"模式 × vendor"列,精简表 |
+| `docs/architecture/orchestration-patterns.md` §一 | 5 拓扑模式 × 3 执行模式 × 2 vendor 适用矩阵(30 cell;✓ 17 / ⚠ 9 / ✗ 4)|
+
+---
+
+## 文档影响清单(全 V0.6.0)
 
 | 文档 | 改动 |
 |---|---|
-| `CLAUDE.md` §一(当前状态表)| Workspace version → 0.6.0;baseline 数字 wave 3 ship 后回填 |
-| `CLAUDE.md` §三红线 | 加"模式"列(精简);link 到 tech-design 详 |
-| `docs/tech-design.md` §0(若存在)/ §2.1 | 三模式定义表 + 红线 × 模式矩阵;`ExecutionAdapter` trait 接口 |
-| `docs/orchestration-patterns.md` §一 | 5 拓扑模式 × 3 执行模式适用矩阵 |
-| `docs/interfaces.md` | MCP 工具名全表更新;workflow.yaml `mode: chat` schema 加入 |
-| `docs/dev-coupling-audit.md` | F106-F111 各一条 finding 简述 |
-| `docs/claude-code-best-practices.md` | 加一节"用 send-keys + session jsonl 实现长跑 agent"(模式 3 落地经验) |
-| `docs/v0-6-0/user-manual.md`(新)| chat mode 用户使用指南(TG bot 起步教程)|
+| `CLAUDE.md` §一(状态表) | Workspace version → 0.6.0;baseline wave 3 ship 后回填;红线表加 vendor 列 |
+| `docs/tech-design.md` | §0 红线表;§2.1 HarnessAdapter trait + 5 方法;§3.3 Codex 集成 + 双 pricing;§ 新建 chat-mode-design.md |
+| `docs/architecture/orchestration-patterns.md` | §一加 5 × 3 × 2 = 30 cell 矩阵;§五加 V0.7 + V0.6.1 待立项 sugar(`vote`, `approval_gate`, `agent.router`)|
+| `docs/interfaces.md` | MCP 工具子前缀;workflow.yaml `mode: chat` + `vendor:` schema;handoff 文件格式 |
+| `docs/dev-coupling-audit.md` | F106-F118 各 1 finding |
+| `docs/claude-code-best-practices.md` | 新章节 "Agent SDK / `claude -p --resume` + stream-json 模式 3 模式" |
+| `docs/v0-6-0/host-probe.md`(新)| wave 4 验证产物归档 |
+| `README.md`(repo 根)| ≤80 行,产品 pitch + value prop + 5 行 install + 链 quickstart |
+| `docs/quickstart.md`(新,≤120 行)| 5 step Pocket Assistant 教程 |
+| `docs/user-manual.md`(重写,≤300 行)| 5 preset 各一节;不出现 13 项内部术语 |
+| `docs/recipes.md`(新,≤500 行)| 8-10 ready preset 模板 |
+| `docs/troubleshooting.md`(新,≤400 行)| 50+ 故障条目 |
+| `docs/advanced/{customize-workflow,multi-llm-codex,presets-reference}.md`(新)| advanced 文档,2-3 文件 |


### PR DESCRIPTION
## Summary
- **V0.6.0 立项 doc-first PR** — 11 文档 3554 行;实现按 4 wave 跟进(T+18-22 天,baseline 942/1 → 预计 ~1010/1)
- **主线从 F-finding 顶层重构为 3 Epic**:Epic A 5 min IM bot / Epic B bot 像真人 / Epic C 中文用户能用。12 finding(F106-F118,F110 取消)降级为实施手段挂 Epic 下
- **5 teammate review**(architect / cc-expert / pm / researcher / codex-expert)+ **用户多轮 override**(低门槛 Claude-native 硬约束 + Codex Option B 完整 + 不造 channels 轮子 + DM + group + bot-to-bot 全起)synthesize 完成

## 关键架构改动(对比上版 PRD)
- **F107** 扩展现有 `HarnessAdapter` trait(对齐 Codex `ThreadManager`)— 不新建 trait(原 PRD 漏看 V0.4.0 已落)
- **F108** 模式 3 弃 tmux send-keys → `claude -p --resume` + stream-json + JSON-mailbox-trigger(OMC tmux-comm.ts 抄)+ ccteam-owned `<project>/.ccteam/chat/<bot>/turns.jsonl` SoT
- **F109** IM bridge 统一 lift `openhuman/channels` Rust crate(14+ IM 平台 含 Lark/DingTalk/QQ);`claude-plugins-official/telegram` 作 backup transport
- **F110** ccteam → ct MCP rename 取消(保 `mcp__ccteam__*` namespace + 子前缀 `workflow_*`/`chat_*`)
- **F112** Codex Option B 完整:`CodexExecAdapter` + `CodexAppServerAdapter` + `vendor: AgentVendor` enum + 双 pricing table + 4 用户可见场景(advise / auto-critic / opt-in fallback / team-critic)
- **F113-F118** 用户面低门槛改进:`/ccteam` NL dispatcher + ccteam-creator 复活 + ccteam-im-setup + handoff + supervisor daemon + chat session recovery

## 文档清单
| 文件 | 行数 | 受众 |
|---|---|---|
| `docs/v0-6-0/README.md` | 300 | dev / 立项归档 |
| `docs/v0-6-0/prd.md` | 896 | dev / F-finding 详细 |
| `docs/v0-6-0/dev-plan.md` | 291 | dev / 4 wave |
| `README.md`(repo 根 重写) | 70 | 用户 |
| `docs/quickstart.md`(新)| 120 | 用户 |
| `docs/user-manual.md`(新)| 290 | 用户 |
| `docs/recipes.md`(新)| 495 | 用户 |
| `docs/troubleshooting.md`(新)| 283 | 用户 |
| `docs/advanced/customize-workflow.md`(新)| 230 | 高级 |
| `docs/advanced/multi-llm-codex.md`(新)| 273 | 高级 |
| `docs/advanced/presets-reference.md`(新)| 306 | 高级 |

## Test plan
- [ ] 文档自洽:用户面 5 文档(README/quickstart/user-manual/recipes/troubleshooting)13 项内部术语 grep 验证全 0 命中
- [ ] V0.5 现有 host E2E 不退步(本 PR 0 代码改动,baseline 942/1 保持)
- [ ] 行数限制全达标:README ≤80(70 ✓)/ quickstart ≤120(120 ✓)/ user-manual ≤300(290 ✓)/ recipes ≤500(495 ✓)/ troubleshooting ≤400(283 ✓)
- [ ] Wave 1 trait 抽离 PR(后续)接此 PR base + baseline 持平

🤖 Generated with [Claude Code](https://claude.com/claude-code)