### PR TITLE
v0.6.1 W1: F122 CodexAppServerAdapter progress.jsonl bridge

### DIFF
--- a/crates/ccteam-core/src/execution/codex_app_server.rs
+++ b/crates/ccteam-core/src/execution/codex_app_server.rs
@@ -12,7 +12,13 @@
 //!   carries the codex `thread_id`.
 //! - `submit_turn`: `turn/start` with `[{type:"text", text:...}]`.
 //! - `events`: subscribe to broadcast notifications, translate
-//!   `item/*` + `turn/*` notifications → [`ThreadEvent`].
+//!   `item/*` + `turn/*` notifications → [`ThreadEvent`]. **V0.6.1 F122**:
+//!   also mirror the key boundary events (`turn/completed` / `turn/failed`
+//!   / `error`) into the project's `progress.jsonl` as `agent_done`
+//!   entries tagged `vendor: codex` so the `cost_24h_by_vendor["codex"]`
+//!   roll-up + budget cap surfaces stay live without the orchestrator
+//!   needing to wire a separate poller (the V0.6.0 Wave 3 D9 retained
+//!   risk).
 //! - `resume_thread`: `thread/resume` with the persistent id.
 //! - `close_thread`: `thread/archive` + `thread/unsubscribe` (best-effort).
 //!
@@ -29,6 +35,7 @@
 //! probe codex without touching tmux. The orchestrator's mode-3
 //! dispatch (e2e-wiring's territory) decides which adapter to mount.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -44,6 +51,8 @@ use crate::harness::{
     ThreadErrorEvent, ThreadEvent, ThreadHandle, ThreadItem, ThreadItemDetails, TurnId, TurnInput,
     UnifiedTokenUsage,
 };
+use crate::paths::CcteamPaths;
+use crate::progress::append_event;
 
 /// Env override for the UDS path the adapter dials. Tests set this to
 /// a tempdir socket; production resolves
@@ -56,18 +65,45 @@ pub const APP_SERVER_SOCKET_ENV: &str = "CCTEAM_CODEX_APP_SERVER_SOCKET";
 /// real codex.
 pub const CODEX_BIN_ENV: &str = "CCTEAM_CODEX_BIN";
 
+/// V0.6.1 F122 — per-thread context the adapter consults when bridging
+/// boundary events into `progress.jsonl`. Populated by `start_thread`
+/// from the [`SpawnCtx`]; consumed by the `events()` stream the first
+/// time a notification matches the thread.
+///
+/// `progress_path` lands at `~/.ccteam/progress/<slug>.jsonl`
+/// (resolved via [`CcteamPaths::from_env`]) so the bridge stays
+/// consistent with the orchestrator's own writes. Tests inject a
+/// custom ctx via [`CodexAppServerAdapter::register_bridge_for_test`].
+#[derive(Debug, Clone)]
+pub struct ProgressBridgeCtx {
+    pub progress_path: PathBuf,
+    pub role: String,
+    pub sid: String,
+    pub slug: String,
+    pub model: Option<String>,
+}
+
 /// V0.6.0 F112 [`HarnessAdapter`] that drives mode-3 codex bot sessions
 /// via `codex app-server` UDS. The adapter is stateless across threads
 /// — each `start_thread` lazily connects (and caches) a client per
 /// process so reused for `submit_turn` / `events` / `close_thread`.
+///
+/// **V0.6.1 F122**: holds an optional `bridges` map keyed by codex
+/// `thread_id`. Each entry carries the project's `progress.jsonl`
+/// path + role/sid/slug/model so the `events()` stream can mirror
+/// `turn/completed` / `turn/failed` notifications into `agent_done`
+/// rows tagged `vendor: codex`. Without an entry the stream behaves
+/// exactly like V0.6.0 (translation only — no IO side effect).
 #[derive(Clone, Default)]
 pub struct CodexAppServerAdapter {
     inner: Arc<Mutex<Option<Arc<CodexJsonRpcClient>>>>,
+    bridges: Arc<Mutex<HashMap<String, ProgressBridgeCtx>>>,
 }
 
 impl std::fmt::Debug for CodexAppServerAdapter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CodexAppServerAdapter").finish_non_exhaustive()
