### PR TITLE
v0.6.1 W1: F119 probe daemon-start + F120 overnight full probe

### DIFF
--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -40,6 +40,7 @@ pub mod transport;
 
 use std::fs;
 use std::path::PathBuf;
+use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{Context, Result};
 use ccteam_core::harness::AgentVendor;
@@ -170,6 +171,47 @@ pub fn imd_heartbeat_path() -> PathBuf {
         .join("imd.heartbeat")
 }
 
+/// Result of [`wait_for_health`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthResult {
+    /// A heartbeat written at or after `started_at` was observed before
+    /// the timeout elapsed.
+    Ready,
+    /// The timeout elapsed without observing a fresh heartbeat.
+    Timeout,
+}
+
+/// V0.6.1 F119 — block until the daemon publishes a heartbeat written
+/// at or after `started_at`, or `timeout` elapses.
+///
+/// "Fresh" is defined as the heartbeat file's mtime being `>=
+/// started_at`. Comparing against a caller-recorded `started_at` (not
+/// just "exists") prevents a stale heartbeat from a previous daemon
+/// invocation from spoofing readiness. Callers using `ccteam-imd
+/// health` semantics capture `SystemTime::now()` *before* spawning
+/// the daemon, then pass it here.
+///
+/// `poll` is the sleep between filesystem checks (200ms is a sane
+/// default; tests pass `Duration::from_millis(5)` for hermetic
+/// fast-loop checks).
+pub fn wait_for_health(started_at: SystemTime, timeout: Duration, poll: Duration) -> HealthResult {
+    let deadline = Instant::now() + timeout;
+    let hb = imd_heartbeat_path();
+    loop {
+        if let Ok(meta) = fs::metadata(&hb) {
+            if let Ok(mtime) = meta.modified() {
+                if mtime >= started_at {
+                    return HealthResult::Ready;
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            return HealthResult::Timeout;
+        }
+        std::thread::sleep(poll);
+    }
+}
+
 /// Re-export the main daemon entry so `main.rs` stays a thin shim.
 pub use daemon::{run_daemon, DaemonArgs};
 
@@ -181,5 +223,12 @@ mod tests {
     fn registration_path_layout() {
         let p = registration_path("dev-foo", "lead");
         assert!(p.ends_with(".ccteam/imd/registry/dev-foo/lead.json"));
+    }
+
+    #[test]
+    fn health_result_round_trip_ready_eq_timeout_distinct() {
+        // Sanity: HealthResult variants aren't accidentally collapsed.
+        assert_eq!(HealthResult::Ready, HealthResult::Ready);
+        assert_ne!(HealthResult::Ready, HealthResult::Timeout);
     }
 }

--- a/crates/ccteam-imd/src/main.rs
+++ b/crates/ccteam-imd/src/main.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use ccteam_core::harness::AgentVendor;
 use ccteam_imd::{
     daemon::{run_daemon, DaemonArgs},
-    imd_heartbeat_path, list_bots, register_bot, unregister_bot,
+    imd_heartbeat_path, list_bots, register_bot, unregister_bot, wait_for_health, HealthResult,
 };
 use clap::{Parser, Subcommand};
 
@@ -78,6 +78,22 @@ enum Command {
     },
     /// Print the daemon status (heartbeat freshness + registered bots).
     Status,
+    /// V0.6.1 F119 — block until the daemon publishes a *fresh*
+    /// heartbeat (mtime ≥ the moment this command started), or the
+    /// timeout elapses.
+    ///
+    /// `exit 0` = ready; `exit 1` = timed out. Scripted callers like
+    /// `scripts/host-probe/run-probes.sh` use this to wait after
+    /// spawning the daemon before exercising mode-3 scenarios.
+    Health {
+        /// Maximum seconds to wait for a fresh heartbeat (default 30).
+        #[arg(long, default_value_t = 30)]
+        timeout_seconds: u64,
+        /// Poll interval in milliseconds between filesystem checks
+        /// (default 200ms; tests may shorten).
+        #[arg(long, default_value_t = 200)]
+        poll_ms: u64,
+    },
 }
 
 fn parse_vendor(s: &str) -> Result<AgentVendor, String> {
@@ -149,6 +165,31 @@ fn main() -> Result<()> {
                     "  {}/{} → {} (chat_id={})",
                     reg.workflow_slug, reg.role, reg.im_platform, reg.im_chat_id
                 );
+            }
+        }
+        Command::Health {
+            timeout_seconds,
+            poll_ms,
+        } => {
+            let started = std::time::SystemTime::now();
+            let result = wait_for_health(
+                started,
+                std::time::Duration::from_secs(timeout_seconds),
+                std::time::Duration::from_millis(poll_ms),
+            );
+            match result {
+                HealthResult::Ready => {
+                    let hb = imd_heartbeat_path();
+                    println!("daemon: ready (heartbeat at {})", hb.display());
+                }
+                HealthResult::Timeout => {
+                    let hb = imd_heartbeat_path();
+                    eprintln!(
+                        "daemon: NOT READY after {timeout_seconds}s (no fresh heartbeat at {})",
+                        hb.display()
+                    );
+                    std::process::exit(1);
+                }
             }
         }
     }

