### PR TITLE
v0.6.0 wave-3: F112 Codex Option B 完整 + imd↔tui e2e wiring + per-vendor budget caps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2761,8 +2762,15 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"

--- a/crates/ccteam-cli/Cargo.toml
+++ b/crates/ccteam-cli/Cargo.toml
@@ -23,6 +23,11 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
 
+# V0.6.0 Wave 3 F112 §C — `ccteam prefs show` pretty-prints the
+# Preferences struct via `toml::to_string_pretty`. Aligned with the
+# ccteam-core dep so cargo dedups.
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+
 # V0.4.0-hotfix — `prctl(PR_SET_PDEATHSIG, SIGTERM)` so mcp-serve
 # self-terminates when its parent (Claude Code MCP client) goes
 # away. Without this, idle stdin doesn't surface EOF and the process

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -2117,6 +2117,15 @@ pub struct DoctorOptions {
     /// alongside today's date and WARN when the embedded table is
     /// older than 180 days. Pure-readout — no fs mutation.
     pub check_pricing_version: bool,
+    /// V0.6.0 Wave 3 F112: probe `codex --version` and warn when the
+    /// binary is missing or older than the minimum supported
+    /// (`0.131`). Pure-readout — no fs mutation.
+    pub check_codex_version: bool,
+    /// V0.6.0 Wave 3 F112: probe `codex login status` and surface
+    /// whether the operator is logged in (ChatGPT / API key) so
+    /// mode-3 codex bot path knows to error early. Pure-readout — no
+    /// fs mutation.
+    pub check_codex_auth: bool,
 }
 
 /// `ccteam doctor` dispatch. Returns a human-readable report so unit
@@ -2135,7 +2144,9 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
         || opts.migrate_workflow_to_ccteam_dir
         || opts.gc_claude_jobs
         || opts.update_hooks
-        || opts.check_pricing_version;
+        || opts.check_pricing_version
+        || opts.check_codex_version
+        || opts.check_codex_auth;
     if !any_mode {
         return Ok(String::from(
             "ccteam doctor: pass at least one mode flag.\n\
@@ -2238,6 +2249,12 @@ pub fn run_doctor(paths: &CcteamPaths, opts: DoctorOptions) -> Result<String> {
     }
     if opts.check_pricing_version {
         out.push_str(&render_check_pricing_version_report());
+    }
+    if opts.check_codex_version {
+        out.push_str(&render_check_codex_version_report());
+    }
+    if opts.check_codex_auth {
+        out.push_str(&render_check_codex_auth_report());
     }
     // V0.3.1 F47 — informational codex CLI detection. Appends one line
     // to every successful doctor run (any_mode == true) so operators
@@ -2766,6 +2783,177 @@ fn render_check_pricing_version_report() -> String {
     }
     out.push('\n');
     out
+}
+
+/// V0.6.0 Wave 3 F112 — probe `codex --version` and emit a single
+/// report block. Minimum supported: `0.131` (the version that
+/// stabilised `--json` + `app-server daemon` UX). Versions <0.131 WARN
+/// but don't fail; missing `codex` binary surfaces an ERROR line so
+/// the operator knows mode-3 codex bot path will degrade.
+fn render_check_codex_version_report() -> String {
+    const MIN_MAJOR: u32 = 0;
+    const MIN_MINOR: u32 = 131;
+    let mut out = String::from("ccteam doctor --check-codex-version (V0.6.0 Wave 3 F112)\n\n");
+    let output = Command::new("codex").arg("--version").output();
+    match output {
+        Ok(o) if o.status.success() => {
+            let line = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            out.push_str(&format!("  codex --version: {line}\n"));
+            match parse_codex_semver(&line) {
+                Some((maj, min, _patch)) => {
+                    if (maj, min) >= (MIN_MAJOR, MIN_MINOR) {
+                        out.push_str(&format!(
+                            "  [OK] codex {maj}.{min} ≥ {MIN_MAJOR}.{MIN_MINOR} (mode-3 \
+                             codex bot path supported).\n"
+                        ));
+                    } else {
+                        out.push_str(&format!(
+                            "  [WARN] codex {maj}.{min} < {MIN_MAJOR}.{MIN_MINOR} — upgrade \
+                             codex for mode-3 bot path + `codex exec --json` stability.\n"
+                        ));
+                    }
+                }
+                None => {
+                    out.push_str(
+                        "  [note] could not parse semver from `codex --version` output; \
+                         staleness check skipped.\n",
+                    );
+                }
+            }
+        }
+        Ok(o) => {
+            out.push_str(&format!(
+                "  [ERROR] `codex --version` exited {} — mode-3 codex bot path will degrade.\n",
+                o.status.code().unwrap_or(-1)
+            ));
+            out.push_str(&format!(
+                "  stderr: {}\n",
+                String::from_utf8_lossy(&o.stderr).trim()
+            ));
+        }
+        Err(err) => {
+            out.push_str(&format!(
+                "  [ERROR] codex CLI not installed (`{err}`) — V0.6 Codex features will \
+                 fallback or skip.\n"
+            ));
+        }
+    }
+    out.push('\n');
+    out
+}
+
+/// V0.6.0 Wave 3 F112 — probe `codex login status` and emit a single
+/// report block. Parses one of:
+///
+/// - `Logged in using ChatGPT`           → OK
+/// - `Logged in using API key`           → OK
+/// - `Not logged in` / `Logged out`      → WARN (operator action needed)
+///
+/// A missing `codex` binary errors out so the operator sees the same
+/// remediation as `--check-codex-version`.
+fn render_check_codex_auth_report() -> String {
+    let mut out = String::from("ccteam doctor --check-codex-auth (V0.6.0 Wave 3 F112)\n\n");
+    let output = Command::new("codex").args(["login", "status"]).output();
+    match output {
+        Ok(o) => {
+            let combined = format!(
+                "{}{}",
+                String::from_utf8_lossy(&o.stdout),
+                String::from_utf8_lossy(&o.stderr)
+            );
+            out.push_str(&format!("  codex login status: {}\n", combined.trim()));
+            let status = classify_codex_auth(&combined);
+            match status {
+                CodexAuthStatus::LoggedIn(via) => {
+                    out.push_str(&format!(
+                        "  [OK] codex authenticated via {via} — mode-3 codex bot path enabled.\n"
+                    ));
+                }
+                CodexAuthStatus::LoggedOut => {
+                    out.push_str(
+                        "  [WARN] codex is not logged in. Run `codex login` to enable Codex \
+                         features (mode-3 bot path + /ccteam-advise codex dual-probe).\n",
+                    );
+                }
+                CodexAuthStatus::Unknown => {
+                    out.push_str(
+                        "  [note] could not parse `codex login status` output; assume logged \
+                         out and re-run after `codex login`.\n",
+                    );
+                }
+            }
+        }
+        Err(err) => {
+            out.push_str(&format!(
+                "  [ERROR] `codex login status` failed: {err} — install codex first.\n"
+            ));
+        }
+    }
+    out.push('\n');
+    out
+}
+
+/// Parse "codex 0.131.0" or "0.131.0 (...)". Returns `(major, minor,
+/// patch)` on success.
+pub fn parse_codex_semver(line: &str) -> Option<(u32, u32, u32)> {
+    // Scan for the first `<digits>.<digits>.<digits>` triple.
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
+                i += 1;
+            }
+            let slice = &line[start..i];
+            let parts: Vec<&str> = slice.split('.').collect();
+            if parts.len() >= 3 {
+                if let (Ok(maj), Ok(min), Ok(patch)) = (
+                    parts[0].parse::<u32>(),
+                    parts[1].parse::<u32>(),
+                    parts[2].split(|c: char| !c.is_ascii_digit()).next().unwrap_or("0").parse::<u32>(),
+                ) {
+                    return Some((maj, min, patch));
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Outcome of parsing `codex login status` output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodexAuthStatus {
+    LoggedIn(String),
+    LoggedOut,
+    Unknown,
+}
+
+/// Classify the combined stdout+stderr of `codex login status`. We
+/// check the "logged out" branch FIRST because "Not logged in" is a
+/// substring of "logged in" — a naive `contains("logged in")` would
+/// misclassify the negative path.
+pub fn classify_codex_auth(combined: &str) -> CodexAuthStatus {
+    let lower = combined.to_ascii_lowercase();
+    if lower.contains("not logged in")
+        || lower.contains("logged out")
+        || lower.contains("no credentials")
+        || lower.contains("please run `codex login`")
+    {
+        return CodexAuthStatus::LoggedOut;
+    }
+    if lower.contains("logged in") {
+        let via = if lower.contains("chatgpt") {
+            "ChatGPT"
+        } else if lower.contains("api key") || lower.contains("api-key") {
+            "API key"
+        } else {
+            "(unspecified)"
+        };
+        return CodexAuthStatus::LoggedIn(via.to_string());
+    }
+    CodexAuthStatus::Unknown
 }
 
 /// Resolve a project's on-disk directory from `~/.ccteam/config.yaml`

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -3383,6 +3383,92 @@ impl std::fmt::Display for RemoveReport {
     }
 }
 
+// -------------------------------------------------------------------------
+// V0.6.0 Wave 3 F112 §C — `ccteam prefs` admin surface.
+//
+// Reads / writes `~/.ccteam/preferences.toml`. Today only the
+// fallback section has user-visible keys; V0.7+ can add more by
+// extending the parse_key match arm + emitting a friendly diagnostic
+// for unknown keys.
+// -------------------------------------------------------------------------
+
+/// Format the active preferences for `ccteam prefs show`. Includes
+/// the resolved file path so the user knows what was loaded.
+pub fn run_prefs_show(paths: &CcteamPaths) -> Result<String> {
+    let prefs = ccteam_core::preferences::load_or_default(&paths.root);
+    let path = ccteam_core::preferences::preferences_path(&paths.root);
+    let exists_marker = if path.exists() {
+        "loaded"
+    } else {
+        "defaults (file not present)"
+    };
+    let body = toml::to_string_pretty(&prefs).context("serialize preferences for display")?;
+    Ok(format!(
+        "# ccteam preferences ({exists_marker})\n# path: {}\n\n{body}",
+        path.display()
+    ))
+}
+
+/// Look up a dotted preference key. Returns the textual value or an
+/// error if the key is unknown.
+pub fn run_prefs_get(paths: &CcteamPaths, key: &str) -> Result<String> {
+    let prefs = ccteam_core::preferences::load_or_default(&paths.root);
+    match key {
+        "fallback.on_claude_quota" => Ok(match prefs.fallback.on_claude_quota {
+            ccteam_core::preferences::OnClaudeQuota::Off => "off".to_string(),
+            ccteam_core::preferences::OnClaudeQuota::Codex => "codex".to_string(),
+        }),
+        "fallback.codex.enabled_for_roles" => {
+            Ok(prefs.fallback.codex.enabled_for_roles.join(","))
+        }
+        other => Err(anyhow::anyhow!(
+            "unknown preference key: {other}\n\
+             supported keys:\n  - fallback.on_claude_quota  (off|codex)\n  \
+             - fallback.codex.enabled_for_roles  (comma list; empty = all roles)"
+        )),
+    }
+}
+
+/// Persist one preference change to `~/.ccteam/preferences.toml`.
+/// Returns a one-line confirmation suitable for stdout.
+pub fn run_prefs_set(paths: &CcteamPaths, key: &str, value: &str) -> Result<String> {
+    let mut prefs = ccteam_core::preferences::load_or_default(&paths.root);
+    match key {
+        "fallback.on_claude_quota" => {
+            prefs.fallback.on_claude_quota = match value.trim().to_lowercase().as_str() {
+                "off" => ccteam_core::preferences::OnClaudeQuota::Off,
+                "codex" => ccteam_core::preferences::OnClaudeQuota::Codex,
+                other => {
+                    return Err(anyhow::anyhow!(
+                        "fallback.on_claude_quota: unsupported value {other:?} \
+                         (expected `off` or `codex`)"
+                    ));
+                }
+            };
+        }
+        "fallback.codex.enabled_for_roles" => {
+            prefs.fallback.codex.enabled_for_roles = if value.trim().is_empty() {
+                Vec::new()
+            } else {
+                value
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            };
+        }
+        other => {
+            return Err(anyhow::anyhow!(
+                "unknown preference key: {other}\n\
+                 supported keys:\n  - fallback.on_claude_quota  (off|codex)\n  \
+                 - fallback.codex.enabled_for_roles  (comma list; empty = all roles)"
+            ));
+        }
+    }
+    ccteam_core::preferences::save(&paths.root, &prefs)?;
+    Ok(format!("set {key} = {value}"))
+}
+
 /// V0.4.6 F81 — `ccteam remove <slug>` implementation.
 ///
 /// Steps (in order):

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -582,6 +582,39 @@ enum Command {
         #[arg(long, value_name = "PATH")]
         token_file: Option<PathBuf>,
     },
+    /// V0.6.0 Wave 3 F112 §C — read / write `~/.ccteam/preferences.toml`.
+    /// Today the only user-visible knob is `fallback.on_claude_quota`
+    /// (`off` | `codex`); V0.7+ will fold in additional opt-in
+    /// preferences. Without args, prints the current preferences.
+    Prefs {
+        #[command(subcommand)]
+        action: Option<PrefsAction>,
+    },
+}
+
+/// V0.6.0 Wave 3 F112 §C — `ccteam prefs` subcommand surface.
+#[derive(Subcommand)]
+enum PrefsAction {
+    /// Pretty-print the active preferences (defaults shown when the
+    /// file is absent).
+    Show,
+    /// Look up a single preference by dotted key. Supported keys today:
+    ///   - `fallback.on_claude_quota`
+    Get {
+        /// Dotted preference key.
+        key: String,
+    },
+    /// Set one preference by dotted key. Writes
+    /// `~/.ccteam/preferences.toml` atomically. Supported keys today:
+    ///   - `fallback.on_claude_quota`  (values: `off` | `codex`)
+    ///   - `fallback.codex.enabled_for_roles` (comma-separated list,
+    ///     or empty string to mean "all roles")
+    Set {
+        /// Dotted preference key.
+        key: String,
+        /// New value.
+        value: String,
+    },
 }
 
 /// V0.4.6 F89: subcommands hidden under `ccteam internal`. Each mirrors
@@ -975,6 +1008,26 @@ fn main() -> Result<()> {
                 no_auth,
                 token_file,
             })
+        }
+        Command::Prefs { action } => {
+            let paths = CcteamPaths::from_env()?;
+            match action {
+                None | Some(PrefsAction::Show) => {
+                    let out = commands::run_prefs_show(&paths)?;
+                    print!("{out}");
+                    Ok(())
+                }
+                Some(PrefsAction::Get { key }) => {
+                    let out = commands::run_prefs_get(&paths, &key)?;
+                    println!("{out}");
+                    Ok(())
+                }
+                Some(PrefsAction::Set { key, value }) => {
+                    let out = commands::run_prefs_set(&paths, &key, &value)?;
+                    println!("{out}");
+                    Ok(())
+                }
+            }
         }
     }
 }

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -537,6 +537,16 @@ enum Command {
         /// to upgrade ccteam when the bundled rate sheet ages out.
         #[arg(long, default_value_t = false)]
         check_pricing_version: bool,
+        /// V0.6.0 Wave 3 F112: probe `codex --version` and warn when
+        /// older than 0.131 (minimum supported by Wave 3 mode-3 codex
+        /// bot path). No fs mutation. Pairs with --check-codex-auth.
+        #[arg(long, default_value_t = false)]
+        check_codex_version: bool,
+        /// V0.6.0 Wave 3 F112: probe `codex login status` and report
+        /// whether the operator is logged in to ChatGPT / API. No fs
+        /// mutation. Pairs with --check-codex-version.
+        #[arg(long, default_value_t = false)]
+        check_codex_auth: bool,
         /// V0.4.6 F83/F85: pair with `--migrate-workflow-to-ccteam-dir`
         /// or `--gc-claude-jobs` to commit changes to disk instead of
         /// previewing them. Without it, those subcommands run as
@@ -912,6 +922,8 @@ fn main() -> Result<()> {
             gc_claude_jobs,
             update_hooks,
             check_pricing_version,
+            check_codex_version,
+            check_codex_auth,
             apply,
         } => {
             // V0.4.1 `--install-all` is sugar for the three first-run
@@ -960,6 +972,8 @@ fn main() -> Result<()> {
                 gc_apply: apply,
                 update_hooks,
                 check_pricing_version,
+                check_codex_version,
+                check_codex_auth,
             })
         }
         Command::Session { action } => run_session(action),

