### PR TITLE
v0.6.1 W1: F125 doc sweep + F126 EN README + CLAUDE.md 红线

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,12 @@
 | **`ccteam-core` 零 team 名字面量** | 守 | 守 | 守 |
 | **跨项目记忆走官方接口** | 守 | Claude: `~/.claude/CLAUDE.md` + `~/.claude/rules/*.md`;Codex: `~/.codex/AGENTS.md`(`ccteam init` 落 AGENTS.md → CLAUDE.md POSIX symlink)| 同 |
 | **新建项目走 `<projects_root>/<team>-<slug>/`** | — | 守(`pick_unused_slug` 强制 team 前缀)| 守(per-bot tmux session = `<project>/<bot>`,IM bot 落 `.ccteam/chat/<bot>/`)|
+| **root README.md MUST be English** | 守 | 守 | 守 |
+| **README.md 不含版本进展/状态信息** | 守 | 守 | 守 |
+
+**README / 版本进展红线**(V0.6.1 F126):
+- root `README.md` = OSS 主入口,必须英文。`docs/{quickstart,user-manual,recipes,troubleshooting}.md` + `docs/advanced/*` 持续中文(国内用户面);所有版本归档 `docs/v0-X-Y/` 中英不限(开发过程语)。
+- root `README.md` **不**含 `Status` / `V0.x.y in production` / `shipped 日期` / `baseline 数字` / `candidate finding` 列表等版本进展段。版本进展全部去 `docs/v0-X-Y/README.md`(每版本独立 dir);F-finding 索引去 `docs/dev-coupling-audit.md`。README 是产品介绍,**始终反映当前可用状态**,不夹版本时间轴。
 
 **vendor 红线补充**(V0.6 F107 / F112):
 - ccteam **不 vendor** Claude / Codex 二进制(`references/{claude-code,codex/codex-rs}/` git-ignore 不入库,仅协议参考;实际 spawn 走 `$PATH` 内 `claude` / `codex` binary + `CCTEAM_{CLAUDE,CODEX}_BIN` env override)

--- a/README.md
+++ b/README.md
@@ -1,92 +1,80 @@
 # ccteam
 
-> **Claude Code 之上的 multi-agent 编排器** — 一个工具,三档能力:in-proc 临时帮手 / bg 工作流长跑 / IM bot 24/7 常驻。
+> **A multi-agent orchestrator on top of Claude Code** — one tool, three tiers: in-proc temporary helpers / bg long-running workflows / IM bots running 24/7.
 
 ![demo](docs/v0-6-0/demos/30s-tg-bot-team.gif)
 
-> _GIF 展示形态 3(TG bot 团队)— wave 2 ship 后填_
+## Three runtime modes (the core of ccteam)
 
-## 三种运行形态(ccteam 的本体)
+ccteam adds **three multi-agent runtime modes** to Claude Code, each for a different cadence:
 
-ccteam 给 Claude Code 加了 **3 种 multi-agent 运行形态**,各自解决不同节奏的需求:
-
-| # | 形态 | 怎么 host | 用来干啥(典型场景)|
+| # | Mode | How it's hosted | Typical use |
 |---|---|---|---|
-| **1** | **最轻量(in-proc)** | 用户已有 Claude session 内,ccteam 作 plugin/skill 用内置模板创建临时 teammate;native `Task` 起,跟随 session 同生灭 | 写代码时临时召唤帮手 / 几小时冲一波 3-5 agent 并行 |
-| **2** | **bg 工作流编排** | `claude --bg --agent <role>` 多 session 协作,workflow.yaml 编排 trigger,文件 artifact 接力;ccteam Rust daemon 长跑,bg-job 短命 | 高级用户在某领域编排长跑多 agent workflow(qa-loop:test-fix-release / 自激励 build,几小时-几天)|
-| **3** | **IM bot(tmux 常驻)** | tmux + `claude` TUI 多 session 24/7 常驻,每 session = 1 个 agent bot;bot ↔ bot 通过 IM group 互相 @ 交流 | 手机 IM 私聊 AI 助理 / IM 群多 bot 团队跨设备协作 |
+| **1** | **Lightweight (in-proc)** | Inside an existing Claude session; ccteam acts as a plugin/skill that spawns temporary teammates via the native `Task` tool, sharing the session lifecycle | Summoning helpers while coding / a quick 3–5 agent burst |
+| **2** | **bg workflow orchestration** | Multiple `claude --bg --agent <role>` sessions collaborating through a `workflow.yaml` of triggers; file artifacts pass the baton; the ccteam Rust daemon runs long while bg jobs come and go | Power users running long workflows in a domain (qa-loop: test-fix-release / self-driving builds) |
+| **3** | **IM bots (tmux-resident)** | Long-running tmux + `claude` TUI sessions, one per agent bot, always on; bots talk to each other in an IM group by @-mentioning | Chatting privately with an AI assistant on your phone / a multi-bot team collaborating across devices in an IM group |
 