--- a/crates/ccteam-imd/tests/daemon_test.rs
+++ b/crates/ccteam-imd/tests/daemon_test.rs
@@ -1,11 +1,12 @@
 //! Daemon lifecycle + registry round-trip integration tests.
 
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use ccteam_core::harness::AgentVendor;
 use ccteam_imd::{
     daemon::{run_daemon, DaemonArgs},
     imd_heartbeat_path, list_bots, register_bot, registration_path, unregister_bot,
+    wait_for_health, HealthResult,
 };
 use tempfile::TempDir;
 
@@ -90,4 +91,71 @@ fn register_overwrites_existing() {
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].im_platform, "slack");
     assert!(matches!(listed[0].vendor, AgentVendor::Codex));
+}
+
+// ---------- V0.6.1 F119 — `wait_for_health` ----------
+
+/// Background-write a fresh heartbeat once, after the configured delay.
+/// Mirrors how the real daemon's supervisor tick refreshes
+/// `imd_heartbeat_path()`.
+fn schedule_heartbeat_write(after: Duration) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        std::thread::sleep(after);
+        let path = imd_heartbeat_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, "fresh").unwrap();
+    })
+}
+
+#[test]
+fn health_returns_ready_when_fresh_heartbeat_arrives() {
+    let _g = env_lock();
+    let _tmp = isolate_home();
+    let started = SystemTime::now();
+    // Daemon writes a fresh heartbeat ~50ms after we start waiting.
+    let writer = schedule_heartbeat_write(Duration::from_millis(50));
+    let result = wait_for_health(started, Duration::from_secs(2), Duration::from_millis(10));
+    writer.join().unwrap();
+    assert_eq!(result, HealthResult::Ready);
+}
+
+#[test]
+fn health_returns_timeout_when_no_heartbeat_ever_written() {
+    let _g = env_lock();
+    let _tmp = isolate_home();
+    // Make sure no leftover heartbeat exists from a sibling test
+    // sharing this `HOME` (lock ensures sequential, isolate_home gives
+    // us a fresh HOME but be defensive).
+    let _ = std::fs::remove_file(imd_heartbeat_path());
+    let started = SystemTime::now();
+    let result = wait_for_health(
+        started,
+        Duration::from_millis(150),
+        Duration::from_millis(10),
+    );
+    assert_eq!(result, HealthResult::Timeout);
+}
+
+#[test]
+fn health_rejects_stale_heartbeat_from_previous_run() {
+    let _g = env_lock();
+    let _tmp = isolate_home();
+    // A leftover heartbeat from a previous daemon should NOT count as
+    // ready — that's the spoof we're guarding against.
+    let path = imd_heartbeat_path();
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(&path, "stale").unwrap();
+    // Sleep so the filesystem clock advances past the heartbeat's
+    // mtime; otherwise `started >= mtime` is a coin flip on 1-second
+    // resolution filesystems.
+    std::thread::sleep(Duration::from_millis(1100));
+    let started = SystemTime::now();
+    let result = wait_for_health(
+        started,
+        Duration::from_millis(150),
+        Duration::from_millis(10),
+    );
+    assert_eq!(result, HealthResult::Timeout);
 }

--- a/scripts/host-probe/README.md
+++ b/scripts/host-probe/README.md
@@ -43,6 +43,53 @@ CCTEAM_PROBE_REAL_TG=1 \
   `im-squad` use the real Telegram channel instead of the mock
   channel. Default is mock — wave-4 ship gate accepts mock for
   Telegram scenarios per the wave-4 handoff.