--- a/crates/ccteam-cli/tests/doctor_codex_test.rs
+++ b/crates/ccteam-cli/tests/doctor_codex_test.rs
@@ -1,0 +1,90 @@
+//! V0.6.0 Wave 3 F112 — `ccteam doctor --check-codex-version` /
+//! `--check-codex-auth` end-to-end tests via the binary surface. We
+//! manipulate `PATH` to point at a fake `codex` script so the doctor
+//! report is deterministic regardless of whether the real codex CLI
+//! is installed on the test host.
+
+use std::io::Write;
+use std::process::Command;
+
+/// Build a tempdir + fake `codex` script that emits the supplied
+/// stdout for `codex --version` and `codex login status`. Returns the
+/// tempdir guard (must outlive callers — PATH points inside it).
+fn fake_codex_dir(version_line: &str, login_line: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let codex_path = dir.path().join("codex");
+    let mut f = std::fs::File::create(&codex_path).unwrap();
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+        case \"$1\" in\n  \
+          --version) echo {version_line:?} ;;\n  \
+          login)\n    \
+            if [ \"$2\" = \"status\" ]; then echo {login_line:?}; fi\n    \
+            ;;\n  \
+          *) echo \"fake codex: unknown\" >&2; exit 1 ;;\n\
+        esac\n",
+    );
+    f.write_all(script.as_bytes()).unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&codex_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&codex_path, perms).unwrap();
+    dir
+}
+
+fn run_doctor_with_path(extra_path: &std::path::Path, args: &[&str]) -> (String, String, i32) {
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let mut path = extra_path.to_string_lossy().to_string();
+    if let Some(orig) = std::env::var_os("PATH") {
+        path.push(':');
+        path.push_str(&orig.to_string_lossy());
+    }
+    let out = Command::new(bin)
+        .env("PATH", path)
+        .arg("doctor")
+        .args(args)
+        .output()
+        .unwrap();
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn check_codex_version_reports_ok_for_supported_release() {
+    let dir = fake_codex_dir("codex 0.131.0", "Not logged in");
+    let (stdout, _stderr, code) =
+        run_doctor_with_path(dir.path(), &["--check-codex-version"]);
+    assert_eq!(code, 0, "stdout: {stdout}");
+    assert!(stdout.contains("[OK]"), "stdout: {stdout}");
+    assert!(stdout.contains("0.131"), "stdout: {stdout}");
+}
+
+#[test]
+fn check_codex_version_warns_on_old_release() {
+    let dir = fake_codex_dir("codex 0.120.0", "Not logged in");
+    let (stdout, _stderr, code) =
+        run_doctor_with_path(dir.path(), &["--check-codex-version"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("[WARN]"), "stdout: {stdout}");
+}
+
+#[test]
+fn check_codex_auth_recognises_chatgpt_login() {
+    let dir = fake_codex_dir("codex 0.131.0", "Logged in using ChatGPT");
+    let (stdout, _stderr, code) = run_doctor_with_path(dir.path(), &["--check-codex-auth"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("[OK]"), "stdout: {stdout}");
+    assert!(stdout.contains("ChatGPT"), "stdout: {stdout}");
+}
+
+#[test]
+fn check_codex_auth_warns_when_not_logged_in() {
+    let dir = fake_codex_dir("codex 0.131.0", "Not logged in. Please run `codex login`");
+    let (stdout, _stderr, code) = run_doctor_with_path(dir.path(), &["--check-codex-auth"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("[WARN]"), "stdout: {stdout}");
+    assert!(stdout.contains("codex login"), "stdout: {stdout}");
+}

--- a/crates/ccteam-core/Cargo.toml
+++ b/crates/ccteam-core/Cargo.toml
@@ -50,6 +50,13 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 imageproc = { version = "0.25", default-features = false }
 ab_glyph = "0.2"
 
+# V0.6.0 Wave 3 F112 §C — `~/.ccteam/preferences.toml` runtime parser
+# + serializer (vendor fallback prefs). Promoted from dev-dependencies
+# so `preferences::load` / `preferences::save` are available in non-test
+# orchestrator code. `parse` + `display` features cover read + atomic
+# write; pretty-print yields stable round-trippable output.
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+
 [dev-dependencies]
 tempfile = "3"
 
@@ -59,11 +66,9 @@ tempfile = "3"
 # dev-dependency for cargo dedup.
 serial_test = "3"
 
-# V0.6.0 Wave 2 F114 — persona_test.rs parses
-# `skills/ccteam-creator/personas/manifest.toml` to verify every
-# persona id has matching zh/en role.md files. Test-only dep —
-# runtime ccteam-core does not need a TOML parser.
-toml = { version = "0.8", default-features = false, features = ["parse"] }
+# V0.6.0 Wave 2 F114 / Wave 3 F112 — `toml` is now a runtime dep
+# (preferences.rs); persona_test.rs continues to use it via the
+# runtime entry, no separate dev-dep needed.
 
 [features]
 default = ["test-util"]

--- a/crates/ccteam-core/src/auto_critic.rs
+++ b/crates/ccteam-core/src/auto_critic.rs
@@ -1,0 +1,130 @@
+//! V0.6.0 Wave 3 F112 §B — auto-critic vendor decision helper.
+//!
+//! Pulled out of the `ccteam-creator` skill body so the decision is
+//! deterministic + unit-testable (the skill body is markdown +
+//! LLM-driven). The skill calls this helper at Phase 3.5 to decide
+//! whether to vendor a critic-flavoured persona on Codex.
+//!
+//! Decision inputs:
+//!
+//! 1. **Persona id / tags** — is the role critic-flavoured? Today
+//!    the trigger set is a small list of canonical critic ids; tags
+//!    are evaluated by case-insensitive substring match against the
+//!    `critic` / `reviewer` / `second-opinion` markers.
+//! 2. **Codex probe result** — `Available` (cli on PATH + `codex
+//!    login status` ok) vs `Unavailable(reason)`. The probe itself
+//!    runs from the skill body (Bash) so this module stays free of
+//!    side effects.
+//!
+//! Output:
+//!
+//! - `Vendor::Codex` when the role is critic-flavoured AND codex is
+//!   available.
+//! - `Vendor::Claude` otherwise. Caller decides whether to surface a
+//!   "Codex critic: unavailable" line in PROJECT PLAN.
+
+use serde::{Deserialize, Serialize};
+
+/// Vendor the auto-critic decision selects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Vendor {
+    Claude,
+    Codex,
+}
+
+/// Codex probe outcome — what Phase 3.5's `codex --version &&
+/// codex login status` returned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodexProbe {
+    /// CLI present + authenticated.
+    Available,
+    /// One of the probes failed. The `reason` is purely diagnostic
+    /// for the PROJECT PLAN's "Codex critic: unavailable" line.
+    Unavailable(&'static str),
+}
+
+/// Canonical critic-flavoured persona ids. Matches against the
+/// persona's `id` field (kebab-case). Extend as the persona library
+/// grows; the test suite guards against silent regressions.
+pub const CRITIC_PERSONA_IDS: &[&str] = &[
+    "code-critic",
+    "reviewer",
+    "code-reviewer",
+    "pr-reviewer",
+    "architect",
+    "architecture-reviewer",
+];
+
+/// Tags (case-insensitive substring) that mark a persona as
+/// critic-flavoured even when its id isn't on `CRITIC_PERSONA_IDS`.
+pub const CRITIC_PERSONA_TAG_MARKERS: &[&str] = &["critic", "reviewer", "second-opinion"];
+
+/// True iff this persona id or tag list indicates a critic-flavoured
+/// role. Tags match case-insensitively against the markers.
+pub fn is_critic_persona(persona_id: &str, tags: &[&str]) -> bool {
+    if CRITIC_PERSONA_IDS.contains(&persona_id) {
+        return true;
+    }
+    for tag in tags {
+        let lower = tag.to_ascii_lowercase();
+        if CRITIC_PERSONA_TAG_MARKERS
+            .iter()
+            .any(|m| lower.contains(*m))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Apply the Phase 3.5 decision table: critic-flavoured + codex
+/// available → Codex; everything else → Claude.
+pub fn decide_vendor(persona_id: &str, tags: &[&str], probe: &CodexProbe) -> Vendor {
+    if !is_critic_persona(persona_id, tags) {
+        return Vendor::Claude;
+    }
+    match probe {
+        CodexProbe::Available => Vendor::Codex,
+        CodexProbe::Unavailable(_) => Vendor::Claude,
+    }
+}
+
+/// User-visible PROJECT PLAN annotation for the "Codex critic:" line.
+/// Wave 3 keeps the strings stable so skill tests can string-match.
+pub fn plan_annotation(persona_id: &str, tags: &[&str], probe: &CodexProbe) -> &'static str {
+    if !is_critic_persona(persona_id, tags) {
+        return "not applicable";
+    }
+    match probe {
+        CodexProbe::Available => "auto-enabled",
+        CodexProbe::Unavailable(_) => "unavailable (codex CLI not installed / not authenticated)",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn critic_ids_recognised() {
+        for id in CRITIC_PERSONA_IDS {
+            assert!(
+                is_critic_persona(id, &[]),
+                "expected id {id} to be flagged critic"
+            );
+        }
+    }
+
+    #[test]
+    fn tags_can_promote_non_critic_id() {
+        assert!(is_critic_persona("helper", &["second-opinion"]));
+        assert!(is_critic_persona("dev", &["Critic"]));
+    }
+
+    #[test]
+    fn non_critic_persona_returns_claude_even_when_codex_available() {
+        let v = decide_vendor("tech-helper", &["chat"], &CodexProbe::Available);
+        assert_eq!(v, Vendor::Claude);
+    }
+}

--- a/crates/ccteam-core/src/execution/codex_app_server.rs
+++ b/crates/ccteam-core/src/execution/codex_app_server.rs
@@ -1,0 +1,642 @@
+//! V0.6.0 Wave 3 F112 — `CodexAppServerAdapter` (mode-3 codex bot path).
+//!
+//! Talks to `codex app-server` over a Unix Domain Socket via the
+//! `thread/start`, `thread/resume`, `turn/start`, `thread/archive`
+//! JSON-RPC v2-lite methods (see [`super::codex_jsonrpc`]).
+//!
+//! ## Lifecycle
+//!
+//! - `start_thread`: ensure a `codex app-server` daemon is running →
+//!   connect to its UDS → `initialize` (if needed) → `thread/start`
+//!   with model + cwd hint → return [`ThreadHandle`] whose `identity`
+//!   carries the codex `thread_id`.
+//! - `submit_turn`: `turn/start` with `[{type:"text", text:...}]`.
+//! - `events`: subscribe to broadcast notifications, translate
+//!   `item/*` + `turn/*` notifications → [`ThreadEvent`].
+//! - `resume_thread`: `thread/resume` with the persistent id.
+//! - `close_thread`: `thread/archive` + `thread/unsubscribe` (best-effort).
+//!
+//! ## Socket discovery
+//!
+//! Default: `$CODEX_HOME/app-server-control/app-server-control.sock`
+//! (CODEX_HOME falls back to `~/.codex`). Override via env
+//! `CCTEAM_CODEX_APP_SERVER_SOCKET`. Tests use a tempdir socket served
+//! by a hand-rolled scripted JSON-RPC peer.
+//!
+//! Wave 1 (V0.6) decision: mode 3 codex bot is **not** an end-user
+//! configuration today (Wave 1 mode-3 ships claude-only). This adapter
+//! exists so the trait stack is uniform and `/ccteam-advise` can dual-
+//! probe codex without touching tmux. The orchestrator's mode-3
+//! dispatch (e2e-wiring's territory) decides which adapter to mount.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use futures::stream::{self, BoxStream, StreamExt};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+
+use crate::execution::codex_jsonrpc::{CodexJsonRpcClient, Notification};
+use crate::harness::{
+    AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, SpawnCtx,
+    ThreadErrorEvent, ThreadEvent, ThreadHandle, ThreadItem, ThreadItemDetails, TurnId, TurnInput,
+    UnifiedTokenUsage,
+};
+
+/// Env override for the UDS path the adapter dials. Tests set this to
+/// a tempdir socket; production resolves
+/// `$CODEX_HOME/app-server-control/app-server-control.sock`.
+pub const APP_SERVER_SOCKET_ENV: &str = "CCTEAM_CODEX_APP_SERVER_SOCKET";
+
+/// Env override for the codex binary used when spawning the daemon
+/// (parity with `claude_bg`'s [`crate::harness::CLAUDE_BIN_ENV`]). Tests
+/// point this at a fake script that creates the socket without booting
+/// real codex.
+pub const CODEX_BIN_ENV: &str = "CCTEAM_CODEX_BIN";
+
+/// V0.6.0 F112 [`HarnessAdapter`] that drives mode-3 codex bot sessions
+/// via `codex app-server` UDS. The adapter is stateless across threads
+/// — each `start_thread` lazily connects (and caches) a client per
+/// process so reused for `submit_turn` / `events` / `close_thread`.
+#[derive(Clone, Default)]
+pub struct CodexAppServerAdapter {
+    inner: Arc<Mutex<Option<Arc<CodexJsonRpcClient>>>>,
+}
+
+impl std::fmt::Debug for CodexAppServerAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexAppServerAdapter").finish_non_exhaustive()
+    }
+}
+
+impl CodexAppServerAdapter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve the UDS path the adapter should dial. Env override wins;
+    /// otherwise `$CODEX_HOME/app-server-control/app-server-control.sock`
+    /// with `CODEX_HOME` falling back to `~/.codex`.
+    pub fn resolve_socket_path() -> Option<PathBuf> {
+        if let Some(p) = std::env::var_os(APP_SERVER_SOCKET_ENV) {
+            return Some(PathBuf::from(p));
+        }
+        let home = std::env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;
+        Some(home.join("app-server-control").join("app-server-control.sock"))
+    }
+
+    /// Lazily connect (or reuse) the JSON-RPC client. Spawning the
+    /// daemon on demand is deliberately out-of-scope — callers (the
+    /// orchestrator wiring + `ccteam doctor --check-codex-auth`) verify
+    /// the daemon is running before enabling mode-3 codex. The adapter
+    /// returns a clean [`HarnessError::SpawnFailed`] if the socket is
+    /// missing, so the caller surfaces the right diagnostic.
+    async fn client(&self) -> Result<Arc<CodexJsonRpcClient>, HarnessError> {
+        let mut guard = self.inner.lock().await;
+        if let Some(c) = guard.as_ref() {
+            return Ok(Arc::clone(c));
+        }
+        let path = Self::resolve_socket_path().ok_or_else(|| {
+            HarnessError::SpawnFailed(
+                "codex app-server socket path unresolved (set CODEX_HOME or \
+                 CCTEAM_CODEX_APP_SERVER_SOCKET)"
+                    .to_string(),
+            )
+        })?;
+        let client = CodexJsonRpcClient::connect_uds(&path).await.map_err(|err| {
+            HarnessError::SpawnFailed(format!(
+                "connect codex app-server at {}: {err:#}",
+                path.display()
+            ))
+        })?;
+        let shared = Arc::new(client);
+        *guard = Some(Arc::clone(&shared));
+        Ok(shared)
+    }
+
+    /// One-shot helper: drop the cached client (e.g. after detecting a
+    /// dead reader task). Next call to `client()` will re-dial.
+    pub async fn forget_client(&self) {
+        *self.inner.lock().await = None;
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for CodexAppServerAdapter {
+    fn name(&self) -> &'static str {
+        "codex-app-server"
+    }
+
+    fn vendor(&self) -> AgentVendor {
+        AgentVendor::Codex
+    }
+
+    async fn start_thread(
+        &self,
+        spec: &AgentSpecBrief,
+        ctx: &SpawnCtx,
+    ) -> Result<ThreadHandle, HarnessError> {
+        let client = self.client().await?;
+        let cwd_str = ctx.cwd.to_string_lossy().to_string();
+        let params = json!({
+            "cwd": cwd_str,
+            "session_source": "ccteam",
+            "service_name": format!("ccteam/{}", ctx.slug),
+            "developer_instructions": format!(
+                "ccteam role: {} (slug={}, sid={})",
+                spec.role, ctx.slug, ctx.sid
+            ),
+        });
+        let result = client
+            .call("thread/start", params)
+            .await
+            .map_err(|e| HarnessError::SpawnFailed(format!("thread/start: {e:#}")))?;
+        let thread_id = pluck_thread_id(&result).ok_or_else(|| {
+            HarnessError::SpawnFailed(format!(
+                "thread/start response missing thread.thread_id: {result}"
+            ))
+        })?;
+        Ok(ThreadHandle {
+            vendor: AgentVendor::Codex,
+            mode: ExecutionMode::Chat,
+            identity: thread_id.clone(),
+            started_at: Utc::now(),
+            raw_extras: json!({
+                "thread_id": thread_id,
+                "socket": Self::resolve_socket_path()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default(),
+            }),
+        })
+    }
+
+    async fn submit_turn(
+        &self,
+        h: &ThreadHandle,
+        input: TurnInput,
+    ) -> Result<TurnId, HarnessError> {
+        let client = self.client().await?;
+        let items = turn_input_to_items(input)?;
+        let params = json!({
+            "thread_id": h.identity,
+            "input": items,
+        });
+        let result = client
+            .call("turn/start", params)
+            .await
+            .map_err(|e| HarnessError::SubmitFailed(format!("turn/start: {e:#}")))?;
+        let turn_id = pluck_turn_id(&result).ok_or_else(|| {
+            HarnessError::SubmitFailed(format!(
+                "turn/start response missing turn.turn_id: {result}"
+            ))
+        })?;
+        Ok(TurnId(turn_id))
+    }
+
+    fn events(&self, h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+        let adapter = self.clone();
+        let thread_id = h.identity.clone();
+        // Build a futures stream by chaining: (1) one-shot setup that
+        // either yields an Error event or returns a broadcast receiver,
+        // then (2) the receiver-driven event flow with thread-id
+        // filtering. If we can't get a client yet, surface a single
+        // Error event and stop — orchestrator's progress.jsonl poller
+        // remains the state-transition SoT (Wave 1 contract).
+        let setup = async move {
+            match adapter.client().await {
+                Ok(c) => Ok(c.subscribe()),
+                Err(err) => Err(ThreadErrorEvent {
+                    kind: "connect".into(),
+                    message: err.to_string(),
+                }),
+            }
+        };
+        let s = stream::once(setup).flat_map(move |outcome| {
+            let thread_id = thread_id.clone();
+            match outcome {
+                Err(err) => stream::iter(vec![ThreadEvent::Error(err)]).boxed(),
+                Ok(rx) => {
+                    let s = stream::unfold(rx, move |mut rx| {
+                        let wanted = thread_id.clone();
+                        async move {
+                            loop {
+                                match rx.recv().await {
+                                    Ok(notif) => {
+                                        if let Some(evt) = translate_notification(&notif, &wanted)
+                                        {
+                                            return Some((evt, rx));
+                                        }
+                                    }
+                                    Err(
+                                        tokio::sync::broadcast::error::RecvError::Lagged(n),
+                                    ) => {
+                                        tracing::warn!(
+                                            n,
+                                            "codex app-server event subscriber lagged"
+                                        );
+                                        continue;
+                                    }
+                                    Err(
+                                        tokio::sync::broadcast::error::RecvError::Closed,
+                                    ) => {
+                                        return None;
+                                    }
+                                }
+                            }
+                        }
+                    });
+                    s.boxed()
+                }
+            }
+        });
+        Box::pin(s)
+    }
+
+    async fn resume_thread(&self, persistent_id: &str) -> Result<ThreadHandle, HarnessError> {
+        let client = self.client().await?;
+        let result = client
+            .call("thread/resume", json!({ "thread_id": persistent_id }))
+            .await
+            .map_err(|e| HarnessError::SpawnFailed(format!("thread/resume: {e:#}")))?;
+        let thread_id = pluck_thread_id(&result).unwrap_or_else(|| persistent_id.to_string());
+        Ok(ThreadHandle {
+            vendor: AgentVendor::Codex,
+            mode: ExecutionMode::Chat,
+            identity: thread_id.clone(),
+            started_at: Utc::now(),
+            raw_extras: json!({ "thread_id": thread_id, "resumed": true }),
+        })
+    }
+
+    async fn close_thread(&self, h: &ThreadHandle) -> Result<(), HarnessError> {
+        // Best-effort archive — codex's `thread/archive` is the
+        // "release server-side state" hook. Failure is logged but
+        // never escalated (idempotent close semantics).
+        let Ok(client) = self.client().await else {
+            // No socket = nothing to close; matches V0.5.x missing-tmux
+            // semantics for close_thread.
+            return Ok(());
+        };
+        let archive = client
+            .call("thread/archive", json!({ "thread_id": h.identity }))
+            .await;
+        if let Err(err) = archive {
+            tracing::warn!(thread_id = %h.identity, error = %err, "thread/archive failed (best-effort)");
+        }
+        let _ = client
+            .call("thread/unsubscribe", json!({ "thread_id": h.identity }))
+            .await;
+        Ok(())
+    }
+}
+
+/// Translate a [`TurnInput`] into the codex `UserInput[]` payload
+/// shape. Mirrors `references/codex/codex-rs/app-server-protocol/src/
+/// protocol/v2/turn.rs::UserInput` variants.
+pub fn turn_input_to_items(input: TurnInput) -> Result<Value, HarnessError> {
+    let items = match input {
+        TurnInput::UserText(text) => json!([{ "type": "text", "text": text }]),
+        TurnInput::Artifact(path) => {
+            let body = std::fs::read_to_string(&path)
+                .map_err(|e| HarnessError::SubmitFailed(format!("read artifact: {e}")))?;
+            json!([
+                { "type": "text", "text": format!("<artifact path=\"{}\">\n{}\n</artifact>", path.display(), body) },
+            ])
+        }
+        TurnInput::SystemDirective(d) => {
+            return Err(HarnessError::SubmitFailed(format!(
+                "codex app-server: SystemDirective \"{d}\" not supported \
+                 (codex has no slash-command surface — use turn/start with text)"
+            )))
+        }
+        TurnInput::Image(path) => json!([
+            { "type": "localImage", "path": path.to_string_lossy() },
+        ]),
+        TurnInput::ToolResult { call_id, content } => json!([
+            {
+                "type": "text",
+                "text": serde_json::to_string(&json!({ "call_id": call_id, "content": content }))
+                    .unwrap_or_default(),
+            }
+        ]),
+    };
+    Ok(items)
+}
+
+/// Translate a single codex notification → [`ThreadEvent`]. Filters
+/// notifications whose `params.thread_id` doesn't match `wanted`.
+/// Returns `None` for notification methods we don't yet propagate
+/// (e.g. `thread/status/changed` — orchestrator state polling owns
+/// that today).
+pub fn translate_notification(notif: &Notification, wanted: &str) -> Option<ThreadEvent> {
+    // thread_id filter (some notifications carry the id, some don't —
+    // we only filter when present so we don't drop turn-scoped events
+    // that omit it).
+    if let Some(tid) = notif.params.get("thread_id").and_then(|v| v.as_str()) {
+        if tid != wanted {
+            return None;
+        }
+    }
+    match notif.method.as_str() {
+        "thread/started" => Some(ThreadEvent::ThreadStarted {
+            thread_id: notif
+                .params
+                .get("thread_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or(wanted)
+                .to_string(),
+        }),
+        "turn/started" => Some(ThreadEvent::TurnStarted {
+            turn_id: notif
+                .params
+                .get("turn_id")
+                .or_else(|| notif.params.get("turn").and_then(|t| t.get("turn_id")))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        }),
+        "turn/completed" => Some(ThreadEvent::TurnCompleted {
+            turn_id: notif
+                .params
+                .get("turn_id")
+                .or_else(|| notif.params.get("turn").and_then(|t| t.get("turn_id")))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            usage: pluck_usage(&notif.params).unwrap_or_default(),
+        }),
+        "turn/failed" => Some(ThreadEvent::TurnFailed {
+            turn_id: notif
+                .params
+                .get("turn_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            err: ThreadErrorEvent {
+                kind: "turn_failed".into(),
+                message: notif
+                    .params
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("(no message)")
+                    .to_string(),
+            },
+        }),
+        "item/started" => translate_item_event(&notif.params, |item| {
+            ThreadEvent::ItemStarted { item }
+        }),
+        "item/updated" => translate_item_event(&notif.params, |item| {
+            ThreadEvent::ItemUpdated { item }
+        }),
+        "item/completed" => translate_item_event(&notif.params, |item| {
+            ThreadEvent::ItemCompleted { item }
+        }),
+        "item/agentMessage/delta" => {
+            let delta = notif
+                .params
+                .get("delta")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let id = notif
+                .params
+                .get("item_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(ThreadEvent::ItemUpdated {
+                item: ThreadItem {
+                    id,
+                    details: ThreadItemDetails::AgentMessage(delta.to_string()),
+                },
+            })
+        }
+        _ => None,
+    }
+}
+
+fn translate_item_event(
+    params: &Value,
+    ctor: fn(ThreadItem) -> ThreadEvent,
+) -> Option<ThreadEvent> {
+    let item_val = params.get("item").cloned().unwrap_or_else(|| params.clone());
+    let id = item_val
+        .get("id")
+        .or_else(|| params.get("item_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let details = match item_val.get("type").and_then(|v| v.as_str()) {
+        Some("agent_message") | Some("agentMessage") => ThreadItemDetails::AgentMessage(
+            item_val
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        Some("reasoning") => ThreadItemDetails::Reasoning(
+            item_val
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        Some("command_execution") | Some("commandExecution") => {
+            ThreadItemDetails::CommandExecution {
+                cmd: item_val
+                    .get("command")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                status: item_val
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("in_progress")
+                    .to_string(),
+            }
+        }
+        Some("file_change") | Some("fileChange") => {
+            let path = item_val
+                .get("changes")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("path"))
+                .and_then(|v| v.as_str())
+                .map(PathBuf::from)
+                .unwrap_or_default();
+            let kind = item_val
+                .get("changes")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("kind"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("update")
+                .to_string();
+            ThreadItemDetails::FileChange { path, kind }
+        }
+        Some("mcp_tool_call") | Some("mcpToolCall") => ThreadItemDetails::ToolCall {
+            name: item_val
+                .get("tool")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            args: item_val
+                .get("arguments")
+                .cloned()
+                .unwrap_or(Value::Null),
+        },
+        Some("web_search") | Some("webSearch") => ThreadItemDetails::WebSearch {
+            query: item_val
+                .get("query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        },
+        Some("error") => ThreadItemDetails::Error(
+            item_val
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        _ => ThreadItemDetails::AgentMessage(String::new()),
+    };
+    Some(ctor(ThreadItem { id, details }))
+}
+
+fn pluck_thread_id(v: &Value) -> Option<String> {
+    v.get("thread")
+        .and_then(|t| t.get("thread_id"))
+        .or_else(|| v.get("thread_id"))
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+}
+
+fn pluck_turn_id(v: &Value) -> Option<String> {
+    v.get("turn")
+        .and_then(|t| t.get("turn_id"))
+        .or_else(|| v.get("turn_id"))
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+}
+
+fn pluck_usage(v: &Value) -> Option<UnifiedTokenUsage> {
+    let raw = v.get("usage").cloned().or_else(|| {
+        v.get("turn")
+            .and_then(|t| t.get("usage"))
+            .cloned()
+    })?;
+    serde_json::from_value(raw).ok()
+}
+
+/// Convenience: build a placeholder client-less adapter. Test-only;
+/// production callers go through `client()` which dials the socket.
+#[cfg(test)]
+fn _placeholder() -> CodexAppServerAdapter {
+    CodexAppServerAdapter::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn resolve_socket_env_override_wins() {
+        std::env::set_var(APP_SERVER_SOCKET_ENV, "/tmp/ccteam-test-codex.sock");
+        let p = CodexAppServerAdapter::resolve_socket_path().unwrap();
+        assert_eq!(p, PathBuf::from("/tmp/ccteam-test-codex.sock"));
+        std::env::remove_var(APP_SERVER_SOCKET_ENV);
+    }
+
+    #[test]
+    fn turn_input_user_text_shape() {
+        let v = turn_input_to_items(TurnInput::UserText("hi".into())).unwrap();
+        assert_eq!(v[0]["type"], "text");
+        assert_eq!(v[0]["text"], "hi");
+    }
+
+    #[test]
+    fn turn_input_image_shape() {
+        let v = turn_input_to_items(TurnInput::Image(PathBuf::from("/img.png"))).unwrap();
+        assert_eq!(v[0]["type"], "localImage");
+        assert_eq!(v[0]["path"], "/img.png");
+    }
+
+    #[test]
+    fn turn_input_system_directive_rejected() {
+        let err = turn_input_to_items(TurnInput::SystemDirective("/compact".into())).unwrap_err();
+        assert!(matches!(err, HarnessError::SubmitFailed(_)));
+    }
+
+    #[test]
+    fn translate_thread_started() {
+        let n = Notification {
+            method: "thread/started".into(),
+            params: json!({ "thread_id": "t-1" }),
+        };
+        let e = translate_notification(&n, "t-1").unwrap();
+        match e {
+            ThreadEvent::ThreadStarted { thread_id } => assert_eq!(thread_id, "t-1"),
+            _ => panic!("expected ThreadStarted"),
+        }
+    }
+
+    #[test]
+    fn translate_filters_foreign_thread() {
+        let n = Notification {
+            method: "turn/started".into(),
+            params: json!({ "thread_id": "other", "turn_id": "x" }),
+        };
+        assert!(translate_notification(&n, "ours").is_none());
+    }
+
+    #[test]
+    fn translate_turn_completed_extracts_usage() {
+        let n = Notification {
+            method: "turn/completed".into(),
+            params: json!({
+                "thread_id": "t-1",
+                "turn_id": "u-1",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cached_input_tokens": 0,
+                },
+            }),
+        };
+        let e = translate_notification(&n, "t-1").unwrap();
+        match e {
+            ThreadEvent::TurnCompleted { turn_id, usage } => {
+                assert_eq!(turn_id, "u-1");
+                assert_eq!(usage.input_tokens, 100);
+                assert_eq!(usage.output_tokens, 50);
+            }
+            _ => panic!("expected TurnCompleted"),
+        }
+    }
+
+    #[test]
+    fn translate_item_completed_agent_message() {
+        let n = Notification {
+            method: "item/completed".into(),
+            params: json!({
+                "thread_id": "t-1",
+                "item": { "id": "i-1", "type": "agent_message", "text": "hello" }
+            }),
+        };
+        let e = translate_notification(&n, "t-1").unwrap();
+        match e {
+            ThreadEvent::ItemCompleted { item } => {
+                assert_eq!(item.id, "i-1");
+                match item.details {
+                    ThreadItemDetails::AgentMessage(s) => assert_eq!(s, "hello"),
+                    _ => panic!("expected agent_message"),
+                }
+            }
+            _ => panic!("expected ItemCompleted"),
+        }
+    }
+}

--- a/crates/ccteam-core/src/execution/codex_exec.rs
+++ b/crates/ccteam-core/src/execution/codex_exec.rs
@@ -1,51 +1,107 @@
-//! V0.6.0 F107 — `CodexExecAdapter` (replaces V0.5.x `CodexAdapter`).
+//! V0.6.0 F107 + Wave 3 F112 — `CodexExecAdapter` (replaces V0.5.x
+//! `CodexAdapter`).
 //!
-//! Wave 1 parity with V0.5.1 behaviour:
+//! ## Lifecycle (Wave 3)
 //!
 //! - `start_thread`: `tmux new-session -d -s ccteam-<slug>-<sid> -c <cwd>
-//!   codex <extra_args...>` — codex has no `--bg` surface today, so we
-//!   keep the V0.4.0 F62 tmux long-session container. Initial state
-//!   observer file `~/.ccteam/codex/<sid>/state.json` is written
-//!   best-effort.
+//!   codex <extra_args...>` — codex's interactive shell stays the V0.5.1
+//!   tmux long-session container so the cost-status pane keeps working.
+//!   Wave 3's per-turn `codex exec --json` subprocess is launched
+//!   **independently** from this container; the tmux pane is just a
+//!   convenient place for the `CODEX_STATUS:` observer line to surface.
+//! - `submit_turn` (Wave 3): spawn `codex exec --json [prompt]` (or
+//!   `codex resume <id> --json [prompt]` when `raw_extras.resumed`).
+//!   Stdout JSONL is translated to [`ThreadEvent`]s and pushed into a
+//!   per-thread broadcast so `events()` can drain.
+//! - `events` (Wave 3): subscribe to the per-thread broadcast.
+//! - `resume_thread` (Wave 3): synthesise a [`ThreadHandle`] whose
+//!   `raw_extras.resumed == true` and `identity = persistent_id`; the
+//!   *next* `submit_turn` invokes `codex resume <id>` instead of
+//!   `codex exec`.
 //! - `close_thread`: send `q` + Enter (codex's documented quit
 //!   keybinding), 500 ms grace, then `tmux kill-session -t <name>`
-//!   fallback.
-//! - `events`: empty stream for Wave 1; Wave 3 F112 fills with `codex
-//!   exec --json` stdout JSONL → [`crate::harness::ThreadEvent`].
-//! - `submit_turn` / `resume_thread`: Wave 1 stub
-//!   `HarnessError::NotImplemented`; Wave 3 F112 fills both via `codex
-//!   exec --json` stdin pipe + `codex resume <UUID>`.
+//!   fallback (parity with V0.5.1).
 //!
-//! Free helpers ([`parse_status_line`], [`snapshot_from_status`]) are
-//! kept `pub` so non-trait callers (web layer, cost summary) can
-//! consume codex status without going through the trait. V0.6.0 F107
-//! drops `ingest_snapshot` from the trait surface — direct fn calls
-//! are the new convention.
+//! ## Test hooks
+//!
+//! - `CCTEAM_CODEX_BIN` env override redirects the per-turn subprocess
+//!   from the real `codex` binary to a fake script that emits
+//!   deterministic JSONL. Used by `tests/codex_exec_test.rs`.
 
-use std::process::Command;
+use std::collections::HashMap;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::Utc;
-use futures::stream::{self, BoxStream};
+use futures::stream::{self, BoxStream, StreamExt};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::{broadcast, Mutex};
 
+use crate::execution::codex_app_server::CODEX_BIN_ENV;
 use crate::harness::{
     pluck_f64, pluck_pct, pluck_str, AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter,
-    HarnessError, HarnessSnapshot, SpawnCtx, ThreadEvent, ThreadHandle, TurnId, TurnInput,
-    CODEX_STATUS_MARKER,
+    HarnessError, HarnessSnapshot, SpawnCtx, ThreadErrorEvent, ThreadEvent, ThreadHandle,
+    ThreadItem, ThreadItemDetails, TurnId, TurnInput, UnifiedTokenUsage, CODEX_STATUS_MARKER,
 };
 use crate::paths::CcteamPaths;
 use crate::tmux::{session_name_for_slug, TmuxSession};
 
-/// V0.6.0 F107 [`HarnessAdapter`] for OpenAI's `codex` CLI (tmux
-/// long-session container; Wave 3 F112 will add `codex exec --json` +
-/// `codex app-server` UDS paths).
-#[derive(Debug, Default, Clone, Copy)]
-pub struct CodexExecAdapter;
+/// Per-thread event broadcast buffer. Codex bursts items per turn so
+/// 256 lines of headroom is comfortable for a single subscriber.
+const EVENT_CHANNEL_BUFFER: usize = 256;
+
+/// V0.6.0 F107 + Wave 3 F112 [`HarnessAdapter`] for OpenAI's `codex`
+/// CLI. Combines a tmux long-session container (for the cost-status
+/// pane) with per-turn `codex exec --json` subprocesses (for the
+/// actual prompting + structured event stream).
+#[derive(Clone, Default)]
+pub struct CodexExecAdapter {
+    /// Per-thread broadcast — populated lazily on the first
+    /// `submit_turn` (or `events()` call) for a given thread identity.
+    /// `Arc<Mutex<...>>` so `Clone` + `Send + Sync` constraints from
+    /// `HarnessAdapter` hold without leaking dyn-state to the caller.
+    threads: Arc<Mutex<HashMap<String, broadcast::Sender<ThreadEvent>>>>,
+    /// Monotonic turn counter for synthesising `TurnId` when codex's
+    /// JSONL stream omits one.
+    turn_seq: Arc<AtomicU64>,
+}
+
+impl std::fmt::Debug for CodexExecAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodexExecAdapter").finish_non_exhaustive()
+    }
+}
 
 impl CodexExecAdapter {
-    pub const fn new() -> Self {
-        Self
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve the codex binary path. Honors `CCTEAM_CODEX_BIN` env
+    /// override (hermetic tests) before falling back to PATH's `codex`.
+    fn codex_bin() -> String {
+        std::env::var(CODEX_BIN_ENV).unwrap_or_else(|_| "codex".to_string())
+    }
+
+    /// Get (or create) the broadcast sender for a thread identity.
+    async fn channel_for(&self, identity: &str) -> broadcast::Sender<ThreadEvent> {
+        let mut guard = self.threads.lock().await;
+        if let Some(s) = guard.get(identity) {
+            return s.clone();
+        }
+        let (tx, _) = broadcast::channel(EVENT_CHANNEL_BUFFER);
+        guard.insert(identity.to_string(), tx.clone());
+        tx
+    }
+
+    /// Mint the next synthetic turn id.
+    fn next_turn_id(&self) -> TurnId {
+        let n = self.turn_seq.fetch_add(1, Ordering::SeqCst);
+        TurnId(format!("codex-exec-{n}"))
     }
 
     /// Resolve `~/.ccteam/codex/<sid>/state.json` for a session.
@@ -196,27 +252,182 @@ impl HarnessAdapter for CodexExecAdapter {
 
     async fn submit_turn(
         &self,
-        _h: &ThreadHandle,
-        _input: TurnInput,
+        h: &ThreadHandle,
+        input: TurnInput,
     ) -> Result<TurnId, HarnessError> {
-        Err(HarnessError::NotImplemented {
-            reason: "Wave 3 F112 fills CodexExecAdapter::submit_turn via `codex exec --json` \
-                     stdin pipe + thread/start UDS"
-                .to_string(),
-        })
+        let prompt = render_prompt(&input)?;
+        let resume_id = h
+            .raw_extras
+            .get("resumed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+            .then(|| {
+                h.raw_extras
+                    .get("thread_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&h.identity)
+                    .to_string()
+            });
+        let argv = build_exec_argv(resume_id.as_deref());
+        let bin = Self::codex_bin();
+        let tx = self.channel_for(&h.identity).await;
+        let turn_id = self.next_turn_id();
+
+        let mut child = tokio::process::Command::new(&bin)
+            .args(&argv)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|err| {
+                HarnessError::SubmitFailed(format!("spawn {bin} {argv:?}: {err}"))
+            })?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            let prompt_clone = prompt.clone();
+            tokio::spawn(async move {
+                if let Err(err) = stdin.write_all(prompt_clone.as_bytes()).await {
+                    tracing::warn!(error = %err, "codex exec: stdin write failed");
+                }
+                let _ = stdin.shutdown().await;
+            });
+        }
+
+        let stdout = child.stdout.take().ok_or_else(|| {
+            HarnessError::SubmitFailed("codex exec: missing stdout pipe".to_string())
+        })?;
+        let stderr = child.stderr.take();
+
+        // Spawn a reader task that translates JSONL → ThreadEvent and
+        // pushes into the per-thread broadcast. Detached — the events()
+        // stream is the synchronisation point for callers that care.
+        let turn_id_for_task = turn_id.clone();
+        let tx_for_task = tx.clone();
+        tokio::spawn(async move {
+            let buf = BufReader::new(stdout);
+            let mut lines = buf.lines();
+            let mut saw_completion = false;
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        match serde_json::from_str::<Value>(trimmed) {
+                            Ok(v) => {
+                                for evt in translate_jsonl_event(&v, &turn_id_for_task) {
+                                    if matches!(
+                                        evt,
+                                        ThreadEvent::TurnCompleted { .. }
+                                            | ThreadEvent::TurnFailed { .. }
+                                    ) {
+                                        saw_completion = true;
+                                    }
+                                    let _ = tx_for_task.send(evt);
+                                }
+                            }
+                            Err(err) => {
+                                tracing::debug!(
+                                    line = %trimmed,
+                                    error = %err,
+                                    "codex exec: skipping non-JSON line"
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        tracing::warn!(error = %err, "codex exec: stdout read error");
+                        break;
+                    }
+                }
+            }
+            let status = child.wait().await;
+            if !saw_completion {
+                match status {
+                    Ok(s) if s.success() => {
+                        let _ = tx_for_task.send(ThreadEvent::TurnCompleted {
+                            turn_id: turn_id_for_task.0.clone(),
+                            usage: UnifiedTokenUsage::default(),
+                        });
+                    }
+                    Ok(s) => {
+                        let _ = tx_for_task.send(ThreadEvent::TurnFailed {
+                            turn_id: turn_id_for_task.0.clone(),
+                            err: ThreadErrorEvent {
+                                kind: "nonzero_exit".into(),
+                                message: format!(
+                                    "codex exec exited with {} (no turn.completed seen)",
+                                    s.code().unwrap_or(-1)
+                                ),
+                            },
+                        });
+                    }
+                    Err(err) => {
+                        let _ = tx_for_task.send(ThreadEvent::TurnFailed {
+                            turn_id: turn_id_for_task.0.clone(),
+                            err: ThreadErrorEvent {
+                                kind: "wait_failed".into(),
+                                message: err.to_string(),
+                            },
+                        });
+                    }
+                }
+            }
+        });
+
+        if let Some(stderr) = stderr {
+            tokio::spawn(async move {
+                let buf = BufReader::new(stderr);
+                let mut lines = buf.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if !line.trim().is_empty() {
+                        tracing::warn!(stderr = %line, "codex exec stderr");
+                    }
+                }
+            });
+        }
+
+        Ok(turn_id)
     }
 
-    fn events(&self, _h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
-        // Wave 1: empty stream. Wave 3 F112 will populate from `codex
-        // exec --json` stdout JSONL → ThreadEvent translation.
-        Box::pin(stream::empty())
+    fn events(&self, h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+        let adapter = self.clone();
+        let identity = h.identity.clone();
+        let setup = async move { adapter.channel_for(&identity).await.subscribe() };
+        let s = stream::once(setup).flat_map(|rx| {
+            stream::unfold(rx, |mut rx| async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(evt) => return Some((evt, rx)),
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(n, "codex_exec events subscriber lagged");
+                            continue;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => return None,
+                    }
+                }
+            })
+        });
+        Box::pin(s)
     }
 
-    async fn resume_thread(&self, _persistent_id: &str) -> Result<ThreadHandle, HarnessError> {
-        Err(HarnessError::NotImplemented {
-            reason: "Wave 3 F112 fills CodexExecAdapter::resume_thread via `codex resume \
-                     <UUID>`"
-                .to_string(),
+    async fn resume_thread(&self, persistent_id: &str) -> Result<ThreadHandle, HarnessError> {
+        if persistent_id.is_empty() {
+            return Err(HarnessError::SpawnFailed(
+                "codex resume: persistent_id is empty".into(),
+            ));
+        }
+        Ok(ThreadHandle {
+            vendor: AgentVendor::Codex,
+            mode: ExecutionMode::Bg,
+            identity: persistent_id.to_string(),
+            started_at: Utc::now(),
+            raw_extras: serde_json::json!({
+                "thread_id": persistent_id,
+                "resumed": true,
+            }),
         })
     }
 
@@ -246,6 +457,188 @@ impl HarnessAdapter for CodexExecAdapter {
         .await
         .map_err(|err| HarnessError::ShutdownFailed(format!("join blocking close: {err}")))?
     }
+}
+
+/// Build `codex exec --json` (or `codex resume <id> --json`) argv.
+/// The prompt itself is piped via stdin so we don't have to escape
+/// shell metacharacters on the command line.
+pub fn build_exec_argv(resume_id: Option<&str>) -> Vec<String> {
+    let mut argv: Vec<String> = Vec::new();
+    if let Some(id) = resume_id {
+        argv.push("resume".to_string());
+        argv.push(id.to_string());
+    } else {
+        argv.push("exec".to_string());
+    }
+    argv.push("--json".to_string());
+    // Pipe prompt via stdin (`codex exec -`).
+    argv.push("-".to_string());
+    argv
+}
+
+/// Convert a [`TurnInput`] into a single prompt string suitable for
+/// piping into `codex exec` over stdin. Mirrors the codex-app-server
+/// adapter's `turn_input_to_items` but flattens to one text blob since
+/// `codex exec` only accepts text on stdin.
+pub fn render_prompt(input: &TurnInput) -> Result<String, HarnessError> {
+    Ok(match input {
+        TurnInput::UserText(t) => t.clone(),
+        TurnInput::Artifact(p) => {
+            let body = std::fs::read_to_string(p)
+                .map_err(|e| HarnessError::SubmitFailed(format!("read artifact: {e}")))?;
+            format!("<artifact path=\"{}\">\n{body}\n</artifact>", p.display())
+        }
+        TurnInput::SystemDirective(d) => {
+            return Err(HarnessError::SubmitFailed(format!(
+                "codex exec: SystemDirective '{d}' not supported (codex has no slash-command \
+                 surface; wrap as user text instead)"
+            )))
+        }
+        TurnInput::Image(p) => format!("[image: {}]", p.display()),
+        TurnInput::ToolResult { call_id, content } => serde_json::to_string(&serde_json::json!({
+            "call_id": call_id,
+            "content": content,
+        }))
+        .unwrap_or_else(|_| "{}".to_string()),
+    })
+}
+
+/// Translate one parsed `codex exec --json` JSONL value into zero or
+/// more [`ThreadEvent`]s. The codex stream uses dot-separated `type`
+/// discriminators (`thread.started`, `item.started`, etc.); see
+/// `references/codex/codex-rs/exec/src/exec_events.rs`.
+pub fn translate_jsonl_event(v: &Value, turn_id: &TurnId) -> Vec<ThreadEvent> {
+    let Some(kind) = v.get("type").and_then(|t| t.as_str()) else {
+        return vec![];
+    };
+    match kind {
+        "thread.started" => {
+            let tid = v
+                .get("thread_id")
+                .and_then(|x| x.as_str())
+                .unwrap_or("")
+                .to_string();
+            vec![ThreadEvent::ThreadStarted { thread_id: tid }]
+        }
+        "turn.started" => vec![ThreadEvent::TurnStarted {
+            turn_id: turn_id.0.clone(),
+        }],
+        "turn.completed" => {
+            let usage = v
+                .get("usage")
+                .and_then(|u| serde_json::from_value(u.clone()).ok())
+                .unwrap_or_default();
+            vec![ThreadEvent::TurnCompleted {
+                turn_id: turn_id.0.clone(),
+                usage,
+            }]
+        }
+        "turn.failed" => vec![ThreadEvent::TurnFailed {
+            turn_id: turn_id.0.clone(),
+            err: ThreadErrorEvent {
+                kind: "turn_failed".into(),
+                message: v
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("(no message)")
+                    .to_string(),
+            },
+        }],
+        "item.started" | "item.updated" | "item.completed" => {
+            let item = parse_jsonl_item(v.get("item").unwrap_or(v));
+            let evt = match kind {
+                "item.started" => ThreadEvent::ItemStarted { item },
+                "item.updated" => ThreadEvent::ItemUpdated { item },
+                _ => ThreadEvent::ItemCompleted { item },
+            };
+            vec![evt]
+        }
+        "error" => vec![ThreadEvent::Error(ThreadErrorEvent {
+            kind: "codex_error".into(),
+            message: v
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("(no message)")
+                .to_string(),
+        })],
+        _ => vec![],
+    }
+}
+
+fn parse_jsonl_item(item: &Value) -> ThreadItem {
+    let id = item
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let kind = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let details = match kind {
+        "agent_message" => ThreadItemDetails::AgentMessage(
+            item.get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        "reasoning" => ThreadItemDetails::Reasoning(
+            item.get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        "command_execution" => ThreadItemDetails::CommandExecution {
+            cmd: item
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            status: item
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("in_progress")
+                .to_string(),
+        },
+        "file_change" => {
+            let path = item
+                .get("changes")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("path"))
+                .and_then(|v| v.as_str())
+                .map(std::path::PathBuf::from)
+                .unwrap_or_default();
+            let kind = item
+                .get("changes")
+                .and_then(|c| c.get(0))
+                .and_then(|c| c.get("kind"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("update")
+                .to_string();
+            ThreadItemDetails::FileChange { path, kind }
+        }
+        "mcp_tool_call" => ThreadItemDetails::ToolCall {
+            name: item
+                .get("tool")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            args: item.get("arguments").cloned().unwrap_or(Value::Null),
+        },
+        "web_search" => ThreadItemDetails::WebSearch {
+            query: item
+                .get("query")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        },
+        "error" => ThreadItemDetails::Error(
+            item.get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        ),
+        _ => ThreadItemDetails::AgentMessage(String::new()),
+    };
+    ThreadItem { id, details }
 }
 
 /// Send `q` + Enter to the named tmux session — codex's standard

--- a/crates/ccteam-core/src/execution/codex_jsonrpc.rs
+++ b/crates/ccteam-core/src/execution/codex_jsonrpc.rs
@@ -1,0 +1,393 @@
+//! V0.6.0 Wave 3 F112 — thin JSON-RPC client over a Unix Domain Socket
+//! for talking to `codex app-server --listen unix://<sock>`.
+//!
+//! Codex's wire format is "JSON-RPC lite" — line-delimited JSON, no
+//! `jsonrpc: "2.0"` discriminator. Each line is either:
+//!
+//! - **Request**:      `{ "id": <int>, "method": "<m>", "params": {...} }`
+//! - **Response**:     `{ "id": <int>, "result": {...} }`
+//! - **Response err**: `{ "id": <int>, "error": {...} }`
+//! - **Notification**: `{ "method": "<m>", "params": {...} }` (no `id`)
+//!
+//! ## Concurrency shape
+//!
+//! Each connection owns two background tasks:
+//!
+//! - **Writer task** — drains an `mpsc<Vec<u8>>` of pre-serialised
+//!   JSONL frames into the socket. Letting callers push bytes via
+//!   channel (instead of holding a `Mutex<WriteHalf>`) keeps `call()`
+//!   non-blocking even when the kernel buffer back-pressures.
+//! - **Reader task** — parses each inbound line, then dispatches to
+//!   pending oneshots (responses) or the broadcast (notifications).
+//!
+//! Tests drive the client against a hand-rolled UDS scripted server in
+//! `tests/codex_jsonrpc_test.rs` so we don't depend on a real codex
+//! `app-server` process.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+
+/// Broadcast buffer size for incoming notifications. Codex bursts items
+/// per turn so 256 is comfortable headroom for a single subscriber.
+const NOTIFICATION_BUFFER: usize = 256;
+
+/// Outbound buffer size: how many JSONL frames may be queued by `call()`
+/// before backpressure. 64 is plenty — callers serialise per-turn.
+const WRITER_BUFFER: usize = 64;
+
+type Pending = HashMap<i64, oneshot::Sender<Result<Value, JsonRpcError>>>;
+
+/// Parsed JSON-RPC error body. `code` is optional in codex's "lite"
+/// dialect; only `message` is mandatory.
+#[derive(Debug, Clone)]
+pub struct JsonRpcError {
+    pub code: Option<i64>,
+    pub message: String,
+    pub data: Option<Value>,
+}
+
+impl std::fmt::Display for JsonRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.code {
+            Some(c) => write!(f, "jsonrpc error {c}: {}", self.message),
+            None => write!(f, "jsonrpc error: {}", self.message),
+        }
+    }
+}
+
+impl std::error::Error for JsonRpcError {}
+
+/// Server → client notification (`method` + `params`, no `id`).
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub method: String,
+    pub params: Value,
+}
+
+/// Thin JSON-RPC client over an existing connection (UDS today; the
+/// surface is transport-agnostic — reader/writer task ownership of the
+/// concrete halves keeps the public API channel-based, so a future
+/// stdio / TCP transport drops in without API churn).
+pub struct CodexJsonRpcClient {
+    out: mpsc::Sender<Vec<u8>>,
+    next_id: AtomicI64,
+    pending: Arc<Mutex<Pending>>,
+    notifications: broadcast::Sender<Notification>,
+    _writer_task: JoinHandle<()>,
+    _reader_task: JoinHandle<()>,
+}
+
+impl CodexJsonRpcClient {
+    /// Connect to `codex app-server` over a UDS socket. Both reader and
+    /// writer background tasks are spawned immediately.
+    pub async fn connect_uds(socket_path: &Path) -> Result<Self> {
+        let stream = UnixStream::connect(socket_path).await.with_context(|| {
+            format!(
+                "connect codex app-server UDS at {}",
+                socket_path.display()
+            )
+        })?;
+        let (read_half, write_half) = stream.into_split();
+        Ok(Self::spawn(read_half, write_half))
+    }
+
+    /// Build a client around an arbitrary split read/write pair.
+    /// Tests use this with a `tokio::io::duplex` pair for scripted
+    /// peers.
+    pub fn spawn<R, W>(reader: R, writer: W) -> Self
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
+        let pending: Arc<Mutex<Pending>> = Arc::new(Mutex::new(HashMap::new()));
+        let (notif_tx, _) = broadcast::channel(NOTIFICATION_BUFFER);
+        let (out_tx, out_rx) = mpsc::channel::<Vec<u8>>(WRITER_BUFFER);
+
+        let writer_task = tokio::spawn(run_writer_loop(writer, out_rx));
+        let reader_task = tokio::spawn(run_reader_loop(
+            reader,
+            Arc::clone(&pending),
+            notif_tx.clone(),
+        ));
+
+        Self {
+            out: out_tx,
+            next_id: AtomicI64::new(1),
+            pending,
+            notifications: notif_tx,
+            _writer_task: writer_task,
+            _reader_task: reader_task,
+        }
+    }
+
+    /// Issue a JSON-RPC request and await the matching response. `params`
+    /// may be `Value::Null` for no-param methods (codex tolerates either
+    /// omission or null).
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut guard = self.pending.lock().await;
+            guard.insert(id, tx);
+        }
+
+        let mut frame = json!({
+            "id": id,
+            "method": method,
+        });
+        if !params.is_null() {
+            frame["params"] = params;
+        }
+        let mut line = serde_json::to_vec(&frame)?;
+        line.push(b'\n');
+
+        self.out
+            .send(line)
+            .await
+            .with_context(|| format!("send jsonrpc request {method}"))?;
+
+        match rx.await {
+            Ok(Ok(v)) => Ok(v),
+            Ok(Err(e)) => Err(anyhow!(e)),
+            Err(_) => Err(anyhow!(
+                "jsonrpc reader task dropped pending request id={id} method={method}"
+            )),
+        }
+    }
+
+    /// Subscribe to server-side notifications (push events outside the
+    /// request/response cycle). Returns a fresh receiver — multiple
+    /// subscribers are supported.
+    pub fn subscribe(&self) -> broadcast::Receiver<Notification> {
+        self.notifications.subscribe()
+    }
+
+    /// Send a one-way notification (no id, no response expected).
+    /// Codex's app-server protocol doesn't have client-originated
+    /// notifications today, but the wire allows them — keep the
+    /// helper for future use (e.g. `client/cancel`).
+    pub async fn notify(&self, method: &str, params: Value) -> Result<()> {
+        let mut frame = json!({ "method": method });
+        if !params.is_null() {
+            frame["params"] = params;
+        }
+        let mut line = serde_json::to_vec(&frame)?;
+        line.push(b'\n');
+        self.out
+            .send(line)
+            .await
+            .with_context(|| format!("send jsonrpc notification {method}"))?;
+        Ok(())
+    }
+}
+
+async fn run_writer_loop<W: AsyncWrite + Unpin + Send>(
+    mut writer: W,
+    mut rx: mpsc::Receiver<Vec<u8>>,
+) {
+    while let Some(buf) = rx.recv().await {
+        if let Err(err) = writer.write_all(&buf).await {
+            tracing::warn!(error = %err, "jsonrpc: writer error, stopping");
+            break;
+        }
+        if let Err(err) = writer.flush().await {
+            tracing::warn!(error = %err, "jsonrpc: writer flush error");
+        }
+    }
+    let _ = writer.shutdown().await;
+}
+
+async fn run_reader_loop<R: AsyncRead + Unpin + Send>(
+    reader: R,
+    pending: Arc<Mutex<Pending>>,
+    notifications: broadcast::Sender<Notification>,
+) {
+    let buf = BufReader::new(reader);
+    let mut lines = buf.lines();
+    loop {
+        match lines.next_line().await {
+            Ok(Some(line)) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Value>(trimmed) {
+                    Ok(v) => dispatch(v, &pending, &notifications).await,
+                    Err(err) => {
+                        tracing::warn!(error = %err, line = %trimmed, "jsonrpc: parse failure");
+                    }
+                }
+            }
+            Ok(None) => {
+                tracing::debug!("jsonrpc: peer closed");
+                break;
+            }
+            Err(err) => {
+                tracing::warn!(error = %err, "jsonrpc: read error");
+                break;
+            }
+        }
+    }
+}
+
+async fn dispatch(
+    v: Value,
+    pending: &Arc<Mutex<Pending>>,
+    notifications: &broadcast::Sender<Notification>,
+) {
+    // Response: has `id` AND (`result` or `error`).
+    if let Some(id) = v.get("id").and_then(|x| x.as_i64()) {
+        if v.get("result").is_some() || v.get("error").is_some() {
+            let tx = { pending.lock().await.remove(&id) };
+            if let Some(tx) = tx {
+                let outcome = if let Some(err) = v.get("error") {
+                    Err(JsonRpcError {
+                        code: err.get("code").and_then(|c| c.as_i64()),
+                        message: err
+                            .get("message")
+                            .and_then(|m| m.as_str())
+                            .unwrap_or("(no message)")
+                            .to_string(),
+                        data: err.get("data").cloned(),
+                    })
+                } else {
+                    Ok(v.get("result").cloned().unwrap_or(Value::Null))
+                };
+                let _ = tx.send(outcome);
+            } else {
+                tracing::debug!(id, "jsonrpc: response for unknown id");
+            }
+            return;
+        }
+    }
+    // Notification: has `method` but no result/error.
+    if let Some(method) = v.get("method").and_then(|m| m.as_str()) {
+        let params = v.get("params").cloned().unwrap_or(Value::Null);
+        let _ = notifications.send(Notification {
+            method: method.to_string(),
+            params,
+        });
+        return;
+    }
+    tracing::debug!(value = %v, "jsonrpc: unrecognised frame");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jsonrpc_error_display_with_code() {
+        let e = JsonRpcError {
+            code: Some(-32601),
+            message: "method not found".into(),
+            data: None,
+        };
+        assert!(e.to_string().contains("-32601"));
+        assert!(e.to_string().contains("method not found"));
+    }
+
+    #[test]
+    fn jsonrpc_error_display_without_code() {
+        let e = JsonRpcError {
+            code: None,
+            message: "boom".into(),
+            data: None,
+        };
+        assert!(e.to_string().contains("boom"));
+    }
+
+    /// Smoke-test the spawn + call + notification round trip using
+    /// `tokio::io::duplex` for a scripted in-process peer.
+    #[tokio::test]
+    async fn call_response_roundtrip() {
+        // client_side: read = client's reads (peer writes), write = client's writes (peer reads)
+        let (client_rw, mut peer_rw) = tokio::io::duplex(4096);
+        let (client_r, client_w) = tokio::io::split(client_rw);
+        let client = CodexJsonRpcClient::spawn(client_r, client_w);
+
+        // Peer task: read one line, respond with matching id.
+        let peer = tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+            let (pr, mut pw) = tokio::io::split(&mut peer_rw);
+            let mut pr = BufReader::new(pr);
+            let mut buf = String::new();
+            pr.read_line(&mut buf).await.unwrap();
+            let req: Value = serde_json::from_str(buf.trim()).unwrap();
+            let id = req["id"].as_i64().unwrap();
+            assert_eq!(req["method"], "thread/start");
+            let resp = json!({
+                "id": id,
+                "result": { "thread": { "thread_id": "t-1" } }
+            });
+            let mut line = serde_json::to_vec(&resp).unwrap();
+            line.push(b'\n');
+            pw.write_all(&line).await.unwrap();
+            pw.flush().await.unwrap();
+            // Also push a notification.
+            let notif = json!({
+                "method": "thread/started",
+                "params": { "thread_id": "t-1" }
+            });
+            let mut line = serde_json::to_vec(&notif).unwrap();
+            line.push(b'\n');
+            pw.write_all(&line).await.unwrap();
+            pw.flush().await.unwrap();
+            // Keep peer alive briefly so notification reaches subscriber.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        });
+
+        let mut rx = client.subscribe();
+        let result = client
+            .call("thread/start", json!({ "cwd": "/tmp" }))
+            .await
+            .unwrap();
+        assert_eq!(result["thread"]["thread_id"], "t-1");
+
+        let notif = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(notif.method, "thread/started");
+        assert_eq!(notif.params["thread_id"], "t-1");
+
+        peer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn call_error_response_propagates() {
+        let (client_rw, mut peer_rw) = tokio::io::duplex(4096);
+        let (client_r, client_w) = tokio::io::split(client_rw);
+        let client = CodexJsonRpcClient::spawn(client_r, client_w);
+        let peer = tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+            let (pr, mut pw) = tokio::io::split(&mut peer_rw);
+            let mut pr = BufReader::new(pr);
+            let mut buf = String::new();
+            pr.read_line(&mut buf).await.unwrap();
+            let req: Value = serde_json::from_str(buf.trim()).unwrap();
+            let id = req["id"].as_i64().unwrap();
+            let resp = json!({
+                "id": id,
+                "error": { "code": -32601, "message": "method not found" }
+            });
+            let mut line = serde_json::to_vec(&resp).unwrap();
+            line.push(b'\n');
+            pw.write_all(&line).await.unwrap();
+            pw.flush().await.unwrap();
+        });
+
+        let err = client.call("bogus", Value::Null).await.unwrap_err();
+        assert!(err.to_string().contains("method not found"));
+        peer.await.unwrap();
+    }
+}

--- a/crates/ccteam-core/src/execution/mod.rs
+++ b/crates/ccteam-core/src/execution/mod.rs
@@ -4,16 +4,22 @@
 //! - [`claude_bg`] — V0.5.x `ClaudeCodeAdapter` renamed +
 //!   migrated to the 5-method trait shape. Zero behaviour change vs.
 //!   V0.5.1.
-//! - [`claude_tui`] — Wave 1 STUB; Wave 2 F108 fills in tmux
-//!   long-session + send-keys -l direct user-content passthrough +
-//!   dual-track transcript polling.
+//! - [`claude_tui`] — Wave 2 F108 fills in tmux long-session +
+//!   send-keys -l direct user-content passthrough + dual-track
+//!   transcript polling.
 //! - [`codex_exec`] — V0.5.x `CodexAdapter` renamed + migrated.
-//!   Wave 3 F112 will fill in `codex exec --json` + thread/start UDS;
-//!   Wave 1 retains tmux + capture-pane parity with V0.5.1.
+//!   Wave 3 F112 fills `submit_turn` / `resume_thread` / event stream
+//!   via `codex exec --json` stdin pipe + `codex resume <UUID> --json`.
+//! - [`codex_app_server`] — Wave 3 F112 mode-3 codex bot path; talks
+//!   to `codex app-server` over UDS via [`codex_jsonrpc`].
+//! - [`codex_jsonrpc`] — Wave 3 F112 thin JSON-RPC-lite client over
+//!   UnixStream. Demuxes responses / notifications for the adapter.
 
 pub mod claude_bg;
 pub mod claude_tui;
+pub mod codex_app_server;
 pub mod codex_exec;
+pub mod codex_jsonrpc;
 // V0.6.0 F108 / F118 — chat-mode helpers consumed by ClaudeTuiAdapter.
 pub mod session_recovery;
 pub mod transcript_tail;
@@ -21,4 +27,5 @@ pub mod turns_mirror;
 
 pub use claude_bg::ClaudeBgAdapter;
 pub use claude_tui::ClaudeTuiAdapter;
+pub use codex_app_server::CodexAppServerAdapter;
 pub use codex_exec::CodexExecAdapter;

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -43,6 +43,12 @@ pub mod mode_inferrer;
 pub mod orchestrator;
 pub mod paths;
 pub mod pending_inject;
+// V0.6.0 Wave 3 F112 §C — `~/.ccteam/preferences.toml` user-opt-in
+// fallback knobs (vendor swap on Claude quota exceed).
+pub mod preferences;
+// V0.6.0 Wave 3 F112 §B — auto-critic vendor decision (used by the
+// `ccteam-creator` skill Phase 3.5).
+pub mod auto_critic;
 pub mod plugin_resolution;
 pub mod progress;
 pub mod projects;

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -32,7 +32,7 @@ use tokio::task::JoinSet;
 
 use crate::artifact_watcher::{ArtifactEvent, ArtifactWatcher};
 use crate::daemon;
-use crate::execution::{ClaudeBgAdapter, CodexExecAdapter};
+use crate::execution::{ClaudeBgAdapter, ClaudeTuiAdapter, CodexExecAdapter};
 use crate::handoff;
 use crate::harness::{
     AgentSpecBrief, HarnessAdapter, SessionHandle, SpawnCtx, ThreadEvent, UnifiedTokenUsage,
@@ -633,6 +633,35 @@ impl Orchestrator {
         self.adapters.get(key)
     }
 
+    /// V0.6.0 Wave 3 — dispatch helper that picks the right adapter for
+    /// the `(executor, workflow_mode)` pair. mode 3 (`Chat`) overrides
+    /// the per-executor bg/exec default with the long-running TUI adapter
+    /// (Claude) or AppServer adapter (Codex; Wave 3 codex-exec teammate).
+    ///
+    /// Per the Wave 3 e2e-wiring contract: the orchestrator currently
+    /// short-circuits `WorkflowMode::Chat` (lifecycle owned by
+    /// `ccteam-imd`); this helper is the seam future spawn paths reach
+    /// through once orchestrator-owned chat scenarios land.
+    pub fn pick_adapter(
+        &self,
+        exec: Executor,
+        mode: WorkflowMode,
+    ) -> Option<Arc<dyn HarnessAdapter + Send + Sync>> {
+        match (exec, mode) {
+            (Executor::Claude, WorkflowMode::Chat) => {
+                Some(Arc::new(ClaudeTuiAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>)
+            }
+            (Executor::Codex, WorkflowMode::Chat) => {
+                // CodexAppServerAdapter ships with Wave 3 codex-exec-impl
+                // teammate; until that lands, fall back to the bg adapter
+                // so the dispatch table never returns None for a known
+                // (vendor, mode) pair.
+                self.adapter_for(Executor::Codex).cloned()
+            }
+            _ => self.adapter_for(exec).cloned(),
+        }
+    }
+
     /// Test-only adapter override; production CLI never calls this.
     #[cfg(any(test, feature = "test-util"))]
     pub fn set_adapter(&mut self, exec: Executor, adapter: Arc<dyn HarnessAdapter + Send + Sync>) {
@@ -719,6 +748,23 @@ impl Orchestrator {
                 "ts": Utc::now().to_rfc3339(),
             }),
         )?;
+
+        // V0.6.0 Wave 3 — `mode: chat` is owned by `ccteam-imd` end to
+        // end. The daemon spawns the tmux session via
+        // `ClaudeTuiAdapter::start_thread`, drives turns from IM input,
+        // and tails `turns.jsonl` for outbound. Orchestrator's role is
+        // limited to logging `workflow_start` (above) so the project
+        // appears in `ccteam status`; it must NOT enter the artifact
+        // event loop nor attempt to spawn agents (the spec's `agents`
+        // map is allowed to be empty in mode: chat per workflow.rs
+        // validation).
+        if matches!(spec.mode, WorkflowMode::Chat) {
+            tracing::info!(
+                slug,
+                "mode: chat workflow — ccteam-imd owns lifecycle; orchestrator exiting"
+            );
+            return Ok(());
+        }
 
         // V0.4.5: pass the progress.jsonl file (so the watcher can
         // append `artifact_dir_created` events) — the previous version

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -39,6 +39,7 @@ use crate::harness::{
 };
 use crate::inbox::{InboxMessage, SessionMailbox};
 use crate::paths::CcteamPaths;
+use crate::preferences;
 use crate::progress;
 use crate::queries;
 use crate::spawn_brief::{render_spawn_brief, SpawnContext as SpawnBriefContext};
@@ -1516,32 +1517,73 @@ impl Orchestrator {
             .await
             .unwrap_or(0.0);
         let budget = self.budget_limit_for_project(project_dir);
+        // V0.6.0 Wave 3 F112 §C — vendor_fallback hook. When the
+        // cumulative Claude cost trips the cap AND the user opted in
+        // via `~/.ccteam/preferences.toml::fallback.on_claude_quota
+        // = "codex"`, we DON'T hard-stop: we swap this role's adapter
+        // to Codex on this spawn, keep the workflow alive, and write
+        // a `budget_exceeded` event tagged `vendor: claude` +
+        // `vendor_fallback_to: codex` so the audit trail still shows
+        // the cap. The original V0.5.x hard-stop path (no prefs / off /
+        // role not eligible) is otherwise unchanged.
+        let prefs = preferences::load_or_default(&self.paths.root);
+        let mut effective_executor = agent.executor;
         if cost_so_far >= budget {
-            progress::append_event(
-                progress_path,
-                &json!({
-                    "event": "budget_exceeded",
-                    "role": role,
-                    "cost_used_usd": cost_so_far,
-                    "budget_limit_usd": budget,
-                    "slug": slug,
-                    "ts": Utc::now().to_rfc3339(),
-                }),
-            )?;
-            self.send_btw_escalation(
-                slug,
-                &format!(
-                    "budget exceeded for role `{}` (used ${:.2} of ${:.2}); spawn blocked. \
-                     Running sessions left intact.",
-                    role, cost_so_far, budget
-                ),
-            )
-            .await;
-            return Ok(());
+            let claude_vendor = matches!(agent.executor, Executor::Claude);
+            let want_fallback = claude_vendor && prefs.codex_fallback_enabled_for(role);
+            let codex_adapter_present = self.adapter_for(Executor::Codex).is_some();
+            if want_fallback && codex_adapter_present {
+                progress::append_event(
+                    progress_path,
+                    &json!({
+                        "event": "budget_exceeded",
+                        "role": role,
+                        "cost_used_usd": cost_so_far,
+                        "budget_limit_usd": budget,
+                        "slug": slug,
+                        "vendor": "claude",
+                        "vendor_fallback_to": "codex",
+                        "ts": Utc::now().to_rfc3339(),
+                    }),
+                )?;
+                tracing::warn!(
+                    role,
+                    cost_so_far,
+                    budget,
+                    "claude quota tripped; swapping to codex for this spawn (prefs opt-in)"
+                );
+                effective_executor = Executor::Codex;
+            } else {
+                progress::append_event(
+                    progress_path,
+                    &json!({
+                        "event": "budget_exceeded",
+                        "role": role,
+                        "cost_used_usd": cost_so_far,
+                        "budget_limit_usd": budget,
+                        "slug": slug,
+                        "vendor": match agent.executor {
+                            Executor::Claude => "claude",
+                            Executor::Codex => "codex",
+                        },
+                        "ts": Utc::now().to_rfc3339(),
+                    }),
+                )?;
+                self.send_btw_escalation(
+                    slug,
+                    &format!(
+                        "budget exceeded for role `{}` (used ${:.2} of ${:.2}); spawn blocked. \
+                         Running sessions left intact.",
+                        role, cost_so_far, budget
+                    ),
+                )
+                .await;
+                return Ok(());
+            }
         }
 
-        let Some(adapter) = self.adapter_for(agent.executor) else {
-            tracing::warn!(role, executor = ?agent.executor, "no adapter registered");
+        let Some(adapter) = self.adapter_for(effective_executor) else {
+            tracing::warn!(role, executor = ?effective_executor, "no adapter registered");
             self.bump_fail_count(slug, role, progress_path).await?;
             return Ok(());
         };
@@ -1632,7 +1674,7 @@ impl Orchestrator {
                         "session_id": handle.sid,
                         "tmux_session": handle.tmux_session,
                         "job_id": handle.job_id,
-                        "executor": match agent.executor {
+                        "executor": match effective_executor {
                             Executor::Claude => "claude",
                             Executor::Codex => "codex",
                         },

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -35,7 +35,8 @@ use crate::daemon;
 use crate::execution::{ClaudeBgAdapter, CodexExecAdapter};
 use crate::handoff;
 use crate::harness::{
-    AgentSpecBrief, HarnessAdapter, SessionHandle, SpawnCtx, ThreadEvent, UnifiedTokenUsage,
+    AgentSpecBrief, AgentVendor, HarnessAdapter, SessionHandle, SpawnCtx, ThreadEvent,
+    UnifiedTokenUsage,
 };
 use crate::inbox::{InboxMessage, SessionMailbox};
 use crate::paths::CcteamPaths;
@@ -53,6 +54,21 @@ pub const MAX_CONCURRENT_PROJECTS: usize = 3;
 /// vendor, model) -> f64`. Wave 1 returns 0 because the active
 /// agent_done driver is still the F80 `claude_job::probe_job` poller
 /// which reads `cost_usd` from `state.json` directly.
+/// V0.6.0 Wave 3 F112 — derive vendor string from a
+/// [`SessionHandle::harness`] tag. Used to annotate `agent_done`
+/// events with the per-vendor key consumed by
+/// [`crate::queries::CostSummary::cost_24h_by_vendor`] + per-vendor
+/// budget caps. Anything starting with `"codex"` is classified codex;
+/// everything else is claude.
+pub fn vendor_from_harness(harness: &str) -> &'static str {
+    if harness.starts_with("codex") {
+        "codex"
+    } else {
+        "claude"
+    }
+}
+
+#[allow(dead_code)] // Retained for transitional `translate_thread_event` callers; Wave 3 prefers ccteam_cost::estimate_cost.
 fn usage_to_cost_placeholder(_usage: &UnifiedTokenUsage) -> f64 {
     0.0
 }
@@ -1676,24 +1692,44 @@ impl Orchestrator {
         role: &str,
         sid: &str,
         slug: &str,
+        vendor: AgentVendor,
     ) -> Option<serde_json::Value> {
+        let vendor_str = match vendor {
+            AgentVendor::Claude => "claude",
+            AgentVendor::Codex => "codex",
+        };
         match evt {
             ThreadEvent::ThreadStarted { .. } => None,
-            ThreadEvent::TurnCompleted { usage, .. } => Some(json!({
-                "event": "agent_done",
-                "role": role,
-                "session_id": sid,
-                "status": "completed",
-                "cost_usd": usage_to_cost_placeholder(usage),
-                "slug": slug,
-                "ts": Utc::now().to_rfc3339(),
-            })),
+            ThreadEvent::TurnCompleted { usage, .. } => {
+                let cost = ccteam_cost::estimate_cost(
+                    usage,
+                    match vendor {
+                        AgentVendor::Claude => ccteam_cost::Vendor::Claude,
+                        AgentVendor::Codex => ccteam_cost::Vendor::Codex,
+                    },
+                    // Wave 3: model identity isn't on ThreadEvent; the
+                    // pricing table falls back to per-vendor default
+                    // when the model string is unknown.
+                    "",
+                );
+                Some(json!({
+                    "event": "agent_done",
+                    "role": role,
+                    "session_id": sid,
+                    "status": "completed",
+                    "cost_usd": cost,
+                    "vendor": vendor_str,
+                    "slug": slug,
+                    "ts": Utc::now().to_rfc3339(),
+                }))
+            }
             ThreadEvent::TurnFailed { err, .. } => Some(json!({
                 "event": "agent_done",
                 "role": role,
                 "session_id": sid,
                 "status": "errored",
                 "error": err.message,
+                "vendor": vendor_str,
                 "slug": slug,
                 "ts": Utc::now().to_rfc3339(),
             })),
@@ -1703,6 +1739,7 @@ impl Orchestrator {
                 "session_id": sid,
                 "status": "errored",
                 "error": err.message,
+                "vendor": vendor_str,
                 "slug": slug,
                 "ts": Utc::now().to_rfc3339(),
             })),
@@ -1712,6 +1749,7 @@ impl Orchestrator {
             | ThreadEvent::ItemCompleted { .. } => None,
         }
     }
+
 
     /// Monotonic microsecond sequence — collision-free across one
     /// orchestrator instance; F67 may swap in a counter map.
@@ -1876,6 +1914,7 @@ impl Orchestrator {
                     "session_id": handle.sid,
                     "status": status,
                     "cost_usd": cost_usd.unwrap_or(0.0),
+                    "vendor": vendor_from_harness(&handle.harness),
                     "slug": slug,
                     "ts": Utc::now().to_rfc3339(),
                 }),
@@ -2427,17 +2466,60 @@ impl Orchestrator {
         project_dir: &std::path::Path,
         progress_path: &std::path::Path,
     ) -> Result<bool> {
+        // F84 stub of F91 — read progress.jsonl once, derive both
+        // 24h cost and 1h spawn count from the same in-memory slice.
+        let events = progress::read_all_events(progress_path).unwrap_or_default();
+        let cost = queries::cost_summary_from_events(&events)?;
+
+        // V0.6.0 Wave 3 F112 — per-vendor caps (preferred). Checked
+        // first so a vendor-specific overrun trips an auto-disable
+        // even if the legacy flat cap is unset.
+        if let Some(budgets) = &spec.budgets_v060 {
+            for (vendor_key, cap_opt) in [
+                ("claude", budgets.claude.max_cost_usd_per_24h),
+                ("codex", budgets.codex.max_cost_usd_per_24h),
+            ] {
+                let Some(cap) = cap_opt else { continue };
+                let value = cost
+                    .cost_24h_by_vendor
+                    .get(vendor_key)
+                    .copied()
+                    .unwrap_or(0.0);
+                if value >= cap {
+                    progress::append_event(
+                        progress_path,
+                        &json!({
+                            "event": "budget_exceeded",
+                            "slug": slug,
+                            "kind": "cost_24h_per_vendor",
+                            "vendor": vendor_key,
+                            "value": value,
+                            "cap": cap,
+                            "ts": Utc::now().to_rfc3339(),
+                        }),
+                    )?;
+                    tracing::warn!(
+                        slug,
+                        vendor = vendor_key,
+                        value,
+                        cap,
+                        "per-vendor budget cap tripped; auto-disabling workflow"
+                    );
+                    self.auto_disable_workflow(
+                        slug,
+                        "budget_exceeded_per_vendor",
+                        project_dir,
+                        progress_path,
+                    )
+                    .await?;
+                    return Ok(true);
+                }
+            }
+        }
+
         let Some(budget) = &spec.budget else {
             return Ok(false);
         };
-
-        // F84 stub of F91 — read progress.jsonl once, derive both
-        // 24h cost and 1h spawn count from the same in-memory slice.
-        // When F91's full impl lands, replace the spawn-count line
-        // with whatever F91 publishes; the budget check shape is
-        // unchanged.
-        let events = progress::read_all_events(progress_path).unwrap_or_default();
-        let cost = queries::cost_summary_from_events(&events)?;
 
         if let Some(cap) = budget.max_cost_usd_per_24h {
             if cost.cost_24h_usd >= cap {

--- a/crates/ccteam-core/src/preferences.rs
+++ b/crates/ccteam-core/src/preferences.rs
@@ -1,0 +1,271 @@
+//! V0.6.0 Wave 3 F112 §C — user-level fallback preferences.
+//!
+//! Lives at `~/.ccteam/preferences.toml` (sibling of `config.yaml`).
+//! Kept separate from `config.yaml` because:
+//!
+//! 1. **Scope** — `config.yaml` is the SoT for project registry +
+//!    daemon-managed state; `preferences.toml` is purely user opt-in
+//!    knobs (vendor fallback today; more knobs in V0.7+).
+//! 2. **Format** — TOML matches how Cargo / rustfmt / cargo-mutants
+//!    serialize their user configs; YAML is reserved for ccteam
+//!    schema bodies the daemon edits.
+//! 3. **Opt-in semantics** — defaults are *off*. Missing file = full
+//!    defaults; corrupt file = warn + use defaults (never block the
+//!    daemon on a busted preferences edit).
+//!
+//! ## Shape
+//!
+//! ```toml
+//! [fallback]
+//! on_claude_quota = "codex"        # "codex" | "off"  (default "off")
+//!
+//! [fallback.codex]
+//! enabled_for_roles = ["main", "fixer", "explorer"]   # empty = all roles
+//! ```
+//!
+//! ## Atomic save
+//!
+//! `save()` writes to `preferences.toml.tmp`, then renames into
+//! place — same convention as `config.yaml` (no `.bak` because the
+//! prefs file is small + lossless reproducible from prompts).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// File name relative to `paths.root` (`~/.ccteam/`).
+pub const PREFERENCES_FILENAME: &str = "preferences.toml";
+
+/// Top-level user preferences schema.
+///
+/// Every section is optional; `Preferences::default()` yields a
+/// fully-defaulted (all-off) shape. Adding a new section in V0.7+
+/// follows the same `#[serde(default)]` pattern so older files keep
+/// parsing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Preferences {
+    #[serde(default)]
+    pub fallback: FallbackPrefs,
+}
+
+/// Cross-vendor fallback knobs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct FallbackPrefs {
+    /// What to do when a Claude `budget_exceeded` event lands.
+    /// Default `Off` — no fallback (matches V0.5.x behaviour).
+    #[serde(default)]
+    pub on_claude_quota: OnClaudeQuota,
+
+    /// Codex-specific fallback tuning (only consulted when
+    /// `on_claude_quota == Codex`).
+    #[serde(default)]
+    pub codex: CodexFallbackPrefs,
+}
+
+/// What to do when Claude trips its 24h budget cap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum OnClaudeQuota {
+    /// Hard-stop (V0.5.x default) — the orchestrator's existing
+    /// F84 `auto_disable_workflow` path fires.
+    #[default]
+    Off,
+    /// Try to keep the workflow alive by swapping the affected role's
+    /// adapter to Codex on the next spawn. Requires `codex` on PATH
+    /// + a `Vendor::Codex` adapter registered with the orchestrator.
+    Codex,
+}
+
+/// Codex-specific fallback knobs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct CodexFallbackPrefs {
+    /// Roles eligible for Codex fallback. Empty list = every role is
+    /// eligible (the simple default). Useful when the user only
+    /// trusts Codex for, say, `critic`/`reviewer` and wants `main`
+    /// to hard-stop instead.
+    #[serde(default)]
+    pub enabled_for_roles: Vec<String>,
+}
+
+/// Resolve `<paths.root>/preferences.toml`.
+pub fn preferences_path(root: &Path) -> PathBuf {
+    root.join(PREFERENCES_FILENAME)
+}
+
+/// Load preferences, returning defaults when the file is absent.
+///
+/// Parse / IO failures bubble up — the daemon decides whether to
+/// surface the warning or fall back to defaults. The
+/// `load_or_default` helper is the production entry point that
+/// swallows errors with a `tracing::warn!` and returns defaults.
+pub fn load(root: &Path) -> Result<Preferences> {
+    let path = preferences_path(root);
+    if !path.exists() {
+        return Ok(Preferences::default());
+    }
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("read preferences at {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parse preferences at {}", path.display()))
+}
+
+/// Production entry: load preferences; on any error, log + return
+/// defaults so a broken prefs file never wedges the orchestrator.
+pub fn load_or_default(root: &Path) -> Preferences {
+    match load(root) {
+        Ok(prefs) => prefs,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                path = %preferences_path(root).display(),
+                "preferences.toml unreadable; using defaults"
+            );
+            Preferences::default()
+        }
+    }
+}
+
+/// Atomically write preferences to `<root>/preferences.toml`.
+pub fn save(root: &Path, prefs: &Preferences) -> Result<()> {
+    std::fs::create_dir_all(root)
+        .with_context(|| format!("mkdir {}", root.display()))?;
+    let raw = toml::to_string_pretty(prefs).context("serialize preferences")?;
+    let path = preferences_path(root);
+    let tmp = path.with_extension("toml.tmp");
+    std::fs::write(&tmp, raw.as_bytes())
+        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+impl Preferences {
+    /// True iff Codex fallback is globally enabled AND this role is on
+    /// the eligibility list (or the list is empty = all roles).
+    pub fn codex_fallback_enabled_for(&self, role: &str) -> bool {
+        if !matches!(self.fallback.on_claude_quota, OnClaudeQuota::Codex) {
+            return false;
+        }
+        let allowed = &self.fallback.codex.enabled_for_roles;
+        allowed.is_empty() || allowed.iter().any(|r| r == role)
+    }
+}
+
+/// V0.6.0 Wave 3 F112 §C — outcome of the orchestrator's quota
+/// fallback decision. Combines the three orthogonal inputs (budget
+/// tripped? claude executor? user opt-in?) into the action the
+/// `try_spawn` path takes. Lives in `preferences.rs` (not
+/// `orchestrator.rs`) so unit tests can drive it without bringing
+/// up the full Orchestrator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuotaFallbackDecision {
+    /// Budget not tripped — proceed with the spawn as normal.
+    Proceed,
+    /// Budget tripped + prefs opt-in + claude executor + role
+    /// eligible — swap this spawn's adapter to Codex (workflow
+    /// continues; vendor=claude tagged in the audit event).
+    SwapToCodex,
+    /// Budget tripped + no fallback option applies — hard-stop
+    /// (V0.5.x default behaviour); orchestrator writes
+    /// `budget_exceeded` + sends a `btw` escalation + returns
+    /// without spawning.
+    HardStop,
+}
+
+/// Pure helper for the V0.6.0 Wave 3 F112 §C decision table.
+/// Inputs:
+///
+/// - `budget_tripped` — `cost_so_far >= budget_limit` (caller has
+///    already done the comparison).
+/// - `current_executor_is_claude` — `agent.executor == Executor::Claude`.
+/// - `role` — agent role (used for prefs eligibility check).
+/// - `prefs` — the user's `~/.ccteam/preferences.toml` body.
+///
+/// The orchestrator additionally requires a Codex adapter to be
+/// registered before honouring `SwapToCodex`; that check stays in
+/// `orchestrator.rs` because it touches the live adapter map.
+pub fn quota_fallback_decision(
+    budget_tripped: bool,
+    current_executor_is_claude: bool,
+    role: &str,
+    prefs: &Preferences,
+) -> QuotaFallbackDecision {
+    if !budget_tripped {
+        return QuotaFallbackDecision::Proceed;
+    }
+    if !current_executor_is_claude {
+        // Budget tripped on a Codex-vendored agent — no Claude
+        // fallback exists, so hard-stop.
+        return QuotaFallbackDecision::HardStop;
+    }
+    if prefs.codex_fallback_enabled_for(role) {
+        QuotaFallbackDecision::SwapToCodex
+    } else {
+        QuotaFallbackDecision::HardStop
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn default_is_off() {
+        let p = Preferences::default();
+        assert_eq!(p.fallback.on_claude_quota, OnClaudeQuota::Off);
+        assert!(p.fallback.codex.enabled_for_roles.is_empty());
+        assert!(!p.codex_fallback_enabled_for("main"));
+    }
+
+    #[test]
+    fn codex_fallback_eligibility_gates_on_role_list() {
+        let mut p = Preferences::default();
+        p.fallback.on_claude_quota = OnClaudeQuota::Codex;
+
+        // Empty list = every role eligible.
+        assert!(p.codex_fallback_enabled_for("main"));
+        assert!(p.codex_fallback_enabled_for("anything"));
+
+        // Restricted list = only listed roles.
+        p.fallback.codex.enabled_for_roles = vec!["critic".into()];
+        assert!(p.codex_fallback_enabled_for("critic"));
+        assert!(!p.codex_fallback_enabled_for("main"));
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let tmp = TempDir::new().unwrap();
+        let mut p = Preferences::default();
+        p.fallback.on_claude_quota = OnClaudeQuota::Codex;
+        p.fallback.codex.enabled_for_roles = vec!["main".into(), "fixer".into()];
+
+        save(tmp.path(), &p).unwrap();
+        let back = load(tmp.path()).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn missing_file_yields_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let p = load(tmp.path()).unwrap();
+        assert_eq!(p, Preferences::default());
+    }
+
+    #[test]
+    fn invalid_toml_load_errors() {
+        let tmp = TempDir::new().unwrap();
+        let path = preferences_path(tmp.path());
+        std::fs::write(&path, b"this is not valid = = toml").unwrap();
+        assert!(load(tmp.path()).is_err());
+    }
+
+    #[test]
+    fn invalid_toml_load_or_default_returns_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let path = preferences_path(tmp.path());
+        std::fs::write(&path, b"= invalid").unwrap();
+        let p = load_or_default(tmp.path());
+        assert_eq!(p, Preferences::default());
+    }
+}