-底层 3 形态固定,**上层应用场景开放** — 下面 5 个 preset 是 V0.6 开箱;`ccteam-creator` skill 也支持 NL 描述新场景自动生成。
+The three modes are fixed at the bottom; **the application layer on top is open** — the five presets below ship as a starter set, and the `ccteam-creator` skill can generate new scenarios from a natural-language description.
 
-## 5 分钟上手(按形态选入口)
+## 5-minute quickstart (pick an entry point by mode)
 
 ```bash
-# 0. 先装 Claude Code + ccteam plugin
+# 0. Install Claude Code + the ccteam plugin first.
 # https://code.claude.com/docs/install
 claude
 /plugin install ccteam
 
-# === 形态 1:已有 session 内召唤临时帮手 ===
-/ccteam "帮我把这个 TS 报错全清掉"
-# 或多 agent 冲一波:
-/ccteam-team 3 "重构 src/auth 子模块"
+# === Mode 1: summon a temporary helper inside an existing session ===
+/ccteam "clean up all the TypeScript errors here"
+# Or burst a few agents in parallel:
+/ccteam-team 3 "refactor the src/auth submodule"
 
-# === 形态 2:起 bg 长跑工作流 ===
-/ccteam-creator "夜里跑 qa-loop:每次提交跑测试,失败自动 fix"
+# === Mode 2: kick off a bg long-running workflow ===
+/ccteam-creator "overnight qa-loop: run tests on every commit, auto-fix on failure"
 
-# === 形态 3:接 IM bot(V0.6 旗舰)===
-/ccteam-im-setup                        # 一次性绑 TG/Slack/Discord
-/ccteam-creator "做个 TG 私聊助理 bot,帮我管邮件"
+# === Mode 3: hook up IM bots ===
+/ccteam-im-setup                            # one-time bind for TG/Slack/Discord
+/ccteam-creator "build me a TG DM assistant that helps manage my email"
 ```
 
-→ 详 [quickstart](docs/quickstart.md)。
+→ See [quickstart](docs/quickstart.md) for the full walkthrough.
 
-## 5 个开箱用法,任你挑
+## 5 presets, pick whichever fits
 
-每个 preset = 一个推荐"形态 × 编排模式 × persona"配方,`ccteam-creator` 在 NL 对话中自动配:
+Each preset is a recommended "mode × orchestration pattern × persona" recipe; `ccteam-creator` wires it up through NL dialogue:
 
-| Preset | 一句话场景 | 怎么起 | 形态 |
+| Preset | One-line scenario | How to launch | Mode |
 |---|---|---|---|
-| **Solo Sidekick** | Claude 写代码时临时召唤一个帮手 | `/ccteam <自然语言>` | 1 |
-| **Team Sprint** | 几小时冲一波,3-5 agent 并行 | `/ccteam-team 3 "<task>"` | 1 |
-| **Overnight Builder** | 丢任务睡觉去,长跑几小时到几天 | `/ccteam-creator "夜里跑 …"` | 2 |
-| **Pocket Assistant** ⭐ | 手机 IM 私聊一个 AI 助理 | `/ccteam-creator "做个 TG 助理"` | 3 |
-| **IM Squad** ⭐ | IM 群里多个 bot 互相 @ 协作 | `/ccteam-creator "做个 TG 多 bot 团队"` | 3 |
+| **Solo Sidekick** | Summon a single helper while coding with Claude | `/ccteam <natural language>` | 1 |
+| **Team Sprint** | A few-hour burst with 3–5 agents in parallel | `/ccteam-team 3 "<task>"` | 1 |
+| **Overnight Builder** | Drop a task and go to sleep; runs for hours to days | `/ccteam-creator "overnight ..."` | 2 |
+| **Pocket Assistant** ⭐ | A private AI assistant in your phone IM | `/ccteam-creator "build a TG assistant"` | 3 |
+| **IM Squad** ⭐ | Multiple bots in an IM group @-mentioning each other | `/ccteam-creator "build a multi-bot TG team"` | 3 |
 