+- `CCTEAM_PROBE_LOCAL` (V0.6.1 F119) — when `1`, scenarios run
+  locally (no SSH; `NAS_PATH` is interpreted as the repo root).
+  Used for PR-review dry-run of script changes without touching
+  the NAS.
+- `CCTEAM_PROBE_SKIP_DAEMON_START` (V0.6.1 F119) — when `1`, the
+  `pocket-assistant` / `im-squad` scenarios skip the new
+  daemon-spawn + health-wait + stop block and assume the caller
+  has a `ccteam-imd` daemon already running. Default is `0`
+  (probe owns lifecycle).
+
+## V0.6.1 F119 — daemon lifecycle in mode-3 probes
+
+`pocket-assistant` and `im-squad` now own the `ccteam-imd` daemon
+end-to-end:
+
+1. `nohup ./target/release/ccteam-imd run --tick-seconds 2 &` →
+   stash pid + stderr to `/tmp/ccteam-imd-probe-<scenario>.{pid,stderr}`.
+2. `./target/release/ccteam-imd health --timeout-seconds 30 --poll-ms 200`
+   blocks until the daemon writes a heartbeat with `mtime ≥` the
+   moment the health check started (rejects stale heartbeats from
+   prior runs).
+3. Run the scenario's bot interactions.
+4. `kill -TERM <pid>`; wait 5s for graceful exit; `kill -KILL` if
+   still alive; tail stderr into the scenario log.
+
+`run-probes.sh` then `scp`s `/tmp/ccteam-imd-probe-<scenario>.stderr`
+back into `<out>/<scenario>/daemon-stderr.log` so post-mortems are
+self-contained.
+
+## V0.6.1 F120 — overnight-builder real workflow
+
+The `overnight-builder` scenario is no longer a `ccteam --help`
+smoke. It now:
+
+1. Scaffolds `/tmp/host-probe-overnight/` with an isolated
+   `CCTEAM_HOME` + `CCTEAM_PROJECTS_ROOT`, a 1-agent
+   artifact-driven `workflow.yaml`, and `.claude/agents/worker.md`.
+2. Plants a stub `claude` binary (via `CCTEAM_CLAUDE_BIN`) that
+   prints `backgrounded · <id>` + writes a synthetic
+   `state.json`, so the orchestrator's `poll_completions` emits
+   `agent_done` without burning real LLM cost.
+3. Backgrounds `ccteam start --no-web --tick-seconds 1`, drops a
+   trigger marker, polls `progress.jsonl` for both `agent_spawn`
+   and `agent_done` (60s deadline).
+4. Exit codes: `0` = both events, `2` = spawn only (partial), `1` =
+   neither (orchestrator didn't pick up the trigger). The wrapper
+   marks status `happy` / `partial` / `fail` accordingly.
 
 ## Output layout
 

--- a/scripts/host-probe/run-probes.sh
+++ b/scripts/host-probe/run-probes.sh
@@ -2,17 +2,30 @@
 #
 # scripts/host-probe/run-probes.sh
 #
-# V0.6.0 Wave 4 host-probe execution step. Runs the 5 preset E2E
-# scenarios + the 3 Codex scenarios against an already-deployed remote
-# (see `deploy-to-nas.sh`).
+# V0.6.0 Wave 4 host-probe execution step + V0.6.1 F119/F120
+# enhancements. Runs the 5 preset E2E scenarios + the 3 Codex scenarios
+# against an already-deployed remote (see `deploy-to-nas.sh`) or, with
+# `CCTEAM_PROBE_LOCAL=1`, against the local checkout for dry-run.
+#
+# V0.6.1 F119 — pocket-assistant / im-squad now actively manage the
+# ccteam-imd daemon lifecycle: spawn → health-wait → exercise → stop +
+# capture daemon stderr on crash. `CCTEAM_PROBE_SKIP_DAEMON_START=1`
+# leaves daemon management to the caller.
+#
+# V0.6.1 F120 — overnight-builder now scaffolds a fake artifact-driven
+# workflow under `/tmp/host-probe-overnight/`, plants a stub claude
+# binary (no real LLM cost), starts `ccteam start` in the background,
+# trips the trigger, and asserts `agent_spawn` + `agent_done` events
+# in `progress.jsonl`. Previously it was `ccteam --help` smoke only.
 #
 # Output layout (per scenario):
-#   $OUT_DIR/<scenario>/cmd.txt   — actual command(s) executed
-#   $OUT_DIR/<scenario>/log       — combined stdout/stderr tail
-#   $OUT_DIR/<scenario>/cost.txt  — `ccteam cost summary` snapshot
-#   $OUT_DIR/<scenario>/status    — "happy" | "mock" | "skip" | "fail"
-#   $OUT_DIR/summary.md           — table the team-lead pastes into
-#                                   docs/v0-6-0/host-probe.md
+#   $OUT_DIR/<scenario>/cmd.txt            — actual command(s) executed
+#   $OUT_DIR/<scenario>/log                — combined stdout/stderr tail
+#   $OUT_DIR/<scenario>/cost.txt           — `ccteam cost summary` snapshot
+#   $OUT_DIR/<scenario>/daemon-stderr.log  — F119 daemon stderr (when spawned)
+#   $OUT_DIR/<scenario>/status             — "happy" | "mock" | "skip" | "fail"
+#   $OUT_DIR/summary.md                    — table the team-lead pastes into
+#                                            docs/v0-6-X/host-probe.md
 #
 # Usage:
 #   scripts/host-probe/run-probes.sh [SCENARIO...]
@@ -23,21 +36,25 @@
 #       codex-advise codex-auto-critic codex-fallback
 #
 # Env overrides:
-#   CCTEAM_NAS_HOST       — ssh target (default: nas-box005)
-#   CCTEAM_NAS_PATH       — remote checkout (default:
-#                           /home/rob/nasworkspace/ccteam)
-#   CCTEAM_PROBE_OUT_DIR  — local output dir (default:
-#                           ./.probe-results/<UTC-timestamp>)
-#   CCTEAM_PROBE_REAL_TG  — "1" enables real Telegram probes for
-#                           pocket-assistant / im-squad; default "0"
-#                           runs the mock-channel path (the user has
-#                           pasted credentials.json but is allowed to
-#                           defer real TG e2e to V0.6.1 post-ship).
+#   CCTEAM_NAS_HOST              — ssh target (default: nas-box005)
+#   CCTEAM_NAS_PATH              — remote checkout (default:
+#                                  /home/rob/nasworkspace/ccteam)
+#   CCTEAM_PROBE_OUT_DIR         — local output dir (default:
+#                                  ./.probe-results/<UTC-timestamp>)
+#   CCTEAM_PROBE_REAL_TG         — "1" enables real Telegram probes for
+#                                  pocket-assistant / im-squad; default "0"
+#                                  runs the mock-channel path.
+#   CCTEAM_PROBE_LOCAL           — "1" runs scenarios locally (no SSH).
+#                                  Used by `cargo` callers to dry-run the
+#                                  script during PR review.
+#   CCTEAM_PROBE_SKIP_DAEMON_START — "1" leaves ccteam-imd daemon lifecycle
+#                                    to the caller (F119); the script
+#                                    assumes a daemon is already running.
 #
 # Each scenario function MUST be safe to skip independently. A
 # scenario records `status=skip` with a reason when its prerequisites
-# (tooling, auth, allowed_chat_ids) are missing; the wave-4 ship gate
-# accepts mock/skip per the wave-4 handoff message.
+# (tooling, auth, allowed_chat_ids) are missing; the wave gate accepts
+# mock/skip per the wave handoff message.
 #
 # Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 
@@ -47,6 +64,8 @@ NAS_HOST="${CCTEAM_NAS_HOST:-nas-box005}"
 NAS_PATH="${CCTEAM_NAS_PATH:-/home/rob/nasworkspace/ccteam}"
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 OUT_DIR="${CCTEAM_PROBE_OUT_DIR:-./.probe-results/$TS}"
+LOCAL_MODE="${CCTEAM_PROBE_LOCAL:-0}"
+SKIP_DAEMON_START="${CCTEAM_PROBE_SKIP_DAEMON_START:-0}"
 
 ALL_SCENARIOS=(
     solo-sidekick
@@ -70,32 +89,156 @@ log() { printf '[%s] %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
 
 # ---------- helpers ----------
 
+# Run a bash script in the right execution context (remote SSH or
+# local shell). Both paths strip HTTP_PROXY (V0.6 lesson: the 64
+# ccteam-web tests false-positive 502 against proxied connections).
 remote_run() {
     # remote_run <scenario> <bash-script>
     local scenario="$1"; shift
     local script="$1"
     local d="$OUT_DIR/$scenario"
     mkdir -p "$d"
-    echo "ssh $NAS_HOST 'cd $NAS_PATH && ...'" > "$d/cmd.txt"
-    printf '%s\n' "$script" >> "$d/cmd.txt"
-    ssh "$NAS_HOST" bash -s <<EOF >"$d/log" 2>&1
+    if [[ "$LOCAL_MODE" == "1" ]]; then
+        echo "local: bash -s (LOCAL_MODE=1)" > "$d/cmd.txt"
+        printf '%s\n' "$script" >> "$d/cmd.txt"
+        # NAS_PATH is interpreted as "the checkout root" — locally that
+        # is the repo root (two levels up from this script).
+        local local_root
+        local_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+        (
+            cd "$local_root"
+            env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy \
+                bash -c "$script"
+        ) >"$d/log" 2>&1
+        echo $? > "$d/rc"
+    else
+        echo "ssh $NAS_HOST 'cd $NAS_PATH && ...'" > "$d/cmd.txt"
+        printf '%s\n' "$script" >> "$d/cmd.txt"
+        ssh "$NAS_HOST" bash -s <<EOF >"$d/log" 2>&1
 set -uo pipefail
 cd "$NAS_PATH"
 env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy bash -c '$script'
 EOF
-    echo $? > "$d/rc"
+        echo $? > "$d/rc"
+    fi
 }
 
 snapshot_cost() {
     local scenario="$1"
     local d="$OUT_DIR/$scenario"
-    ssh "$NAS_HOST" "cd $NAS_PATH && ./target/release/ccteam cost summary --json" \
-        > "$d/cost.txt" 2>/dev/null || echo '{"note":"cost summary unavailable"}' > "$d/cost.txt"
+    if [[ "$LOCAL_MODE" == "1" ]]; then
+        local local_root
+        local_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+        if [[ -x "$local_root/target/release/ccteam" ]]; then
+            "$local_root/target/release/ccteam" cost summary --json \
+                > "$d/cost.txt" 2>/dev/null \
+                || echo '{"note":"cost summary unavailable (local)"}' > "$d/cost.txt"
+        elif [[ -x "$local_root/target/debug/ccteam" ]]; then
+            "$local_root/target/debug/ccteam" cost summary --json \
+                > "$d/cost.txt" 2>/dev/null \
+                || echo '{"note":"cost summary unavailable (local debug)"}' > "$d/cost.txt"
+        else
+            echo '{"note":"ccteam binary not built locally"}' > "$d/cost.txt"
+        fi
+    else
+        ssh "$NAS_HOST" "cd $NAS_PATH && ./target/release/ccteam cost summary --json" \
+            > "$d/cost.txt" 2>/dev/null \
+            || echo '{"note":"cost summary unavailable"}' > "$d/cost.txt"
+    fi
+}
+
+# V0.6.1 F119 — pull daemon-stderr back from the run (remote or local)
+# into the per-scenario output dir. The daemon-lifecycle inline block
+# writes stderr to a known path; this fn copies it.
+fetch_daemon_stderr() {
+    local scenario="$1"
+    local d="$OUT_DIR/$scenario"
+    local remote_path="/tmp/ccteam-imd-probe-$scenario.stderr"
+    if [[ "$LOCAL_MODE" == "1" ]]; then
+        if [[ -f "$remote_path" ]]; then
+            cp "$remote_path" "$d/daemon-stderr.log" 2>/dev/null || true
+        fi
+    else
+        ssh "$NAS_HOST" "cat $remote_path 2>/dev/null" > "$d/daemon-stderr.log" 2>/dev/null || true
+        if [[ ! -s "$d/daemon-stderr.log" ]]; then
+            rm -f "$d/daemon-stderr.log"
+        fi
+    fi
 }
 
 mark() {
     # mark <scenario> <status>
     echo "$2" > "$OUT_DIR/$1/status"
+}
+
+# ---------- F119 daemon-lifecycle snippets ----------
+#
+# `daemon_start_snippet <scenario>` returns a bash snippet that:
+#   - spawns `ccteam-imd run` in background (writes pid + stderr to /tmp)
+#   - polls `ccteam-imd health --timeout-seconds 30` for readiness
+#   - on health failure: dumps daemon stderr, kills the pid, exits 11
+#
+# When CCTEAM_PROBE_SKIP_DAEMON_START=1, the snippet becomes a no-op
+# stub so callers managing their own daemons aren't disturbed.
+daemon_start_snippet() {
+    local scenario="$1"
+    local pidfile="/tmp/ccteam-imd-probe-$scenario.pid"
+    local stderrfile="/tmp/ccteam-imd-probe-$scenario.stderr"
+    if [[ "$SKIP_DAEMON_START" == "1" ]]; then
+        cat <<EOF
+echo "[probe/$scenario] CCTEAM_PROBE_SKIP_DAEMON_START=1 — assuming caller-managed daemon"
+EOF
+        return
+    fi
+    cat <<EOF
+echo "[probe/$scenario] F119: starting ccteam-imd daemon"
+nohup ./target/release/ccteam-imd run --tick-seconds 2 \\
+    >/tmp/ccteam-imd-probe-$scenario.stdout 2>$stderrfile &
+echo \$! > $pidfile
+echo "[probe/$scenario] daemon pid=\$(cat $pidfile)"
+if ! ./target/release/ccteam-imd health --timeout-seconds 30 --poll-ms 200; then
+    echo "[probe/$scenario] F119: health-wait FAILED — dumping last 50 lines of daemon stderr:"
+    echo "=== DAEMON STDERR (tail 50) ==="
+    tail -50 $stderrfile 2>/dev/null || true
+    echo "=== END DAEMON STDERR ==="
+    kill -TERM \$(cat $pidfile) 2>/dev/null || true
+    exit 11
+fi
+echo "[probe/$scenario] F119: daemon ready"
+EOF
+}
+
+daemon_stop_snippet() {
+    local scenario="$1"
+    local pidfile="/tmp/ccteam-imd-probe-$scenario.pid"
+    local stderrfile="/tmp/ccteam-imd-probe-$scenario.stderr"
+    if [[ "$SKIP_DAEMON_START" == "1" ]]; then
+        cat <<EOF
+echo "[probe/$scenario] CCTEAM_PROBE_SKIP_DAEMON_START=1 — not stopping caller-managed daemon"
+EOF
+        return
+    fi
+    cat <<EOF
+echo "[probe/$scenario] F119: stopping ccteam-imd daemon"
+if [[ -f $pidfile ]]; then
+    PID=\$(cat $pidfile)
+    kill -TERM \$PID 2>/dev/null || true
+    for _i in 1 2 3 4 5; do
+        if ! kill -0 \$PID 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+    if kill -0 \$PID 2>/dev/null; then
+        echo "[probe/$scenario] F119: daemon did not exit gracefully; SIGKILL"
+        kill -KILL \$PID 2>/dev/null || true
+    fi
+    rm -f $pidfile
+fi
+echo "=== DAEMON STDERR (tail 30) ==="
+tail -30 $stderrfile 2>/dev/null || true
+echo "=== END DAEMON STDERR ==="
+EOF
 }
 
 # ---------- scenario fns ----------
@@ -125,37 +268,180 @@ probe_team_sprint() {
     mark team-sprint manual
 }
 
+# V0.6.1 F120 — real artifact-driven workflow, not a `--help` smoke test.
+#
+# Steps (inside the remote bash block):
+#   1. Wipe + scaffold /tmp/host-probe-overnight/ with a 1-agent
+#      artifact-driven workflow.yaml.
+#   2. Plant a stub claude binary that prints the `backgrounded · <id>`
+#      marker and writes a synthetic state.json so the orchestrator's
+#      `poll_completions` will emit `agent_done` without burning real
+#      LLM cost.
+#   3. Start `ccteam start` in the background pointed at the fake
+#      project; tail progress.jsonl until both `agent_spawn` and
+#      `agent_done` land, or a 60s deadline.
+#   4. Clean up the daemon + tempdir; exit nonzero iff either event
+#      is missing.
 probe_overnight_builder() {
-    log "preset 3: overnight-builder (mode 2 bg)"
+    log "preset 3: overnight-builder (mode 2 bg) — F120 real workflow"
     remote_run overnight-builder '
-        echo "[probe] overnight-builder: ccteam-creator → workflow.yaml → daemon"
-        echo "[probe] runs ccteam-creator preset check + a 5-minute mock cycle"
-        ./target/release/ccteam --help | head -3
-        # smoke: workflow.yaml load + validate is the contract surface
-        ls .ccteam 2>/dev/null || true
+        set +e
+        # F120 root: holds an isolated CCTEAM_HOME + projects_root so
+        # the probe does not touch the user latency real ~/.ccteam state.
+        ROOT=/tmp/host-probe-overnight
+        rm -rf $ROOT
+        mkdir -p $ROOT
+        export CCTEAM_HOME=$ROOT/ccteam-home
+        export CCTEAM_PROJECTS_ROOT=$ROOT/projects
+        mkdir -p $CCTEAM_HOME $CCTEAM_PROJECTS_ROOT
+        PROJ=$CCTEAM_PROJECTS_ROOT/overnight-probe
+        mkdir -p $PROJ/.ccteam/triggers/worker
+        mkdir -p $PROJ/.claude/agents
+
+        # Stash the abs path to the ccteam + ccteam-imd binaries before
+        # any cd, so background invocations are unambiguous.
+        CCTEAM_BIN="$(pwd)/target/release/ccteam"
+
+        # F120 step 1 — minimal artifact-driven workflow.yaml
+        cat > $PROJ/workflow.yaml <<YAML
+name: overnight-probe
+description: |
+  F120 host-probe minimal artifact-driven workflow. One worker agent
+  fires on a trigger marker; the stub claude binary terminates
+  instantly so agent_done lands within the probe deadline.
+agents:
+  worker:
+    executor: claude
+    trigger: watch:.ccteam/triggers/worker/
+    parallelism: 1
+YAML
+
+        cat > $PROJ/.claude/agents/worker.md <<MD
+# worker
+
+Stub agent for F120 host-probe.
+MD
+
+        # F120 step 2 — stub claude binary. Prints `backgrounded · <id>`
+        # (parsed by ClaudeBgAdapter.start_thread) + writes synthetic
+        # state.json so poll_completions emits agent_done.
+        cat > $ROOT/fake-claude <<STUB
+#!/bin/sh
+echo "backgrounded · stub\$\$"
+JOBS_DIR=\${CCTEAM_CLAUDE_JOBS_DIR:-\$HOME/.claude/jobs}
+mkdir -p \$JOBS_DIR/stub\$\$
+cat > \$JOBS_DIR/stub\$\$/state.json <<JSON
+{"status":"completed","cost_usd":0.0,"started_at":"2026-01-01T00:00:00Z","ended_at":"2026-01-01T00:00:01Z"}
+JSON
+exit 0
+STUB
+        chmod +x $ROOT/fake-claude
+        export CCTEAM_CLAUDE_BIN=$ROOT/fake-claude
+        export CCTEAM_CLAUDE_JOBS_DIR=$ROOT/claude-jobs
+        mkdir -p $CCTEAM_CLAUDE_JOBS_DIR
+
+        echo "[probe/overnight] scaffold ready at $PROJ (root=$ROOT)"
+
+        # F120 step 3 — start orchestrator (no-web). It scans
+        # CCTEAM_PROJECTS_ROOT for projects.
+        nohup "$CCTEAM_BIN" start --no-web --tick-seconds 1 \
+            >$ROOT/start.stdout 2>$ROOT/start.stderr &
+        ORCH_PID=$!
+        echo $ORCH_PID > $ROOT/orch.pid
+        echo "[probe/overnight] orchestrator pid=$ORCH_PID"
+
+        sleep 3
+        touch $PROJ/.ccteam/triggers/worker/wake.md
+        echo "[probe/overnight] trigger placed; polling progress.jsonl"
+
+        SPAWN_SEEN=0
+        DONE_SEEN=0
+        for i in $(seq 1 60); do
+            if [[ -f $PROJ/.ccteam/progress.jsonl ]]; then
+                if grep -q "\"event\":\"agent_spawn\"" $PROJ/.ccteam/progress.jsonl 2>/dev/null; then
+                    SPAWN_SEEN=1
+                fi
+                if grep -q "\"event\":\"agent_done\"" $PROJ/.ccteam/progress.jsonl 2>/dev/null; then
+                    DONE_SEEN=1
+                    break
+                fi
+            fi
+            sleep 1
+        done
+
+        echo "[probe/overnight] progress.jsonl dump:"
+        if [[ -f $PROJ/.ccteam/progress.jsonl ]]; then
+            cat $PROJ/.ccteam/progress.jsonl
+            echo "[probe/overnight] event types observed:"
+            (command -v jq >/dev/null && jq -r .event $PROJ/.ccteam/progress.jsonl | sort -u) \
+                || grep -oE "\"event\":\"[^\"]*\"" $PROJ/.ccteam/progress.jsonl | sort -u
+        else
+            echo "[probe/overnight] progress.jsonl was never created"
+        fi
+
+        kill -TERM $ORCH_PID 2>/dev/null || true
+        for _i in 1 2 3 4 5; do
+            kill -0 $ORCH_PID 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL $ORCH_PID 2>/dev/null || true
+
+        echo "[probe/overnight] orchestrator stderr (tail 30):"
+        tail -30 $ROOT/start.stderr 2>/dev/null || true
+
+        if [[ "$SPAWN_SEEN" == "1" && "$DONE_SEEN" == "1" ]]; then
+            echo "[probe/overnight] PASS: agent_spawn + agent_done observed"
+            rm -rf $ROOT
+            exit 0
+        elif [[ "$SPAWN_SEEN" == "1" ]]; then
+            echo "[probe/overnight] PARTIAL: agent_spawn seen but no agent_done within 60s"
+            rm -rf $ROOT
+            exit 2
+        else
+            echo "[probe/overnight] FAIL: no agent_spawn within 60s"
+            rm -rf $ROOT
+            exit 1
+        fi
     '
     snapshot_cost overnight-builder
-    mark overnight-builder mock
+    local rc
+    rc="$(cat "$OUT_DIR/overnight-builder/rc" 2>/dev/null || echo '-')"
+    case "$rc" in
+        0) mark overnight-builder happy ;;
+        2) mark overnight-builder partial ;;
+        *) mark overnight-builder fail ;;
+    esac
 }
 
 probe_pocket_assistant() {
     log "preset 4: pocket-assistant (mode 3 chat — Telegram DM)"
     if [[ "${CCTEAM_PROBE_REAL_TG:-0}" == "1" ]]; then
-        remote_run pocket-assistant '
-            echo "[probe] pocket-assistant: real TG e2e against @web3op_bot"
-            echo "[probe] expects ~/.ccteam/im/credentials.json on remote"
-            test -f ~/.ccteam/im/credentials.json || { echo "missing credentials.json"; exit 9; }
+        remote_run pocket-assistant "
+            $(daemon_start_snippet pocket-assistant)
+            echo '[probe] pocket-assistant: real TG e2e against @web3op_bot'
+            echo '[probe] expects ~/.ccteam/im/credentials.json on remote'
+            test -f \$HOME/.ccteam/im/credentials.json || { echo 'missing credentials.json'; exit 9; }
             ./target/release/ccteam-imd status 2>&1 || true
-        '
+            $(daemon_stop_snippet pocket-assistant)
+        "
+        fetch_daemon_stderr pocket-assistant
         snapshot_cost pocket-assistant
-        mark pocket-assistant real
+        local rc
+        rc="$(cat "$OUT_DIR/pocket-assistant/rc" 2>/dev/null || echo '-')"
+        case "$rc" in
+            0) mark pocket-assistant real ;;
+            9) mark pocket-assistant skip ;;
+            *) mark pocket-assistant fail ;;
+        esac
     else