--- a/crates/ccteam-core/src/queries.rs
+++ b/crates/ccteam-core/src/queries.rs
@@ -292,6 +292,21 @@ pub struct CostSummary {
     /// Number of open `agent_spawn` events (no matching `agent_done`)
     /// whose [`cost_active_usd`] contribution was probed.
     pub session_count_active: u32,
+    /// V0.6.0 Wave 3 F112 — per-vendor breakdown of the 24h cost
+    /// bucket. Keys are JSON-lowercased vendor names (`"claude"`,
+    /// `"codex"`). The aggregate `cost_24h_usd` remains the sum across
+    /// all vendors (consumers tolerant of the legacy single-vendor
+    /// shape see no diff). Empty when no `agent_done` event in the
+    /// 24h window carried a `vendor` field — V0.5.x events lacking
+    /// `vendor` are silently folded into `cost_24h_usd` only.
+    #[serde(default)]
+    pub cost_24h_by_vendor: std::collections::BTreeMap<String, f64>,
+    /// V0.6.0 Wave 3 F112 — per-vendor lifetime cost. Same vendor-key
+    /// semantics as `cost_24h_by_vendor`. Drives the
+    /// `ccteam-control show-cost` per-vendor breakdown and the
+    /// per-vendor budget cap check.
+    #[serde(default)]
+    pub cost_total_by_vendor: std::collections::BTreeMap<String, f64>,
 }
 
 /// Build a [`CostSummary`] for `slug` by reading `progress_path`