-⭐ V0.6 旗舰场景。形态 3 把 AI 团队带进你的 IM,跨设备 24/7 替你干活 — 与 ChatGPT / Cursor / Devin 的差异:bot 跑在**你电脑上**,能动你的文件 / 跑你的命令 / 看你的代码,手机只是入口。
+⭐ flagship scenarios. Mode 3 brings your AI team into IM, working on your behalf across devices 24/7 — the difference vs. ChatGPT / Cursor / Devin: the bots run **on your computer**, can touch your files, run your commands, read your code; your phone is just the entry point.
 
-## 三种跟 ccteam 对话的方式
+## Three ways to talk to ccteam
 
-- 🟢 **Claude session 内**:`/ccteam <自然语言>` 总入口(形态 1/2/3 通用)
-- 🟢 **IM 端**(形态 3):私聊 bot 或群里 `@ccteam <NL admin>`
-- 🟡 **Web 仪表板**(形态 2/3):`http://localhost:7331`(只看不操作)
+- 🟢 **Inside a Claude session**: `/ccteam <natural language>` is the universal entry point (works for modes 1/2/3)
+- 🟢 **From IM** (mode 3): DM a bot, or `@ccteam <NL admin>` in a group
+- 🟡 **Web dashboard** (modes 2/3): `http://localhost:7331` (read-only)
 
-> 你**不需要**学一堆 CLI 命令,也**不需要**写任何 yaml 配置。所有 setup 都通过 Claude session 对话生成。
+> You **do not** need to learn CLI commands, and you **do not** need to write any YAML. All setup happens through dialogue inside a Claude session.
 
-## 文档
+## Docs
 
-| 想干什么 | 读这个 |
+| What you want | Read this |
 |---|---|
-| 5 分钟跑通第一个 preset | [docs/quickstart.md](docs/quickstart.md) |
-| 完整 3 形态 + 5 preset 使用手册 | [docs/user-manual.md](docs/user-manual.md) |
-| 抄一份现成的 use case | [docs/recipes.md](docs/recipes.md) |
-| 出错查不到 | [docs/troubleshooting.md](docs/troubleshooting.md) |
-| 高级定制 / Codex 集成 | [docs/advanced/](docs/advanced/) |
-| 看代码 / 改 ccteam | [docs/architecture/](docs/architecture/) |
+| Get the first preset running in 5 minutes | [docs/quickstart.md](docs/quickstart.md) |
+| Full 3-mode + 5-preset user manual | [docs/user-manual.md](docs/user-manual.md) |
+| Copy-paste a ready-made use case | [docs/recipes.md](docs/recipes.md) |
+| Something broke and you cannot find it | [docs/troubleshooting.md](docs/troubleshooting.md) |
+| Advanced customization / Codex integration | [docs/advanced/](docs/advanced/) |
 
-## Status
+## License & acknowledgements
 