-        remote_run pocket-assistant '
-            echo "[probe] pocket-assistant: mock channel e2e"
-            echo "[probe] inject ChannelMessage via MockChannel::push"
-            echo "[probe] assert turns.jsonl mirror + outbox forward"
-            ./target/release/ccteam-imd --help 2>&1 | head -10 || true
-        '
+        remote_run pocket-assistant "
+            $(daemon_start_snippet pocket-assistant)
+            echo '[probe] pocket-assistant: mock channel e2e'
+            echo '[probe] F119 daemon-up smoke: status output + heartbeat fresh'
+            ./target/release/ccteam-imd status 2>&1 | head -10 || true
+            $(daemon_stop_snippet pocket-assistant)
+        "
+        fetch_daemon_stderr pocket-assistant
         snapshot_cost pocket-assistant
         mark pocket-assistant mock
     fi
@@ -164,19 +450,31 @@ probe_pocket_assistant() {
 probe_im_squad() {
     log "preset 5: im-squad (mode 3 chat — group + bot-to-bot)"
     if [[ "${CCTEAM_PROBE_REAL_TG:-0}" == "1" ]]; then
-        remote_run im-squad '
-            echo "[probe] im-squad: real TG group + 2 bots"
-            test -f ~/.ccteam/im/credentials.json || { echo "missing credentials.json"; exit 9; }
+        remote_run im-squad "
+            $(daemon_start_snippet im-squad)
+            echo '[probe] im-squad: real TG group + 2 bots'
+            test -f \$HOME/.ccteam/im/credentials.json || { echo 'missing credentials.json'; exit 9; }
             ./target/release/ccteam-imd status 2>&1 || true
-        '
+            $(daemon_stop_snippet im-squad)
+        "
+        fetch_daemon_stderr im-squad
         snapshot_cost im-squad
-        mark im-squad real
+        local rc
+        rc="$(cat "$OUT_DIR/im-squad/rc" 2>/dev/null || echo '-')"
+        case "$rc" in
+            0) mark im-squad real ;;
+            9) mark im-squad skip ;;
+            *) mark im-squad fail ;;
+        esac
     else