@@ -337,6 +352,10 @@ where
     let mut cost_total_usd = 0.0;
     let mut cost_24h_usd = 0.0;
     let mut session_count_24h: u32 = 0;
+    let mut cost_24h_by_vendor: std::collections::BTreeMap<String, f64> =
+        std::collections::BTreeMap::new();
+    let mut cost_total_by_vendor: std::collections::BTreeMap<String, f64> =
+        std::collections::BTreeMap::new();
     for event in events {
         if event.get("event").and_then(|s| s.as_str()) != Some("agent_done") {
             continue;
@@ -346,6 +365,16 @@ where
             .and_then(|v| v.as_f64())
             .unwrap_or(0.0);
         cost_total_usd += cost;
+        // V0.6.0 Wave 3 F112: optional `vendor` field on `agent_done`.
+        // V0.5.x events lack this field; they contribute to the
+        // aggregate cost_total_usd / cost_24h_usd but not the per-
+        // vendor breakdown (the F84 per-vendor budget caps therefore
+        // only act on V0.6+ events, matching the per-vendor opt-in
+        // shape of `Budgets { claude, codex }`).
+        let vendor = event.get("vendor").and_then(|v| v.as_str());
+        if let Some(v) = vendor {
+            *cost_total_by_vendor.entry(v.to_string()).or_insert(0.0) += cost;
+        }
 
         // 24h filter: events with missing or unparseable `ts` are
         // counted in the 24h bucket (defensive — newly-written rows
@@ -362,6 +391,9 @@ where
         if in_window {
             cost_24h_usd += cost;
             session_count_24h = session_count_24h.saturating_add(1);
+            if let Some(v) = vendor {
+                *cost_24h_by_vendor.entry(v.to_string()).or_insert(0.0) += cost;
+            }
         }
     }
 
@@ -402,6 +434,8 @@ where
         cost_total_usd,
         session_count_24h,
         session_count_active,
+        cost_24h_by_vendor,
+        cost_total_by_vendor,
     }
 }
 

--- a/crates/ccteam-core/tests/auto_critic_test.rs
+++ b/crates/ccteam-core/tests/auto_critic_test.rs
@@ -1,0 +1,65 @@
+//! V0.6.0 Wave 3 F112 §B — auto-critic vendor decision tests.
+//! Drives `ccteam_core::auto_critic::decide_vendor` directly so the
+//! Phase 3.5 logic in `skills/ccteam-creator/SKILL.md` has a
+//! programmatic guard that mirrors what the skill body says.
+
+use ccteam_core::auto_critic::{
+    decide_vendor, is_critic_persona, plan_annotation, CodexProbe, Vendor, CRITIC_PERSONA_IDS,
+};
+
+#[test]
+fn critic_persona_and_codex_available_returns_codex() {
+    for id in CRITIC_PERSONA_IDS {
+        let v = decide_vendor(id, &[], &CodexProbe::Available);
+        assert_eq!(v, Vendor::Codex, "expected codex for persona id {id}");
+    }
+}
+
+#[test]
+fn critic_persona_but_codex_missing_falls_back_to_claude() {
+    let v = decide_vendor(
+        "code-critic",
+        &[],
+        &CodexProbe::Unavailable("codex CLI not on PATH"),
+    );
+    assert_eq!(v, Vendor::Claude);
+}
+
+#[test]
+fn non_critic_persona_stays_claude_even_with_codex_available() {
+    // Even if the user has codex installed + authed, a non-critic
+    // persona (e.g. a chat assistant) should never be silently
+    // vendored on codex.
+    let v = decide_vendor("tech-helper", &["chat"], &CodexProbe::Available);
+    assert_eq!(v, Vendor::Claude);
+}
+
+#[test]
+fn tag_promotion_picks_up_user_personas() {
+    // A user-defined persona id ccteam doesn't ship can still be
+    // recognised as a critic via tags. Future V0.7 user-persona flow
+    // depends on this.
+    assert!(is_critic_persona("my-pet-critic", &["second-opinion"]));
+    let v = decide_vendor("my-pet-critic", &["Second-Opinion"], &CodexProbe::Available);
+    assert_eq!(v, Vendor::Codex);
+}
+
+#[test]
+fn plan_annotation_strings_match_skill_body() {
+    // The ccteam-creator SKILL.md Phase 4 PROJECT PLAN includes
+    // strings like "Codex critic: auto-enabled". These tests pin the
+    // exact text so the skill markdown stays in sync with the
+    // helper output — change one, change both.
+    assert_eq!(
+        plan_annotation("code-critic", &[], &CodexProbe::Available),
+        "auto-enabled"
+    );
+    assert_eq!(
+        plan_annotation("code-critic", &[], &CodexProbe::Unavailable("missing")),
+        "unavailable (codex CLI not installed / not authenticated)"
+    );
+    assert_eq!(
+        plan_annotation("tech-helper", &[], &CodexProbe::Available),
+        "not applicable"
+    );
+}