-**V0.6.0 in production**(2026-05-19 shipped,`git tag v0.6.0`)— Epic A 5 min 起第一个 IM bot · Epic B bot 在 IM 像真人助理 · Epic C 中文用户能用(铺底)。`HarnessAdapter` 5-method trait + tmux 长跑 mode 3 + Codex Option B + per-vendor budget caps + ccteam-imd daemon。baseline 1283/1 · clippy `-D warnings` clean · 4 wave handoff doc 全 land。详 [docs/v0-6-0/README.md](docs/v0-6-0/README.md) + [wave-4-handoff.md](docs/v0-6-0/wave-4-handoff.md)。
+See [LICENSE](LICENSE). Built on [Claude Code](https://code.claude.com/) (the runtime) and [openhuman/channels](https://github.com/openhuman/channels) (14+ IM platforms in Rust); orchestration taxonomy from Anthropic's *Building Effective Agents*; mode-3 IM bot pattern (tmux + send-keys + transcript polling) inspired by `ccgram` and `oh-my-claudecode`.
 
-**V0.6.1 蓄势中** — F119 probe daemon-start / F120 overnight-builder full probe / F121 pricing version check / F122 mode-3 Codex bridge / F123 demo GIF 录制 / F98 plan-approval↔outbox / F124 HITL Approval Gating(详 wave-4-handoff §Remaining)。
+---
 
-## License
-
-详 [LICENSE](LICENSE)。
-
-## 致谢
-
-- [Claude Code](https://code.claude.com/) — 运行时
-- [openhuman/channels](https://github.com/openhuman/channels) — 14+ IM 平台 Rust 抽象
-- Anthropic *Building Effective Agents* — 5 编排模式 taxonomy
-- `ccgram` + `oh-my-claudecode` — 形态 3 IM bot 模式(tmux + send-keys + transcript polling)参考实施
+See [docs/v0-6-1/README.md](docs/v0-6-1/README.md) for current release notes.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -262,7 +262,7 @@ progress.jsonl 由两个域共同写入:
 | event | 必有字段 | 选填字段 | 写入时机 |
 |---|---|---|---|
 | `workflow_start` | `workflow` (`WorkflowSpec::name`), `slug`, `ts` | — | `Orchestrator::run_project` 入口,加载 workflow.yaml 成功后 |
-| `agent_spawn` | `role`, `session_id`, `executor` (`claude`\|`codex`), `slug`, `ts` | `tmux_session` (claude 用 `ccteam-<slug>-<sid>` 占位;codex 写真名),`job_id` (Claude Code `--bg` 返回的短 hash,如 `"9432490e"`,codex 行为 `null`) | `HarnessAdapter::spawn_session` 返回 `Ok(handle)` 后 |
+| `agent_spawn` | `role`, `session_id`, `executor` (`claude`\|`codex`), `slug`, `ts` | `tmux_session` (claude 用 `ccteam-<slug>-<sid>` 占位;codex 写真名),`job_id` (Claude Code `--bg` 返回的短 hash,如 `"9432490e"`,codex 行为 `null`) | `HarnessAdapter::start_thread` 返回 `Ok(handle)` 后 |
 | `agent_done` | `role`, `session_id`, `status` (`completed`\|`stopped`\|`error`\|`killed`), `cost_usd` (f64;无 cost 时 `0.0`), `slug`, `ts` | — | (a) `session_state_path` 文件 `status` ∈ {`stopped`, `completed`, `error`} 时,poll 一次;(b) `poll_completions` 发现 progress.jsonl 含 open `agent_spawn` 但其 `job_id` 对应的 `~/.claude/jobs/<id>/state.json` 已 terminal,orchestrator 合成 `agent_done`,`status: "killed"` 用于 SIGKILL 死亡的 phantom row(防止 web UI 显示僵尸 running) |
 | `artifact_received` | `role`, `artifact_path` (abs), `slug`, `ts` | — | `ArtifactWatcher` 通过 mpsc 投递 `ArtifactEvent` 后,orchestrator 立刻 append(spawn 决策之前) |
 | `gate_triggered` | `role`, `forced` (bool), `threshold_met` (bool), `slug`, `ts` | — | `check_gates` 解锁 Gate 时;`forced=true` 表示 `.ccteam/gate_override/<role>` marker 触发 |
@@ -331,12 +331,12 @@ progress.jsonl 由两个域共同写入:
 | 事件 | 写入方 |
 |---|---|
 | `workflow_start` / `workflow_done` | orchestrator(`Orchestrator::run_project` 入口 / `check_workflow_done` 守门) |
-| `agent_spawn` | orchestrator(`HarnessAdapter::spawn_session` 返回 Ok 后) |
+| `agent_spawn` | orchestrator(`HarnessAdapter::start_thread` 返回 Ok 后) |
 | `agent_done` | orchestrator(`poll_completions` 检测到 session state.json `status` ∈ {`completed`, `stopped`, `error`}) |
 | `artifact_received` | orchestrator(`ArtifactWatcher` mpsc 投递后) |
 | `gate_triggered` | orchestrator(`check_gates` 释放 Gate 时) |
 | `budget_exceeded` | orchestrator(`try_spawn` budget guard) |
-| `escalation` | orchestrator(`bump_fail_count`,fix-loop 3-strike 与 `spawn_session` 持续失败) |
+| `escalation` | orchestrator(`bump_fail_count`,fix-loop 3-strike 与 `start_thread` 持续失败) |
 | `team_member_joined` / `team_member_left` / `team_message_sent` | F95 `AgentTeamsWatcher`(watcher only;Anthropic 没对应 hook surface) |
 | `team_task_created` / `team_task_completed` | F94 hook 优先(advanced path),F95 watcher fallback |
 | `team_teammate_idle` | F94 hook only(`TeammateIdle`,仅 advanced path 装) |

--- a/docs/tech-design.md
+++ b/docs/tech-design.md
@@ -714,7 +714,7 @@ tmux new-session -d -s "${SESSION}" -c "${PROJECT_DIR}" "codex --bypass"
 # 状态写 .ccteam/sessions/<sid>/state.json(codex adapter trait 实现)
 ```
 
-**V0.6 mode 3 Claude bot tmux**(F108 决策 flip — 不走 `claude -p --resume` + stream-json,改回 tmux 长跑 + send-keys -l):
+**V0.6 mode 3 Claude bot tmux**(F108 决策 — tmux 长跑 + send-keys -l):
 ```bash
 SESSION="<project>/<bot_name>"          # 例:pocket-bot
 tmux new-session -d -s "${SESSION}" -c "${PROJECT_DIR}" \


### PR DESCRIPTION
## Summary

Wave 1 task **W1-T4** (`doc-curator`) — V0.6.1 / F125 sweep + F126 (EN README + 2 CLAUDE.md 红线 row).

### F125 — tier-1 evergreen doc drift sweep
- `docs/interfaces.md`: 3× `HarnessAdapter::spawn_session` → `start_thread` (V0.6 F107 trait rename)
- `docs/tech-design.md` L717: drop V0.5→V0.6 mode-3 flip historical aside per Pre-v1.0 *"tier-1 docs only describe current architecture"*
- **All `prd.md §F125 §2` drift greps now 0 in tier-1 evergreen docs**:
  - `spawn_session` / `shutdown_session` / `fn ingest_snapshot`
  - V0.4 phase fields (only legacy struct field references remain — fields still exist in `state.rs`, not drift)
  - unprefixed `mcp__ccteam__*` (V0.5 names)
  - `ccteam_core::pricing` / `ccteam_core::cost` (V0.5 paths, since moved to `ccteam-cost` crate)
  - `claude -p --resume` / `stream-json + stdin pipe` (V0.5 mode-3 paths, since flipped to tmux long-session)
- **Not touched** per scope:
  - `docs/v0-X-Y/` historical archives (CLAUDE.md §五 EOL → version dir)
  - `docs/{quickstart,user-manual,recipes,troubleshooting}.md` + `docs/advanced/*` (Wave 3 `manual-prover` scope)

### F126 — EN README + CLAUDE.md 红线
- `README.md`: full EN rewrite (80 lines, ≤80 gate)
  - Preserved 3-mode narrative (in-proc / bg / IM bot) + 5-preset table + 3 entry-point table
  - **Dropped** `Status` / `V0.6.x 蓄势中` / "in production XXXX-XX-XX shipped" sections — README is the product landing, always reflecting current capabilities, not a version timeline
  - Footer: single line `See [docs/v0-6-1/README.md](docs/v0-6-1/README.md) for current release notes`
  - Dropped broken `docs/architecture/` link
- `CLAUDE.md` §三 红线表 + 2 row:
  - `| **root README.md MUST be English** | 守 | 守 | 守 |`
  - `| **README.md 不含版本进展/状态信息** | 守 | 守 | 守 |`
- `CLAUDE.md` explanatory paragraph below the table: version progress lives in `docs/v0-X-Y/README.md` per version; F-finding index in `docs/dev-coupling-audit.md`.

## Acceptance gates (all met)

| Gate | Result |
|---|---|
| baseline test count | `1283 / 1` (≥ Wave 1 gate) |
| clippy `--workspace --all-targets -D warnings` | clean |
| F125 drift greps in tier-1 evergreen docs | 0 hits |
| `head -3 README.md | grep -i 'claude code'` | hit (EN sentence) |
| `grep -c '[一-鿿]' README.md` | `0` |
| `grep -niE 'status|shipped|baseline|in production|wave|finding|F[0-9]+|V0\.[0-9]+' README.md` | `0` hits |
| `grep 'root README.md MUST be English' CLAUDE.md` | hit |
| `grep 'README.md 不含版本进展' CLAUDE.md` | hit |

## Files changed

- `CLAUDE.md` (+6 lines: 2 红线 row + 1 explanatory para in §三)
- `README.md` (full EN rewrite, 93 → 80 lines)
- `docs/interfaces.md` (3× `spawn_session` → `start_thread`)
- `docs/tech-design.md` (1× drop "flip" historical aside)

## Test plan
- [x] `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy cargo test --workspace --locked --no-fail-fast` → 1283 / 1
- [x] `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy cargo clippy --workspace --all-targets --locked -- -D warnings` → clean
- [x] F125 drift greps all 0 in tier-1 evergreen docs
- [x] F126 README acceptance gates (line count / EN / no Chinese / no version-progress hits)
- [x] F126 CLAUDE.md 红线 row greps hit
- [ ] Reviewer: visual diff for README narrative tone
- [ ] Reviewer: confirm `docs/architecture/` link was indeed broken (drop is intentional)

Refs: `docs/v0-6-1/prd.md` §F125 + §F126; `docs/v0-6-1/dev-plan.md` W1-T4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)