-        remote_run im-squad '
-            echo "[probe] im-squad: mock channel + 2-bot routing"
-            echo "[probe] hop_limit=4 chain → escalate"
-            ./target/release/ccteam-imd --help 2>&1 | head -10 || true
-        '
+        remote_run im-squad "
+            $(daemon_start_snippet im-squad)
+            echo '[probe] im-squad: mock channel + 2-bot routing'
+            echo '[probe] F119 daemon-up smoke: status output + heartbeat fresh'
+            ./target/release/ccteam-imd status 2>&1 | head -10 || true
+            $(daemon_stop_snippet im-squad)
+        "
+        fetch_daemon_stderr im-squad
         snapshot_cost im-squad
         mark im-squad mock
     fi
@@ -210,7 +508,6 @@ probe_codex_auto_critic() {
             echo "[probe] codex binary missing — scenario skipped"
             exit 9
         fi
-        # smoke: verify the codex detection helper returns ok
         ./target/release/ccteam prefs get fallback.on_claude_quota 2>&1 || true
     '
     snapshot_cost codex-auto-critic
@@ -256,7 +553,7 @@ dispatch() {
     esac
 }
 
-log "host-probe run started — out=$OUT_DIR"
+log "host-probe run started — out=$OUT_DIR (LOCAL_MODE=$LOCAL_MODE, SKIP_DAEMON_START=$SKIP_DAEMON_START)"
 for s in "${SCENARIOS[@]}"; do
     dispatch "$s" || true
 done
@@ -277,8 +574,12 @@ log "writing summary.md"
     echo
     echo "Detailed logs:"
     for s in "${SCENARIOS[@]}"; do
+        d="$OUT_DIR/$s"
         echo "- \`$s/log\` (cmd in \`$s/cmd.txt\`)"
+        if [[ -f "$d/daemon-stderr.log" ]]; then
+            echo "  - daemon stderr: \`$s/daemon-stderr.log\`"
+        fi
     done
 } > "$OUT_DIR/summary.md"
 