+        f.debug_struct("CodexAppServerAdapter")
+            .finish_non_exhaustive()
     }
 }
 
@@ -86,7 +122,10 @@ impl CodexAppServerAdapter {
         let home = std::env::var_os("CODEX_HOME")
             .map(PathBuf::from)
             .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;
-        Some(home.join("app-server-control").join("app-server-control.sock"))
+        Some(
+            home.join("app-server-control")
+                .join("app-server-control.sock"),
+        )
     }
 
     /// Lazily connect (or reuse) the JSON-RPC client. Spawning the
@@ -107,12 +146,14 @@ impl CodexAppServerAdapter {
                     .to_string(),
             )
         })?;
-        let client = CodexJsonRpcClient::connect_uds(&path).await.map_err(|err| {
-            HarnessError::SpawnFailed(format!(
-                "connect codex app-server at {}: {err:#}",
-                path.display()
-            ))
-        })?;
+        let client = CodexJsonRpcClient::connect_uds(&path)
+            .await
+            .map_err(|err| {
+                HarnessError::SpawnFailed(format!(
+                    "connect codex app-server at {}: {err:#}",
+                    path.display()
+                ))
+            })?;
         let shared = Arc::new(client);
         *guard = Some(Arc::clone(&shared));
         Ok(shared)
@@ -122,6 +163,30 @@ impl CodexAppServerAdapter {
     /// dead reader task). Next call to `client()` will re-dial.
     pub async fn forget_client(&self) {
         *self.inner.lock().await = None;
+    }
+
+    /// V0.6.1 F122 — register a progress bridge for `thread_id`. Called
+    /// from `start_thread` after the codex `thread/start` response lands;
+    /// also exposed for tests that skip the spawn dance and want to
+    /// drive the events stream directly.
+    pub async fn register_bridge(&self, thread_id: String, ctx: ProgressBridgeCtx) {
+        self.bridges.lock().await.insert(thread_id, ctx);
+    }
+
+    /// V0.6.1 F122 — test escape hatch. Equivalent to [`register_bridge`]
+    /// but named so production call sites (orchestrator wiring) don't
+    /// reach for it by accident.
+    #[doc(hidden)]
+    pub async fn register_bridge_for_test(&self, thread_id: String, ctx: ProgressBridgeCtx) {
+        self.register_bridge(thread_id, ctx).await;
+    }
+
+    async fn bridge_for(&self, thread_id: &str) -> Option<ProgressBridgeCtx> {
+        self.bridges.lock().await.get(thread_id).cloned()
+    }
+
+    async fn drop_bridge(&self, thread_id: &str) {
+        self.bridges.lock().await.remove(thread_id);
     }
 }
 
@@ -160,6 +225,24 @@ impl HarnessAdapter for CodexAppServerAdapter {
                 "thread/start response missing thread.thread_id: {result}"
             ))
         })?;