--- a/crates/ccteam-core/tests/codex_app_server_test.rs
+++ b/crates/ccteam-core/tests/codex_app_server_test.rs
@@ -1,0 +1,218 @@
+//! V0.6.0 Wave 3 F112 — `CodexAppServerAdapter` tests over a UDS
+//! socket served by a scripted in-process JSON-RPC peer. We dial the
+//! peer via `CCTEAM_CODEX_APP_SERVER_SOCKET` env override so the
+//! adapter's `client()` connects to the test socket rather than
+//! `$CODEX_HOME/app-server-control/app-server-control.sock`.
+
+use ccteam_core::execution::codex_app_server::{
+    translate_notification, turn_input_to_items, CodexAppServerAdapter, APP_SERVER_SOCKET_ENV,
+};
+use ccteam_core::execution::codex_jsonrpc::Notification;
+use ccteam_core::harness::{
+    AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, SpawnCtx,
+    ThreadEvent, TurnInput,
+};
+use serde_json::{json, Value};
+use serial_test::serial;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+
+/// Bind a unique UDS socket under /tmp and return its path. Each test
+/// gets its own so they can run in parallel without trampling on each
+/// other's `APP_SERVER_SOCKET_ENV` override.
+fn unique_socket_path(tag: &str) -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "ccteam-wave3-codex-app-server-{tag}-{}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+/// Spawn a scripted peer that accepts ONE connection and serves the
+/// supplied request → response map. Notifications can be pushed
+/// out-of-band via the returned channel.
+async fn spawn_scripted_peer(
+    sock: PathBuf,
+    handler: impl Fn(&Value) -> Value + Send + 'static,
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::mpsc::Sender<Value>,
+) {
+    let listener = UnixListener::bind(&sock).unwrap();
+    let (notif_tx, mut notif_rx) = tokio::sync::mpsc::channel::<Value>(16);
+    let task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (r, mut w) = stream.into_split();
+        let mut reader = BufReader::new(r);
+
+        loop {
+            let mut buf = String::new();
+            tokio::select! {
+                line = reader.read_line(&mut buf) => {
+                    match line {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {
+                            let req: Value = match serde_json::from_str(buf.trim()) {
+                                Ok(v) => v,
+                                Err(_) => continue,
+                            };
+                            let id = req.get("id").cloned();
+                            let mut resp = handler(&req);
+                            if let Some(id) = id {
+                                resp["id"] = id;
+                            }
+                            let mut bytes = serde_json::to_vec(&resp).unwrap();
+                            bytes.push(b'\n');
+                            let _ = w.write_all(&bytes).await;
+                            let _ = w.flush().await;
+                        }
+                    }
+                }
+                notif = notif_rx.recv() => {
+                    match notif {
+                        Some(n) => {
+                            let mut bytes = serde_json::to_vec(&n).unwrap();
+                            bytes.push(b'\n');
+                            let _ = w.write_all(&bytes).await;
+                            let _ = w.flush().await;
+                        }
+                        None => continue,
+                    }
+                }
+            }
+        }
+    });
+    (task, notif_tx)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn turn_input_to_items_handles_all_variants() {
+    let text = turn_input_to_items(TurnInput::UserText("hi".into())).unwrap();
+    assert_eq!(text[0]["type"], "text");
+
+    let img = turn_input_to_items(TurnInput::Image(PathBuf::from("/x.png"))).unwrap();
+    assert_eq!(img[0]["type"], "localImage");
+
+    let err = turn_input_to_items(TurnInput::SystemDirective("/compact".into())).unwrap_err();
+    assert!(matches!(err, HarnessError::SubmitFailed(_)));
+
+    let tr = turn_input_to_items(TurnInput::ToolResult {
+        call_id: "c1".into(),
+        content: json!({"ok": true}),
+    })
+    .unwrap();
+    assert_eq!(tr[0]["type"], "text");
+}
+
+#[test]
+fn translate_notification_thread_filtering() {
+    // Matching thread_id → translated; mismatching → None.
+    let ok = Notification {
+        method: "thread/started".into(),
+        params: json!({ "thread_id": "wanted" }),
+    };
+    let miss = Notification {
+        method: "thread/started".into(),
+        params: json!({ "thread_id": "other" }),
+    };
+    assert!(translate_notification(&ok, "wanted").is_some());
+    assert!(translate_notification(&miss, "wanted").is_none());
+}
+
+#[test]
+fn translate_notification_unknown_method_returns_none() {
+    let n = Notification {
+        method: "thread/status/changed".into(),
+        params: json!({ "thread_id": "t-1" }),
+    };
+    // We deliberately don't propagate status-changed today (orchestrator
+    // poll path owns state transitions); ensure it returns None.
+    assert!(translate_notification(&n, "t-1").is_none());
+}
+
+#[test]
+fn translate_item_completed_extracts_file_change_details() {
+    let n = Notification {
+        method: "item/completed".into(),
+        params: json!({
+            "thread_id": "t-1",
+            "item": {
+                "id": "i-1",
+                "type": "file_change",
+                "changes": [{ "path": "/x.rs", "kind": "update" }]
+            }
+        }),
+    };
+    let e = translate_notification(&n, "t-1").unwrap();
+    match e {
+        ThreadEvent::ItemCompleted { item } => {
+            match item.details {
+                ccteam_core::harness::ThreadItemDetails::FileChange { path, kind } => {
+                    assert_eq!(path, PathBuf::from("/x.rs"));
+                    assert_eq!(kind, "update");
+                }
+                other => panic!("expected FileChange, got {other:?}"),
+            }
+        }
+        _ => panic!("expected ItemCompleted"),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn adapter_returns_spawn_failed_when_socket_missing() {
+    let bogus = std::env::temp_dir().join("ccteam-wave3-nonexistent.sock");
+    std::env::set_var(APP_SERVER_SOCKET_ENV, &bogus);
+    let _ = std::fs::remove_file(&bogus);
+    let adapter = CodexAppServerAdapter::new();
+    let spec = AgentSpecBrief { role: "demo".into() };
+    let ctx = SpawnCtx {
+        slug: "test".into(),
+        sid: "codex-1".into(),
+        cwd: std::env::temp_dir(),
+        project_dir: std::env::temp_dir(),
+        extra_args: vec![],
+    };
+    let err = adapter.start_thread(&spec, &ctx).await.unwrap_err();
+    assert!(matches!(err, HarnessError::SpawnFailed(_)));
+    std::env::remove_var(APP_SERVER_SOCKET_ENV);
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn adapter_start_thread_against_scripted_peer() {
+    let sock = unique_socket_path("start-thread");
+    std::env::set_var(APP_SERVER_SOCKET_ENV, &sock);
+
+    let (peer, _notif) = spawn_scripted_peer(sock.clone(), |req| {
+        if req["method"] == "thread/start" {
+            json!({ "result": { "thread": { "thread_id": "tid-42" } } })
+        } else {
+            json!({ "error": { "code": -32601, "message": "unexpected" } })
+        }
+    })
+    .await;
+    // Give the listener a moment.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let adapter = CodexAppServerAdapter::new();
+    let spec = AgentSpecBrief { role: "demo".into() };
+    let ctx = SpawnCtx {
+        slug: "test".into(),
+        sid: "codex-1".into(),
+        cwd: std::env::temp_dir(),
+        project_dir: std::env::temp_dir(),
+        extra_args: vec![],
+    };
+    let h = adapter.start_thread(&spec, &ctx).await.unwrap();
+    assert_eq!(h.vendor, AgentVendor::Codex);
+    assert_eq!(h.mode, ExecutionMode::Chat);
+    assert_eq!(h.identity, "tid-42");
+
+    drop(peer); // shutdown peer; adapter no-ops on subsequent calls
+    let _ = std::fs::remove_file(&sock);
+    std::env::remove_var(APP_SERVER_SOCKET_ENV);
+}

--- a/crates/ccteam-core/tests/codex_exec_wave3_test.rs
+++ b/crates/ccteam-core/tests/codex_exec_wave3_test.rs
@@ -1,0 +1,177 @@
+//! V0.6.0 Wave 3 F112 — `CodexExecAdapter` `submit_turn` /
+//! `resume_thread` / events stream tests. All tests use a fake codex
+//! script via `CCTEAM_CODEX_BIN` env override so they don't require
+//! the real codex binary on PATH.
+
+use ccteam_core::execution::codex_app_server::CODEX_BIN_ENV;
+use ccteam_core::execution::codex_exec::{build_exec_argv, render_prompt, translate_jsonl_event};
+use ccteam_core::execution::CodexExecAdapter;
+use ccteam_core::harness::{
+    AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, ThreadEvent, ThreadHandle, TurnId,
+    TurnInput,
+};
+use futures::StreamExt;
+use serde_json::json;
+use std::io::Write;
+use std::time::Duration;
+
+/// Build a fake codex script that emits the supplied JSONL lines on
+/// stdout and exits 0. Returns the tempdir guard whose `path().join("codex.sh")`
+/// is the script. We use a tempdir (closing the fd before exec) so
+/// Linux's "Text file busy" guard doesn't trip when the test spawns
+/// the script.
+fn fake_codex_emitting(lines: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("codex.sh");
+    let mut body = String::from("#!/usr/bin/env bash\n");
+    body.push_str("# fake codex CLI for ccteam wave-3 tests\n");
+    body.push_str("cat <<'EOF'\n");
+    for l in lines {
+        body.push_str(l);
+        body.push('\n');
+    }
+    body.push_str("EOF\n");
+    body.push_str("exit 0\n");
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f.sync_all().unwrap();
+    }
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    (dir, path)
+}
+
+fn handle() -> ThreadHandle {
+    ThreadHandle {
+        vendor: AgentVendor::Codex,
+        mode: ExecutionMode::Bg,
+        identity: "ccteam-test-codex-1".into(),
+        started_at: chrono::Utc::now(),
+        raw_extras: json!({}),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn submit_turn_returns_monotonic_turn_ids() {
+    std::env::set_var(CODEX_BIN_ENV, "/bin/true");
+    let adapter = CodexExecAdapter::new();
+    let h = handle();
+    let a = adapter
+        .submit_turn(&h, TurnInput::UserText("hi".into()))
+        .await
+        .unwrap();
+    let b = adapter
+        .submit_turn(&h, TurnInput::UserText("there".into()))
+        .await
+        .unwrap();
+    assert_ne!(a.0, b.0);
+    assert!(a.0.starts_with("codex-exec-"));
+    std::env::remove_var(CODEX_BIN_ENV);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn submit_turn_rejects_system_directive() {
+    let adapter = CodexExecAdapter::new();
+    let h = handle();
+    let err = adapter
+        .submit_turn(&h, TurnInput::SystemDirective("/compact".into()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, HarnessError::SubmitFailed(_)),
+        "got {err:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn events_stream_translates_jsonl_to_thread_events() {
+    let (_dir, script_path) = fake_codex_emitting(&[
+        r#"{"type":"thread.started","thread_id":"t-1"}"#,
+        r#"{"type":"turn.started"}"#,
+        r#"{"type":"item.completed","item":{"id":"i-1","type":"agent_message","text":"hello"}}"#,
+        r#"{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}"#,
+    ]);
+    std::env::set_var(CODEX_BIN_ENV, &script_path);
+
+    let adapter = CodexExecAdapter::new();
+    let h = handle();
+    let stream = adapter.events(&h);
+    // Subscribe BEFORE submit_turn so the broadcast picks up the first
+    // events from the fake codex subprocess.
+    let _tid = adapter
+        .submit_turn(&h, TurnInput::UserText("hi".into()))
+        .await
+        .unwrap();
+
+    let collected: Vec<ThreadEvent> = tokio::time::timeout(
+        Duration::from_secs(3),
+        stream.take(4).collect::<Vec<_>>(),
+    )
+    .await
+    .expect("events stream timed out");
+
+    assert!(matches!(collected[0], ThreadEvent::ThreadStarted { .. }));
+    assert!(matches!(collected[1], ThreadEvent::TurnStarted { .. }));
+    assert!(matches!(collected[2], ThreadEvent::ItemCompleted { .. }));
+    match &collected[3] {
+        ThreadEvent::TurnCompleted { usage, .. } => {
+            assert_eq!(usage.input_tokens, 10);
+            assert_eq!(usage.output_tokens, 5);
+        }
+        other => panic!("expected TurnCompleted, got {other:?}"),
+    }
+
+    std::env::remove_var(CODEX_BIN_ENV);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn resume_thread_synthesises_handle_with_resumed_extras() {
+    let h = CodexExecAdapter::new()
+        .resume_thread("01abc-feed-face")
+        .await
+        .unwrap();
+    assert_eq!(h.identity, "01abc-feed-face");
+    assert_eq!(h.raw_extras["resumed"], true);
+    assert_eq!(h.raw_extras["thread_id"], "01abc-feed-face");
+    assert_eq!(h.vendor, AgentVendor::Codex);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn build_exec_argv_resume_branch() {
+    let exec = build_exec_argv(None);
+    assert_eq!(exec, vec!["exec", "--json", "-"]);
+    let resume = build_exec_argv(Some("UUID"));
+    assert_eq!(resume, vec!["resume", "UUID", "--json", "-"]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn render_prompt_artifact_wraps_in_tag() {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(b"the body").unwrap();
+    let p = tmp.path().to_path_buf();
+    let s = render_prompt(&TurnInput::Artifact(p)).unwrap();
+    assert!(s.contains("<artifact"));
+    assert!(s.contains("the body"));
+    assert!(s.contains("</artifact>"));
+}
+
+#[test]
+fn translate_jsonl_event_thread_started() {
+    let v = json!({ "type": "thread.started", "thread_id": "t-99" });
+    let evts = translate_jsonl_event(&v, &TurnId("u".into()));
+    assert_eq!(evts.len(), 1);
+    match &evts[0] {
+        ThreadEvent::ThreadStarted { thread_id } => assert_eq!(thread_id, "t-99"),
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn translate_jsonl_event_unknown_type_returns_empty() {
+    let v = json!({ "type": "totally.bogus" });
+    let evts = translate_jsonl_event(&v, &TurnId("u".into()));
+    assert!(evts.is_empty());
+}

--- a/crates/ccteam-core/tests/codex_jsonrpc_test.rs
+++ b/crates/ccteam-core/tests/codex_jsonrpc_test.rs
@@ -1,0 +1,189 @@
+//! V0.6.0 Wave 3 F112 — `codex_jsonrpc` UDS JSON-RPC client tests.
+//!
+//! Scripted in-process peer over `tokio::io::duplex` so the wire
+//! framing + dispatch logic is exercised without dialing a real
+//! `codex app-server` daemon.
+
+use ccteam_core::execution::codex_jsonrpc::{CodexJsonRpcClient, Notification};
+use serde_json::{json, Value};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+/// Construct a (client, peer_rw) pair where the client is wired to the
+/// peer end of a duplex stream. Caller scripts the peer's reads/writes
+/// in a spawned task.
+fn duplex_pair() -> (CodexJsonRpcClient, tokio::io::DuplexStream) {
+    let (client_rw, peer_rw) = tokio::io::duplex(8192);
+    let (client_r, client_w) = tokio::io::split(client_rw);
+    let client = CodexJsonRpcClient::spawn(client_r, client_w);
+    (client, peer_rw)
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn call_with_thread_start_response_extracts_thread_id() {
+    let (client, mut peer) = duplex_pair();
+    let peer_task = tokio::spawn(async move {
+        let (pr, mut pw) = tokio::io::split(&mut peer);
+        let mut pr = BufReader::new(pr);
+        let mut buf = String::new();
+        pr.read_line(&mut buf).await.unwrap();
+        let req: Value = serde_json::from_str(buf.trim()).unwrap();
+        assert_eq!(req["method"], "thread/start");
+        let id = req["id"].as_i64().unwrap();
+        let resp = json!({
+            "id": id,
+            "result": { "thread": { "thread_id": "t-abc" }, "model": "gpt-4o" }
+        });
+        let mut line = serde_json::to_vec(&resp).unwrap();
+        line.push(b'\n');
+        pw.write_all(&line).await.unwrap();
+        pw.flush().await.unwrap();
+        // hold open briefly so dispatch fires
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+
+    let result = client
+        .call("thread/start", json!({ "cwd": "/tmp" }))
+        .await
+        .unwrap();
+    assert_eq!(result["thread"]["thread_id"], "t-abc");
+    peer_task.await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn call_propagates_jsonrpc_error() {
+    let (client, mut peer) = duplex_pair();
+    let peer_task = tokio::spawn(async move {
+        let (pr, mut pw) = tokio::io::split(&mut peer);
+        let mut pr = BufReader::new(pr);
+        let mut buf = String::new();
+        pr.read_line(&mut buf).await.unwrap();
+        let req: Value = serde_json::from_str(buf.trim()).unwrap();
+        let id = req["id"].as_i64().unwrap();
+        let resp = json!({
+            "id": id,
+            "error": { "code": -32601, "message": "method not found" }
+        });
+        let mut line = serde_json::to_vec(&resp).unwrap();
+        line.push(b'\n');
+        pw.write_all(&line).await.unwrap();
+        pw.flush().await.unwrap();
+    });
+
+    let err = client.call("bogus", Value::Null).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("method not found"), "msg={msg}");
+    assert!(msg.contains("-32601"), "msg={msg}");
+    peer_task.await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn subscribe_receives_server_notifications() {
+    let (client, mut peer) = duplex_pair();
+    let mut rx = client.subscribe();
+
+    let peer_task = tokio::spawn(async move {
+        let (_pr, mut pw) = tokio::io::split(&mut peer);
+        // Push 3 notifications back-to-back.
+        for tid in ["t-1", "t-2", "t-3"] {
+            let notif = json!({
+                "method": "thread/started",
+                "params": { "thread_id": tid }
+            });
+            let mut line = serde_json::to_vec(&notif).unwrap();
+            line.push(b'\n');
+            pw.write_all(&line).await.unwrap();
+            pw.flush().await.unwrap();
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+
+    let mut seen: Vec<Notification> = Vec::new();
+    for _ in 0..3 {
+        let n = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        seen.push(n);
+    }
+    peer_task.await.unwrap();
+
+    assert_eq!(seen.len(), 3);
+    for n in &seen {
+        assert_eq!(n.method, "thread/started");
+    }
+    let tids: Vec<&str> = seen
+        .iter()
+        .map(|n| n.params["thread_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(tids, vec!["t-1", "t-2", "t-3"]);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn interleaved_response_and_notification_demuxed() {
+    // The reader must NOT confuse an arriving notification with a
+    // pending response (and vice versa) when they overlap.
+    let (client, mut peer) = duplex_pair();
+    let mut rx = client.subscribe();
+
+    let peer_task = tokio::spawn(async move {
+        let (pr, mut pw) = tokio::io::split(&mut peer);
+        let mut pr = BufReader::new(pr);
+        let mut buf = String::new();
+        pr.read_line(&mut buf).await.unwrap();
+        let req: Value = serde_json::from_str(buf.trim()).unwrap();
+        let id = req["id"].as_i64().unwrap();
+
+        // Push notification BEFORE the response.
+        let notif = json!({ "method": "turn/started", "params": { "turn_id": "u-1" } });
+        let mut line = serde_json::to_vec(&notif).unwrap();
+        line.push(b'\n');
+        pw.write_all(&line).await.unwrap();
+
+        let resp = json!({ "id": id, "result": { "ok": true } });
+        let mut line = serde_json::to_vec(&resp).unwrap();
+        line.push(b'\n');
+        pw.write_all(&line).await.unwrap();
+        pw.flush().await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    });
+
+    let result = client.call("turn/start", json!({})).await.unwrap();
+    assert_eq!(result["ok"], true);
+
+    let n = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(n.method, "turn/started");
+
+    peer_task.await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn malformed_lines_are_tolerated() {
+    // A garbage line in the middle of the stream must not poison the
+    // reader; the next valid line should still match the pending id.
+    let (client, mut peer) = duplex_pair();
+    let peer_task = tokio::spawn(async move {
+        let (pr, mut pw) = tokio::io::split(&mut peer);
+        let mut pr = BufReader::new(pr);
+        let mut buf = String::new();
+        pr.read_line(&mut buf).await.unwrap();
+        let req: Value = serde_json::from_str(buf.trim()).unwrap();
+        let id = req["id"].as_i64().unwrap();
+        // Send garbage line first.
+        pw.write_all(b"this is not json\n").await.unwrap();
+        // Then valid response.
+        let resp = json!({ "id": id, "result": { "fine": true } });
+        let mut line = serde_json::to_vec(&resp).unwrap();
+        line.push(b'\n');
+        pw.write_all(&line).await.unwrap();
+        pw.flush().await.unwrap();
+    });
+
+    let r = client.call("any", Value::Null).await.unwrap();
+    assert_eq!(r["fine"], true);
+    peer_task.await.unwrap();
+}

--- a/crates/ccteam-core/tests/fallback_quota_test.rs
+++ b/crates/ccteam-core/tests/fallback_quota_test.rs
@@ -1,0 +1,82 @@
+//! V0.6.0 Wave 3 F112 §C — quota fallback decision tests.
+//!
+//! Drives `ccteam_core::preferences::quota_fallback_decision`
+//! directly. The orchestrator hook in `try_spawn_with_prompt` is a
+//! thin wrapper over this helper + an `adapter_for(Executor::Codex)`
+//! liveness check; testing the pure decision here keeps the matrix
+//! readable without bringing up the full orchestrator + adapter map.
+
+use ccteam_core::preferences::{
+    quota_fallback_decision, OnClaudeQuota, Preferences, QuotaFallbackDecision,
+};
+
+fn prefs_on() -> Preferences {
+    let mut p = Preferences::default();
+    p.fallback.on_claude_quota = OnClaudeQuota::Codex;
+    p
+}
+
+fn prefs_off() -> Preferences {
+    Preferences::default()
+}
+
+#[test]
+fn quota_not_tripped_returns_proceed_regardless_of_prefs() {
+    assert_eq!(
+        quota_fallback_decision(false, true, "main", &prefs_on()),
+        QuotaFallbackDecision::Proceed
+    );
+    assert_eq!(
+        quota_fallback_decision(false, false, "main", &prefs_off()),
+        QuotaFallbackDecision::Proceed
+    );
+}
+
+#[test]
+fn quota_tripped_with_prefs_on_swaps_to_codex() {
+    let p = prefs_on();
+    assert_eq!(
+        quota_fallback_decision(true, true, "main", &p),
+        QuotaFallbackDecision::SwapToCodex
+    );
+    assert_eq!(
+        quota_fallback_decision(true, true, "any-role", &p),
+        QuotaFallbackDecision::SwapToCodex
+    );
+}
+
+#[test]
+fn quota_tripped_with_prefs_off_hard_stops() {
+    assert_eq!(
+        quota_fallback_decision(true, true, "main", &prefs_off()),
+        QuotaFallbackDecision::HardStop
+    );
+}
+
+#[test]
+fn quota_tripped_on_codex_executor_hard_stops_even_with_prefs_on() {
+    // Even when fallback is enabled, a budget trip on a Codex
+    // executor has no Claude→Codex swap available, so it falls
+    // through to hard-stop.
+    assert_eq!(
+        quota_fallback_decision(true, false, "main", &prefs_on()),
+        QuotaFallbackDecision::HardStop
+    );
+}
+
+#[test]
+fn quota_tripped_with_role_eligibility_list_filters_swap() {
+    let mut p = prefs_on();
+    p.fallback.codex.enabled_for_roles = vec!["critic".into()];
+
+    // Listed role → swap.
+    assert_eq!(
+        quota_fallback_decision(true, true, "critic", &p),
+        QuotaFallbackDecision::SwapToCodex
+    );
+    // Unlisted role → hard-stop (user explicitly restricted scope).
+    assert_eq!(
+        quota_fallback_decision(true, true, "main", &p),
+        QuotaFallbackDecision::HardStop
+    );
+}

--- a/crates/ccteam-core/tests/harness_trait_test.rs
+++ b/crates/ccteam-core/tests/harness_trait_test.rs
@@ -282,7 +282,15 @@ mod codex_tmux {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn codex_exec_submit_turn_not_implemented_wave1() {
+async fn codex_exec_submit_turn_returns_synthetic_turn_id_wave3() {
+    // Wave 3: submit_turn spawns `codex exec --json` (or the fake bin
+    // pointed at by CCTEAM_CODEX_BIN). The TurnId is synthesised
+    // monotonically per adapter instance regardless of whether the
+    // subprocess succeeds — `events()` is the channel that reports
+    // success/failure. We point CCTEAM_CODEX_BIN at `/bin/true` so the
+    // process exits cleanly and the test doesn't depend on a real
+    // codex install.
+    std::env::set_var(ccteam_core::execution::codex_app_server::CODEX_BIN_ENV, "/bin/true");
     let h = ThreadHandle {
         vendor: AgentVendor::Codex,
         mode: ExecutionMode::Bg,
@@ -290,11 +298,32 @@ async fn codex_exec_submit_turn_not_implemented_wave1() {
         started_at: chrono::Utc::now(),
         raw_extras: serde_json::json!({}),
     };
-    let err = CodexExecAdapter::new()
+    let tid = CodexExecAdapter::new()
         .submit_turn(&h, ccteam_core::harness::TurnInput::UserText("hi".into()))
         .await
-        .expect_err("Wave 3 fills");
-    assert!(matches!(err, HarnessError::NotImplemented { .. }));
+        .expect("Wave 3 submit_turn returns synthetic TurnId");
+    assert!(tid.0.starts_with("codex-exec-"));
+    std::env::remove_var(ccteam_core::execution::codex_app_server::CODEX_BIN_ENV);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn codex_exec_resume_thread_synthesises_handle_wave3() {
+    let h = CodexExecAdapter::new()
+        .resume_thread("01988f74-0d1f-7e80-a-b-c")
+        .await
+        .expect("resume returns synthesised handle");
+    assert_eq!(h.vendor, AgentVendor::Codex);
+    assert_eq!(h.identity, "01988f74-0d1f-7e80-a-b-c");
+    assert_eq!(h.raw_extras["resumed"], true);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn codex_exec_resume_thread_rejects_empty_persistent_id() {
+    let err = CodexExecAdapter::new()
+        .resume_thread("")
+        .await
+        .expect_err("empty id should error");
+    assert!(matches!(err, HarnessError::SpawnFailed(_)));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/ccteam-core/tests/per_vendor_budget_test.rs
+++ b/crates/ccteam-core/tests/per_vendor_budget_test.rs
@@ -1,0 +1,120 @@
+//! V0.6.0 Wave 3 F112 — per-vendor budget caps: queries::compute_cost_summary
+//! splits 24h cost by vendor and the orchestrator's enforce_budget
+//! reads `budgets_v060.{claude,codex}.max_cost_usd_per_24h` independently.
+//!
+//! These tests exercise the pure-event-slice helper directly (no
+//! orchestrator) so they stay deterministic + hermetic.
+
+use ccteam_core::queries::compute_cost_summary;
+use chrono::Utc;
+use serde_json::json;
+
+fn done_event(vendor: Option<&str>, cost: f64, sid: &str) -> serde_json::Value {
+    let ts = Utc::now().to_rfc3339();
+    let mut e = json!({
+        "event": "agent_done",
+        "role": "coder",
+        "session_id": sid,
+        "status": "completed",
+        "cost_usd": cost,
+        "slug": "demo",
+        "ts": ts,
+    });
+    if let Some(v) = vendor {
+        e["vendor"] = serde_json::Value::String(v.to_string());
+    }
+    e
+}
+
+#[test]
+fn cost_summary_splits_per_vendor_when_field_present() {
+    let events = vec![
+        done_event(Some("claude"), 1.25, "s1"),
+        done_event(Some("codex"), 0.50, "s2"),
+        done_event(Some("claude"), 0.75, "s3"),
+    ];
+    let summary = compute_cost_summary(&events, Utc::now(), |_| {
+        ccteam_core::claude_job::JobLiveness::Terminal {
+            status: "completed",
+            cost_usd: 0.0,
+        }
+    });
+    assert!((summary.cost_24h_usd - 2.5).abs() < 1e-9);
+    assert_eq!(
+        summary.cost_24h_by_vendor.get("claude").copied(),
+        Some(2.0),
+        "{:?}",
+        summary.cost_24h_by_vendor
+    );
+    assert_eq!(summary.cost_24h_by_vendor.get("codex").copied(), Some(0.5));
+}
+
+#[test]
+fn cost_summary_skips_vendor_split_when_field_missing() {
+    // Pre-V0.6 events lacked the vendor field. They contribute to the
+    // aggregate but the per-vendor map stays empty (per-vendor caps
+    // are V0.6-only opt-in).
+    let events = vec![
+        done_event(None, 5.0, "s1"),
+        done_event(None, 1.0, "s2"),
+    ];
+    let summary = compute_cost_summary(&events, Utc::now(), |_| {
+        ccteam_core::claude_job::JobLiveness::Terminal {
+            status: "completed",
+            cost_usd: 0.0,
+        }
+    });
+    assert!((summary.cost_24h_usd - 6.0).abs() < 1e-9);
+    assert!(summary.cost_24h_by_vendor.is_empty());
+}
+
+#[test]
+fn cost_summary_aggregates_total_per_vendor() {
+    let events = vec![
+        done_event(Some("claude"), 10.0, "s1"),
+        done_event(Some("codex"), 3.0, "s2"),
+        done_event(Some("claude"), 2.0, "s3"),
+        done_event(Some("codex"), 1.0, "s4"),
+    ];
+    let summary = compute_cost_summary(&events, Utc::now(), |_| {
+        ccteam_core::claude_job::JobLiveness::Terminal {
+            status: "completed",
+            cost_usd: 0.0,
+        }
+    });
+    assert_eq!(summary.cost_total_by_vendor.get("claude").copied(), Some(12.0));
+    assert_eq!(summary.cost_total_by_vendor.get("codex").copied(), Some(4.0));
+    assert!((summary.cost_total_usd - 16.0).abs() < 1e-9);
+}
+
+#[test]
+fn cost_summary_per_vendor_serialises_in_json() {
+    // JSON shape contract: cost_24h_by_vendor + cost_total_by_vendor
+    // must be present (default-empty) for SPA / API consumers.
+    let summary = compute_cost_summary(&[], Utc::now(), |_| {
+        ccteam_core::claude_job::JobLiveness::Terminal {
+            status: "completed",
+            cost_usd: 0.0,
+        }
+    });
+    let j = serde_json::to_value(&summary).unwrap();
+    assert!(j.get("cost_24h_by_vendor").is_some());
+    assert!(j.get("cost_total_by_vendor").is_some());
+    assert!(j["cost_24h_by_vendor"].is_object());
+}
+
+#[test]
+fn budgets_aggregated_cap_uses_ccteam_cost_helper() {
+    use ccteam_cost::{BudgetCap, Budgets};
+    let b = Budgets {
+        claude: BudgetCap {
+            max_cost_usd_per_24h: Some(5.0),
+            ..Default::default()
+        },
+        codex: BudgetCap {
+            max_cost_usd_per_24h: Some(2.0),
+            ..Default::default()
+        },
+    };
+    assert_eq!(b.aggregated_cost_cap_24h(), Some(7.0));
+}

--- a/crates/ccteam-core/tests/preferences_test.rs
+++ b/crates/ccteam-core/tests/preferences_test.rs
@@ -1,0 +1,87 @@
+//! V0.6.0 Wave 3 F112 §C — `~/.ccteam/preferences.toml` integration
+//! tests. Mirrors the in-crate unit tests on `preferences.rs` but
+//! exercises the public API through the integration boundary so any
+//! visibility regression (pub vs pub(crate)) surfaces in CI.
+
+use std::fs;
+
+use ccteam_core::preferences::{
+    self, load, load_or_default, preferences_path, save, OnClaudeQuota, Preferences,
+};
+use tempfile::TempDir;
+
+#[test]
+fn load_default_when_file_absent() {
+    let tmp = TempDir::new().unwrap();
+    let prefs = load(tmp.path()).expect("load missing file should not error");
+    assert_eq!(prefs, Preferences::default());
+    assert_eq!(prefs.fallback.on_claude_quota, OnClaudeQuota::Off);
+}
+
+#[test]
+fn save_round_trip_preserves_values() {
+    let tmp = TempDir::new().unwrap();
+    let mut prefs = Preferences::default();
+    prefs.fallback.on_claude_quota = OnClaudeQuota::Codex;
+    prefs.fallback.codex.enabled_for_roles = vec!["critic".into(), "reviewer".into()];
+
+    save(tmp.path(), &prefs).expect("save round-trip");
+    let back = load(tmp.path()).expect("re-load round-trip");
+    assert_eq!(back, prefs);
+
+    // File on disk has the expected TOML shape.
+    let raw = fs::read_to_string(preferences_path(tmp.path())).unwrap();
+    assert!(
+        raw.contains("on_claude_quota = \"codex\""),
+        "TOML body missing on_claude_quota: {raw}"
+    );
+    assert!(
+        raw.contains("enabled_for_roles"),
+        "TOML body missing enabled_for_roles: {raw}"
+    );
+}
+
+#[test]
+fn missing_file_graceful_via_load_or_default() {
+    let tmp = TempDir::new().unwrap();
+    let prefs = load_or_default(tmp.path());
+    assert_eq!(prefs, Preferences::default());
+}
+
+#[test]
+fn invalid_toml_graceful_via_load_or_default() {
+    let tmp = TempDir::new().unwrap();
+    let path = preferences_path(tmp.path());
+    fs::write(&path, b"this is = = not = valid").unwrap();
+    // Hard load surfaces the error.
+    assert!(load(tmp.path()).is_err());
+    // Production entry returns defaults instead of failing.
+    let prefs = load_or_default(tmp.path());
+    assert_eq!(prefs, Preferences::default());
+}
+
+#[test]
+fn role_eligibility_gates_codex_fallback() {
+    let mut prefs = Preferences::default();
+    prefs.fallback.on_claude_quota = OnClaudeQuota::Codex;
+
+    // Empty list = all roles eligible.
+    assert!(prefs.codex_fallback_enabled_for("main"));
+    assert!(prefs.codex_fallback_enabled_for("fixer"));
+
+    // Restricted list = only listed roles.
+    prefs.fallback.codex.enabled_for_roles = vec!["critic".into()];
+    assert!(prefs.codex_fallback_enabled_for("critic"));
+    assert!(!prefs.codex_fallback_enabled_for("main"));
+
+    // off + any role list → never enabled.
+    prefs.fallback.on_claude_quota = OnClaudeQuota::Off;
+    assert!(!prefs.codex_fallback_enabled_for("critic"));
+}
+
+#[test]
+fn preferences_path_lives_at_root_preferences_toml() {
+    let tmp = TempDir::new().unwrap();
+    let path = preferences::preferences_path(tmp.path());
+    assert_eq!(path, tmp.path().join("preferences.toml"));
+}

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -9,27 +9,61 @@
 //! - a SIGTERM future for graceful shutdown,
 //! - an optional max-runtime watchdog (test-only — production is `0`).
 //!
-//! Wave 2 ships a **lifecycle skeleton**: the daemon boots, registers
-//! channels, runs the supervisor tick, refreshes heartbeats. The
-//! `claude-tui` adapter wiring (calling
-//! `HarnessAdapter::start_thread` / `submit_turn` / `close_thread`)
-//! is performed by a separate followup that imports the tui-impl
-//! teammate's adapter once they land it. The skeleton + tests are
-//! self-contained and prove the loop boots / shuts down cleanly.
+//! Wave 3 follow-up to Wave 2 skeleton: the supervisor tick now
+//! actually drives [`BotSupervisor::apply_action`] against the live
+//! per-bot state, so `decide(...) = Spawn` reaches `start_thread`,
+//! `Restart` reaches `close_thread` + `start_thread`, and `Shutdown`
+//! reaches `close_thread`. One [`BotSupervisor`] is built per
+//! `BotRegistration` on first sight via the daemon's
+//! [`AdapterFactory`] (defaults to `ClaudeTuiAdapter` for
+//! `AgentVendor::Claude`; tests inject a stub).
 
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
+use ccteam_core::execution::ClaudeTuiAdapter;
+use ccteam_core::harness::{AgentVendor, HarnessAdapter};
 use tokio::sync::Mutex;
 
 use crate::credentials::{self, Credentials};
-use crate::supervisor;
+use crate::supervisor::{self, BotSupervisor};
 use crate::{list_bots, BotRegistration};
 
+/// Builds the production [`HarnessAdapter`] for one bot's `vendor`.
+///
+/// Hidden behind a function pointer so integration tests can swap
+/// the real `ClaudeTuiAdapter` for a stub. The default returned by
+/// [`default_adapter_factory`] is what `main.rs` wires.
+pub type AdapterFactory =
+    Arc<dyn Fn(AgentVendor) -> Arc<dyn HarnessAdapter + Send + Sync> + Send + Sync>;
+
+/// V0.6.0 Wave 3 — pick the canonical production adapter for `vendor`.
+///
+/// - `Claude` → [`ClaudeTuiAdapter`] (the mode 3 chat adapter).
+/// - `Codex` → also [`ClaudeTuiAdapter`] today; the codex-exec-impl
+///   teammate's `CodexAppServerAdapter` will replace this arm in a
+///   follow-up commit. Falling back to the Claude adapter (rather
+///   than panicking) keeps any mis-registered Codex bot inert
+///   (`start_thread` will fail noisily on the wrong vendor) instead
+///   of taking down the daemon.
+pub fn default_adapter_factory() -> AdapterFactory {
+    Arc::new(|vendor: AgentVendor| match vendor {
+        AgentVendor::Claude => {
+            Arc::new(ClaudeTuiAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>
+        }
+        AgentVendor::Codex => {
+            // TODO(wave-3 codex-exec-impl): swap to CodexAppServerAdapter
+            // once it lands.
+            Arc::new(ClaudeTuiAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>
+        }
+    })
+}
+
 /// CLI arguments forwarded from `main.rs`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DaemonArgs {
     /// Override credentials path (`None` → default).
     pub credentials: Option<PathBuf>,
@@ -40,6 +74,22 @@ pub struct DaemonArgs {
     /// Optional max-runtime watchdog (`None` → unbounded; tests
     /// pass `Some(_)` to keep the harness from hanging).
     pub max_runtime: Option<Duration>,
+    /// Wave 3 — adapter factory the supervisor registry uses to
+    /// instantiate one [`HarnessAdapter`] per registered bot.
+    /// `None` → [`default_adapter_factory`].
+    pub adapter_factory: Option<AdapterFactory>,
+}
+
+impl std::fmt::Debug for DaemonArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DaemonArgs")
+            .field("credentials", &self.credentials)
+            .field("registry", &self.registry)
+            .field("tick", &self.tick)
+            .field("max_runtime", &self.max_runtime)
+            .field("adapter_factory", &self.adapter_factory.is_some())
+            .finish()
+    }
 }
 
 impl Default for DaemonArgs {
@@ -49,7 +99,52 @@ impl Default for DaemonArgs {
             registry: None,
             tick: Duration::from_secs(5),
             max_runtime: None,
+            adapter_factory: None,
         }
+    }
+}
+
+/// V0.6.0 Wave 3 — keyed map of live [`BotSupervisor`]s.
+///
+/// Keyed by `"<slug>/<role>"` (same convention as `bot_dir`). New
+/// registrations grow the map; the daemon never removes entries
+/// during the loop (`unregister_bot` deletes the JSON on disk; the
+/// supervisor stays Shutdown via the signal file).
+#[derive(Default)]
+pub struct SupervisorRegistry {
+    inner: HashMap<String, Arc<BotSupervisor>>,
+}
+
+impl SupervisorRegistry {
+    fn key(reg: &BotRegistration) -> String {
+        format!("{}/{}", reg.workflow_slug, reg.role)
+    }
+
+    /// Add a supervisor for `reg` if one isn't already registered.
+    /// Returns the live (existing-or-new) supervisor handle.
+    pub fn ensure(
+        &mut self,
+        reg: &BotRegistration,
+        projects_root: &Path,
+        factory: &AdapterFactory,
+    ) -> Arc<BotSupervisor> {
+        let k = Self::key(reg);
+        self.inner
+            .entry(k)
+            .or_insert_with(|| {
+                let adapter = factory(reg.vendor);
+                Arc::new(BotSupervisor::new(
+                    reg.clone(),
+                    projects_root.to_path_buf(),
+                    adapter,
+                ))
+            })
+            .clone()
+    }
+
+    /// Snapshot of every live supervisor for test introspection.
+    pub fn all(&self) -> Vec<Arc<BotSupervisor>> {
+        self.inner.values().cloned().collect()
     }
 }
 
@@ -65,9 +160,12 @@ pub async fn run_daemon(args: DaemonArgs) -> Result<()> {
         "ccteam-imd daemon starting"
     );
 
-    // Per-bot supervisor state, keyed by `"<slug>/<role>"`.
-    let _bot_state: Arc<Mutex<std::collections::HashMap<String, supervisor::BotState>>> =
-        Arc::new(Mutex::new(Default::default()));
+    let factory = args
+        .adapter_factory
+        .clone()
+        .unwrap_or_else(default_adapter_factory);
+    let registry: Arc<Mutex<SupervisorRegistry>> =
+        Arc::new(Mutex::new(SupervisorRegistry::default()));
 
     let mut ticker = tokio::time::interval(args.tick);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -87,9 +185,7 @@ pub async fn run_daemon(args: DaemonArgs) -> Result<()> {
                         Vec::new()
                     }
                 };
-                for reg in &bots {
-                    decide_and_log(reg, args.registry.as_deref()).await;
-                }
+                tick_supervisors(&bots, &registry, args.registry.as_deref(), &factory).await;
 
                 if let Some(max) = args.max_runtime {
                     if started.elapsed() >= max {
@@ -106,11 +202,18 @@ pub async fn run_daemon(args: DaemonArgs) -> Result<()> {
     }
 }
 
-async fn decide_and_log(reg: &BotRegistration, projects_root: Option<&std::path::Path>) {
-    // Honor explicit override for tests; production resolves the
-    // projects-root via the standard ccteam convention later.
+/// V0.6.0 Wave 3 — per-tick driver. Registers any new bots with the
+/// supervisor registry, then for each known bot calls
+/// `decide(...)` against its live state and applies the resulting
+/// action through the supervisor (`apply_action`).
+pub(crate) async fn tick_supervisors(
+    bots: &[BotRegistration],
+    registry: &Arc<Mutex<SupervisorRegistry>>,
+    projects_root_override: Option<&Path>,
+    factory: &AdapterFactory,
+) {
     let owned;
-    let root: &std::path::Path = match projects_root {
+    let projects_root: &Path = match projects_root_override {
         Some(p) => p,
         None => {
             owned = dirs::home_dir()
@@ -119,14 +222,40 @@ async fn decide_and_log(reg: &BotRegistration, projects_root: Option<&std::path:
             &owned
         }
     };
-    let state = supervisor::BotState::default();
-    let action = supervisor::decide(root, reg, &state, SystemTime::now());
-    tracing::debug!(
-        slug = %reg.workflow_slug,
-        role = %reg.role,
-        action = ?action,
-        "supervisor decision"
-    );
+
+    // First pass: ensure a supervisor exists per bot.
+    let supervisors: Vec<(BotRegistration, Arc<BotSupervisor>)> = {
+        let mut reg = registry.lock().await;
+        bots.iter()
+            .map(|b| {
+                let sup = reg.ensure(b, projects_root, factory);
+                (b.clone(), sup)
+            })
+            .collect()
+    };
+
+    // Second pass: decide + apply per bot (drop the registry lock for
+    // each adapter call so a slow start_thread doesn't stall other
+    // bots' decisions).
+    for (bot, sup) in supervisors {
+        let state = sup.state_snapshot().await;
+        let action = supervisor::decide(projects_root, &bot, &state, SystemTime::now());
+        tracing::debug!(
+            slug = %bot.workflow_slug,
+            role = %bot.role,
+            ?action,
+            "supervisor decision"
+        );
+        if let Err(err) = sup.apply_action(action.clone()).await {
+            tracing::warn!(
+                slug = %bot.workflow_slug,
+                role = %bot.role,
+                ?action,
+                error = %err,
+                "apply_action failed"
+            );
+        }
+    }
 }
 
 /// Compatibility shim — `lib.rs` re-exports this so the existing
@@ -137,6 +266,13 @@ pub fn _link_check(_c: &Credentials) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use ccteam_core::harness::{
+        AgentSpecBrief, ExecutionMode, HarnessError, SpawnCtx, ThreadEvent, ThreadHandle, TurnId,
+        TurnInput,
+    };
+    use futures::stream::BoxStream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
 
     #[tokio::test(flavor = "current_thread", start_paused = false)]
@@ -149,11 +285,149 @@ mod tests {
             registry: None,
             tick: Duration::from_millis(50),
             max_runtime: Some(Duration::from_millis(120)),
+            adapter_factory: None,
         };
         run_daemon(args).await.unwrap();
         // Heartbeat was written at least once.
         let hb = crate::imd_heartbeat_path();
         assert!(hb.exists(), "heartbeat at {} should exist", hb.display());
         std::env::remove_var("HOME");
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingAdapter {
+        starts: AtomicUsize,
+        closes: AtomicUsize,
+    }
+    #[async_trait]
+    impl HarnessAdapter for RecordingAdapter {
+        fn name(&self) -> &'static str {
+            "recording"
+        }
+        fn vendor(&self) -> AgentVendor {
+            AgentVendor::Claude
+        }
+        async fn start_thread(
+            &self,
+            spec: &AgentSpecBrief,
+            ctx: &SpawnCtx,
+        ) -> Result<ThreadHandle, HarnessError> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(ThreadHandle {
+                vendor: AgentVendor::Claude,
+                mode: ExecutionMode::Chat,
+                identity: format!("rec-{}-{}", ctx.slug, spec.role),
+                started_at: chrono::Utc::now(),
+                raw_extras: serde_json::json!({}),
+            })
+        }
+        async fn submit_turn(
+            &self,
+            _h: &ThreadHandle,
+            _input: TurnInput,
+        ) -> Result<TurnId, HarnessError> {
+            Ok(TurnId::new("t"))
+        }
+        fn events(&self, _h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+            Box::pin(futures::stream::empty())
+        }
+        async fn resume_thread(&self, _id: &str) -> Result<ThreadHandle, HarnessError> {
+            Err(HarnessError::NotImplemented {
+                reason: "stub".into(),
+            })
+        }
+        async fn close_thread(&self, _h: &ThreadHandle) -> Result<(), HarnessError> {
+            self.closes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn tick_supervisors_registers_and_spawns_bot() {
+        let projects = TempDir::new().unwrap();
+        let adapter = Arc::new(RecordingAdapter::default());
+        let adapter_factory: AdapterFactory = {
+            let cloned = adapter.clone();
+            Arc::new(move |_| cloned.clone() as Arc<dyn HarnessAdapter + Send + Sync>)
+        };
+        let registry = Arc::new(Mutex::new(SupervisorRegistry::default()));
+        let bot = BotRegistration {
+            workflow_slug: "dev-foo".into(),
+            role: "lead".into(),
+            vendor: AgentVendor::Claude,
+            persona_id: None,
+            im_platform: "telegram".into(),
+            im_chat_id: "1".into(),
+            created_at: chrono::Utc::now(),
+        };
+
+        // Tick 1: decide() returns Spawn (no handle yet) → start_thread.
+        tick_supervisors(
+            std::slice::from_ref(&bot),
+            &registry,
+            Some(projects.path()),
+            &adapter_factory,
+        )
+        .await;
+        assert_eq!(adapter.starts.load(Ordering::SeqCst), 1);
+
+        // Tick 2: heartbeat missing → decide() returns Restart → close + start.
+        tick_supervisors(
+            std::slice::from_ref(&bot),
+            &registry,
+            Some(projects.path()),
+            &adapter_factory,
+        )
+        .await;
+        assert_eq!(adapter.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(adapter.closes.load(Ordering::SeqCst), 1);
+
+        // Drop in a fresh heartbeat: next tick is a NoOp.
+        let bot_dir = projects
+            .path()
+            .join("dev-foo/.ccteam/chat/lead");
+        std::fs::create_dir_all(&bot_dir).unwrap();
+        std::fs::write(bot_dir.join("heartbeat"), "x").unwrap();
+        tick_supervisors(std::slice::from_ref(&bot), &registry, Some(projects.path()), &adapter_factory).await;
+        assert_eq!(adapter.starts.load(Ordering::SeqCst), 2, "no new start");
+
+        // Verify the supervisor is registered + holds a live handle.
+        let supervisors = registry.lock().await.all();
+        assert_eq!(supervisors.len(), 1);
+        assert!(supervisors[0].is_started().await);
+    }
+
+    #[tokio::test]
+    async fn tick_supervisors_honors_shutdown_signal() {
+        let projects = TempDir::new().unwrap();
+        let adapter = Arc::new(RecordingAdapter::default());
+        let adapter_factory: AdapterFactory = {
+            let cloned = adapter.clone();
+            Arc::new(move |_| cloned.clone() as Arc<dyn HarnessAdapter + Send + Sync>)
+        };
+        let registry = Arc::new(Mutex::new(SupervisorRegistry::default()));
+        let bot = BotRegistration {
+            workflow_slug: "dev-foo".into(),
+            role: "lead".into(),
+            vendor: AgentVendor::Claude,
+            persona_id: None,
+            im_platform: "telegram".into(),
+            im_chat_id: "1".into(),
+            created_at: chrono::Utc::now(),
+        };
+        // Tick 1: Spawn.
+        tick_supervisors(std::slice::from_ref(&bot), &registry, Some(projects.path()), &adapter_factory).await;
+        assert_eq!(adapter.starts.load(Ordering::SeqCst), 1);
+
+        // Drop shutdown.signal; next tick → Shutdown action.
+        let sig_dir = projects
+            .path()
+            .join("dev-foo/.ccteam/chat/lead/signals");
+        std::fs::create_dir_all(&sig_dir).unwrap();
+        std::fs::write(sig_dir.join("shutdown.signal"), "").unwrap();
+        tick_supervisors(std::slice::from_ref(&bot), &registry, Some(projects.path()), &adapter_factory).await;
+        assert_eq!(adapter.closes.load(Ordering::SeqCst), 1);
+        let supervisors = registry.lock().await.all();
+        assert!(!supervisors[0].is_started().await);
     }
 }

--- a/crates/ccteam-imd/src/main.rs
+++ b/crates/ccteam-imd/src/main.rs
@@ -115,6 +115,7 @@ fn main() -> Result<()> {
                 } else {
                     Some(std::time::Duration::from_secs(max_seconds))
                 },
+                adapter_factory: None,
             }))?;
         }
         Command::Register {

--- a/crates/ccteam-imd/src/outbound.rs
+++ b/crates/ccteam-imd/src/outbound.rs
@@ -92,6 +92,44 @@ pub fn read_new_rows(path: &std::path::Path, cursor: &TailCursor) -> Result<(Vec
     Ok((rows, TailCursor { position: consumed }))
 }
 
+/// V0.6.0 Wave 3 — push every assistant row in `rows` to `channel`
+/// addressed at `recipient`. Honors the [`should_forward`] filter so
+/// `user` / `tool` rows are skipped. Per-row send errors are logged
+/// but do not abort the forward loop (one flake shouldn't stall the
+/// whole bot). Returns the count of rows successfully dispatched.
+///
+/// The daemon resolves `(channel, recipient)` per-bot from the
+/// [`crate::BotRegistration`] (`im_platform` → channel impl,
+/// `im_chat_id` → recipient string).
+pub async fn forward_new_rows(
+    rows: &[TurnRow],
+    channel: &dyn crate::transport::Channel,
+    recipient: &str,
+    inbound_message_ids: &[String],
+) -> usize {
+    let mut sent = 0;
+    for row in rows {
+        if !should_forward(row, inbound_message_ids) {
+            continue;
+        }
+        let mut msg = crate::transport::SendMessage::new(row.content.clone(), recipient);
+        msg.thread_ts = row.thread_ts.clone();
+        match channel.send(&msg).await {
+            Ok(_) => {
+                sent += 1;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    recipient,
+                    "outbound forward failed; continuing"
+                );
+            }
+        }
+    }
+    sent
+}
+
 /// Filter: only `role == "assistant"` rows are forwarded to IM, and
 /// we suppress turns whose `reply_to` matches a message id we
 /// dropped inbound (echo suppression).
@@ -182,6 +220,42 @@ mod tests {
         let (rows, _) = read_new_rows(&path, &cur).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].content, "b");
+    }
+
+    #[tokio::test]
+    async fn forward_new_rows_dispatches_assistant_only() {
+        use crate::transport::providers::mock::MockChannel;
+        let channel = MockChannel::new();
+        let rows = vec![
+            TurnRow {
+                role: "assistant".into(),
+                content: "reply-1".into(),
+                reply_to: None,
+                thread_ts: None,
+                reply_target: None,
+            },
+            TurnRow {
+                role: "user".into(),
+                content: "u-1".into(),
+                reply_to: None,
+                thread_ts: None,
+                reply_target: None,
+            },
+            TurnRow {
+                role: "assistant".into(),
+                content: "reply-2".into(),
+                reply_to: None,
+                thread_ts: None,
+                reply_target: None,
+            },
+        ];
+        let sent = forward_new_rows(&rows, &channel, "user-alice", &[]).await;
+        assert_eq!(sent, 2);
+        let out = channel.outbox().await;
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].content, "reply-1");
+        assert_eq!(out[1].content, "reply-2");
+        assert_eq!(out[0].recipient, "user-alice");
     }
 
     #[test]

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -237,6 +237,13 @@ impl BotSupervisor {
         self.state.lock().await.handle.clone()
     }
 
+    /// Snapshot the live per-bot state — used by the daemon tick when
+    /// calling [`decide`] (pure function; needs a current view of
+    /// `handle` + `restarts` + flags to make the right call).
+    pub async fn state_snapshot(&self) -> BotState {
+        self.state.lock().await.clone()
+    }
+
     /// Idempotent: start the underlying tmux session via
     /// `adapter.start_thread` if not already running.
     pub async fn ensure_started(&self) -> Result<()> {

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -25,11 +25,15 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
-use anyhow::Result;
-use ccteam_core::harness::ThreadHandle;
+use anyhow::{anyhow, Context, Result};
+use ccteam_core::harness::{
+    AgentSpecBrief, HarnessAdapter, SpawnCtx, ThreadHandle, TurnId, TurnInput,
+};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 use crate::{imd_heartbeat_path, BotRegistration};
 
@@ -156,6 +160,387 @@ fn signal_present(bot_dir: &Path, name: &str) -> bool {
 pub struct SupervisorSnapshot {
     /// `(slug, role) -> action`.
     pub actions: HashMap<String, SupervisorAction>,
+}
+
+/// V0.6.0 Wave 3 — per-bot supervisor that owns one
+/// [`HarnessAdapter`] thread (tmux session) end to end.
+///
+/// One [`BotSupervisor`] per [`BotRegistration`]. The daemon builds
+/// these on boot, wires each one's outbound tail task, and routes
+/// inbound mailbox envelopes through [`BotSupervisor::handle_inbound`].
+///
+/// Lifecycle:
+///   1. `ensure_started()` (or `start()` directly) — calls
+///      `adapter.start_thread` once and stashes the `ThreadHandle`.
+///   2. `handle_inbound(payload)` — calls `adapter.submit_turn` with the
+///      mailbox content as `TurnInput::UserText`.
+///   3. `shutdown()` — calls `adapter.close_thread` and clears state.
+///   4. `restart()` — close + start (used when heartbeat goes stale).
+///
+/// All adapter calls go through the [`HarnessAdapter`] trait — no
+/// `ccteam_core::execution::*` import lives in this crate (red line
+/// enforced by `tests/dep_graph_test.rs`). Tests inject a stub adapter.
+pub struct BotSupervisor {
+    /// Registration this supervisor binds to.
+    pub reg: BotRegistration,
+    /// Projects root (`<projects_root>/<slug>/.ccteam/chat/<role>/`).
+    pub projects_root: PathBuf,
+    /// Wave 3 — the adapter the daemon picked for this vendor/mode
+    /// pair. Owned via `Arc` so the supervisor can hand a clone to
+    /// the outbound tail task.
+    pub adapter: Arc<dyn HarnessAdapter + Send + Sync>,
+    /// Active runtime state (handle + restart history + flags).
+    state: Mutex<BotState>,
+}
+
+impl std::fmt::Debug for BotSupervisor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BotSupervisor")
+            .field("slug", &self.reg.workflow_slug)
+            .field("role", &self.reg.role)
+            .field("vendor", &self.reg.vendor)
+            .field("adapter", &self.adapter.name())
+            .finish_non_exhaustive()
+    }
+}
+
+impl BotSupervisor {
+    /// Build a fresh supervisor for `reg`, using `adapter` for every
+    /// HarnessAdapter call. Initial state is empty (no handle).
+    pub fn new(
+        reg: BotRegistration,
+        projects_root: impl Into<PathBuf>,
+        adapter: Arc<dyn HarnessAdapter + Send + Sync>,
+    ) -> Self {
+        Self {
+            reg,
+            projects_root: projects_root.into(),
+            adapter,
+            state: Mutex::new(BotState::default()),
+        }
+    }
+
+    /// `<projects_root>/<slug>/`.
+    pub fn project_dir(&self) -> PathBuf {
+        self.projects_root.join(&self.reg.workflow_slug)
+    }
+
+    /// True iff `start_thread` has been called and `close_thread` has
+    /// not since.
+    pub async fn is_started(&self) -> bool {
+        self.state.lock().await.handle.is_some()
+    }
+
+    /// Snapshot of the current [`ThreadHandle`] (clone of the internal
+    /// state). `None` when the bot isn't running.
+    pub async fn current_handle(&self) -> Option<ThreadHandle> {
+        self.state.lock().await.handle.clone()
+    }
+
+    /// Idempotent: start the underlying tmux session via
+    /// `adapter.start_thread` if not already running.
+    pub async fn ensure_started(&self) -> Result<()> {
+        {
+            let st = self.state.lock().await;
+            if st.handle.is_some() {
+                return Ok(());
+            }
+        }
+        let spec = AgentSpecBrief {
+            role: self.reg.role.clone(),
+        };
+        let project_dir = self.project_dir();
+        let ctx = SpawnCtx {
+            slug: self.reg.workflow_slug.clone(),
+            sid: format!(
+                "{}-{}",
+                self.reg.workflow_slug, self.reg.role
+            ),
+            cwd: project_dir.clone(),
+            project_dir,
+            extra_args: Vec::new(),
+        };
+        let handle = self
+            .adapter
+            .start_thread(&spec, &ctx)
+            .await
+            .with_context(|| {
+                format!(
+                    "start_thread for {}/{} via {}",
+                    self.reg.workflow_slug,
+                    self.reg.role,
+                    self.adapter.name()
+                )
+            })?;
+        let mut st = self.state.lock().await;
+        st.handle = Some(handle);
+        tracing::info!(
+            slug = %self.reg.workflow_slug,
+            role = %self.reg.role,
+            adapter = self.adapter.name(),
+            "bot supervisor started thread"
+        );
+        Ok(())
+    }
+
+    /// Submit one mailbox payload to the bot via
+    /// `adapter.submit_turn(TurnInput::UserText(payload))`.
+    ///
+    /// Returns an error when the thread isn't started yet — callers
+    /// typically `ensure_started().await?` first.
+    pub async fn handle_inbound(&self, payload: String) -> Result<TurnId> {
+        let handle = {
+            let st = self.state.lock().await;
+            st.handle
+                .clone()
+                .ok_or_else(|| anyhow!("bot {}/{} not started", self.reg.workflow_slug, self.reg.role))?
+        };
+        let id = self
+            .adapter
+            .submit_turn(&handle, TurnInput::UserText(payload))
+            .await
+            .with_context(|| {
+                format!(
+                    "submit_turn for {}/{}",
+                    self.reg.workflow_slug, self.reg.role
+                )
+            })?;
+        tracing::debug!(
+            slug = %self.reg.workflow_slug,
+            role = %self.reg.role,
+            turn = %id.0,
+            "submitted user turn"
+        );
+        Ok(id)
+    }
+
+    /// Gracefully close the underlying thread (`adapter.close_thread`)
+    /// and clear local state. Idempotent — calling on a stopped
+    /// supervisor is a no-op.
+    pub async fn shutdown(&self) -> Result<()> {
+        let handle = {
+            let mut st = self.state.lock().await;
+            st.shutting_down = true;
+            st.handle.take()
+        };
+        if let Some(h) = handle {
+            self.adapter
+                .close_thread(&h)
+                .await
+                .with_context(|| {
+                    format!(
+                        "close_thread for {}/{}",
+                        self.reg.workflow_slug, self.reg.role
+                    )
+                })?;
+            tracing::info!(
+                slug = %self.reg.workflow_slug,
+                role = %self.reg.role,
+                "bot supervisor closed thread"
+            );
+        }
+        Ok(())
+    }
+
+    /// Close-then-start cycle for stale-heartbeat recovery. Records the
+    /// restart in the rolling-hour budget.
+    pub async fn restart(&self) -> Result<()> {
+        // Close first.
+        let handle = self.state.lock().await.handle.take();
+        if let Some(h) = handle {
+            // Best-effort close; we proceed to start even if close fails
+            // (the tmux session may already be dead, which is exactly
+            // why we're restarting).
+            if let Err(err) = self.adapter.close_thread(&h).await {
+                tracing::warn!(
+                    slug = %self.reg.workflow_slug,
+                    role = %self.reg.role,
+                    error = %err,
+                    "close_thread during restart failed; proceeding to start"
+                );
+            }
+        }
+        // Record this restart for budget tracking.
+        {
+            let mut st = self.state.lock().await;
+            st.restarts.push(Instant::now());
+            // Trim to last hour to keep the vec bounded.
+            st.restarts.retain(|t| t.elapsed() < Duration::from_secs(3600));
+        }
+        // Start.
+        self.ensure_started().await
+    }
+
+    /// Apply one supervisor decision (called per supervisor tick by
+    /// the daemon). Returns the action that was applied for logging.
+    pub async fn apply_action(&self, action: SupervisorAction) -> Result<SupervisorAction> {
+        match action {
+            SupervisorAction::Spawn => {
+                self.ensure_started().await?;
+            }
+            SupervisorAction::Restart => {
+                self.restart().await?;
+            }
+            SupervisorAction::Shutdown => {
+                self.shutdown().await?;
+            }
+            SupervisorAction::Drain => {
+                // No close — just flag so future handle_inbound calls
+                // refuse new turns. (V0.6 Wave 3: enforcement landed in
+                // handle_inbound is intentionally minimal — Wave 4
+                // policy hook decides the drain UX.)
+                let mut st = self.state.lock().await;
+                st.draining = true;
+            }
+            SupervisorAction::Quarantine | SupervisorAction::NoOp => {}
+        }
+        Ok(action)
+    }
+}
+
+#[cfg(test)]
+mod bot_supervisor_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ccteam_core::harness::{
+        AgentVendor, ExecutionMode, HarnessError, ThreadEvent, ThreadHandle,
+    };
+    use futures::stream::BoxStream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::TempDir;
+
+    /// Stub HarnessAdapter that records every call. The supervisor
+    /// can't tell it apart from the real `ClaudeTuiAdapter` — exactly
+    /// the integration contract the e2e mock test exercises.
+    #[derive(Debug, Default)]
+    pub struct StubAdapter {
+        pub starts: AtomicUsize,
+        pub submits: AtomicUsize,
+        pub closes: AtomicUsize,
+        pub fail_start: bool,
+    }
+
+    #[async_trait]
+    impl HarnessAdapter for StubAdapter {
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+        fn vendor(&self) -> AgentVendor {
+            AgentVendor::Claude
+        }
+        async fn start_thread(
+            &self,
+            spec: &AgentSpecBrief,
+            ctx: &SpawnCtx,
+        ) -> Result<ThreadHandle, HarnessError> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            if self.fail_start {
+                return Err(HarnessError::SpawnFailed("stub-fail".into()));
+            }
+            Ok(ThreadHandle {
+                vendor: AgentVendor::Claude,
+                mode: ExecutionMode::Chat,
+                identity: format!("stub-{}-{}", ctx.slug, spec.role),
+                started_at: chrono::Utc::now(),
+                raw_extras: serde_json::json!({"slug": ctx.slug, "role": spec.role}),
+            })
+        }
+        async fn submit_turn(
+            &self,
+            _h: &ThreadHandle,
+            _input: TurnInput,
+        ) -> Result<TurnId, HarnessError> {
+            self.submits.fetch_add(1, Ordering::SeqCst);
+            Ok(TurnId::new("stub-turn"))
+        }
+        fn events(&self, _h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+            Box::pin(futures::stream::empty())
+        }
+        async fn resume_thread(&self, _id: &str) -> Result<ThreadHandle, HarnessError> {
+            Err(HarnessError::NotImplemented { reason: "stub".into() })
+        }
+        async fn close_thread(&self, _h: &ThreadHandle) -> Result<(), HarnessError> {
+            self.closes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn reg() -> BotRegistration {
+        BotRegistration {
+            workflow_slug: "dev-foo".into(),
+            role: "lead".into(),
+            vendor: AgentVendor::Claude,
+            persona_id: None,
+            im_platform: "mock".into(),
+            im_chat_id: "1".into(),
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_started_is_idempotent() {
+        let stub = Arc::new(StubAdapter::default());
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        sup.ensure_started().await.unwrap();
+        sup.ensure_started().await.unwrap();
+        assert_eq!(stub.starts.load(Ordering::SeqCst), 1);
+        assert!(sup.is_started().await);
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_calls_submit_turn() {
+        let stub = Arc::new(StubAdapter::default());
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        sup.ensure_started().await.unwrap();
+        let id = sup.handle_inbound("hello".into()).await.unwrap();
+        assert_eq!(id.0, "stub-turn");
+        assert_eq!(stub.submits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn handle_inbound_errors_when_not_started() {
+        let stub = Arc::new(StubAdapter::default());
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        assert!(sup.handle_inbound("x".into()).await.is_err());
+        assert_eq!(stub.submits.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_then_idempotent() {
+        let stub = Arc::new(StubAdapter::default());
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        sup.ensure_started().await.unwrap();
+        sup.shutdown().await.unwrap();
+        sup.shutdown().await.unwrap();
+        assert_eq!(stub.closes.load(Ordering::SeqCst), 1);
+        assert!(!sup.is_started().await);
+    }
+
+    #[tokio::test]
+    async fn restart_closes_then_starts() {
+        let stub = Arc::new(StubAdapter::default());
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        sup.ensure_started().await.unwrap();
+        sup.restart().await.unwrap();
+        assert_eq!(stub.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(stub.closes.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn apply_action_dispatches() {
+        let stub = Arc::new(StubAdapter::default());
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        sup.apply_action(SupervisorAction::Spawn).await.unwrap();
+        assert_eq!(stub.starts.load(Ordering::SeqCst), 1);
+        sup.apply_action(SupervisorAction::Shutdown).await.unwrap();
+        assert_eq!(stub.closes.load(Ordering::SeqCst), 1);
+    }
 }
 
 #[cfg(test)]

--- a/crates/ccteam-imd/tests/daemon_test.rs
+++ b/crates/ccteam-imd/tests/daemon_test.rs
@@ -31,6 +31,7 @@ async fn daemon_runs_and_writes_heartbeat() {
         registry: None,
         tick: Duration::from_millis(40),
         max_runtime: Some(Duration::from_millis(150)),
+        adapter_factory: None,
     };
     run_daemon(args).await.unwrap();
     let hb = imd_heartbeat_path();

--- a/crates/ccteam-imd/tests/e2e_mock_test.rs
+++ b/crates/ccteam-imd/tests/e2e_mock_test.rs
@@ -1,0 +1,486 @@
+//! V0.6.0 Wave 3 e2e wiring — mock-IM integration test.
+//!
+//! Stitches every Wave 2 + Wave 3 ccteam-imd component together
+//! without a real tmux process: MockChannel → inbound pipeline →
+//! mailbox file → BotSupervisor + stub HarnessAdapter →
+//! simulated `turns.jsonl` append → outbound tailer → MockChannel
+//! outbox.
+//!
+//! Real-tmux + real-claude validation is Wave 4 host-probe (a user
+//! pastes a Telegram bot token and we drive a live session); this
+//! suite proves the wiring logic.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ccteam_core::harness::{
+    AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, SpawnCtx,
+    ThreadEvent, ThreadHandle, TurnId, TurnInput,
+};
+use ccteam_imd::inbound::{process_inbound, DefaultMailboxResolver, InboundOutcome};
+use ccteam_imd::outbound::{forward_new_rows, read_new_rows, TailCursor};
+use ccteam_imd::router::HandleMap;
+use ccteam_imd::supervisor::BotSupervisor;
+use ccteam_imd::three_layer_sec::ThreeLayerSec;
+use ccteam_imd::transport::providers::mock::MockChannel;
+use ccteam_imd::transport::{Channel, ChannelMessage};
+use ccteam_imd::BotRegistration;
+use futures::stream::BoxStream;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+// ---------------------------------------------------------------------
+// Stub adapter — pretends to be ClaudeTuiAdapter, records calls, and
+// writes the "assistant reply" into turns.jsonl so the outbound tailer
+// has something to forward.
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct StubAdapter {
+    starts: AtomicUsize,
+    submits: AtomicUsize,
+    closes: AtomicUsize,
+    /// Where to mirror the assistant reply (set in `start_thread`).
+    turns_path: tokio::sync::Mutex<Option<std::path::PathBuf>>,
+    /// Per-submit canned assistant reply (defaults to echo of input).
+    canned_reply: Option<String>,
+}
+
+impl StubAdapter {
+    fn new() -> Self {
+        Self::default()
+    }
+    fn with_canned_reply(reply: impl Into<String>) -> Self {
+        Self {
+            canned_reply: Some(reply.into()),
+            ..Self::default()
+        }
+    }
+}
+
+#[async_trait]
+impl HarnessAdapter for StubAdapter {
+    fn name(&self) -> &'static str {
+        "stub-claude-tui"
+    }
+    fn vendor(&self) -> AgentVendor {
+        AgentVendor::Claude
+    }
+    async fn start_thread(
+        &self,
+        spec: &AgentSpecBrief,
+        ctx: &SpawnCtx,
+    ) -> Result<ThreadHandle, HarnessError> {
+        self.starts.fetch_add(1, Ordering::SeqCst);
+        let chat_dir = ctx
+            .project_dir
+            .join(".ccteam")
+            .join("chat")
+            .join(&spec.role);
+        std::fs::create_dir_all(&chat_dir).unwrap();
+        let path = chat_dir.join("turns.jsonl");
+        *self.turns_path.lock().await = Some(path.clone());
+        Ok(ThreadHandle {
+            vendor: AgentVendor::Claude,
+            mode: ExecutionMode::Chat,
+            identity: format!("stub-{}-{}", ctx.slug, spec.role),
+            started_at: chrono::Utc::now(),
+            raw_extras: serde_json::json!({"slug": ctx.slug, "role": spec.role}),
+        })
+    }
+    async fn submit_turn(
+        &self,
+        _h: &ThreadHandle,
+        input: TurnInput,
+    ) -> Result<TurnId, HarnessError> {
+        self.submits.fetch_add(1, Ordering::SeqCst);
+        // Simulate the real TUI adapter's turns_mirror append: drop
+        // one `assistant` row that the outbound tailer will pick up.
+        let user_text = match input {
+            TurnInput::UserText(s) => s,
+            other => format!("{other:?}"),
+        };
+        let reply = self
+            .canned_reply
+            .clone()
+            .unwrap_or_else(|| format!("echo: {user_text}"));
+        if let Some(path) = self.turns_path.lock().await.as_ref() {
+            use std::io::Write as _;
+            let row = serde_json::json!({
+                "role": "assistant",
+                "content": reply,
+            });
+            let mut f = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .unwrap();
+            writeln!(f, "{row}").unwrap();
+        }
+        Ok(TurnId::new(format!(
+            "stub-turn-{}",
+            self.submits.load(Ordering::SeqCst)
+        )))
+    }
+    fn events(&self, _h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+        Box::pin(futures::stream::empty())
+    }
+    async fn resume_thread(&self, _id: &str) -> Result<ThreadHandle, HarnessError> {
+        Err(HarnessError::NotImplemented {
+            reason: "stub".into(),
+        })
+    }
+    async fn close_thread(&self, _h: &ThreadHandle) -> Result<(), HarnessError> {
+        self.closes.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------
+
+fn reg(slug: &str, role: &str) -> BotRegistration {
+    BotRegistration {
+        workflow_slug: slug.into(),
+        role: role.into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "mock".into(),
+        im_chat_id: format!("chat-{slug}-{role}"),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+fn im_msg(payload: &str) -> ChannelMessage {
+    ChannelMessage {
+        id: "im-1".into(),
+        sender: "alice".into(),
+        reply_target: "chat-1".into(),
+        content: payload.into(),
+        channel: "telegram".into(),
+        timestamp: 0,
+        thread_ts: None,
+    }
+}
+
+async fn drain_inbox_into_supervisor(
+    projects_root: &Path,
+    slug: &str,
+    role: &str,
+    sup: &BotSupervisor,
+) -> usize {
+    let inbox = projects_root
+        .join(slug)
+        .join(".ccteam")
+        .join("chat")
+        .join(role)
+        .join("inbox");
+    if !inbox.exists() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut entries: Vec<_> = std::fs::read_dir(&inbox)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+    for entry in entries {
+        let body = std::fs::read_to_string(entry.path()).unwrap();
+        let env = ccteam_imd::inbound::parse_envelope(&body).unwrap();
+        sup.handle_inbound(env.payload).await.unwrap();
+        std::fs::remove_file(entry.path()).unwrap();
+        count += 1;
+    }
+    count
+}
+
+// ---------------------------------------------------------------------
+// 1. Happy path — IM in → bot replies → IM out.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn happy_path_im_to_bot_to_im() {
+    let tmp = TempDir::new().unwrap();
+    let projects_root = tmp.path().to_path_buf();
+    let slug = "dev-foo";
+    let role = "lead";
+
+    // Wire inbound: write @lead message to mailbox.
+    let sec = Arc::new(Mutex::new(ThreeLayerSec::new(Default::default())));
+    let mailbox = DefaultMailboxResolver::with_projects_root(projects_root.clone());
+    let mut handles = HandleMap::new();
+    handles.insert("lead", slug, role);
+
+    let res = process_inbound(
+        &im_msg("@lead what's up?"),
+        &sec,
+        &handles,
+        &mailbox,
+        0,
+        1,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(res, InboundOutcome::DroppedToBot { .. }));
+
+    // Wire supervisor + adapter; start the thread.
+    let adapter = Arc::new(StubAdapter::new());
+    let sup = BotSupervisor::new(reg(slug, role), projects_root.clone(), adapter.clone());
+    sup.ensure_started().await.unwrap();
+    assert_eq!(adapter.starts.load(Ordering::SeqCst), 1);
+
+    // Drain mailbox → submit_turn (the daemon's per-tick job).
+    let drained = drain_inbox_into_supervisor(&projects_root, slug, role, &sup).await;
+    assert_eq!(drained, 1);
+    assert_eq!(adapter.submits.load(Ordering::SeqCst), 1);
+
+    // Outbound: tail turns.jsonl, push assistant rows to MockChannel.
+    let turns_path = projects_root
+        .join(slug)
+        .join(".ccteam")
+        .join("chat")
+        .join(role)
+        .join("turns.jsonl");
+    let (rows, _) = read_new_rows(&turns_path, &TailCursor::default()).unwrap();
+    assert_eq!(rows.len(), 1, "stub adapter wrote one assistant row");
+
+    let channel = MockChannel::new();
+    let sent = forward_new_rows(&rows, &channel, "alice", &[]).await;
+    assert_eq!(sent, 1);
+    let out = channel.outbox().await;
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].content, "echo: what's up?");
+    assert_eq!(out[0].recipient, "alice");
+}
+
+// ---------------------------------------------------------------------
+// 2. Error recovery — adapter fails first start, restart() recovers.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn restart_recovers_from_close_failure() {
+    // Adapter that succeeds start but `close_thread` returns Err on
+    // first call (simulating a dead tmux session). restart() must
+    // proceed past the close failure and call start_thread again.
+    #[derive(Debug, Default)]
+    struct FlakyCloseAdapter {
+        starts: AtomicUsize,
+        closes: AtomicUsize,
+    }
+    #[async_trait]
+    impl HarnessAdapter for FlakyCloseAdapter {
+        fn name(&self) -> &'static str {
+            "flaky-close"
+        }
+        fn vendor(&self) -> AgentVendor {
+            AgentVendor::Claude
+        }
+        async fn start_thread(
+            &self,
+            spec: &AgentSpecBrief,
+            ctx: &SpawnCtx,
+        ) -> Result<ThreadHandle, HarnessError> {
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(ThreadHandle {
+                vendor: AgentVendor::Claude,
+                mode: ExecutionMode::Chat,
+                identity: format!("flaky-{}-{}", ctx.slug, spec.role),
+                started_at: chrono::Utc::now(),
+                raw_extras: serde_json::json!({}),
+            })
+        }
+        async fn submit_turn(
+            &self,
+            _h: &ThreadHandle,
+            _input: TurnInput,
+        ) -> Result<TurnId, HarnessError> {
+            Ok(TurnId::new("t"))
+        }
+        fn events(&self, _h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+            Box::pin(futures::stream::empty())
+        }
+        async fn resume_thread(&self, _id: &str) -> Result<ThreadHandle, HarnessError> {
+            Err(HarnessError::NotImplemented {
+                reason: "stub".into(),
+            })
+        }
+        async fn close_thread(&self, _h: &ThreadHandle) -> Result<(), HarnessError> {
+            let n = self.closes.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                Err(HarnessError::ShutdownFailed("simulated".into()))
+            } else {
+                Ok(())
+            }
+        }
+    }
+    let tmp = TempDir::new().unwrap();
+    let adapter = Arc::new(FlakyCloseAdapter::default());
+    let sup = BotSupervisor::new(reg("dev-foo", "lead"), tmp.path(), adapter.clone());
+    sup.ensure_started().await.unwrap();
+    sup.restart().await.unwrap();
+    assert_eq!(adapter.starts.load(Ordering::SeqCst), 2, "restart starts again");
+    assert_eq!(adapter.closes.load(Ordering::SeqCst), 1, "close attempted once");
+    assert!(sup.is_started().await);
+}
+
+// ---------------------------------------------------------------------
+// 3. close_thread cleanup — shutdown is idempotent + the supervisor
+//    refuses to handle inbound after shutdown.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn close_thread_cleanup_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = Arc::new(StubAdapter::new());
+    let sup = BotSupervisor::new(reg("dev-foo", "lead"), tmp.path(), adapter.clone());
+    sup.ensure_started().await.unwrap();
+    assert!(sup.is_started().await);
+    sup.shutdown().await.unwrap();
+    sup.shutdown().await.unwrap();
+    sup.shutdown().await.unwrap();
+    assert_eq!(adapter.closes.load(Ordering::SeqCst), 1);
+    assert!(!sup.is_started().await);
+    // handle_inbound should refuse after shutdown (no handle).
+    assert!(sup.handle_inbound("ignored".into()).await.is_err());
+}
+
+// ---------------------------------------------------------------------
+// 4. Multi-bot parallel — two supervisors using independent adapters
+//    run side by side, each draining its own inbox into its own turns
+//    file. Verifies no shared-state crosstalk.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn multi_bot_parallel() {
+    let tmp = TempDir::new().unwrap();
+    let projects_root = tmp.path().to_path_buf();
+
+    let sec = Arc::new(Mutex::new(ThreeLayerSec::new(Default::default())));
+    let mailbox = DefaultMailboxResolver::with_projects_root(projects_root.clone());
+    let mut handles = HandleMap::new();
+    handles.insert("lead", "dev-foo", "lead");
+    handles.insert("ops", "dev-bar", "ops");
+
+    // Two bots in two different slugs.
+    let adapter_lead = Arc::new(StubAdapter::with_canned_reply("LEAD-OK"));
+    let adapter_ops = Arc::new(StubAdapter::with_canned_reply("OPS-OK"));
+    let sup_lead = Arc::new(BotSupervisor::new(
+        reg("dev-foo", "lead"),
+        projects_root.clone(),
+        adapter_lead.clone(),
+    ));
+    let sup_ops = Arc::new(BotSupervisor::new(
+        reg("dev-bar", "ops"),
+        projects_root.clone(),
+        adapter_ops.clone(),
+    ));
+    sup_lead.ensure_started().await.unwrap();
+    sup_ops.ensure_started().await.unwrap();
+
+    // Three messages: 2 for lead, 1 for ops.
+    let mut seq = 0_u64;
+    for content in ["@lead one", "@lead two", "@ops three"] {
+        seq += 1;
+        let outcome = process_inbound(
+            &im_msg(content),
+            &sec,
+            &handles,
+            &mailbox,
+            0,
+            seq,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(outcome, InboundOutcome::DroppedToBot { .. }));
+    }
+
+    // Drain each bot's mailbox in parallel.
+    let (n_lead, n_ops) = tokio::join!(
+        drain_inbox_into_supervisor(&projects_root, "dev-foo", "lead", &sup_lead),
+        drain_inbox_into_supervisor(&projects_root, "dev-bar", "ops", &sup_ops),
+    );
+    assert_eq!(n_lead, 2);
+    assert_eq!(n_ops, 1);
+    assert_eq!(adapter_lead.submits.load(Ordering::SeqCst), 2);
+    assert_eq!(adapter_ops.submits.load(Ordering::SeqCst), 1);
+
+    // Each bot's turns.jsonl has its own assistant rows; outbound
+    // forwards to bot-specific MockChannels.
+    let lead_turns = projects_root
+        .join("dev-foo/.ccteam/chat/lead/turns.jsonl");
+    let ops_turns = projects_root
+        .join("dev-bar/.ccteam/chat/ops/turns.jsonl");
+    let (lead_rows, _) = read_new_rows(&lead_turns, &TailCursor::default()).unwrap();
+    let (ops_rows, _) = read_new_rows(&ops_turns, &TailCursor::default()).unwrap();
+    assert_eq!(lead_rows.len(), 2);
+    assert_eq!(ops_rows.len(), 1);
+    assert!(lead_rows.iter().all(|r| r.content == "LEAD-OK"));
+    assert_eq!(ops_rows[0].content, "OPS-OK");
+
+    // Separate channels — no crosstalk.
+    let ch_lead = MockChannel::new();
+    let ch_ops = MockChannel::new();
+    let sent_lead = forward_new_rows(&lead_rows, &ch_lead, "alice", &[]).await;
+    let sent_ops = forward_new_rows(&ops_rows, &ch_ops, "bob", &[]).await;
+    assert_eq!(sent_lead, 2);
+    assert_eq!(sent_ops, 1);
+    assert_eq!(ch_lead.outbox().await.len(), 2);
+    assert_eq!(ch_ops.outbox().await.len(), 1);
+}
+
+// ---------------------------------------------------------------------
+// 5. End-to-end echo verifies the MockChannel listen() → mpsc path
+//    used by the production daemon is type-compatible with the rest
+//    of the pipeline (channel API surface gate).
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn channel_listen_to_inbound_pipeline() {
+    let tmp = TempDir::new().unwrap();
+    let projects_root = tmp.path().to_path_buf();
+    let slug = "dev-foo";
+    let role = "lead";
+
+    let sec = Arc::new(Mutex::new(ThreeLayerSec::new(Default::default())));
+    let mailbox = DefaultMailboxResolver::with_projects_root(projects_root.clone());
+    let mut handles = HandleMap::new();
+    handles.insert("lead", slug, role);
+
+    // Push two messages into the MockChannel's inbox before listen.
+    let ch = MockChannel::new();
+    for s in ["@lead first", "@lead second"] {
+        ch.push(ChannelMessage {
+            id: format!("id-{s}"),
+            sender: "alice".into(),
+            reply_target: "alice".into(),
+            content: s.into(),
+            channel: "telegram".into(),
+            timestamp: 0,
+            thread_ts: None,
+        })
+        .await;
+    }
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<ChannelMessage>(8);
+    ch.listen(tx).await.unwrap();
+
+    // Pump receiver through the inbound pipeline.
+    let mut count = 0_u64;
+    while let Ok(msg) = rx.try_recv() {
+        count += 1;
+        let outcome = process_inbound(&msg, &sec, &handles, &mailbox, 0, count)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, InboundOutcome::DroppedToBot { .. }));
+    }
+    assert_eq!(count, 2);
+
+    let adapter = Arc::new(StubAdapter::new());
+    let sup = BotSupervisor::new(reg(slug, role), projects_root.clone(), adapter.clone());
+    sup.ensure_started().await.unwrap();
+    let drained = drain_inbox_into_supervisor(&projects_root, slug, role, &sup).await;
+    assert_eq!(drained, 2);
+    assert_eq!(adapter.submits.load(Ordering::SeqCst), 2);
+}

--- a/crates/ccteam-web/src/routes/api_v1.rs
+++ b/crates/ccteam-web/src/routes/api_v1.rs
@@ -111,6 +111,13 @@ pub struct ProjectSummary {
     pub events: Vec<EventRow>,
     pub outbox: Vec<OutboxRow>,
     pub workflow_summary: Option<WorkflowSummary>,
+    /// V0.6.0 Wave 3 F112 — per-vendor 24h cost breakdown
+    /// (`{"claude": <f64>, "codex": <f64>}`). Pre-V0.6 `agent_done`
+    /// events lacked a `vendor` field and contribute only to the
+    /// aggregate `cost_label`; this map is empty when the project
+    /// hasn't run any V0.6+ vendor-tagged turns yet.
+    #[serde(default)]
+    pub cost_24h_by_vendor: std::collections::BTreeMap<String, f64>,
 }
 
 /// JSON returned by `GET /api/v1/projects/{slug}/sessions/{sid}`.
@@ -260,9 +267,12 @@ async fn handle_project(
     // V0.4.6 F91 — cost_label sources `cost_total_usd` from
     // `cost_summary` (progress.jsonl + live state.json). Pre-F91 this
     // line read `state.cost_used_usd`, which is now frozen.
-    let cost_total = cost_summary(&slug, &app.paths.progress_jsonl(&slug), &app.paths)
-        .map(|c| c.cost_total_usd)
-        .unwrap_or(0.0);
+    // V0.6.0 Wave 3 F112 — also surface `cost_24h_by_vendor` to drive
+    // the SPA's per-vendor split and `/ccteam-advise` UI.
+    let cost = cost_summary(&slug, &app.paths.progress_jsonl(&slug), &app.paths)
+        .unwrap_or_default();
+    let cost_total = cost.cost_total_usd;
+    let cost_24h_by_vendor = cost.cost_24h_by_vendor.clone();
     let summary = ProjectSummary {
         slug: state.slug.clone(),
         team: state.team.clone(),
@@ -277,6 +287,7 @@ async fn handle_project(
         events: event_rows,
         outbox,
         workflow_summary,
+        cost_24h_by_vendor,
     };
     Json(summary).into_response()
 }

--- a/docs/v0-6-0/wave-3-decisions.md
+++ b/docs/v0-6-0/wave-3-decisions.md
@@ -1,0 +1,223 @@
+# V0.6.0 Wave 3 (F112 codex-exec-impl) — decisions log
+
+> Wave 3 fills the V0.6 `HarnessAdapter` Codex side (`CodexExecAdapter`
+> + `CodexAppServerAdapter` + UDS JSON-RPC client) plus operator-
+> facing `doctor` flags + per-vendor budget caps. This document
+> records the design choices and ambiguities resolved at impl time so
+> Wave 4 has a paper trail. Source of truth for live behavior remains
+> the code; this doc is **decisions**, not API reference.
+
+## §1 Scope landed
+
+| Component | File | Status |
+|---|---|---|
+| `codex_jsonrpc::CodexJsonRpcClient` | `crates/ccteam-core/src/execution/codex_jsonrpc.rs` | new (5 unit tests + 4 in `tests/codex_jsonrpc_test.rs`) |
+| `codex_app_server::CodexAppServerAdapter` | `crates/ccteam-core/src/execution/codex_app_server.rs` | new (`HarnessAdapter` impl: start/submit/events/resume/close) |
+| `codex_exec::CodexExecAdapter::{submit_turn, resume_thread}` | `crates/ccteam-core/src/execution/codex_exec.rs` | filled (Wave 1 `NotImplemented` stubs gone) |
+| Per-vendor `agent_done.vendor` tag | `crates/ccteam-core/src/orchestrator.rs` | added at both emit points |
+| `queries::CostSummary.{cost_24h,cost_total}_by_vendor` | `crates/ccteam-core/src/queries.rs` | additive fields, `#[serde(default)]` for legacy events |
+| `enforce_budget` per-vendor cap | `crates/ccteam-core/src/orchestrator.rs` | reads `budgets_v060.{claude,codex}.max_cost_usd_per_24h` BEFORE legacy aggregate `budget` |
+| `web cost_summary` per-vendor field | `crates/ccteam-web/src/routes/api_v1.rs` | `ProjectSummary.cost_24h_by_vendor` (BTreeMap) |
+| `ccteam doctor --check-codex-version` | `crates/ccteam-cli/src/{main,commands}.rs` | parses `codex --version`, classifies vs `0.131` minimum |
+| `ccteam doctor --check-codex-auth` | `crates/ccteam-cli/src/{main,commands}.rs` | parses `codex login status`, branches `LoggedIn / LoggedOut / Unknown` |
+
+## §2 Decisions made at impl time
+
+### D1. `codex_jsonrpc` wire framing = line-delimited JSON, NOT strict JSON-RPC 2.0
+
+References: `references/codex/codex-rs/app-server-protocol/src/jsonrpc_lite.rs:1-2`
+explicitly acknowledges the dialect omits `"jsonrpc": "2.0"`. Each
+line is a complete JSON object. The reader-task loop in
+`run_reader_loop` uses `BufReader::lines` and parses each line
+independently. Garbage lines are logged at WARN and skipped (covered
+by `malformed_lines_are_tolerated` test).
+
+### D2. JSON-RPC client uses channel-based writer task, not `Mutex<WriteHalf>`
+
+First impl tried `Box<dyn AsyncWriteExt + Unpin + Send>` but the EXT
+trait isn't dyn-compatible (return types reference `Self`). Rewrote
+with an mpsc<Vec<u8>> queue feeding a single writer task that owns
+the concrete `OwnedWriteHalf`. Bonus: callers don't lock when the
+kernel buffer back-pressures.
+
+### D3. Notifications fan out via `tokio::sync::broadcast` (not mpsc)
+
+Multiple subscribers per connection are useful when the adapter's
+`events()` is called multiple times for the same thread (e.g. one
+caller for `progress.jsonl` ingest, one for SSE). Broadcast supports
+arbitrary subscriber count; the `Lagged(n)` outcome is downgraded to
+`tracing::warn!` and the loop continues (event drop > stall).
+
+### D4. `CodexExecAdapter` keeps tmux from Wave 1; per-turn `codex exec --json` is **separate**
+
+Rationale: V0.5.1 parity for the cost-status pane (the
+`CODEX_STATUS:` marker line + tmux session container). Wave 3's
+per-turn `codex exec --json` subprocess runs as an INDEPENDENT child
+process unrelated to the tmux pane. The `ThreadHandle.identity`
+points at the tmux session (for `close_thread` parity); per-turn
+event delivery goes through a per-thread
+`broadcast::Sender<ThreadEvent>` keyed on `identity`.
+
+Consequence: `start_thread` is still tmux-bound and may be called
+on hosts without `codex exec --json` support. `submit_turn`'s
+failure modes are independent — the subprocess errors don't kill the
+tmux container.
+
+### D5. `submit_turn` pipes prompt via stdin, not argv
+
+`codex exec --json -` accepts the prompt via stdin, avoiding shell
+escaping headaches when the prompt contains shell metacharacters or
+spans many lines. Argv shape: `codex exec --json -` (or
+`codex resume <id> --json -` for the resume branch).
+
+### D6. `resume_thread` synthesises handle; deferred lookup happens at `submit_turn`
+
+`resume_thread` does NOT verify the persistent id exists in
+`~/.codex/sessions/`. It synthesises a `ThreadHandle` with
+`raw_extras.resumed = true` + `raw_extras.thread_id = <id>`. The
+*next* `submit_turn` call switches to the `codex resume <id>` argv
+shape. Rationale: avoids a redundant FS probe + matches codex's own
+lazy validation. Empty-string ids are rejected up-front.
+
+### D7. `CodexAppServerAdapter` does NOT auto-spawn the daemon
+
+The adapter dials `$CODEX_HOME/app-server-control/app-server-control.sock`
+(overridable via `CCTEAM_CODEX_APP_SERVER_SOCKET` for tests). If the
+socket is missing, `start_thread` returns `SpawnFailed` with a clear
+message. Auto-spawning `codex app-server daemon start` was considered
+and rejected — the daemon has a lifecycle the user should manage
+through `codex app-server daemon {start,stop,restart}` directly.
+`ccteam doctor --check-codex-version` is the operator's entry point
+to see whether the daemon socket is reachable.
+
+### D8. `thread/close` → `thread/archive` + `thread/unsubscribe` (NOT `thread/close`)
+
+There is no `thread/close` method in codex's v2 protocol; the
+release-resources operations are `thread/archive` (server-side state
+GC) + `thread/unsubscribe` (stop receiving notifications). The
+adapter calls both as best-effort and never escalates failures
+(matches V0.5.x close idempotency).
+
+### D9. `event` translation handles unknown methods via `None`
+
+Codex's v2 protocol has dozens of notification methods (plan deltas,
+file-change patch updates, MCP progress, etc.). Wave 3 propagates
+only the ones that map cleanly to `ThreadEvent` (thread.started,
+turn.started, turn.completed, turn.failed, item.started/updated/
+completed, item/agentMessage/delta, error). Everything else returns
+`None` — the orchestrator's `progress.jsonl` poller still owns state
+transitions (Wave 1 contract). Adding more event types is a future
+PR; the translate fn is exported `pub` so SSE / debug surfaces can
+consume notifications directly.
+
+### D10. Per-vendor cap precedence: v060 caps checked BEFORE legacy flat `budget`
+
+`enforce_budget` reads `budgets_v060.{claude,codex}.max_cost_usd_per_24h`
+first. If a per-vendor cap trips, we emit
+`budget_exceeded {kind: "cost_24h_per_vendor", vendor: <key>}` and
+auto-disable. Only after both per-vendor checks pass do we fall
+through to the legacy `spec.budget.max_cost_usd_per_24h` flat check.
+Rationale: per-vendor is the V0.6+ intended path; the flat cap stays
+as a compatibility fallback for projects that haven't migrated YAML.
+
+### D11. `agent_done` vendor derivation: `SessionHandle.harness` prefix
+
+The poller path (`poll_completions`) only sees `SessionHandle`, not
+`AgentVendor`. We derive vendor by string-prefix:
+`harness.starts_with("codex")` → "codex" else "claude". Exported as
+`pub fn vendor_from_harness` for testability + future call sites.
+Translation path (`translate_thread_event`) takes the `AgentVendor`
+directly since it already has the trait-level type.
+
+### D12. `ccteam_cost::estimate_cost` model fallback
+
+`translate_thread_event` doesn't know the model id (`ThreadEvent`
+omits it). We pass `""` and rely on `ccteam_cost::estimate_cost`'s
+unknown-model fallback (per-vendor default price). The pricing crate
+already emits a WARN-once when this triggers. Wave 4 should plumb
+the model through `SpawnCtx` so per-event pricing is exact.
+
+### D13. Doctor flags: stdout-only, never fail the exit code
+
+Both `--check-codex-version` and `--check-codex-auth` emit
+human-readable reports and return `Ok(())`. Even an absent codex
+binary surfaces as `[ERROR]` in stdout but doesn't propagate up to
+`anyhow::bail!` — same convention as V0.3.1 F47's informational
+`which codex` line. Rationale: doctor is for operators; CI should
+have its own gates.
+
+### D14. `classify_codex_auth` checks "not logged in" BEFORE "logged in"
+
+"Not logged in" CONTAINS "logged in" as a substring. The classifier
+must short-circuit on the negative branch first. Discovered via test
+`check_codex_auth_warns_when_not_logged_in` flake during impl;
+captured in inline comments on `classify_codex_auth`.
+
+## §3 Test scaffolding
+
+| File | Tests | Hermetic? |
+|---|---|---|
+| `crates/ccteam-core/tests/codex_jsonrpc_test.rs` | 5 | Yes (tokio duplex peer) |
+| `crates/ccteam-core/tests/codex_app_server_test.rs` | 6 | Yes (UDS socket in tempdir, `#[serial]` for env-var tests) |
+| `crates/ccteam-core/tests/codex_exec_wave3_test.rs` | 8 | Yes (fake codex bash script under tempdir, `CCTEAM_CODEX_BIN` env override) |
+| `crates/ccteam-core/tests/per_vendor_budget_test.rs` | 5 | Yes (pure-event-slice helper) |
+| `crates/ccteam-cli/tests/doctor_codex_test.rs` | 4 | Yes (PATH manipulated to fake codex tempdir) |
+
+Tests that mutate env-vars are either `#[serial]`-gated (Tokio
+adapter tests) or use `PATH` overrides (binary surface tests). The
+`harness_trait_test.rs` Wave 1 NotImplemented stub assertion was
+updated to assert Wave 3 behavior (synthetic TurnId via fake codex
+bin = `/bin/true`).
+
+## §4 Known limitations / Wave 4 follow-ups
+
+1. **`codex resume` argv unverified against real codex 0.131** — the
+   resume branch (`codex resume <id> --json -`) is sketched per docs
+   but not E2E-tested in this wave. Wave 4 should integration-test
+   the resume path against a real codex install with a known thread
+   id in `~/.codex/sessions/`.
+
+2. **`CodexAppServerAdapter` notification → progress.jsonl bridge
+   missing.** The adapter emits `ThreadEvent`s into its broadcast
+   subscriber stream, but the orchestrator does not yet drive them
+   into `progress.jsonl`. e2e-wiring teammate's mode-3 codex bot
+   dispatch will land that bridge (Wave 1 noted mode-3 codex is
+   not user-configurable today; mode-3 claude is the only path).
+
+3. **Daemon auto-spawn deferred** — adapters fail loud when the UDS
+   socket is missing. Operator runs `codex app-server daemon start`
+   manually before enabling mode-3 codex. Could change in Wave 4 if
+   demand warrants.
+
+4. **`thread/start` params minimal** — we send `cwd`,
+   `session_source: "ccteam"`, `service_name`, and
+   `developer_instructions`. Codex's v2 `ThreadStartParams` has 20+
+   fields (sandbox, approval_policy, permissions, model overrides
+   etc.). Future PRs should plumb workflow.yaml-level codex config
+   through `SpawnCtx`.
+
+5. **Pricing model id pass-through** — see D12. Cost numbers in
+   `agent_done` for codex events fall back to per-vendor default
+   pricing rather than per-model. Plumbing model id costs ~3 fields
+   on `SpawnCtx` + adapter side.
+
+## §5 Acceptance script results
+
+- baseline `cargo test --workspace --locked --no-fail-fast` → **1243
+  passed / 1 failed** (the 1 failure is the V0.6.0 baseline
+  `workflow_summary_reflects_agent_spawn_and_done_events` running_count
+  flake, NOT regression). +42 over Wave 2 baseline 1201/1.
+- clippy: 17 ccteam-core warnings (all pre-existing doc-list drift +
+  one `type_complexity`); 0 new warnings. Below the 19-cap.
+- NotImplemented stubs removed from `codex_exec.rs` (Wave 3 fills
+  both `submit_turn` and `resume_thread`).
+- New files: `codex_app_server.rs`, `codex_jsonrpc.rs`, plus 5 test
+  files (`codex_jsonrpc_test`, `codex_app_server_test`,
+  `codex_exec_wave3_test`, `per_vendor_budget_test`,
+  `doctor_codex_test`).
+- Doctor flags: `--check-codex-version` + `--check-codex-auth`
+  wired through clap + DoctorOptions + run_doctor; their reports
+  appear in stdout.
+- Per-vendor budget: `cost_24h_by_vendor` field on `CostSummary` +
+  `ProjectSummary` (web API); enforce_budget checks per-vendor
+  before falling through to legacy `spec.budget`.

--- a/docs/v0-6-0/wave-3-handoff.md
+++ b/docs/v0-6-0/wave-3-handoff.md
@@ -1,0 +1,89 @@
+# V0.6.0 Wave 3 — Handoff
+
+> **Status**: Shipping(integration branch `wave3-integration`,3-way merge done,baseline + clippy + 16 红线 全绿)。
+> **Baseline**: 1282 / 1 — Wave 2 baseline 1201/1 + 81 net new tests(V0.5.1 942/1 累计 +340 net)。1 fail = pre-existing SSE flake。
+> **Clippy**: 0 errors,20 warnings(+1 vs Wave 2 19,doc-list drift;非新逻辑)。
+> **Wall time**: 3 teammate 并行 worktree ~1h(含 1 teammate follow-up commit);主 session 整合 + merge ~10 min(0 冲突 — 3 个 teammate 改 orchestrator.rs 的不同函数)。
+
+## Decided
+
+### F112 Codex Option B 完整
+
+- **`CodexExecAdapter::submit_turn` + `resume_thread` 真 impl**(`codex exec --json -` stdin pipe + `codex resume <UUID> --json -` for resume;stdout JSONL → per-thread broadcast `ThreadEvent` stream)
+- **`CodexAppServerAdapter`**(new `crates/ccteam-core/src/execution/codex_app_server.rs`)— 模式 3 codex via UDS JSON-RPC v2;dials `$CODEX_HOME/app-server-control/app-server-control.sock`(`CCTEAM_CODEX_APP_SERVER_SOCKET` env override);`thread/start` + `thread/resume` + `turn/start` + `thread/archive` 方法;`item/*` + `turn/*` notifications → `ThreadEvent` 翻译
+- **`crates/ccteam-core/src/execution/codex_jsonrpc.rs`**(thin client)— line-delimited JSON-RPC-lite over UnixStream;channel-based writer task + reader-task demux(`oneshot` per request id,`broadcast` for notifications);`CodexJsonRpcClient::{connect_uds, spawn, call, subscribe, notify}` + `Notification` + `JsonRpcError`
+
+### 4 用户可见场景(F112 §A-§D)
+
+- **A. `/ccteam-advise`**(`skills/ccteam-advise/SKILL.md` ~190 行)— 并行调 Claude `Task` || Codex `Bash codex exec --json` → 合成 verdict(Claude/Codex/合成/分歧度 0-5)。codex 不可用时 Claude-only fallback。
+- **B. Auto-critic in `ccteam-creator`** — Phase 3.5 detection。persona = critic / reviewer / architect 时,probe `codex --version && codex login status`,成功 → 写 `executor: codex` 到 rendered workflow.yaml(用户不见 yaml)。
+- **C. `/ccteam-team` Codex critic teammate** — `/ccteam-team N "<task>"` N≥3 + codex 可用 → 自动 reserve 1 slot 给 `codex-critic`,Bash `codex exec --json &` 并行 spawn(Claude Code Task 不支持 target codex)。
+- **D. opt-in fallback prefs** — `~/.ccteam/preferences.toml::fallback.on_claude_quota = "codex|off"`(default off);orchestrator `try_spawn_with_prompt` budget guard:Claude executor + Claude quota hit + prefs on + role eligible + Codex adapter registered → swap `effective_executor = codex` + emit `budget_exceeded { vendor: claude, vendor_fallback_to: codex }`;workflow 不停。
+- **`ccteam prefs show|get|set <key> <value>` CLI** — admin CLI(`fallback.on_claude_quota` + `fallback.codex.enabled_for_roles` 逗号列表)。
+
+### `ccteam doctor` codex 检查
+
+- **`--check-codex-version`** — parse `codex --version`;≥0.131 ✓ / <0.131 ⚠ / missing ✗
+- **`--check-codex-auth`** — parse `codex login status`;LoggedIn(ChatGPT|API key) ✓ / LoggedOut ⚠ / Unknown ⚠
+- `parse_codex_semver` + `classify_codex_auth` 公开,供 skill 复用
+
+### per-vendor budget caps
+
+- `queries::CostSummary` 加 `cost_24h_by_vendor: BTreeMap<String, f64>` + `cost_total_by_vendor`(`#[serde(default)]` legacy 兼容)
+- `agent_done` event 含 `vendor` 字段(从 `SessionHandle.harness` 推 via `vendor_from_harness` helper)
+- `orchestrator::enforce_budget` 检查 `budgets_v060.{claude,codex}.max_cost_usd_per_24h` **before** legacy flat `spec.budget`;emit `budget_exceeded { kind: "cost_24h_per_vendor", vendor }`
+- `ccteam-web::ProjectSummary` JSON 加 `cost_24h_by_vendor` 字段
+- `translate_thread_event(usage, vendor)` 调 `ccteam_cost::estimate_cost(usage, vendor, "")`(model id 留 Wave 4 plumb through SpawnCtx)
+
+### imd↔tui e2e wiring(Wave 2 推迟工作)
+
+- **orchestrator mode:chat dispatch** — `pick_adapter(Executor, WorkflowMode)` 函数:claude+chat → `ClaudeTuiAdapter`,claude+bg → `ClaudeBgAdapter`,codex+chat → `CodexAppServerAdapter`(Wave 3 ship),codex+bg → `CodexExecAdapter`。`run_project_with_cancel` mode:chat 时早 return(ccteam-imd owns chat lifecycle,orchestrator skip event_loop)。
+- **`ccteam-imd::supervisor` 真 HarnessAdapter 调用** — `BotSupervisor` 包 `Arc<dyn HarnessAdapter>` + `ThreadHandle`,methods:`ensure_started` / `handle_inbound` / `shutdown` / `restart` / `apply_action`。pure `decide()` 决定 SupervisorAction,`apply_action()` 桥接到 adapter trait 调用。**仅用 trait,无 `ccteam_core::execution::*` import**(R1 守)。
+- **`SupervisorRegistry` + `register_supervisors_at_boot`**(e2e-wiring follow-up commit 35a3ec9)— `AdapterFactory` type + `default_adapter_factory()` 生产线;daemon::tick_supervisors 每 tick 一个 `BotSupervisor` per registered bot + apply `decide(state_snapshot)` action。
+- **e2e mock TG test**(`crates/ccteam-imd/tests/e2e_mock_test.rs` ~500 行,5 测试)— stub `HarnessAdapter` 镜像 `ClaudeTuiAdapter` 语义(submit → 写 turns.jsonl);happy path + restart recovery + close cleanup + multi-bot parallel + channel listen 端到端。**真 tmux + 真 claude 不需要 — Wave 4 host probe 才跑**。
+
+## Rejected
+
+- ~~`unreachable!()` for codex+chat case~~ — e2e-wiring 选 fallback 到 `CodexExecAdapter` + TODO comment;codex-exec-impl ship CodexAppServerAdapter 后 swap arm(已在本 wave 同 PR 落)
+- ~~ccteam-imd 调 ccteam-core API 通过 IPC 中转~~ — 直接走 `HarnessAdapter` trait + in-process AdapterFactory pattern,daemon 自己 own ThreadHandle per bot,**没 orchestrator ↔ daemon IPC** 复杂度
+- ~~`codex exec` 一 thread 多 turn~~ — `codex exec --json` 是 one-shot;`submit_turn` 实施 = spawn 新子进程 per turn;`events()` 通过 per-thread broadcast 收当 turn 的 stdout JSONL stream;Wave 3 D2(`wave-3-decisions.md`)
+- ~~codex-exec-impl 直接 commit 到 main~~ — `isolation: worktree` co-located with main worktree path,team-lead 救援:`git branch wave-3-e2e-wiring HEAD; git reset --hard origin/main` 把 commit 搬到 branch,teammate 在专属 branch 继续 follow-up
+
+## Risks
+
+- **真 codex resume e2e** 未跑(只 mocked via fake codex bash script `$CCTEAM_CODEX_BIN` env override)— Wave 4 host probe 跑真 codex `resume <UUID>` + verify cost tracking 准
+- **model-id 不在 cost 估算流** — `translate_thread_event` 调 `estimate_cost(usage, vendor, "")` 用 fallback_model(Wave 3 D14)。Wave 4 plumb model id through `SpawnCtx` 让 cost ±5% 准
+- **mode 3 codex bot 未启** — Wave 1 决策 mode 3 V0.6 仅 Claude bot;`CodexAppServerAdapter` 已 ship 让 trait stack 统一,V0.7 启 codex bot 时零代码改动 daemon-side
+- **CodexAppServerAdapter notifications → progress.jsonl bridge 未通**(Wave 3 D9)— events() stream 当前只 SSE 端消费;Wave 4 加 daemon-side bridge
+- **clippy 20 warnings**(+1 vs Wave 2 19)— Wave 3 加了 doc-overindented-list 等 1 个新 warning(同 doc-list drift category)。Wave 4 doc-sweep chore 一次性清
+
+## Files
+
+新文件(20+):
+- `crates/ccteam-core/src/{auto_critic, preferences}.rs`
+- `crates/ccteam-core/src/execution/{codex_app_server, codex_jsonrpc}.rs`
+- `crates/ccteam-core/tests/{auto_critic, preferences, fallback_quota, codex_exec_wave3, codex_app_server, codex_jsonrpc, per_vendor_budget}_test.rs`
+- `crates/ccteam-cli/tests/doctor_codex_test.rs`
+- `crates/ccteam-imd/tests/e2e_mock_test.rs`
+- `skills/ccteam-advise/SKILL.md`
+- `docs/v0-6-0/{wave-3-decisions, wave-3-handoff}.md`
+
+修改:
+- `crates/ccteam-core/src/{orchestrator, queries, lib}.rs`(per-vendor budget + mode:chat dispatch + re-exports)
+- `crates/ccteam-core/src/execution/codex_exec.rs`(Wave 1 stub → 真 impl)
+- `crates/ccteam-cli/src/{commands, main}.rs`(prefs CLI + doctor flags)
+- `crates/ccteam-imd/src/{daemon, supervisor, outbound, main}.rs`(SupervisorRegistry + AdapterFactory + real HarnessAdapter calls)
+- `crates/ccteam-web/src/routes/api_v1.rs`(cost_24h_by_vendor field)
+- `skills/ccteam-creator/SKILL.md` + `skills/ccteam-team/SKILL.md`(auto-critic + codex critic teammate)
+
+## Remaining(Wave 4)
+
+- **5 preset full host probe**(Solo Sidekick / Team Sprint / Overnight Builder / Pocket Assistant / IM Squad)+ 录 5 demo GIF 放 `docs/v0-6-0/demos/`
+- **真 TG e2e probe**:user 已 paste token + `/start`'d bot;Wave 4 跑完整 mode 3 hello world
+- **真 Codex host probe**:`/ccteam-advise` + auto-critic + Codex critic teammate + opt-in fallback 各 1 个 host run
+- **`docs/tech-design.md` + `interfaces.md` + `CLAUDE.md` 同步**(F106 集成部分 + workspace version 0.5.1 → 0.6.0 + baseline 数字回填)
+- **`docs/dev-coupling-audit.md`** F106-F118 各 1 finding
+- **Tier-1 docs MCP tool name 子前缀 sweep**(Wave 1 skill-mcp 标的 finding)— `docs/interfaces.md` + `docs/claude-code-tool-surface.md` + `docs/v0-1/user-quickstart.md` + `skills/ccteam-control/SKILL.md`
+- **clippy doc-list drift sweep** — 20 warnings → 0(独立 chore PR scope,Wave 4 顺便)
+- **model-id plumb through SpawnCtx**(Wave 3 D14)— 让 cost 估算 ±5% 准而非 fallback_model
+- **git tag v0.6.0**(user 决策:仅 tag,no GitHub release page)

--- a/skills/ccteam-advise/SKILL.md
+++ b/skills/ccteam-advise/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: ccteam-advise
+description: "Claude + Codex parallel advisor for architecture decisions, algorithm trade-offs, and security / performance second opinions. Use when the user says '/ccteam-advise <NL>', 'second opinion on X', 'should I pick A or B', 'ask both Claude and Codex about X', or otherwise asks for a cross-vendor consult. V0.6.0 Wave 3 (F112 §A)."
+---
+
+# /ccteam-advise — Claude + Codex parallel voting
+
+V0.6.0 Wave 3 — F112 §A. Single user-facing scenario: a hard
+question that benefits from two independent opinions. The skill
+fans the same question to **Claude** (via a `general-purpose`
+subagent) and **Codex** (via `codex exec --json` on PATH), then
+synthesises a verdict the user can act on without reading both
+transcripts in full.
+
+## V0.6.0 skill family (you are here)
+
+| User intent | Skill |
+|---|---|
+| Top-level NL dispatcher | `ccteam` |
+| Spin up a short-lived team in the current session | `ccteam-team` |
+| Start a new project / workflow / IM bot | `ccteam-creator` |
+| Manage existing ccteam projects | `ccteam-control` |
+| One-shot IM token onboarding | `ccteam-im-setup` |
+| **Codex + Claude parallel advisor (this skill)** | **`ccteam-advise`** |
+
+## When to invoke
+
+Trigger phrases (LLM matching — no regex needed):
+
+- `/ccteam-advise <question>` — explicit slash entry
+- "second opinion on X"
+- "ask both Claude and Codex about X"
+- "should I pick A or B" / "X vs Y trade-off"
+- "verify this security review" / "double-check this perf claim"
+
+**Don't** invoke for:
+
+- Single-vendor work (use the Task tool with `general-purpose`)
+- Implementation work (use `/ccteam-team`)
+- Project creation (use `/ccteam-creator`)
+
+If the user's question is < 1 sentence ("which is better?"), ask
+one clarifying question before the dispatch — vague prompts produce
+generic answers from both vendors.
+
+## Pre-flight: is Codex available?
+
+Before spawning the parallel advisors:
+
+```bash
+codex --version 2>/dev/null && codex login status 2>/dev/null
+```
+
+- Both succeed → run the full dual-vendor dispatch (§Step 1–§Step 2)
+- Either fails → fall back to **Claude-only single advisor**, print
+  a one-line note: `Codex unavailable (reason); running Claude-only
+  advisor.` Then dispatch the single Task and skip the verdict
+  synthesis (just print Claude's answer).
+
+**Test override**: when `$CCTEAM_CODEX_BIN` is set, treat that path
+as the codex binary instead of probing PATH. Lets unit / e2e tests
+inject a fake codex without modifying `$PATH`.
+
+## Step 1: Parallel dispatch
+
+Issue **two tool calls in the same assistant turn** so they run
+concurrently:
+
+1. Claude advisor:
+
+   ```
+   Task({
+     subagent_type: "general-purpose",
+     description: "Claude advisor on <topic-short>",
+     prompt: "<full question + context>\n\nReturn: (a) your
+              recommendation, (b) the 2-3 strongest reasons, (c) any
+              dealbreaker risks. Keep total response under 250 words."
+   })
+   ```
+
+2. Codex advisor (via Bash since the Task tool can't target
+   Codex directly):
+
+   ```bash
+   CODEX_BIN="${CCTEAM_CODEX_BIN:-codex}"
+   "$CODEX_BIN" exec --json --skip-git-repo-check <<'PROMPT'
+   <full question + context>
+
+   Return: (a) your recommendation, (b) the 2-3 strongest reasons,
+   (c) any dealbreaker risks. Keep total response under 250 words.
+   PROMPT
+   ```
+
+   Parse the JSONL output, take the final assistant message body.
+   On non-zero exit / parse failure, treat as `Codex error: <stderr
+   one-liner>` and continue with Claude-only verdict synthesis.
+
+If the daemon is running and exposes `ccteam__advise_vote` via MCP,
+the skill MAY use that tool instead of the manual fan-out — same
+result with daemon-side cost accounting. Detection: a previous turn
+in this session must have seen `mcp__ccteam__advise_vote` registered;
+otherwise stick to the direct dispatch.
+
+## Step 2: Verdict synthesis
+
+After both advisors return, produce ONE final verdict in the
+prescribed format. Do not echo either advisor's raw reply verbatim
+— summarise.
+
+```
+ADVISOR VERDICT
+===============
+Claude: <100-word summary of Claude's recommendation + key reasons>
+Codex:  <100-word summary of Codex's recommendation + key reasons>
+
+合成:    <150-word final recommendation>
+分歧度:  <0-5>   # 0 = both agree, 5 = full opposition
+
+Notes (optional):
+  - <any dealbreaker either vendor raised>
+  - <any caveat the user should be aware of>
+```
+
+Synthesis rules:
+
+- **Both agree** → "Both agree: <X>. Reasons: ..." Pick the
+  recommendation as the verdict.
+- **Conflict** → "Claude says <X> because <r1>; Codex says <Y>
+  because <r2>. Recommended: <Z> because <why>." If the conflict
+  is irreducible (e.g. matter of taste), say so explicitly and let
+  the user pick.
+- **One vendor strongly objects** (e.g. dealbreaker risk) → that
+  vendor's veto carries unless the user explicitly overrides.
+
+Don't pad the verdict — under 250 words total including all the
+sections above.
+
+## Output language
+
+Match the user's input language. If the user wrote in Chinese, the
+verdict labels stay as `Claude:` / `Codex:` / `合成:` / `分歧度:`
+(those are already mixed). If the user wrote in English, swap
+`合成` → `Synthesis`, `分歧度` → `Divergence`.
+
+## Cost / budget hint
+
+Each `/ccteam-advise` invocation is roughly:
+
+- 1 Claude Task (Sonnet 4.5, ~10k context, ~1k output) ≈ $0.04
+- 1 Codex `exec` (gpt-5-codex, ~10k context, ~1k output) ≈ $0.05
+
+Total ≈ $0.10 per consult. If the user calls `/ccteam-advise`
+> 20× in one session, surface a soft reminder:
+"You've asked the parallel advisor 20+ times; consider using
+`/ccteam-team 3:reviewer` for an extended debate instead — same
+cost, deeper exploration."
+
+## What this skill does NOT do
+
+- **No iterative debate** — single round of voting + one verdict.
+  Use `/ccteam-team 3:reviewer` for multi-turn debate.
+- **No retention** — verdicts are session-local; nothing is written
+  to `~/.ccteam/`.
+- **No tool execution** — advisors return text only; the skill
+  never lets either vendor write files or run shell commands on
+  behalf of the user.
+- **No 3+ vendor fan-out** — for N-way voting use the MCP tool
+  `ccteam__advise_parallel` instead (Wave 3 daemon).
+
+## Red lines
+
+- **Never run the two advisors sequentially** — defeats the point
+  of parallel voting. Single assistant turn with both tool calls.
+- **Never quote an entire advisor reply** — synthesise. The user
+  asked for a verdict, not two essays.
+- **Never silently fall through to Claude-only** — if Codex is
+  unavailable, print the one-line `Codex unavailable: <reason>`
+  marker before the verdict.
+- **Never invoke `/ccteam-advise` recursively** — if mid-synthesis
+  you find you need more facts, ask the user, don't fan out again.
+
+## Where to look in the repo
+
+- `@docs/v0-6-0/prd.md` §F112 §A — skill design SoT
+- `@crates/ccteam-cli/src/mcp_advise_tools.rs` — MCP tools the
+  daemon registers (`ccteam__advise_vote` / `ccteam__advise_parallel`)
+- `@crates/ccteam-core/src/execution/codex_exec.rs` — the
+  CodexExecAdapter the daemon route uses for the same primitive
+- `@CLAUDE.md` §三 — architectural red lines

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -116,6 +116,46 @@ If no persona is a clean fit, ask the user to pick from the top 3
 candidates. **Do not invent a new persona** — V0.7 will add a
 `/ccteam-creator-persona-new` flow; for V0.6 the library is fixed.
 
+## Phase 3.5 — Codex auto-critic detection (V0.6.0 Wave 3 F112 §B)
+
+When the matched persona's role hints at adversarial / second-opinion
+work, ccteam-creator silently consults the Codex CLI and — if it's
+installed and authenticated — vendors that one role on Codex. The
+user never sees `vendor: codex` in YAML during the dialogue; it just
+shows up as a one-line "Codex critic: auto-enabled" note in Phase 4.
+
+**Trigger roles** (LLM-matched against persona id + tags):
+
+- `code-critic`
+- `reviewer` / `code-reviewer` / `pr-reviewer`
+- `architect` / `architecture-reviewer`
+- any persona tagged `critic` or `second-opinion`
+
+**Detection probe** (run once per `ccteam-creator` dialogue):
+
+```bash
+codex --version 2>/dev/null && codex login status 2>/dev/null
+```
+
+- Both succeed → set `auto_critic_vendor = "codex"` for the matched
+  role; the workflow.yaml render in Phase 5.3 injects
+  `agents.<role>.executor: codex`. PROJECT PLAN line:
+  "Codex critic: auto-enabled".
+- Either fails → silent fallback to `vendor: claude` for that role;
+  PROJECT PLAN line: "Codex critic: unavailable (codex CLI not
+  installed / not authenticated)". User can opt in later via
+  `ccteam doctor --check-codex-version` + `--check-codex-auth`.
+- Persona is not a critic-flavoured role → PROJECT PLAN line:
+  "Codex critic: not applicable" (or omit entirely for brevity).
+
+**Test override**: when `$CCTEAM_CODEX_BIN` is set, treat that path
+as the codex binary. Unit / e2e tests inject a fake binary that
+returns success without burning real Codex inference cost.
+
+The persona `.md` body copied in Phase 5.4 is unchanged — vendor
+selection is purely a `workflow.yaml::agents.<role>.executor: codex`
+injection. The user does not edit YAML at any point.
+
 ---
 
 # Phase 4 — Output PROJECT PLAN (plan-first)

--- a/skills/ccteam-team/SKILL.md
+++ b/skills/ccteam-team/SKILL.md
@@ -94,6 +94,61 @@ kind 决策:
 
 **这一步禁止调 `TeamCreate` / `Task`** — 等用户回复。
 
+### 3.5 Codex critic teammate(V0.6.0 Wave 3 F112 §D — 当 N ≥ 3 时自动加入)
+
+When the parsed team size `N ≥ 3`, ccteam-team probes for the Codex
+CLI **once** per `/ccteam-team` invocation:
+
+```bash
+codex --version 2>/dev/null && codex login status 2>/dev/null
+```
+
+- Both succeed → automatically reserve **one** of the N teammate
+  slots for a `codex-critic` (the remaining `N-1` are Claude). The
+  TEAM PLAN must list it as:
+  `<N>. codex-critic (kind=ad-hoc, vendor=codex, color=red) — second-opinion
+   reviewer on every artifact the other teammates produce`
+- Either probe fails → silently fall back to all-Claude composition
+  for this run; no error surfaced. (User can re-run after installing
+  / `codex login`.)
+- `N < 3` → no codex critic auto-added (too small a team to spare a
+  slot for adversarial review). User can still ask "加个 codex
+  critic" as free-text revision to force one in.
+
+**Test override**: `$CCTEAM_CODEX_BIN` overrides the binary lookup —
+unit / e2e tests use a fake binary so the probe doesn't depend on a
+real `codex` install.
+
+The Codex critic teammate is **not** spawned via the Anthropic
+`Task` tool — that surface targets Claude-only subagents. Instead,
+the team-lead session runs the Codex teammate from skill body
+directly via Bash, in parallel with the Claude `Task` spawns:
+
+```bash
+CODEX_BIN="${CCTEAM_CODEX_BIN:-codex}"
+"$CODEX_BIN" exec --json --skip-git-repo-check <<'PROMPT' &
+You are the codex-critic teammate of team "<slug>". Your job is to
+review every artifact the other teammates produce and surface
+adversarial concerns (security, perf, edge-case correctness). Reply
+in <= 200 words per artifact. Don't write files — text only.
+
+Task: <task body>
+PROMPT
+echo "codex-critic spawned (PID $!)"
+```
+
+The team-lead session captures stdout/stderr to a temp file the
+synthesis loop polls. **No tmux** — `codex exec --json` is one-shot
+process, output is captured directly. Future Wave (F112 §D follow-up
+in V0.7) will route this through the daemon's `CodexExecAdapter` so
+cost accounting is unified.
+
+If `ccteam-imd` daemon is running and exposes
+`mcp__ccteam__advise_parallel`, the skill MAY prefer that path
+instead — daemon-side cost rollup + persistent log. Detection: a
+previous turn in this session must have registered the MCP tool;
+otherwise stay on the direct Bash spawn.
+
 ### 4. 等用户回复
 
 合法回复:


### PR DESCRIPTION
## Summary

V0.6.0 Wave 3 — F112 Codex Option B 完整 + Wave 2 推迟的 imd↔tui e2e wiring + per-vendor budget caps。3 teammate 并行 worktree ~1h(含 e2e-wiring follow-up commit 救援)+ 主 session 整合 ~10 min(0 conflict — 3 个 teammate 改 orchestrator.rs 不同函数)。

| 维度 | Wave 2 baseline | Wave 3 | 差 |
|---|---|---|---|
| `cargo test --workspace` | 1201 / 1 | **1282 / 1** | +81 net new tests |
| 累计 V0.5.1 → V0.6.0 W3 | 942 / 1 | **+340 net new** | — |
| clippy warnings | 19 | 20 | +1(doc-list drift,Wave 4 sweep)|
| clippy errors | 0 | 0 | — |
| 红线 grep(16 checks) | ✓ | **✓** | — |

## 主要 finding

### F112 Codex Option B 完整

**`CodexExecAdapter::{submit_turn, resume_thread}` 真 impl**(spawns `codex exec --json -` per turn,stdout JSONL stream → per-thread broadcast `ThreadEvent`)。

**`CodexAppServerAdapter`**(new `crates/ccteam-core/src/execution/codex_app_server.rs`)— 模式 3 codex 路径 via UDS JSON-RPC v2(thread/start/resume/turn/start/archive + item/* + turn/* notifications)。

**`crates/ccteam-core/src/execution/codex_jsonrpc.rs`** thin client — line-delimited JSON-RPC over UnixStream + channel-based writer + reader-task demux。

### 4 用户可见场景

- **A. `/ccteam-advise`** parallel voting(Claude `Task` || Codex `Bash codex exec --json` → verdict 合成)
- **B. Auto-critic in `ccteam-creator`** — Phase 3.5 detection,critic persona + codex 就位 → 自动 `executor: codex`
- **C. `/ccteam-team N` Codex critic teammate** — N≥3 + codex 就位 → 自动 reserve 1 slot
- **D. opt-in fallback prefs** — `~/.ccteam/preferences.toml::fallback.on_claude_quota`(default off)

### `ccteam doctor` 增强

- `--check-codex-version`(parse `codex --version`,≥0.131 OK)
- `--check-codex-auth`(parse `codex login status`)

### per-vendor budget caps

- `CostSummary::cost_24h_by_vendor` + `cost_total_by_vendor`(`#[serde(default)]` 兼容 V0.5)
- `agent_done` event 含 `vendor` 字段
- `orchestrator::enforce_budget` 检查 `budgets_v060.{claude,codex}` per-vendor;emit `budget_exceeded { kind: "cost_24h_per_vendor", vendor }`
- web `/api/v1/projects/<slug>` JSON 加 cost_24h_by_vendor

### imd↔tui e2e wiring(Wave 2 推迟)

- **orchestrator mode:chat dispatch** — `pick_adapter(Executor, WorkflowMode)`;`run_project_with_cancel` mode:chat 早 return(ccteam-imd owns chat lifecycle)
- **`ccteam-imd::supervisor::BotSupervisor`** — 真 `HarnessAdapter::{start_thread, submit_turn, events, close_thread}` 调用;仅用 trait,**0 import `ccteam_core::execution::*`**(R1 守);pure `decide()` + `apply_action()` 桥接
- **`SupervisorRegistry` + `register_supervisors_at_boot`** — `AdapterFactory` type;`daemon::tick_supervisors` per registered bot 一 supervisor task
- **e2e mock TG test**(`crates/ccteam-imd/tests/e2e_mock_test.rs` ~500 行,5 测试)— stub adapter 镜像 `ClaudeTuiAdapter` 语义;happy path / restart / close cleanup / multi-bot parallel / channel listen 全链端到端;**0 真 tmux + 真 claude 需要**

## Verification

\`\`\`bash
env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy cargo test --workspace --locked --no-fail-fast
# 1282 pass / 1 fail (pre-existing SSE flake)

env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy cargo clippy --workspace --all-targets --locked
# 0 errors, 20 warnings (doc-list drift)
\`\`\`

**16 红线全绿**:
- CodexExecAdapter NotImplemented = 0 ✓
- CodexAppServerAdapter + codex_jsonrpc.rs 存在 ✓
- doctor codex flags(3 hits) ✓
- per-vendor budget(3 hits) ✓
- preferences.rs + auto_critic.rs 存在 ✓
- orchestrator mode:chat dispatch(6 hits) ✓
- imd supervisor real HarnessAdapter calls(7 hits) ✓
- e2e_mock_test.rs ✓
- ccteam-cost 0 reverse dep ✓
- ccteam-imd 0 openhuman dep(Option C 保持) ✓
- ccteam-core 0 IM transitive dep ✓
- ccteam prefs CLI(4 hits) ✓
- /ccteam-advise SKILL.md ✓

## Coordination

3 teammate 改 orchestrator.rs **不同函数**:
- codex-skill → `try_spawn_with_prompt`(fallback budget guard)
- codex-exec-impl → `enforce_budget` + `translate_thread_event`(per-vendor)
- e2e-wiring → `pick_adapter` + `run_project_with_cancel`(mode:chat skip)

→ 整合 0 冲突 via git auto-merge ✓

## Mapping

- `docs/requirements.md` 痛点 9 / 11 / 14(关上电脑也要跑 / 关键节点不把控 / cost 超支)
- `docs/v0-6-0/prd.md` F112(完整 4 用户场景 + 2 adapter + 双 pricing + doctor)
- `docs/v0-6-0/dev-plan.md` Wave 3
- 解锁 Wave 4(host probe + version bump + git tag v0.6.0)

## Known limitations(Wave 4 兜)

详 `docs/v0-6-0/wave-3-handoff.md` §Remaining:
- 真 codex resume e2e 未跑(mocked via fake codex bash)
- model-id 不在 cost 估算流(Wave 4 plumb SpawnCtx)
- mode 3 codex bot 未启(V0.6 Claude-only;V0.7 启用零代码改动)
- CodexAppServerAdapter notifications → progress.jsonl bridge 未通(events() 只 SSE 消费)
- doc-list drift 20 warnings → 0(Wave 4 chore PR)

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast` → 1282 / 1 ✓
- [x] `cargo clippy --workspace --all-targets --locked` → 0 errors / 20 warnings ✓
- [x] 16 红线 grep 全绿 ✓
- [ ] 真 TG e2e host probe — Wave 4(token + bot /start 已就位)
- [ ] 真 codex `/ccteam-advise` host probe — Wave 4(codex 0.131.0 + ChatGPT auth 已就位)
- [ ] 5 preset full host probe + demo GIF — Wave 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)