-log "done — paste $OUT_DIR/summary.md into docs/v0-6-0/host-probe.md"
+log "done — paste $OUT_DIR/summary.md into docs/v0-6-X/host-probe.md"


### PR DESCRIPTION
## Summary

V0.6.1 Wave 1 / W1-T1 (probe-fix teammate) — clears the two V0.6.0 ship-time deferred host-probe gaps:

- **F119** (`docs/v0-6-1/prd.md` §F119): `scripts/host-probe/run-probes.sh` now actively manages the `ccteam-imd` daemon lifecycle in the mode-3 probes (pocket-assistant / im-squad). New `ccteam-imd health` CLI subcommand + `wait_for_health` library fn polls heartbeat freshness (rejects stale leftovers from prior runs).
- **F120** (`docs/v0-6-1/prd.md` §F120): `overnight-builder` scenario is no longer a `ccteam --help` smoke. It scaffolds a fake artifact-driven project, plants a stub `claude` binary (no LLM cost), starts the orchestrator, trips the trigger, and asserts both `agent_spawn` + `agent_done` events land in `progress.jsonl` within 60s.

Also adds `CCTEAM_PROBE_LOCAL=1` knob for PR-review dry-run without SSH, and `CCTEAM_PROBE_SKIP_DAEMON_START=1` for caller-managed daemons.