+        // V0.6.1 F122 — register a progress bridge so the events()
+        // stream can mirror turn boundaries into progress.jsonl.
+        // CcteamPaths resolution honours CCTEAM_HOME so test runs land
+        // in their tempdir layout; production lands in ~/.ccteam/progress/.
+        if let Ok(paths) = CcteamPaths::from_env() {
+            let progress_path = paths.progress_jsonl(&ctx.slug);
+            self.register_bridge(
+                thread_id.clone(),
+                ProgressBridgeCtx {
+                    progress_path,
+                    role: spec.role.clone(),
+                    sid: ctx.sid.clone(),
+                    slug: ctx.slug.clone(),
+                    model: ctx.model_id.clone(),
+                },
+            )
+            .await;
+        }
         Ok(ThreadHandle {
             vendor: AgentVendor::Codex,
             mode: ExecutionMode::Chat,
@@ -198,7 +281,8 @@ impl HarnessAdapter for CodexAppServerAdapter {
     }
 
     fn events(&self, h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
-        let adapter = self.clone();
+        let adapter_setup = self.clone();
+        let adapter_bridge = self.clone();
         let thread_id = h.identity.clone();
         // Build a futures stream by chaining: (1) one-shot setup that
         // either yields an Error event or returns a broadcast receiver,
@@ -207,7 +291,7 @@ impl HarnessAdapter for CodexAppServerAdapter {
         // Error event and stop — orchestrator's progress.jsonl poller
         // remains the state-transition SoT (Wave 1 contract).
         let setup = async move {
-            match adapter.client().await {
+            match adapter_setup.client().await {
                 Ok(c) => Ok(c.subscribe()),
                 Err(err) => Err(ThreadErrorEvent {
                     kind: "connect".into(),
@@ -217,18 +301,66 @@ impl HarnessAdapter for CodexAppServerAdapter {
         };
         let s = stream::once(setup).flat_map(move |outcome| {
             let thread_id = thread_id.clone();
+            let adapter_bridge = adapter_bridge.clone();
             match outcome {
-                Err(err) => stream::iter(vec![ThreadEvent::Error(err)]).boxed(),
+                Err(err) => {
+                    // F122: connect failures still bridge to progress.jsonl
+                    // when a bridge ctx is registered (e.g. a test that
+                    // registers manually and then drops the peer). Fire
+                    // a best-effort write before yielding the Error event.
+                    let adapter_for_err = adapter_bridge.clone();
+                    let wanted = thread_id.clone();
+                    let err_for_evt = err.clone();
+                    let s = stream::once(async move {
+                        if let Some(ctx) = adapter_for_err.bridge_for(&wanted).await {
+                            if let Some(line) = build_progress_line(
+                                &ThreadEvent::Error(err_for_evt.clone()),
+                                &wanted,
+                                &ctx,
+                            ) {
+                                let _ = append_event(&ctx.progress_path, &line);
+                            }
+                            adapter_for_err.drop_bridge(&wanted).await;
+                        }
+                        ThreadEvent::Error(err_for_evt)
+                    });
+                    s.boxed()
+                }
                 Ok(rx) => {
-                    let s = stream::unfold(rx, move |mut rx| {
+                    let s = stream::unfold((rx, adapter_bridge), move |(mut rx, bridge)| {
                         let wanted = thread_id.clone();
                         async move {
                             loop {
                                 match rx.recv().await {
                                     Ok(notif) => {
-                                        if let Some(evt) = translate_notification(&notif, &wanted)
+                                        if let Some(evt) =
+                                            translate_notification(&notif, &wanted)
                                         {
-                                            return Some((evt, rx));
+                                            if let Some(ctx) = bridge.bridge_for(&wanted).await {
+                                                if let Some(line) =
+                                                    build_progress_line(&evt, &wanted, &ctx)
+                                                {
+                                                    if let Err(err) = append_event(
+                                                        &ctx.progress_path,
+                                                        &line,
+                                                    ) {
+                                                        tracing::warn!(
+                                                            thread_id = %wanted,
+                                                            error = %err,
+                                                            "codex bridge: append progress.jsonl failed"
+                                                        );
+                                                    }
+                                                    // Terminal events: drop
+                                                    // the bridge so we don't
+                                                    // double-write if codex
+                                                    // re-fires the same
+                                                    // notification.
+                                                    if is_terminal_progress(&evt) {
+                                                        bridge.drop_bridge(&wanted).await;
+                                                    }
+                                                }
+                                            }
+                                            return Some((evt, (rx, bridge)));
                                         }
                                     }
                                     Err(
@@ -387,15 +519,15 @@ pub fn translate_notification(notif: &Notification, wanted: &str) -> Option<Thre
                     .to_string(),
             },
         }),
-        "item/started" => translate_item_event(&notif.params, |item| {
-            ThreadEvent::ItemStarted { item }
-        }),
-        "item/updated" => translate_item_event(&notif.params, |item| {
-            ThreadEvent::ItemUpdated { item }
-        }),
-        "item/completed" => translate_item_event(&notif.params, |item| {
-            ThreadEvent::ItemCompleted { item }
-        }),
+        "item/started" => {
+            translate_item_event(&notif.params, |item| ThreadEvent::ItemStarted { item })
+        }
+        "item/updated" => {
+            translate_item_event(&notif.params, |item| ThreadEvent::ItemUpdated { item })
+        }
+        "item/completed" => {
+            translate_item_event(&notif.params, |item| ThreadEvent::ItemCompleted { item })
+        }
         "item/agentMessage/delta" => {
             let delta = notif
                 .params
@@ -419,11 +551,91 @@ pub fn translate_notification(notif: &Notification, wanted: &str) -> Option<Thre
     }
 }
 
+/// V0.6.1 F122 — translate a [`ThreadEvent`] into the `progress.jsonl`
+/// row the cost/budget pipelines consume. Mirrors the orchestrator's
+/// own `translate_thread_event` shape (vendor-tagged `agent_done`) so
+/// `compute_cost_summary` rolls codex turns into
+/// `cost_24h_by_vendor["codex"]` without any consumer-side changes.
+///
+/// Returns `None` for events the bridge intentionally does **not**
+/// surface (`ThreadStarted` is covered by `agent_spawn`; `Item*` /
+/// `TurnStarted` are presentation-only and noisy).
+pub fn build_progress_line(
+    evt: &ThreadEvent,
+    thread_id: &str,
+    ctx: &ProgressBridgeCtx,
+) -> Option<Value> {
+    match evt {
+        ThreadEvent::TurnCompleted { turn_id, usage } => {
+            let cost = ccteam_cost::estimate_cost(
+                usage,
+                ccteam_cost::Vendor::Codex,
+                ctx.model.as_deref().unwrap_or(""),
+            );
+            Some(json!({
+                "event": "agent_done",
+                "role": ctx.role,
+                "session_id": ctx.sid,
+                "slug": ctx.slug,
+                "status": "completed",
+                "vendor": "codex",
+                "cost_usd": cost,
+                "thread_id": thread_id,
+                "turn_id": turn_id,
+                "usage": serde_json::to_value(usage).unwrap_or(Value::Null),
+                "ts": Utc::now().to_rfc3339(),
+            }))
+        }
+        ThreadEvent::TurnFailed { turn_id, err } => Some(json!({
+            "event": "agent_done",
+            "role": ctx.role,
+            "session_id": ctx.sid,
+            "slug": ctx.slug,
+            "status": "errored",
+            "vendor": "codex",
+            "error": err.message,
+            "thread_id": thread_id,
+            "turn_id": turn_id,
+            "ts": Utc::now().to_rfc3339(),
+        })),
+        ThreadEvent::Error(err) => Some(json!({
+            "event": "agent_done",
+            "role": ctx.role,
+            "session_id": ctx.sid,
+            "slug": ctx.slug,
+            "status": "errored",
+            "vendor": "codex",
+            "error": err.message,
+            "thread_id": thread_id,
+            "ts": Utc::now().to_rfc3339(),
+        })),
+        ThreadEvent::ThreadStarted { .. }
+        | ThreadEvent::TurnStarted { .. }
+        | ThreadEvent::ItemStarted { .. }
+        | ThreadEvent::ItemUpdated { .. }
+        | ThreadEvent::ItemCompleted { .. } => None,
+    }
+}
+
+/// V0.6.1 F122 — return `true` for events that close out a thread from
+/// the bridge's point of view. After a terminal write the bridge drops
+/// its ctx so a duplicate `turn/completed` notification (codex
+/// app-server may re-broadcast on resubscribe) doesn't double-count.
+fn is_terminal_progress(evt: &ThreadEvent) -> bool {
+    matches!(
+        evt,
+        ThreadEvent::TurnCompleted { .. } | ThreadEvent::TurnFailed { .. } | ThreadEvent::Error(_)
+    )
+}
+
 fn translate_item_event(
     params: &Value,
     ctor: fn(ThreadItem) -> ThreadEvent,
 ) -> Option<ThreadEvent> {
-    let item_val = params.get("item").cloned().unwrap_or_else(|| params.clone());
+    let item_val = params
+        .get("item")
+        .cloned()
+        .unwrap_or_else(|| params.clone());
     let id = item_val
         .get("id")
         .or_else(|| params.get("item_id"))
@@ -482,10 +694,7 @@ fn translate_item_event(
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-            args: item_val
-                .get("arguments")
-                .cloned()
-                .unwrap_or(Value::Null),
+            args: item_val.get("arguments").cloned().unwrap_or(Value::Null),
         },
         Some("web_search") | Some("webSearch") => ThreadItemDetails::WebSearch {
             query: item_val
@@ -523,11 +732,10 @@ fn pluck_turn_id(v: &Value) -> Option<String> {
 }
 
 fn pluck_usage(v: &Value) -> Option<UnifiedTokenUsage> {
-    let raw = v.get("usage").cloned().or_else(|| {
-        v.get("turn")
-            .and_then(|t| t.get("usage"))
-            .cloned()
-    })?;
+    let raw = v
+        .get("usage")
+        .cloned()
+        .or_else(|| v.get("turn").and_then(|t| t.get("usage")).cloned())?;
     serde_json::from_value(raw).ok()
 }
 

--- a/crates/ccteam-core/tests/codex_app_server_progress_bridge_test.rs
+++ b/crates/ccteam-core/tests/codex_app_server_progress_bridge_test.rs
@@ -1,0 +1,350 @@
+//! V0.6.1 F122 — `CodexAppServerAdapter` progress.jsonl bridge tests.
+//!
+//! Closes the V0.6.0 Wave 3 D9 retained risk: when codex
+//! notifications arrive on the app-server UDS, the adapter mirrors
+//! `turn/completed` / `turn/failed` / `error` events into the
+//! project's `progress.jsonl` as `agent_done` rows tagged
+//! `vendor: codex` so `compute_cost_summary` rolls them into
+//! `cost_24h_by_vendor["codex"]` without needing the orchestrator to
+//! wire a separate poller.
+//!
+//! Two complementary paths are exercised:
+//!
+//! 1. **Unit-level bridge** — pre-register a ctx via
+//!    [`CodexAppServerAdapter::register_bridge_for_test`] then call
+//!    [`ccteam_core::execution::codex_app_server::build_progress_line`]
+//!    directly. Verifies the row shape + cost roll-up without a real
+//!    UDS round-trip (deterministic; runs on every box).
+//! 2. **End-to-end UDS** — mock a JSON-RPC peer, drive
+//!    `start_thread` → push a `turn/completed` notification → poll
+//!    `events()` → assert `progress.jsonl` ends up with the expected
+//!    `agent_done` row.
+//!
+//! The end-to-end path mirrors `codex_app_server_test.rs`'s scripted-
+//! peer harness so any future `app-server` protocol drift surfaces in
+//! both suites.
+
+use ccteam_core::execution::codex_app_server::{
+    build_progress_line, CodexAppServerAdapter, ProgressBridgeCtx, APP_SERVER_SOCKET_ENV,
+};
+use ccteam_core::harness::{
+    AgentSpecBrief, HarnessAdapter, SpawnCtx, ThreadErrorEvent, ThreadEvent, UnifiedTokenUsage,
+};
+use ccteam_core::queries::cost_summary_from_events;
+use ccteam_core::CcteamPaths;
+use futures::StreamExt;
+use serde_json::{json, Value};
+use serial_test::serial;
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+
+/// Bind a unique UDS socket under /tmp. Each test gets its own so the
+/// parallel runner doesn't trample `APP_SERVER_SOCKET_ENV`.
+fn unique_socket_path(tag: &str) -> PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "ccteam-v061-codex-bridge-{tag}-{}.sock",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+/// Read + parse every progress.jsonl row. Returns `vec![]` when the
+/// file is absent (the bridge is a no-op until the first relevant
+/// event lands).
+fn read_progress(path: &std::path::Path) -> Vec<Value> {
+    if !path.exists() {
+        return Vec::new();
+    }
+    std::fs::read_to_string(path)
+        .expect("read progress.jsonl")
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("parse progress row"))
+        .collect()
+}
+
+/// Scripted UDS peer that echoes `thread/start` and lets the test
+/// push notifications out-of-band via the returned channel.
+async fn spawn_scripted_peer(
+    sock: PathBuf,
+) -> (
+    tokio::task::JoinHandle<()>,
+    tokio::sync::mpsc::Sender<Value>,
+) {
+    let listener = UnixListener::bind(&sock).unwrap();
+    let (notif_tx, mut notif_rx) = tokio::sync::mpsc::channel::<Value>(16);
+    let task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (r, mut w) = stream.into_split();
+        let mut reader = BufReader::new(r);
+        loop {
+            let mut buf = String::new();
+            tokio::select! {
+                line = reader.read_line(&mut buf) => {
+                    match line {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {
+                            let req: Value = match serde_json::from_str(buf.trim()) {
+                                Ok(v) => v,
+                                Err(_) => continue,
+                            };
+                            let id = req.get("id").cloned();
+                            let mut resp = if req["method"] == "thread/start" {
+                                json!({ "result": { "thread": { "thread_id": "codex-tid-7" } } })
+                            } else {
+                                json!({ "result": {} })
+                            };
+                            if let Some(id) = id {
+                                resp["id"] = id;
+                            }
+                            let mut bytes = serde_json::to_vec(&resp).unwrap();
+                            bytes.push(b'\n');
+                            let _ = w.write_all(&bytes).await;
+                            let _ = w.flush().await;
+                        }
+                    }
+                }
+                notif = notif_rx.recv() => {
+                    match notif {
+                        Some(n) => {
+                            let mut bytes = serde_json::to_vec(&n).unwrap();
+                            bytes.push(b'\n');
+                            let _ = w.write_all(&bytes).await;
+                            let _ = w.flush().await;
+                        }
+                        None => continue,
+                    }
+                }
+            }
+        }
+    });
+    (task, notif_tx)
+}
+
+// --------- 1. Unit-level bridge: build_progress_line shape ---------
+
+#[test]
+fn build_progress_line_turn_completed_tags_vendor_codex() {
+    let ctx = ProgressBridgeCtx {
+        progress_path: PathBuf::from("/tmp/unused.jsonl"),
+        role: "codex-bot".into(),
+        sid: "sid-1".into(),
+        slug: "demo".into(),
+        model: Some("gpt-5-codex".into()),
+    };
+    let usage = UnifiedTokenUsage {
+        input_tokens: 1_000,
+        output_tokens: 500,
+        ..Default::default()
+    };
+    let evt = ThreadEvent::TurnCompleted {
+        turn_id: "turn-9".into(),
+        usage,
+    };
+    let row = build_progress_line(&evt, "codex-tid-7", &ctx).expect("turn/completed must bridge");
+    assert_eq!(row["event"], "agent_done");
+    assert_eq!(row["vendor"], "codex");
+    assert_eq!(row["role"], "codex-bot");
+    assert_eq!(row["slug"], "demo");
+    assert_eq!(row["session_id"], "sid-1");
+    assert_eq!(row["status"], "completed");
+    assert_eq!(row["thread_id"], "codex-tid-7");
+    assert_eq!(row["turn_id"], "turn-9");
+    let cost = row["cost_usd"].as_f64().expect("cost_usd numeric");
+    assert!(cost > 0.0, "non-zero cost from non-zero usage");
+}
+
+#[test]
+fn build_progress_line_turn_failed_marks_errored() {
+    let ctx = ProgressBridgeCtx {
+        progress_path: PathBuf::from("/tmp/unused.jsonl"),
+        role: "codex-bot".into(),
+        sid: "sid-1".into(),
+        slug: "demo".into(),
+        model: None,
+    };
+    let evt = ThreadEvent::TurnFailed {
+        turn_id: "turn-9".into(),
+        err: ThreadErrorEvent {
+            kind: "turn_failed".into(),
+            message: "model unavailable".into(),
+        },
+    };
+    let row = build_progress_line(&evt, "codex-tid-7", &ctx).expect("turn/failed must bridge");
+    assert_eq!(row["event"], "agent_done");
+    assert_eq!(row["vendor"], "codex");
+    assert_eq!(row["status"], "errored");
+    assert_eq!(row["error"], "model unavailable");
+}
+
+#[test]
+fn build_progress_line_silent_for_item_events() {
+    let ctx = ProgressBridgeCtx {
+        progress_path: PathBuf::from("/tmp/unused.jsonl"),
+        role: "codex-bot".into(),
+        sid: "sid-1".into(),
+        slug: "demo".into(),
+        model: None,
+    };
+    let evt = ThreadEvent::TurnStarted {
+        turn_id: "turn-9".into(),
+    };
+    assert!(
+        build_progress_line(&evt, "codex-tid-7", &ctx).is_none(),
+        "turn/started is presentation-only — must not write progress.jsonl"
+    );
+}
+
+// --------- 2. Cost roll-up — the SoT the bridge must feed ---------
+
+#[test]
+fn cost_summary_rolls_bridged_agent_done_into_codex_bucket() {
+    let ctx = ProgressBridgeCtx {
+        progress_path: PathBuf::from("/tmp/unused.jsonl"),
+        role: "codex-bot".into(),
+        sid: "sid-1".into(),
+        slug: "demo".into(),
+        model: Some("gpt-5-codex".into()),
+    };
+    let usage = UnifiedTokenUsage {
+        input_tokens: 10_000,
+        output_tokens: 5_000,
+        ..Default::default()
+    };
+    let evt = ThreadEvent::TurnCompleted {
+        turn_id: "turn-1".into(),
+        usage,
+    };
+    let row = build_progress_line(&evt, "codex-tid-7", &ctx).unwrap();
+    let summary = cost_summary_from_events(&[row]).expect("cost summary");
+    let codex_total = summary
+        .cost_24h_by_vendor
+        .get("codex")
+        .copied()
+        .unwrap_or(0.0);
+    assert!(
+        codex_total > 0.0,
+        "bridged agent_done must roll into cost_24h_by_vendor[\"codex\"]; got {codex_total}"
+    );
+    // Total + 24h should match per-vendor codex roll-up (single event).
+    assert!((summary.cost_24h_usd - codex_total).abs() < 1e-12);
+    assert!((summary.cost_total_usd - codex_total).abs() < 1e-12);
+}
+
+// --------- 3. End-to-end: adapter + scripted UDS peer ---------
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn end_to_end_turn_completed_writes_progress_jsonl_with_vendor_codex() {
+    // CCTEAM_HOME → tempdir so the resolved progress.jsonl lands
+    // somewhere disposable.
+    let home = tempdir().unwrap();
+    let prev_home = std::env::var_os("CCTEAM_HOME");
+    std::env::set_var("CCTEAM_HOME", home.path());
+
+    let sock = unique_socket_path("e2e-turn-completed");
+    std::env::set_var(APP_SERVER_SOCKET_ENV, &sock);
+
+    let (peer, notif_tx) = spawn_scripted_peer(sock.clone()).await;
+    // Give the listener a moment.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let adapter = CodexAppServerAdapter::new();
+    let spec = AgentSpecBrief {
+        role: "codex-bot".into(),
+    };
+    let ctx = SpawnCtx {
+        slug: "demo-codex".into(),
+        sid: "codex-sid-1".into(),
+        cwd: home.path().to_path_buf(),
+        project_dir: home.path().to_path_buf(),
+        extra_args: vec![],
+        model_id: Some("gpt-5-codex".into()),
+    };
+    let h = adapter
+        .start_thread(&spec, &ctx)
+        .await
+        .expect("start_thread");
+    assert_eq!(h.identity, "codex-tid-7");
+
+    // Start consuming events in the background so the bridge fires
+    // on the pushed turn/completed notification.
+    let mut events = adapter.events(&h);
+    let collector = tokio::spawn(async move {
+        // Pull a single event then stop — the stream stays open but
+        // the bridge has already written by the time we yield.
+        events.next().await
+    });
+    // Tiny grace so the subscriber registers before we push.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let notif = json!({
+        "jsonrpc": "2.0",
+        "method": "turn/completed",
+        "params": {
+            "thread_id": "codex-tid-7",
+            "turn_id": "turn-42",
+            "usage": {
+                "input_tokens": 2_000,
+                "output_tokens": 1_000,
+                "cached_input_tokens": 0,
+            },
+        }
+    });
+    notif_tx.send(notif).await.unwrap();
+
+    let got = tokio::time::timeout(Duration::from_secs(2), collector)
+        .await
+        .expect("collector timed out")
+        .expect("collector join");
+    let evt = got.expect("expected one ThreadEvent");
+    matches!(evt, ThreadEvent::TurnCompleted { .. })
+        .then_some(())
+        .expect("expected ThreadEvent::TurnCompleted");
+
+    // The bridge appends synchronously inside the events() stream
+    // poll — by the time the consumer sees the ThreadEvent the
+    // progress.jsonl row is on disk.
+    let paths = CcteamPaths::from_env().expect("paths");
+    let progress_path = paths.progress_jsonl("demo-codex");
+    let rows = read_progress(&progress_path);
+    assert!(
+        !rows.is_empty(),
+        "expected at least one progress.jsonl row at {}",
+        progress_path.display()
+    );
+    let last = rows.last().unwrap();
+    assert_eq!(last["event"], "agent_done");
+    assert_eq!(last["vendor"], "codex");
+    assert_eq!(last["role"], "codex-bot");
+    assert_eq!(last["slug"], "demo-codex");
+    assert_eq!(last["thread_id"], "codex-tid-7");
+    assert_eq!(last["turn_id"], "turn-42");
+    let cost = last["cost_usd"].as_f64().expect("cost_usd numeric");
+    assert!(cost > 0.0, "expected non-zero cost; got {cost}");
+
+    // And the cost summary picks it up on the codex bucket.
+    let summary = cost_summary_from_events(&rows).expect("summary");
+    let codex_total = summary
+        .cost_24h_by_vendor
+        .get("codex")
+        .copied()
+        .unwrap_or(0.0);
+    assert!(
+        (codex_total - cost).abs() < 1e-12,
+        "cost_24h_by_vendor[\"codex\"]={codex_total} must equal the bridged row's cost {cost}"
+    );
+
+    // Cleanup
+    drop(peer);
+    let _ = std::fs::remove_file(&sock);
+    std::env::remove_var(APP_SERVER_SOCKET_ENV);
+    match prev_home {
+        Some(p) => std::env::set_var("CCTEAM_HOME", p),
+        None => std::env::remove_var("CCTEAM_HOME"),
+    }
+}


### PR DESCRIPTION
## Summary

Closes V0.6.0 Wave 3 D9 retained risk (`docs/v0-6-1/prd.md` §F122): the codex
`app-server` adapter now mirrors `turn/completed` / `turn/failed` / `error`
notifications into the project's `progress.jsonl` as `agent_done` rows tagged
`vendor: codex` so `compute_cost_summary` rolls them into
`cost_24h_by_vendor["codex"]` + the F84 per-vendor budget cap surfaces stay
live without the orchestrator wiring a separate poller.

- `CodexAppServerAdapter` holds a `thread_id → ProgressBridgeCtx` map
  (`progress_path` / `role` / `sid` / `slug` / `model`). `start_thread`
  populates it from `SpawnCtx` + `CcteamPaths::from_env` (`CCTEAM_HOME`
  honoured for tests). `events()` stream looks up the ctx on each
  translated `ThreadEvent`, appends to `progress.jsonl` synchronously, and
  drops the bridge on terminal events to prevent double-counts on
  app-server resubscribe.
- New `pub fn build_progress_line(evt, thread_id, ctx) -> Option<Value>`
  emits the same `agent_done` shape `orchestrator::translate_thread_event`
  uses for codex (vendor: codex, `cost_usd` via
  `ccteam_cost::estimate_cost` with the spawned `model_id`).
- `register_bridge` / `register_bridge_for_test` for explicit wiring
  (orchestrator + tests).
- Doc-list clippy lint fixed; full `-D warnings` clean.

Maps to: `docs/requirements.md` §cost-transparency,
`docs/tech-design.md` §5.5 (progress.jsonl SoT), `docs/dev-coupling-audit.md`
F122 (V0.6.1 retained-risk).

## Test plan

- [x] `env -u HTTP_PROXY ... cargo test --workspace --locked --no-fail-fast`
      → **1292/1** (+5 from F122 vs prior 1287/1; the 1 fail is the
      pre-existing `workflow_summary_reflects_agent_spawn_and_done_events`
      flake noted in `CLAUDE.md` §一).
- [x] `env -u HTTP_PROXY ... cargo clippy --workspace --all-targets --locked -- -D warnings`
      → 0 warnings.
- [x] `cargo test -p ccteam-core --test codex_app_server_progress_bridge_test`
      → 5/5 pass (unit `build_progress_line` shape × 3, cost roll-up × 1,
      end-to-end UDS round-trip × 1).
- [x] `cargo test -p ccteam-core --test codex_app_server_test` — unchanged
      baseline holds (no regression in V0.6.0 codex adapter coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)