## Files

| File | Change |
|---|---|
| `crates/ccteam-imd/src/lib.rs` | + `wait_for_health()` + `HealthResult` enum |
| `crates/ccteam-imd/src/main.rs` | + `Health { timeout_seconds, poll_ms }` CLI subcommand |
| `crates/ccteam-imd/tests/daemon_test.rs` | + 3 integration tests |
| `scripts/host-probe/run-probes.sh` | F119 daemon lifecycle + F120 real overnight workflow |
| `scripts/host-probe/README.md` | docs for new env knobs + F119/F120 flow |

## Refs

- `docs/v0-6-1/prd.md` §F119 + §F120
- `docs/v0-6-1/dev-plan.md` Wave 1 — Teammate W1-T1 `probe-fix`
- `CLAUDE.md` §三 `progress.jsonl` SoT red line

## Verification

- baseline: `cargo test --workspace --locked --no-fail-fast` → **1287 pass / 1 fail** (1 = the known `workflow_summary_reflects_agent_spawn_and_done_events` running_count flake from CLAUDE.md §一; +5 over 1282 baseline = 3 new health tests + 1 sanity test + 1 flake flip)
- clippy: `cargo clippy --workspace --all-targets --locked -- -D warnings` → clean
- F119 happy path: `CCTEAM_PROBE_LOCAL=1 ./scripts/host-probe/run-probes.sh pocket-assistant` → rc=0, daemon health-wait + stop verified
- F119 skip path: `CCTEAM_PROBE_LOCAL=1 CCTEAM_PROBE_SKIP_DAEMON_START=1 ./scripts/host-probe/run-probes.sh pocket-assistant` → rc=0, no-op stubs
- script syntax: `bash -n scripts/host-probe/run-probes.sh` → ok

## Test plan

- [x] `wait_for_health` returns Ready when fresh heartbeat arrives
- [x] returns Timeout when no heartbeat
- [x] rejects stale heartbeat (anti-spoof)
- [x] `ccteam-imd health` CLI exit 0 / exit 1
- [x] pocket-assistant probe spawns + health-waits + stops (LOCAL=1)
- [x] SKIP_DAEMON_START honored
- [ ] nas-box005 deploy + pocket-assistant rc=0 + cost.txt non-zero (Wave 1 integration)
- [ ] nas-box005 overnight-builder rc=0 + agent_spawn/done in progress.jsonl (Wave 1 integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)