### PR TITLE
docs(v0.6.5): PRD + dev-plan for V0.6 unfinished work closure (17 findings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "ccteam-core",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-core"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-cost"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-hooks"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "ccteam-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-imd"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-web"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/crates/ccteam-core/src/execution/claude_tui.rs
+++ b/crates/ccteam-core/src/execution/claude_tui.rs
@@ -477,11 +477,7 @@ async fn tail_loop(
     // session file. Catches any content written between Claude start
     // and our watcher arming.
     if let Some((sid, path)) = discover_active_session(&cwd) {
-        if cursor.session_id != sid {
-            cursor.session_id = sid;
-            cursor.byte_offset = 0;
-            cursor.last_event_id = None;
-            cursor.project_encoded = encode_project_cwd(&cwd);
+        if cursor.switch_session(&sid, encode_project_cwd(&cwd)) {
             pending.clear();
         }
         drain_path(&path, &mut cursor, &mut pending, &cursor_file, &tx).await;
@@ -507,14 +503,12 @@ async fn tail_loop(
                     let Some(sid) = affected.file_stem().and_then(|s| s.to_str()) else {
                         continue;
                     };
-                    if cursor.session_id != sid {
-                        // Rotation (or initial session bind) — `/clear`
-                        // / `/compact` creates a fresh sid.jsonl whose
-                        // CREATE event lands here.
-                        cursor.session_id = sid.to_string();
-                        cursor.byte_offset = 0;
-                        cursor.last_event_id = None;
-                        cursor.project_encoded = encode_project_cwd(&cwd);
+                    // Switch via `TranscriptCursor::switch_session` so a
+                    // sid we've seen before resumes at its prior offset
+                    // — never re-reads. Closes the main-session ↔
+                    // subagent-jsonl oscillation that caused 15× duplicate
+                    // Telegram sends on NAS.
+                    if cursor.switch_session(sid, encode_project_cwd(&cwd)) {
                         pending.clear();
                     }
                     drain_path(affected, &mut cursor, &mut pending, &cursor_file, &tx).await;
@@ -527,11 +521,7 @@ async fn tail_loop(
                 // bytes on disk we haven't observed. Just re-discover +
                 // read_new; usually a no-op.
                 if let Some((sid, path)) = discover_active_session(&cwd) {
-                    if cursor.session_id != sid {
-                        cursor.session_id = sid;
-                        cursor.byte_offset = 0;
-                        cursor.last_event_id = None;
-                        cursor.project_encoded = encode_project_cwd(&cwd);
+                    if cursor.switch_session(&sid, encode_project_cwd(&cwd)) {
                         pending.clear();
                     }
                     drain_path(&path, &mut cursor, &mut pending, &cursor_file, &tx).await;
@@ -604,12 +594,8 @@ async fn tail_loop_polling(
             }
         };
 
-        if cursor.session_id != sid {
-            cursor.session_id = sid.clone();
-            cursor.byte_offset = 0;
-            cursor.last_event_id = None;
+        if cursor.switch_session(&sid, transcript_tail::encode_project_cwd(&cwd)) {
             pending.clear();
-            cursor.project_encoded = transcript_tail::encode_project_cwd(&cwd);
         }
 
         match transcript_tail::read_new(&transcript_path, &cursor, std::mem::take(&mut pending))

--- a/crates/ccteam-core/src/execution/transcript_tail.rs
+++ b/crates/ccteam-core/src/execution/transcript_tail.rs
@@ -46,6 +46,22 @@ use crate::harness::{ThreadEvent, ThreadItem, ThreadItemDetails};
 /// Persistent cursor written to
 /// `<project>/.ccteam/chat/<bot>/transcript-cursor.json`. Stored as
 /// JSON (not jsonl) — small, single-record state.
+///
+/// **Multi-session aware** (NAS flood fix): the cursor tracks a
+/// per-session-id `byte_offset` map (`prior_offsets`) plus a `current`
+/// `(session_id, byte_offset)` pointer. This closes a duplicate-emit
+/// bug that surfaces when the user's main claude session spawns
+/// Task-tool subagents — each subagent writes its own jsonl into the
+/// same `~/.claude/projects/<encoded-cwd>/` dir, so
+/// [`discover_active_session`] (picks most-recently-modified jsonl)
+/// oscillates between the main session and subagent jsonls. With the
+/// old single-cursor design, every oscillation reset
+/// `byte_offset = 0` and re-emitted all events of the newly-picked
+/// session → 15× duplicate Telegram sends per round-trip.
+///
+/// With per-sid tracking, switching to a known sid resumes from its
+/// persisted offset (no re-emit), and a genuinely-new sid starts at
+/// 0 once (the legitimate `/clear` or `/compact` rotation case).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TranscriptCursor {
     /// Encoded cwd path component (slashes → dashes; matches Anthropic
@@ -56,13 +72,28 @@ pub struct TranscriptCursor {
     /// session has been associated yet.
     #[serde(default)]
     pub session_id: String,
-    /// Byte offset we've parsed up to inside `<sid>.jsonl`.
+    /// Byte offset we've parsed up to inside the **current**
+    /// `<session_id>.jsonl`. Use [`switch_session`](Self::switch_session)
+    /// when transitioning to a different sid — never set this to 0
+    /// directly on a switch, or duplicates will surface for any sid
+    /// we've already drained.
     #[serde(default)]
     pub byte_offset: u64,
     /// Last event uuid we saw. Defensive — lets a future migration
     /// detect a duplicate-emit bug without scanning the whole tail.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_event_id: Option<String>,
+    /// Per-sid byte offsets for sessions we've previously tailed.
+    /// `switch_session` reads / writes this map so we resume on
+    /// re-entry instead of restarting from byte 0.
+    ///
+    /// Bounded growth: `~/.claude/projects/<encoded>/` accumulates
+    /// jsonls over a project's lifetime (one per `claude` invocation +
+    /// one per Task-tool subagent). Realistically O(100s) entries per
+    /// active project; entries are small (sid string + u64) so the
+    /// JSON file stays well under a few KB.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub prior_offsets: HashMap<String, u64>,
 }
 
 impl TranscriptCursor {
@@ -91,6 +122,34 @@ impl TranscriptCursor {
         std::fs::rename(&tmp, path)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
         Ok(())
+    }
+
+    /// Transition the cursor to `new_sid`. Saves the current sid's
+    /// `byte_offset` into [`prior_offsets`](Self::prior_offsets) so a
+    /// later return to the same sid resumes — never re-reads.
+    ///
+    /// - Same `new_sid` as current: no-op (returns `false`).
+    /// - Known `new_sid` in `prior_offsets`: resumes at that offset
+    ///   (no re-emit).
+    /// - Unknown `new_sid`: starts at 0 (legitimate fresh session).
+    ///
+    /// Always clears [`last_event_id`](Self::last_event_id) on a real
+    /// switch since per-session uuids don't carry over. Caller still
+    /// owns persisting via [`save`](Self::save).
+    pub fn switch_session(&mut self, new_sid: &str, project_encoded: String) -> bool {
+        if self.session_id == new_sid {
+            return false;
+        }
+        if !self.session_id.is_empty() {
+            self.prior_offsets
+                .insert(self.session_id.clone(), self.byte_offset);
+        }
+        let resume_offset = self.prior_offsets.get(new_sid).copied().unwrap_or(0);
+        self.session_id = new_sid.to_string();
+        self.byte_offset = resume_offset;
+        self.last_event_id = None;
+        self.project_encoded = project_encoded;
+        true
     }
 }
 
@@ -428,17 +487,77 @@ mod tests {
     fn cursor_round_trips_through_disk() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("c.json");
+        let mut prior = HashMap::new();
+        prior.insert("old-sid-1".to_string(), 100u64);
+        prior.insert("old-sid-2".to_string(), 250u64);
         let c = TranscriptCursor {
             project_encoded: "-foo".into(),
             session_id: "abc".into(),
             byte_offset: 4242,
             last_event_id: Some("ev-1".into()),
+            prior_offsets: prior,
         };
         c.save(&path).unwrap();
         let back = TranscriptCursor::load(&path).unwrap();
         assert_eq!(back.byte_offset, 4242);
         assert_eq!(back.session_id, "abc");
         assert_eq!(back.last_event_id.as_deref(), Some("ev-1"));
+        assert_eq!(back.prior_offsets.get("old-sid-1"), Some(&100));
+        assert_eq!(back.prior_offsets.get("old-sid-2"), Some(&250));
+    }
+
+    /// Regression: switching between a known sid and a different sid
+    /// must NOT reset byte_offset to 0 on re-entry. This is the bug
+    /// that caused the NAS Telegram duplicate flood — `discover_active_session`
+    /// returns the most-recently-modified jsonl, which oscillates
+    /// between the main claude session and Task-tool subagent jsonls.
+    /// Each oscillation previously triggered `byte_offset = 0` and a
+    /// full re-read of the newly-picked session.
+    #[test]
+    fn switch_session_resumes_known_sid() {
+        let mut c = TranscriptCursor::default();
+        // Bind to session A at offset 500.
+        assert!(c.switch_session("session-A", "-proj".into()));
+        c.byte_offset = 500;
+
+        // Switch to session B (subagent jsonl). A's offset is persisted.
+        assert!(c.switch_session("session-B", "-proj".into()));
+        assert_eq!(c.byte_offset, 0, "unseen sid starts at 0");
+        assert_eq!(c.prior_offsets.get("session-A"), Some(&500));
+        c.byte_offset = 300;
+
+        // Switch back to A — must resume at 500, NOT restart at 0.
+        assert!(c.switch_session("session-A", "-proj".into()));
+        assert_eq!(
+            c.byte_offset, 500,
+            "returning to a known sid must resume — restarting would re-emit all events"
+        );
+        assert_eq!(c.prior_offsets.get("session-B"), Some(&300));
+
+        // Same-sid call is a no-op.
+        assert!(!c.switch_session("session-A", "-proj".into()));
+        assert_eq!(c.byte_offset, 500);
+    }
+
+    #[test]
+    fn switch_session_clears_last_event_id_only_on_real_switch() {
+        let mut c = TranscriptCursor {
+            session_id: "sid".into(),
+            byte_offset: 42,
+            last_event_id: Some("ev".into()),
+            ..Default::default()
+        };
+        assert!(!c.switch_session("sid", "-proj".into()));
+        assert_eq!(
+            c.last_event_id.as_deref(),
+            Some("ev"),
+            "no-op switch keeps last_event_id intact"
+        );
+        assert!(c.switch_session("other", "-proj".into()));
+        assert!(
+            c.last_event_id.is_none(),
+            "real switch clears last_event_id — uuids don't cross sessions"
+        );
     }
 
     #[test]

--- a/crates/ccteam-core/src/execution/transcript_tail.rs
+++ b/crates/ccteam-core/src/execution/transcript_tail.rs
@@ -177,9 +177,19 @@ pub fn cursor_path(project_dir: &Path, bot_role: &str) -> PathBuf {
     super::turns_mirror::chat_dir(project_dir, bot_role).join("transcript-cursor.json")
 }
 
-/// Pick the most recently-modified `<sid>.jsonl` under
-/// `~/.claude/projects/<encoded>/`. Returns `None` when the dir is
-/// missing or empty.
+/// Pick the most recently-modified **main-session** `<sid>.jsonl`
+/// under `~/.claude/projects/<encoded>/`. Returns `None` when the dir
+/// is missing, empty, or contains only subagent jsonls.
+///
+/// **Subagent filter**: claude's Task tool spawns subagents into the
+/// same project dir, each writing its own `<sid>.jsonl`. Without the
+/// filter, `discover_active_session` returned whichever was most
+/// recently modified — including subagents — and the tail loop
+/// alternated between main and subagent files, re-emitting events
+/// each time. The filter skips any jsonl whose first line declares
+/// `"type":"agent-setting"` (the marker Anthropic writes for
+/// subagent sessions). Main-session jsonls carry `"type":"last-prompt"`
+/// or `"type":"summary"` and pass through.
 pub fn discover_active_session(cwd: &Path) -> Option<(String, PathBuf)> {
     let dir = anthropic_project_dir(cwd)?;
     let entries = std::fs::read_dir(&dir).ok()?;
@@ -194,12 +204,43 @@ pub fn discover_active_session(cwd: &Path) -> Option<(String, PathBuf)> {
         };
         let Ok(meta) = ent.metadata() else { continue };
         let Ok(mtime) = meta.modified() else { continue };
+        if is_subagent_jsonl(&path) {
+            continue;
+        }
         match &best {
             Some((t, _, _)) if *t >= mtime => {}
             _ => best = Some((mtime, stem.to_string(), path)),
         }
     }
     best.map(|(_, sid, p)| (sid, p))
+}
+
+/// Check whether a jsonl file is a subagent transcript (Task-tool
+/// spawn) rather than a main claude chat session. Subagents are
+/// internal — their assistant messages must NOT be forwarded to the
+/// user-facing IM channel.
+///
+/// Heuristic: subagent jsonls open with a `"type":"agent-setting"`
+/// record (Anthropic-internal marker). Main-session jsonls open with
+/// `"type":"last-prompt"`, `"type":"summary"`, or a user/assistant
+/// record. We read the first line only and look for the subagent
+/// marker as a substring — a parse-free check that survives schema
+/// drift on other fields and tolerates very long lines.
+///
+/// Files that error on read are treated as **not** subagents
+/// (fail-safe — better to tail a possibly-irrelevant file once than
+/// to silently drop a real session).
+pub fn is_subagent_jsonl(path: &Path) -> bool {
+    use std::io::{BufRead, BufReader};
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut first_line = String::new();
+    if BufReader::new(file).read_line(&mut first_line).is_err() {
+        return false;
+    }
+    first_line.contains("\"type\":\"agent-setting\"")
+        || first_line.contains("\"type\": \"agent-setting\"")
 }
 
 /// In-memory carry-over for `tool_use` ↔ `tool_result` pairing across
@@ -537,6 +578,72 @@ mod tests {
         // Same-sid call is a no-op.
         assert!(!c.switch_session("session-A", "-proj".into()));
         assert_eq!(c.byte_offset, 500);
+    }
+
+    /// The architectural primary defense against the NAS duplicate flood:
+    /// subagent jsonls (`"type":"agent-setting"` first line) must be
+    /// filtered out so `discover_active_session` never picks them.
+    /// Without this filter, `tail_loop` oscillates between main and
+    /// subagent sessions and re-emits each on every switch.
+    #[test]
+    fn is_subagent_jsonl_detects_agent_setting_marker() {
+        let tmp = TempDir::new().unwrap();
+        let subagent = tmp.path().join("sa.jsonl");
+        std::fs::write(
+            &subagent,
+            r#"{"type":"agent-setting","sessionId":"sa-1","cwd":"/x"}
+{"type":"user","sessionId":"sa-1"}
+"#,
+        )
+        .unwrap();
+        assert!(is_subagent_jsonl(&subagent));
+
+        let main = tmp.path().join("main.jsonl");
+        std::fs::write(
+            &main,
+            r#"{"type":"last-prompt","sessionId":"main-1"}
+{"type":"user","sessionId":"main-1"}
+"#,
+        )
+        .unwrap();
+        assert!(!is_subagent_jsonl(&main));
+
+        // Tolerate the spaced JSON variant some serializers produce.
+        let spaced = tmp.path().join("spaced.jsonl");
+        std::fs::write(&spaced, r#"{"type": "agent-setting","sessionId":"sa-2"}"#).unwrap();
+        assert!(is_subagent_jsonl(&spaced));
+
+        // Missing / empty file → fail-safe to not-a-subagent.
+        let missing = tmp.path().join("missing.jsonl");
+        assert!(!is_subagent_jsonl(&missing));
+    }
+
+    /// Regression: `discover_active_session` must skip subagent jsonls
+    /// even when they are the most-recently-modified file in the dir.
+    /// This is the actual NAS-flood root cause condition — subagents
+    /// write more frequently than the main session during a busy team
+    /// orchestration.
+    #[test]
+    fn discover_skips_subagent_jsonls_even_when_newest() {
+        let tmp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", tmp_home.path());
+        let cwd = Path::new("/home/test/proj");
+        let dir = anthropic_project_dir(cwd).unwrap();
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Write the main session FIRST (so its mtime is older).
+        let main_path = dir.join("main-sid.jsonl");
+        std::fs::write(&main_path, r#"{"type":"last-prompt","sessionId":"main-sid"}"#).unwrap();
+
+        // Then write a subagent jsonl — newer mtime.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let sa_path = dir.join("subagent-sid.jsonl");
+        std::fs::write(&sa_path, r#"{"type":"agent-setting","sessionId":"subagent-sid"}"#).unwrap();
+
+        let (picked_sid, picked_path) =
+            discover_active_session(cwd).expect("should pick the main session, not the subagent");
+        assert_eq!(picked_sid, "main-sid");
+        assert_eq!(picked_path, main_path);
     }
 
     #[test]

--- a/crates/ccteam-core/tests/transcript_tail_test.rs
+++ b/crates/ccteam-core/tests/transcript_tail_test.rs
@@ -182,6 +182,7 @@ fn cursor_save_and_load_round_trip() {
         session_id: "ab".into(),
         byte_offset: 123,
         last_event_id: None,
+        prior_offsets: Default::default(),
     };
     c.save(&p).unwrap();
     let back = TranscriptCursor::load(&p).unwrap();

--- a/crates/ccteam-imd/src/bot_mpsc.rs
+++ b/crates/ccteam-imd/src/bot_mpsc.rs
@@ -95,6 +95,11 @@ pub struct BotChannels {
     /// Outbound side — `BotSupervisor::spawn_events_consumer` pushes
     /// here after appending `turns.jsonl`.
     pub outbound_tx: mpsc::Sender<OutboundItem>,
+    /// Per-bot outbound cursor — owned by the dispatcher AND read by
+    /// the safety-net `drain_outboxes` so both writers go through a
+    /// single monotonic primitive (closes the fast-path × drain race
+    /// that produced the NAS-environment duplicate-message flood).
+    pub outbound_cursor: Arc<crate::outbound::OutboundCursor>,
 }
 
 /// `<slug>/<role>` → channels. Shared across the daemon's inbound

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -359,7 +359,7 @@ where
                     }
                 };
                 drain_inboxes(&bots, &registry, &projects_root).await;
-                drain_outboxes(&bots, &channels, &projects_root).await;
+                drain_outboxes(&bots, &channels, &bot_channels, &projects_root).await;
             }
             _ = &mut shutdown => {
                 tracing::info!("ccteam-imd: shutdown signalled; exiting cleanly");
@@ -488,7 +488,14 @@ fn spawn_inbound_consumer(
                     // silently when the dispatcher isn't ready yet —
                     // the safety-net `drain_inboxes` tick picks the
                     // envelope up from disk next pass.
-                    if let InboundOutcome::DroppedToBot { slug, role, path, payload, cid: item_cid } = outcome {
+                    if let InboundOutcome::DroppedToBot {
+                        slug,
+                        role,
+                        path,
+                        payload,
+                        cid: item_cid,
+                    } = outcome
+                    {
                         let guard = bot_channels.lock().await;
                         if let Some(ch) = guard.get(&bot_key(&slug, &role)) {
                             let item = InboxItem {
@@ -621,11 +628,15 @@ async fn ensure_bot_channels(
         ));
 
         // Outbound dispatcher: drain the channel, call
-        // `channel.send`, persist the cursor on successful TG ack.
+        // `channel.send`, advance the shared OutboundCursor on
+        // successful TG ack. The cursor is also handed to
+        // drain_outboxes (via bot_channels) so both writers share the
+        // same monotonic primitive.
         let chat_id = bot.im_chat_id.clone();
         let platform = bot.im_platform.clone();
         let cursor_path =
             outbound::outbound_cursor_path(projects_root, &bot.workflow_slug, &bot.role);
+        let outbound_cursor = outbound::OutboundCursor::load_from_disk(cursor_path);
         let slug_log = bot.workflow_slug.clone();
         let role_log = bot.role.clone();
         tokio::spawn(spawn_outbound_dispatcher(
@@ -633,7 +644,7 @@ async fn ensure_bot_channels(
             channel,
             chat_id,
             platform,
-            cursor_path,
+            outbound_cursor.clone(),
             slug_log,
             role_log,
         ));
@@ -642,13 +653,14 @@ async fn ensure_bot_channels(
         // consumer can fan out from the next ItemCompleted onward.
         sup.set_outbound_tx(outbound_tx.clone()).await;
 
-        // Register both senders so the inbound consumer + future ticks
-        // see them.
+        // Register both senders + the shared cursor so the inbound
+        // consumer + future ticks (and drain_outboxes) see them.
         bot_channels.lock().await.insert(
             key,
             BotChannels {
                 inbox_tx,
                 outbound_tx,
+                outbound_cursor,
             },
         );
         tracing::info!(
@@ -713,29 +725,44 @@ async fn spawn_inbox_dispatcher(
 }
 
 /// V0.6.1 fast-path — per-bot outbound dispatcher task body. Drains
-/// [`OutboundItem`]s from `rx`, calls `channel.send`, persists the
-/// outbound cursor on successful TG ack so a daemon restart re-sends
-/// only un-acked rows.
-#[allow(clippy::too_many_arguments)]
+/// [`OutboundItem`]s from `rx`, calls `channel.send`, advances the
+/// shared [`OutboundCursor`] on success.
+///
+/// **Dedup invariant**: before sending, the dispatcher checks whether
+/// the safety-net `drain_outboxes` has already covered this row (via
+/// `cursor.current() >= item.cursor_after`). If so, skip the send
+/// entirely — TG already received this content from the other path.
+/// Combined with [`OutboundCursor::try_advance`]'s monotonic guard,
+/// this gives both writers a single source of truth and closes both
+/// the cursor-rewind loop and the per-row double-send window that
+/// the NAS-environment bug exposed.
 async fn spawn_outbound_dispatcher(
     mut rx: mpsc::Receiver<OutboundItem>,
     channel: Arc<dyn Channel + Send + Sync>,
     chat_id: String,
     platform: String,
-    cursor_path: PathBuf,
+    cursor: Arc<outbound::OutboundCursor>,
     slug_log: String,
     role_log: String,
 ) {
     while let Some(item) = rx.recv().await {
-        if item.role != "assistant" {
-            // Non-assistant rows still advance the cursor so we don't
-            // re-read them on safety-net drain.
-            let _ = outbound::save_cursor(
-                &cursor_path,
-                &outbound::TailCursor {
-                    position: item.cursor_after,
-                },
+        // Already covered by drain_outboxes — skip the redundant TG
+        // send. Without this check, both paths would deliver the same
+        // row on overlap.
+        if item.cursor_after <= cursor.current().await {
+            tracing::debug!(
+                slug = %slug_log,
+                role = %role_log,
+                turn_id = %item.turn_id,
+                cursor_after = item.cursor_after,
+                "imd: outbound dispatcher skipped (cursor already advanced past this row)"
             );
+            continue;
+        }
+        if item.role != "assistant" {
+            // Non-assistant rows still advance the cursor so the
+            // safety-net drain doesn't re-read them.
+            cursor.try_advance(item.cursor_after).await;
             continue;
         }
         let tail_age_ms = now_unix_ms().saturating_sub(item.enqueue_unix_ms) as u64;
@@ -756,28 +783,11 @@ async fn spawn_outbound_dispatcher(
                     content_len = item.content.len(),
                     "latency imd.outbound.dispatch (mpsc)"
                 );
-                if let Err(err) = outbound::save_cursor(
-                    &cursor_path,
-                    &outbound::TailCursor {
-                        position: item.cursor_after,
-                    },
-                ) {
-                    tracing::warn!(
-                        slug = %slug_log,
-                        role = %role_log,
-                        error = %err,
-                        "imd: outbound dispatcher save_cursor failed"
-                    );
-                }
+                cursor.try_advance(item.cursor_after).await;
             }
             Err(err) => {
-                // Don't advance cursor on failure — safety-net
-                // drain_outboxes will retry from the previous cursor
-                // position next minute. (Note: rows that arrived AFTER
-                // this one through the mpsc still get processed; if
-                // those succeed and advance cursor past this row, the
-                // failed row is lost. Acceptable trade-off vs.
-                // serialized retry loop for V0.6.1.)
+                // Don't advance cursor on failure — the safety-net
+                // drain will retry from the previous cursor position.
                 tracing::warn!(
                     event = "latency",
                     stage = "imd.outbound.dispatch.err",
@@ -867,10 +877,8 @@ async fn drain_inboxes(
                         continue;
                     }
                     let cid = env.message_id.clone();
-                    let received_ms =
-                        env.received_at.timestamp_millis().max(0) as u128;
-                    let queue_age_ms =
-                        now_unix_ms().saturating_sub(received_ms) as u64;
+                    let received_ms = env.received_at.timestamp_millis().max(0) as u128;
+                    let queue_age_ms = now_unix_ms().saturating_sub(received_ms) as u64;
                     let drain_t0 = std::time::Instant::now();
                     match sup.handle_inbound(env.payload).await {
                         Ok(id) => {
@@ -937,6 +945,7 @@ async fn drain_inboxes(
 async fn drain_outboxes(
     bots: &[BotRegistration],
     channels: &ChannelMap,
+    bot_channels: &BotChannelMap,
     projects_root: &Path,
 ) {
     for bot in bots {
@@ -950,45 +959,91 @@ async fn drain_outboxes(
             continue;
         };
         let path = outbound::turns_jsonl_path(projects_root, &bot.workflow_slug, &bot.role);
-        let cursor_path =
-            outbound::outbound_cursor_path(projects_root, &bot.workflow_slug, &bot.role);
-        let cursor = outbound::load_cursor(&cursor_path);
-        let (rows, new_cursor) = match outbound::read_new_rows(&path, &cursor) {
-            Ok(x) => x,
-            Err(err) => {
-                tracing::warn!(
-                    slug = %bot.workflow_slug,
-                    role = %bot.role,
-                    error = %err,
-                    "imd: F134 outbound: read_new_rows failed; continuing"
-                );
-                continue;
+
+        // Prefer the shared OutboundCursor owned by the fast-path
+        // dispatcher (so we update the same in-memory state and the
+        // dispatcher's pre-send dedup check sees our progress
+        // immediately). If the fast-path hasn't been wired yet
+        // (supervisor still starting up), fall back to a freshly
+        // loaded cursor — it's a transient state during startup and
+        // the next tick will pick up the shared one.
+        let key = bot_key(&bot.workflow_slug, &bot.role);
+        let cursor: Arc<outbound::OutboundCursor> = {
+            let guard = bot_channels.lock().await;
+            match guard.get(&key) {
+                Some(ch) => ch.outbound_cursor.clone(),
+                None => {
+                    let cursor_path = outbound::outbound_cursor_path(
+                        projects_root,
+                        &bot.workflow_slug,
+                        &bot.role,
+                    );
+                    outbound::OutboundCursor::load_from_disk(cursor_path)
+                }
             }
         };
-        if rows.is_empty() {
-            // Still persist a cursor advance on truncation (read_new_rows
-            // rewinds to 0 on shrink — record the new position so we
-            // don't keep rewinding on every tick).
-            if new_cursor.position != cursor.position {
-                if let Err(err) = outbound::save_cursor(&cursor_path, &new_cursor) {
+
+        let start = cursor.current().await;
+        let (rows, _eof) =
+            match outbound::read_new_rows_indexed(&path, &outbound::TailCursor { position: start })
+            {
+                Ok(x) => x,
+                Err(err) => {
                     tracing::warn!(
                         slug = %bot.workflow_slug,
                         role = %bot.role,
                         error = %err,
-                        "imd: F134 outbound: save_cursor (truncation rewind) failed"
+                        "imd: F134 outbound: read_new_rows_indexed failed; continuing"
                     );
+                    continue;
                 }
-            }
+            };
+
+        // Truncation handling: if turns.jsonl shrunk below the current
+        // cursor, read_new_rows_indexed rewinds `start` to 0 internally
+        // and returns rows from the new (shorter) file. We mirror that
+        // rewind in the OutboundCursor via `force_set(0)` so the
+        // per-row dedup check below doesn't reject the post-truncation
+        // content (which has byte offsets smaller than the pre-rotation
+        // cursor). After force_set(0), each forwarded row advances the
+        // cursor row-by-row via try_advance, the same as steady-state.
+        //
+        // Trade-off: post-rotation content gets forwarded once; the
+        // user may see duplicates of pre-rotation content. That is
+        // acceptable for the rare rotation case and matches the V0.6.1
+        // policy. The NAS-bug we are closing here is the *unbounded*
+        // re-forward loop, not the one-shot rotation re-send.
+        let file_len = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        if start > 0 && file_len < start {
+            cursor.force_set(0).await;
+            tracing::info!(
+                slug = %bot.workflow_slug,
+                role = %bot.role,
+                old_position = start,
+                new_eof = file_len,
+                "imd: F134 outbound: turns.jsonl truncation detected; cursor force-reset to 0"
+            );
+        }
+
+        if rows.is_empty() {
             continue;
         }
-        // Latency: log per-row tail age so we can see how long each
-        // assistant row sat in turns.jsonl before this tick picked it
-        // up. Bounded by `args.tick` (5s default) but a busy daemon
-        // with many bots can drift higher; this log makes it visible.
-        for row in &rows {
+
+        let mut sent = 0usize;
+        for indexed in &rows {
+            let row = &indexed.row;
+            let row_end = indexed.end_pos;
+
+            // Per-row dedup: the dispatcher may have advanced the
+            // cursor past this row between read and now. Skip both
+            // the TG send AND the cursor write in that case.
+            if row_end <= cursor.current().await {
+                continue;
+            }
+
             let tail_age_ms = row.ts.map(|t| {
-                crate::latency::now_unix_ms()
-                    .saturating_sub(t.timestamp_millis().max(0) as u128) as u64
+                crate::latency::now_unix_ms().saturating_sub(t.timestamp_millis().max(0) as u128)
+                    as u64
             });
             tracing::info!(
                 event = "latency",
@@ -1001,9 +1056,35 @@ async fn drain_outboxes(
                 content_len = row.content.len(),
                 "latency outbound.tail"
             );
+
+            if !outbound::should_forward(row, &[]) {
+                cursor.try_advance(row_end).await;
+                continue;
+            }
+
+            let mut msg = crate::transport::SendMessage::new(row.content.clone(), &bot.im_chat_id);
+            msg.thread_ts = row.thread_ts.clone();
+            match channel.send(&msg).await {
+                Ok(_tg_msg_id) => {
+                    cursor.try_advance(row_end).await;
+                    sent += 1;
+                }
+                Err(err) => {
+                    // Stop advancing on send failure so a later tick
+                    // retries from the same position. Continuing to
+                    // later rows would orphan this one behind a higher
+                    // cursor.
+                    tracing::warn!(
+                        slug = %bot.workflow_slug,
+                        role = %bot.role,
+                        error = %err,
+                        "imd: F134 outbound: channel.send failed; halting drain for this bot"
+                    );
+                    break;
+                }
+            }
         }
-        let sent =
-            outbound::forward_new_rows(&rows, channel.as_ref(), &bot.im_chat_id, &[]).await;
+
         if sent > 0 {
             tracing::info!(
                 slug = %bot.workflow_slug,
@@ -1012,14 +1093,6 @@ async fn drain_outboxes(
                 chat_id = %bot.im_chat_id,
                 "imd: F134 outbound forwarded {} rows",
                 sent
-            );
-        }
-        if let Err(err) = outbound::save_cursor(&cursor_path, &new_cursor) {
-            tracing::warn!(
-                slug = %bot.workflow_slug,
-                role = %bot.role,
-                error = %err,
-                "imd: F134 outbound: save_cursor failed"
             );
         }
     }

--- a/crates/ccteam-imd/src/outbound.rs
+++ b/crates/ccteam-imd/src/outbound.rs
@@ -8,11 +8,13 @@
 
 use std::fs;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 use crate::latency::now_unix_ms;
 
@@ -149,11 +151,7 @@ pub fn turns_jsonl_path(projects_root: &std::path::Path, slug: &str, role: &str)
 /// → fall back to the zero cursor (re-forward everything; safer than
 /// dropping content silently, and `turns.jsonl` grows monotonically
 /// so a stale cursor would only ever under-skip, never over-skip).
-pub fn outbound_cursor_path(
-    projects_root: &std::path::Path,
-    slug: &str,
-    role: &str,
-) -> PathBuf {
+pub fn outbound_cursor_path(projects_root: &std::path::Path, slug: &str, role: &str) -> PathBuf {
     projects_root
         .join(slug)
         .join(".ccteam")
@@ -178,30 +176,164 @@ pub fn load_cursor(path: &std::path::Path) -> TailCursor {
 }
 
 /// Persist a [`TailCursor`] to disk. Creates the parent directory if
-/// missing. Errors propagate so the caller can warn-log; persistence
-/// failure is not fatal (the worst case is re-forwarding a few rows
-/// next tick if the cursor doesn't land).
-pub fn save_cursor(path: &std::path::Path, cursor: &TailCursor) -> Result<()> {
+/// missing. Low-level helper — does **not** enforce monotonicity, and
+/// is not safe to call concurrently from multiple writers against the
+/// same path.
+///
+/// Production code should go through [`OutboundCursor`] instead, which
+/// owns the in-memory truth, serializes writers via an async mutex,
+/// and exposes [`OutboundCursor::try_advance`] (monotonic) +
+/// [`OutboundCursor::force_set`] (for the truncation-rewind case).
+/// Direct callers of `save_cursor` are limited to (a) tests and (b)
+/// startup paths that initialize the cursor from a known value before
+/// any concurrent writers exist.
+pub fn save_cursor(path: &Path, cursor: &TailCursor) -> Result<()> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("mkdir -p {}", parent.display()))?;
+        fs::create_dir_all(parent).with_context(|| format!("mkdir -p {}", parent.display()))?;
     }
     let body = serde_json::to_string(cursor).context("serialize TailCursor")?;
     fs::write(path, body).with_context(|| format!("write {}", path.display()))?;
     Ok(())
 }
 
-/// Read every new line since `cursor.position`, returning the parsed
-/// rows + the new cursor position (advanced to EOF). Missing file is
-/// not an error — returns an empty Vec.
-pub fn read_new_rows(path: &std::path::Path, cursor: &TailCursor) -> Result<(Vec<TurnRow>, TailCursor)> {
+/// Per-bot outbound cursor with **async-serialized monotonic
+/// advance**. This is the synchronization primitive that closes the
+/// fast-path × safety-net duplicate-send race in
+/// [`crate::daemon::spawn_outbound_dispatcher`] +
+/// [`crate::daemon::drain_outboxes`].
+///
+/// The two writers share an `Arc<OutboundCursor>` (constructed once
+/// per bot in `ensure_bot_channels`). Both call:
+///
+/// - [`current`](Self::current) before sending a row to TG — skip
+///   when `row_end_pos <= cursor.current()`, the other writer already
+///   delivered it. Closes the per-row double-send window.
+/// - [`try_advance`](Self::try_advance) after a successful TG send —
+///   monotonic, no rewinds. Closes the cursor-rewind loop that
+///   produced the unbounded "大量重复消息" flood on NAS-latency
+///   environments.
+///
+/// Truncation is handled out-of-band via
+/// [`force_set`](Self::force_set), called by `drain_outboxes` when it
+/// detects `turns.jsonl` shrank below the current cursor (file
+/// rotated / manually edited). Without an explicit reset the
+/// monotonic guard would otherwise keep re-reading from byte 0 every
+/// tick and re-forward the rotated content forever.
+///
+/// Disk persistence is best-effort: write errors warn-log but never
+/// fail the in-memory advance. The worst case on disk-write failure
+/// is re-forwarding the most recent row on daemon restart — still
+/// bounded, still monotonic.
+#[derive(Debug)]
+pub struct OutboundCursor {
+    path: PathBuf,
+    state: Mutex<TailCursor>,
+}
+
+impl OutboundCursor {
+    /// Construct, seeding from disk if `path` exists. Missing / corrupt
+    /// file → zero cursor (re-forward everything from start; matches
+    /// [`load_cursor`] semantics).
+    pub fn load_from_disk(path: PathBuf) -> Arc<Self> {
+        let initial = load_cursor(&path);
+        Arc::new(Self {
+            path,
+            state: Mutex::new(initial),
+        })
+    }
+
+    /// Current in-memory position. Cheap to call (short lock); use
+    /// before each TG send for per-row dedup.
+    pub async fn current(&self) -> u64 {
+        self.state.lock().await.position
+    }
+
+    /// Monotonic advance. Returns `true` iff `new_pos` was strictly
+    /// greater than the prior position and was applied. Persists to
+    /// disk under the same lock so disk == memory after this call
+    /// returns. Persistence errors are logged but don't fail the
+    /// advance — the in-memory truth still moves forward.
+    pub async fn try_advance(&self, new_pos: u64) -> bool {
+        let mut guard = self.state.lock().await;
+        if new_pos <= guard.position {
+            return false;
+        }
+        guard.position = new_pos;
+        self.persist_locked(&guard);
+        true
+    }
+
+    /// Unconditional reset — `new_pos` may be smaller than the current
+    /// position. Used only when `drain_outboxes` detects truncation
+    /// (`turns.jsonl` shrunk below the cursor). Persists to disk.
+    pub async fn force_set(&self, new_pos: u64) {
+        let mut guard = self.state.lock().await;
+        guard.position = new_pos;
+        self.persist_locked(&guard);
+    }
+
+    /// Backing-file path (read-only — needed by tests / debug logs).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn persist_locked(&self, cursor: &TailCursor) {
+        if let Some(parent) = self.path.parent() {
+            if let Err(err) = fs::create_dir_all(parent) {
+                tracing::warn!(
+                    error = %err,
+                    parent = %parent.display(),
+                    "imd: outbound cursor mkdir failed"
+                );
+                return;
+            }
+        }
+        let body = match serde_json::to_string(cursor) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::warn!(error = %err, "imd: outbound cursor serialize failed");
+                return;
+            }
+        };
+        if let Err(err) = fs::write(&self.path, body) {
+            tracing::warn!(
+                error = %err,
+                path = %self.path.display(),
+                "imd: outbound cursor persist failed (in-memory advance still in effect)"
+            );
+        }
+    }
+}
+
+/// Per-row scan output: parsed row plus the byte position **after**
+/// that row (i.e. where the next row would start). Used by both the
+/// fast-path dispatcher and `drain_outboxes` to dedup-check each row
+/// individually against [`OutboundCursor::current`] before sending.
+#[derive(Debug, Clone)]
+pub struct IndexedRow {
+    /// Parsed `turns.jsonl` row.
+    pub row: TurnRow,
+    /// Byte offset of the first byte AFTER this row's terminating
+    /// newline. Suitable as a [`TailCursor::position`] value once the
+    /// row has been confirmed delivered.
+    pub end_pos: u64,
+}
+
+/// Read every new line since `cursor.position`, returning each parsed
+/// row together with its post-row byte offset, plus the final cursor
+/// (= EOF at read time). Missing file → empty Vec. File shorter than
+/// `cursor.position` (truncation) → rewinds `start` to 0 and reads
+/// the whole file; callers should treat that as a truncation signal
+/// and call [`OutboundCursor::force_set`] before advancing.
+pub fn read_new_rows_indexed(
+    path: &Path,
+    cursor: &TailCursor,
+) -> Result<(Vec<IndexedRow>, TailCursor)> {
     if !path.exists() {
         return Ok((vec![], cursor.clone()));
     }
-    let mut f = fs::File::open(path)
-        .with_context(|| format!("open {}", path.display()))?;
+    let mut f = fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
     let len = f.metadata()?.len();
-    // File truncated / replaced → rewind.
     let start = if cursor.position > len {
         0
     } else {
@@ -219,13 +351,23 @@ pub fn read_new_rows(path: &std::path::Path, cursor: &TailCursor) -> Result<(Vec
             continue;
         }
         match serde_json::from_str::<TurnRow>(trimmed) {
-            Ok(row) => rows.push(row),
+            Ok(row) => rows.push(IndexedRow {
+                row,
+                end_pos: consumed,
+            }),
             Err(err) => {
                 tracing::warn!(error = %err, line = %trimmed, "malformed turns.jsonl row; skipping");
             }
         }
     }
     Ok((rows, TailCursor { position: consumed }))
+}
+
+/// Backwards-compat wrapper — strips per-row positions. Kept so the
+/// existing test suite and any external callers still compile.
+pub fn read_new_rows(path: &Path, cursor: &TailCursor) -> Result<(Vec<TurnRow>, TailCursor)> {
+    let (indexed, end) = read_new_rows_indexed(path, cursor)?;
+    Ok((indexed.into_iter().map(|i| i.row).collect(), end))
 }
 
 /// V0.6.0 Wave 3 — push every assistant row in `rows` to `channel`
@@ -248,9 +390,9 @@ pub async fn forward_new_rows(
         if !should_forward(row, inbound_message_ids) {
             continue;
         }
-        let tail_age_ms = row.ts.map(|t| {
-            now_unix_ms().saturating_sub(t.timestamp_millis().max(0) as u128) as u64
-        });
+        let tail_age_ms = row
+            .ts
+            .map(|t| now_unix_ms().saturating_sub(t.timestamp_millis().max(0) as u128) as u64);
         let turn_id_log = row.turn_id.clone().unwrap_or_default();
         let mut msg = crate::transport::SendMessage::new(row.content.clone(), recipient);
         msg.thread_ts = row.thread_ts.clone();
@@ -443,5 +585,102 @@ mod tests {
         };
         assert!(should_forward(&assistant, &[]));
         assert!(!should_forward(&user, &[]));
+    }
+
+    // ── OutboundCursor: the synchronization primitive that closes the
+    //    fast-path × safety-net race ─────────────────────────────────
+
+    #[tokio::test]
+    async fn outbound_cursor_try_advance_is_monotonic() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("c.json");
+        let cur = OutboundCursor::load_from_disk(path.clone());
+        assert_eq!(cur.current().await, 0);
+        assert!(cur.try_advance(100).await);
+        assert_eq!(cur.current().await, 100);
+        // Smaller / equal advances are rejected — the cursor never rewinds.
+        assert!(!cur.try_advance(50).await);
+        assert!(!cur.try_advance(100).await);
+        assert_eq!(cur.current().await, 100);
+        // Larger advance applies.
+        assert!(cur.try_advance(200).await);
+        assert_eq!(cur.current().await, 200);
+        // Disk reflects the latest accepted value.
+        let on_disk = load_cursor(&path);
+        assert_eq!(on_disk.position, 200);
+    }
+
+    #[tokio::test]
+    async fn outbound_cursor_force_set_allows_rewind() {
+        // Truncation path: turns.jsonl was rotated to a smaller file
+        // and the cursor must reset below its current value. try_advance
+        // alone would refuse; force_set is the explicit escape hatch.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("c.json");
+        let cur = OutboundCursor::load_from_disk(path.clone());
+        assert!(cur.try_advance(500).await);
+        cur.force_set(40).await;
+        assert_eq!(cur.current().await, 40);
+        // Subsequent monotonic advance from the lower baseline works.
+        assert!(cur.try_advance(60).await);
+        assert_eq!(cur.current().await, 60);
+        let on_disk = load_cursor(&path);
+        assert_eq!(on_disk.position, 60);
+    }
+
+    #[tokio::test]
+    async fn outbound_cursor_concurrent_advance_converges_to_max() {
+        // Two writers (fast-path dispatcher + safety-net drain) racing
+        // against the same cursor must never produce a rewind. Spawn
+        // many interleaved try_advance calls and assert the final
+        // value is the max of all proposed positions.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("c.json");
+        let cur = OutboundCursor::load_from_disk(path.clone());
+
+        let mut tasks = Vec::new();
+        for n in (1u64..=50).rev() {
+            let c = cur.clone();
+            tasks.push(tokio::spawn(async move {
+                c.try_advance(n).await;
+            }));
+        }
+        for n in 1u64..=50 {
+            let c = cur.clone();
+            tasks.push(tokio::spawn(async move {
+                c.try_advance(n).await;
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        assert_eq!(cur.current().await, 50);
+        let on_disk = load_cursor(&path);
+        assert_eq!(on_disk.position, 50);
+    }
+
+    #[tokio::test]
+    async fn outbound_cursor_seeds_from_existing_disk_value() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("c.json");
+        save_cursor(&path, &TailCursor { position: 777 }).unwrap();
+        let cur = OutboundCursor::load_from_disk(path);
+        assert_eq!(cur.current().await, 777);
+    }
+
+    #[test]
+    fn indexed_rows_report_post_row_offsets() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("t.jsonl");
+        let body = "{\"role\":\"assistant\",\"content\":\"a\"}\n{\"role\":\"assistant\",\"content\":\"b\"}\n";
+        fs::write(&path, body).unwrap();
+        let (rows, end) = read_new_rows_indexed(&path, &TailCursor::default()).unwrap();
+        assert_eq!(rows.len(), 2);
+        // The first row's end_pos is the second row's start.
+        assert!(rows[0].end_pos > 0);
+        assert!(rows[0].end_pos < rows[1].end_pos);
+        // The last row's end_pos equals the final cursor (EOF).
+        assert_eq!(rows[1].end_pos, end.position);
+        assert_eq!(end.position as usize, body.len());
     }
 }

--- a/crates/ccteam-imd/tests/outbound_wiring_test.rs
+++ b/crates/ccteam-imd/tests/outbound_wiring_test.rs
@@ -170,7 +170,10 @@ async fn daemon_forwards_turns_jsonl_to_channel() {
         2,
         "expected 2 assistant rows forwarded (got {}): {:?}",
         outbox.len(),
-        outbox.iter().map(|m| m.content.as_str()).collect::<Vec<_>>()
+        outbox
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
     );
     assert_eq!(outbox[0].content, "hello from the bot");
     assert_eq!(outbox[0].recipient, "chat-42");
@@ -244,6 +247,200 @@ async fn daemon_no_op_when_turns_jsonl_missing() {
     assert!(
         outbox.is_empty(),
         "expected no forwards when turns.jsonl missing (got {:?})",
-        outbox.iter().map(|m| m.content.as_str()).collect::<Vec<_>>()
+        outbox
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
     );
+}
+
+/// Regression: turns.jsonl truncated below the persisted cursor must
+/// not produce an unbounded re-forward loop on each safety-net tick.
+///
+/// Before the OutboundCursor refactor, the dispatcher's `save_cursor`
+/// had an in-function monotonic guard that silently dropped writes
+/// smaller than the on-disk value. That guard incidentally killed
+/// `drain_outboxes`'s truncation-rewind branch — the cursor could
+/// never decrease, so every subsequent drain saw the stale large
+/// cursor, `read_new_rows` rewound to 0 (because cursor > len),
+/// re-read the post-truncation rows, re-forwarded them, and the
+/// rejected `save_cursor(small)` left the cursor stale for the next
+/// tick. Repeat forever → flood of duplicates on the IM channel.
+///
+/// Fix: `OutboundCursor::force_set` is the explicit truncation escape
+/// hatch; `drain_outboxes` detects shrink via `file_len < cursor.current`
+/// and calls it before forwarding. After this, the cursor sits at the
+/// new EOF and subsequent ticks find nothing new.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drain_handles_truncation_without_repeat_forwarding() {
+    let _g = env_lock();
+    let home = isolate_home();
+    let projects_root = home.path().join("projects");
+    std::fs::create_dir_all(&projects_root).unwrap();
+
+    register_bot(
+        "dev-trunc",
+        "lead",
+        AgentVendor::Claude,
+        "telegram",
+        "chat-99",
+    )
+    .unwrap();
+
+    // Seed turns.jsonl with one short post-truncation row.
+    let chat_dir = projects_root.join("dev-trunc/.ccteam/chat/lead");
+    std::fs::create_dir_all(&chat_dir).unwrap();
+    let turns_path = chat_dir.join("turns.jsonl");
+    let row = r#"{"role":"assistant","content":"post-rotation reply"}"#;
+    std::fs::write(&turns_path, format!("{row}\n")).unwrap();
+    let new_eof = std::fs::metadata(&turns_path).unwrap().len();
+
+    // Seed an outbound.cursor that points well past the new EOF —
+    // simulates a turns.jsonl that was much longer before and got
+    // rotated / truncated while the daemon was offline.
+    let cursor_path = outbound::outbound_cursor_path(&projects_root, "dev-trunc", "lead");
+    std::fs::write(&cursor_path, r#"{"position": 10000}"#).unwrap();
+    assert!(
+        new_eof < 10000,
+        "test pre-condition: new EOF < stale cursor"
+    );
+
+    let mock = Arc::new(MockChannel::new());
+    let mut channels: ChannelMap = std::collections::HashMap::new();
+    channels.insert(
+        "telegram".to_string(),
+        mock.clone() as Arc<dyn Channel + Send + Sync>,
+    );
+    let adapter = Arc::new(QuietAdapter::default());
+    let adapter_factory: AdapterFactory = {
+        let cloned = adapter.clone();
+        Arc::new(move |_| cloned.clone() as Arc<dyn HarnessAdapter + Send + Sync>)
+    };
+    let args = DaemonArgs {
+        credentials: None,
+        registry: Some(projects_root.clone()),
+        tick: Duration::from_millis(50),
+        max_runtime: Some(Duration::from_millis(600)),
+        adapter_factory: Some(adapter_factory),
+        channels_override: Some(channels),
+    };
+    run_daemon_with_shutdown(args, async {
+        futures::future::pending::<()>().await;
+    })
+    .await
+    .unwrap();
+
+    // The post-truncation row is forwarded EXACTLY ONCE, not on every
+    // tick. (Pre-fix this would be 1 forward per safety-net pass — and
+    // since the safety_net_ticker tokio::interval fires immediately on
+    // first poll, even a short test run would see >= 1 duplicate.)
+    let outbox = mock.outbox().await;
+    assert_eq!(
+        outbox.len(),
+        1,
+        "expected exactly 1 forward post-truncation (got {}): {:?}",
+        outbox.len(),
+        outbox
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    // Cursor should sit at the new EOF — not stuck at the stale 10000
+    // and not stuck at 0 (which would re-forward next tick).
+    let body = std::fs::read_to_string(&cursor_path).unwrap();
+    let cursor: outbound::TailCursor = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        cursor.position, new_eof,
+        "cursor should land at the new EOF ({} bytes)",
+        new_eof
+    );
+}
+
+/// Regression: pre-seeded cursor at EOF must not produce a single
+/// forward on the drain pass. Models the steady-state case where the
+/// fast-path dispatcher already delivered every row and persisted the
+/// cursor; the safety-net drain should see "nothing new" and stay
+/// quiet. Pre-fix, a race between the fast-path's per-row save and
+/// the drain's batch save could rewind the cursor under the EOF and
+/// produce a duplicate forward — this exercises the dedup-against-
+/// current-cursor invariant from the OutboundCursor refactor.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drain_no_op_when_cursor_already_at_eof() {
+    let _g = env_lock();
+    let home = isolate_home();
+    let projects_root = home.path().join("projects");
+    std::fs::create_dir_all(&projects_root).unwrap();
+
+    register_bot(
+        "dev-eof",
+        "lead",
+        AgentVendor::Claude,
+        "telegram",
+        "chat-eof",
+    )
+    .unwrap();
+
+    let chat_dir = projects_root.join("dev-eof/.ccteam/chat/lead");
+    std::fs::create_dir_all(&chat_dir).unwrap();
+    let turns_path = chat_dir.join("turns.jsonl");
+    std::fs::write(
+        &turns_path,
+        concat!(
+            r#"{"role":"assistant","content":"already delivered 1"}"#,
+            "\n",
+            r#"{"role":"assistant","content":"already delivered 2"}"#,
+            "\n",
+        ),
+    )
+    .unwrap();
+    let eof = std::fs::metadata(&turns_path).unwrap().len();
+
+    // Cursor pre-positioned at EOF — simulates the steady-state where
+    // the fast-path dispatcher already shipped every row.
+    let cursor_path = outbound::outbound_cursor_path(&projects_root, "dev-eof", "lead");
+    std::fs::write(&cursor_path, format!(r#"{{"position": {eof}}}"#)).unwrap();
+
+    let mock = Arc::new(MockChannel::new());
+    let mut channels: ChannelMap = std::collections::HashMap::new();
+    channels.insert(
+        "telegram".to_string(),
+        mock.clone() as Arc<dyn Channel + Send + Sync>,
+    );
+    let adapter = Arc::new(QuietAdapter::default());
+    let adapter_factory: AdapterFactory = {
+        let cloned = adapter.clone();
+        Arc::new(move |_| cloned.clone() as Arc<dyn HarnessAdapter + Send + Sync>)
+    };
+    let args = DaemonArgs {
+        credentials: None,
+        registry: Some(projects_root.clone()),
+        tick: Duration::from_millis(50),
+        max_runtime: Some(Duration::from_millis(400)),
+        adapter_factory: Some(adapter_factory),
+        channels_override: Some(channels),
+    };
+    run_daemon_with_shutdown(args, async {
+        futures::future::pending::<()>().await;
+    })
+    .await
+    .unwrap();
+
+    let outbox = mock.outbox().await;
+    assert!(
+        outbox.is_empty(),
+        "drain must not re-forward when cursor is already at EOF (got {:?})",
+        outbox
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    // Cursor should remain at EOF — drain saw no new rows so it didn't
+    // call try_advance; the value is preserved.
+    let body = std::fs::read_to_string(&cursor_path).unwrap();
+    let cursor: outbound::TailCursor = serde_json::from_str(&body).unwrap();
+    assert_eq!(cursor.position, eof);
 }

--- a/docs/versions/v0-6-5/README.md
+++ b/docs/versions/v0-6-5/README.md
@@ -1,0 +1,148 @@
+# ccteam V0.6.5 — V0.6 收尾:MCP 桥补全 + advise 落地 + UX cohesion + F113 验收补做
+
+> **状态:doc-first / Wave 0**(本 PR 范围 = `README.md` + `prd.md` + `dev-plan.md`,代码 PR 走后续 Wave 1-3)。
+> **主题:** **关 V0.6 的账**。V0.6.0 立项时承诺的 chat-mode end-to-end onboarding(从 `/ccteam-creator` 跑下来到 TG 收回复)从未真正通过 ── 长期被「老用户手工补 registration 文件」掩盖,2026-05-23 nas-box005 的 Telegram duplicate flood 调研把 chain of root causes 全暴露出来。本版把 V0.6.0 Wave 2/3 应交未交的 MCP `chat_*` / `advise_*` 表面 + creator 注册桥 + advise vote + UX 决策树 + F113 验收 #5 (50-query intent test)一次合上。
+> **基线起点:** workspace `0.6.4` / test `1482 / 1`(V0.6.4 ship 数 + 那次 OutboundCursor PR 的 7 新测试)/ clippy `-D warnings` clean。
+> **基线目标:** workspace `0.6.5` / test ≥ `1530 / 1`(+48 估算,见各 Epic 验收)/ clippy `-D warnings` clean。
+> **痛点对应:** 13 用户痛点中 ── 痛点 4 (零摩擦上手)、痛点 5 (能否真正在 IM 闭环)、痛点 6 (跨 vendor 第二意见)、痛点 11 (Skill / 入口可发现性)。
+
+---
+
+## 0. 概览
+
+| Epic | Finding | 一句话 | 体量 |
+|---|---|---|---|
+| **E — MCP 桥 + creator 通路**(P0)| **F146** | `mcp__ccteam__chat_register_bot` + `chat_list_bots` 真实现(拆 lifecycle 为原子操作)| M |
+|  | **F147** | `mcp__ccteam__chat_send_input` + `chat_history` + `chat_reset` 真实现 | M |
+|  | **F148** | `/ccteam-creator` Phase 5.6 调 F146,end-to-end 跑通(fresh machine → 收 TG 回复 0 手工)| M |
+|  | **F149** | `/ccteam` 总入口移除 Wave 2/3 fallback 提示;intent 2/3 路径合上 | S |
+|  | **F150** | `/ccteam-control` 接 `admin_*` MCP(冒烟验证 + 文档补)| S |
+|  | **F151** | unregister 路径打通(`ccteam remove --purge` 也清 `imd/registry/`)| S |
+| **F — Advise + Codex critic**(P1)| **F152** | `mcp__ccteam__advise_vote` 真实现(基于已有 `CodexExecAdapter` + claude-tui)| M |
+|  | **F153** | `mcp__ccteam__advise_parallel` 真实现 | S |
+|  | **F154** | `/ccteam-advise` skill body 移除 "Wave 3 落地" 占位语,改成真路径文档 | S |
+|  | **F155** | `ccteam-creator` Phase 3.5 Codex auto-critic 验证 + 必要 gate | S |
+|  | **F156** | `/ccteam-team` §3.5 N≥3 critic auto-injection 验证或显式 V0.7 推迟 | S |
+| **G — UX cohesion + F113 收账**(P0/P1 混)| **F157** | `ccteam-scan --quick` 60s 内出小报告 + `/ccteam` 增加 "code-scan" 入口 | M |
+|  | **F158** | `docs/task-to-command.md` 决策树 + README/quickstart/user-manual lead 改写 | S |
+|  | **F159** | `/ccteam` 对未实现 intent 直接隐藏(不再 placeholder)| S |
+|  | **F160** | CLAUDE.md §一 baseline 更新 + skill 状态注释清理 | S |
+|  | **F161** | `/ccteam` dispatcher 文案 drift sweep(6 处 stale Wave 1 fallback)| XS |
+|  | **F162** | F113 验收 #5 补做:50-query intent classifier accuracy test ≥90% | M |
+
+**总计** 17 finding · 3 Epic · 估算 9-12 工作日(单线作业)或 4-5 天(并行 worktree)。
+
+---
+
+## 1. 为什么 V0.6.5 而不是 V0.7.0
+
+V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2/3 落地。**Wave 2/3 实际 ship 了 imd 传输层 + tmux supervisor + 路由器,但 MCP `chat_*` / `advise_*` 工具表面留在 Wave 1 STUB 状态 ── 这是 V0.6.0 自身没收的账,不是新功能**。同理:
+
+- F113 验收 #5 "50-query intent classification ≥90%" 在 v0-6-0 PRD line 61 是 ship gate,Wave 4 doc-syncer 时没补、V0.6.1-V0.6.3 三个 patch 也都没补 ── 这是 V0.6.0 的欠债。
+- `/ccteam-creator` Phase 5.6 说 "call `ccteam_imd::register_bot(...)`" ── Rust 函数存在但**没人能从 Claude TUI 外部调到它**(没 MCP / 没 CLI 子命令)。这条桥从 V0.6.0 立项以来就是断的。
+
+把这些归到 V0.7.0 等于把"V0.6 闭环"主题往后推一个 minor。V0.6.5 单独 ship 这 17 条,让 V0.6 真正闭环,V0.7.0 才能干净地开新主题(国内 IM / monorepo `.mcp.json` / chat memory sync / 第 4 mode HumanApproval 深化)。
+
+**与 CLAUDE.md §五 "pre-v1.0 不留技术债" 原则一致** ── 不写 backward-compat shim、不留 deprecated alias;workflow.yaml / registry schema 直接前进。
+
+---
+
+## 2. 痛点映射(13 用户痛点)
+
+| 痛点 | 本版相关 finding | 解释 |
+|---|---|---|
+| 4 (零摩擦上手) | F157 / F158 / F159 | `ccteam-scan --quick` 是新用户 60 秒看到 value 的零依赖路径;决策树替代 mode/preset/recipe 三层认知 |
+| 5 (IM 闭环) | F146 / F147 / F148 / F151 | chat MCP 桥补全后,**从未跑通**的 `/ccteam-creator → daemon → TG` end-to-end 第一次真正可重现 |
+| 6 (跨 vendor 第二意见) | F152 / F153 / F154 / F155 | advise vote / parallel MCP 真实现,Codex auto-critic 验证 |
+| 11 (Skill / 入口可发现性) | F149 / F158 / F160 / F161 | 用户面文档 + dispatcher 文案对齐当前真实状态;F113 验收 #5 补做让"分类准"有数字 |
+
+---
+
+## 3. 红线核对(CLAUDE.md §三)
+
+| 红线 | 本版触及? | 守的方式 |
+|---|---|---|
+| 文件系统是控制平面 | F146 / F147 / F151(写 / 删 `~/.ccteam/imd/registry/`) | 仍只走 ccteam-owned dir 下文件;MCP 工具内调 `register_bot()` / `unregister_bot()`,行为 = Rust 函数;不引入新 IPC |
+| `progress.jsonl` 是唯一 state SoT | F146-F151 不写 progress | bot lifecycle 事件由 BotSupervisor 自己写 progress,MCP 工具不直接写 |
+| No prompt injection | F147 `chat_send_input` 写 mailbox 文件 | mailbox 是已有路径,与 inbox 同级别处理;不向 tmux pane 直接 send-keys system prompt |
+| 每次 spawn = fresh 1M context(bg 模式) | 不触及 | chat 模式 spawn 复用 context 是 feature(CLAUDE.md §三 原文) |
+| 永不主动 kill 长 session | F146-F151 不 kill | `chat_lifecycle.stop` 走 graceful `close_thread`;`chat_reset` 同 |
+| 不解析 tmux 终端输出 | 不触及 | F147 走 mailbox 写文件,不 scrape |
+| fix-loop 撞 3 次必 escalate | 不触及 | 本版无 fix-loop 改 |
+| `ccteam-core` 零 team 名字面量 | 不触及 | 本版 ccteam-core 改动仅在 cli / imd / mcp 层 |
+| 跨项目记忆走官方接口 | 不触及 | 本版不改 `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` 处理 |
+| 新建项目走 `<projects_root>/<team>-<slug>/` | F151 涉及 remove | 沿用 `pick_unused_slug` 强制 team 前缀;remove --purge 一并清 imd registry |
+| root README.md MUST be English | F158 改 README | F158 决策树插入位置走英文段(中文版进 `docs/quickstart.md` / `docs/user-manual.md`)|
+| README.md 不含版本进展/状态信息 | F158 改 README | 决策树是"产品当前能力"展示,**不**含版本号 / shipping 日期 / 验收数字 |
+| HITL approval state SoT(V0.6.1 F124) | 不触及 | 本版无 plan_approval 改 |
+
+---
+
+## 4. 不在范围(V0.7 候选)
+
+| 项 | 推到 |
+|---|---|
+| Slack / Discord onboarding(provider Rust 已就位,`ccteam-im-setup` skill 拒绝)| V0.7(已在 V0.6.0 PRD §F117 锁定为 V0.7 范围)|
+| Lark / DingTalk / WeChat / QQ Channel | V0.7 Epic C |
+| User-defined personas(用户写 markdown)| V0.7(`ccteam-creator-persona-new` flow)|
+| Voice / 图片 / 多模态 input | V0.7+ |
+| monorepo-aware `.mcp.json` | V0.7+(researcher R6#4)|
+| `ccteam migrate-from-claude` 反向 import | V0.7+(codex-expert CX6#5)|
+| DM 跨设备 sync(chat memory)| V0.7+ |
+| non-Anthropic/non-OpenAI vendor(Gemini / DeepSeek / Qwen)| V0.7+ |
+| ccteam-core 巨石拆分(audit team REQ-006)| V0.7.x patch |
+| ProjectState 上帝对象(audit REQ-002)| V0.7.x patch |
+| 文件即 IPC → Event Bus(audit REQ-004)| V0.7.x or 独立 minor |
+| 老 daemon 不响应 SIGINT/SIGTERM(2026-05-23 调研发现)| 独立 finding,V0.6.6 或 V0.7 |
+| claude-tui adapter 重附接已存在 tmux session(同上)| 独立 finding,V0.7 |
+
+---
+
+## 5. Ship gate(V0.6.5 → main)
+
+1. **baseline**:`cargo test --workspace --locked --no-fail-fast` ≥ **1530 / 1**(1482 起点 + 各 finding 验收测试)
+2. **clippy**:`cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
+3. **`/ccteam-creator` end-to-end**:fresh machine + 零手工写文件 → `/ccteam-creator "做个 TG 助理"` → `go` → daemon 起 → TG 双向通(测试人确认)
+4. **F113 验收 #5 数字**:`scripts/host-probe/intent-accuracy.sh` 输出 ≥ 90% accuracy + confusion matrix 落 `docs/versions/v0-6-5/intent-accuracy.md`
+5. **tier-1 docs 文案 grep**:
+   - `grep -rn "Wave [123]\|wave2-not-ready\|Wave 3.*未落地" skills/*/SKILL.md` 全 0 命中
+   - `grep -rn "mode:.*chat\|preset:.*chat-pocket" docs/{quickstart,user-manual}.md README.md` 全 0 命中(决策树取代,内部架构词汇下沉到 docs/advanced/)
+6. **CLAUDE.md §一 baseline 表更新到 V0.6.5 数字** + §四 skill 状态注释清理
+7. **`cargo run --release -- doctor`** 输出含 "MCP tool surface: 26 active, 0 stubs"(原 9 个 stub 全实现)
+
+---
+
+## 6. Wave 结构
+
+详 `dev-plan.md`。概要:
+
+```
+Wave 0  doc-first(本 PR)
+        ├── README.md           ← 本文件
+        ├── prd.md              ← 17 finding 完整需求
+        └── dev-plan.md         ← worktree-per-epic + acceptance gate
+
+Wave 1  Epic E(MCP chat 桥 + creator)── P0 解今晚 flood 真因
+        worktree-per-finding F146-F151,串行依赖 F146 → F148
+
+Wave 2  Epic F(advise + Codex critic)── 并行
+        worktree-per-finding F152-F156,F152/F153 可并行
+
+Wave 3  Epic G(UX cohesion + F113 验收)
+        F157-F160 并行;F161 文案 sweep;F162 intent fixture + 跑 + 报告
+
+Wave 4  doc-syncer + host-probe + ship gate
+        CLAUDE.md baseline 回填 + tier-1 docs 同步 + version bump 0.6.4 → 0.6.5
+```
+
+每 Wave PR 必须 baseline ≥ 上 Wave 数字 + clippy 0 警告,否则不发。
+
+---
+
+## 7. Doc-first 完成判据(本 PR 验收)
+
+- [ ] `README.md`(本文件)落
+- [ ] `prd.md` 17 finding 各章节完整(痛点 / 现状缺口 / 设计 / 文件 / 验收 / 风险)
+- [ ] `dev-plan.md` 含 4 Wave + worktree 分配 + acceptance gate
+- [ ] CLAUDE.md `§一 当前状态` 表 `当前最新版` 行**暂不动**(代码 ship 后回填)
+- [ ] 用户 review pass → merge → Wave 1 kick-off

--- a/docs/versions/v0-6-5/dev-plan.md
+++ b/docs/versions/v0-6-5/dev-plan.md
@@ -1,0 +1,197 @@
+# V0.6.5 — Dev Plan(4 Wave / worktree-per-finding)
+
+> **Plan-first 原则**(CLAUDE.md §五):本文件 + `README.md` + `prd.md` user review pass 后才进 Wave 1。
+> **Pre-v1.0 不留技术债**:`workflow.yaml` / BotRegistration / MCP tool schema 直接前进;移除 `chat_lifecycle` STUB 时**不留 deprecated alias**;旧 user 手工 poke 的 registry JSON 文件 schema 不变,自然兼容。
+> **多 session 并行**:worktree-per-finding,主仓 `main` 不变 dirty;每 Wave 完成 PR 提交后再开下 Wave。
+
+---
+
+## Wave 0 — doc-first(本 session,~45 min)
+
+- ✅ `docs/versions/v0-6-5/README.md`
+- ✅ `docs/versions/v0-6-5/prd.md`
+- ✅ `docs/versions/v0-6-5/dev-plan.md`(本文件)
+- ⏭️ user review pass → `go` → Wave 1 kick-off
+
+---
+
+## Wave 1 — Epic E:MCP chat 桥 + creator 通路(P0)
+
+**目标**:V0.6.0 立项就承诺、从未真正交付的 `/ccteam-creator` end-to-end onboarding 这次走通。今晚 2026-05-23 Telegram duplicate flood 的最深 root cause 关上。Wave 1 完成后第一次:fresh machine + 零手工编辑 → `/ccteam-creator` → daemon → TG 收回复。
+
+### 串行 + 并行依赖
+
+```
+F146 (register/list/unregister MCP)
+  ↓
+F148 (creator Phase 5.6 真调 F146)  ──┐
+F151 (remove --purge 也清 registry)  ──┴── 各自 worktree,F148/F151 可并行
+  ↓
+F147 (send_input/history/reset MCP)  ── 独立 worktree(可与 F148/F151 并行)
+F149 (/ccteam dispatcher 文案 sweep) ── 独立(F146 ship 后才动)
+F150 (/ccteam-control 接 admin_*)    ── 独立(全 wave 任何时点都可启)
+```
+
+### 工作树分配
+
+| Teammate | Branch | Findings | Briefing 重点 | Est. |
+|---|---|---|---|---|
+| W1-T1 `mcp-chat-register` | `v065-w1-mcp-chat-register` | **F146** | `mcp_chat_tools.rs::dispatch` 拆 stub;register/unregister/list 三个真 dispatch;**vendor lowercase enforcement**;**daemon heartbeat file** 给 `bot_running_status` 用 | 1.5 d |
+| W1-T2 `mcp-chat-runtime` | `v065-w1-mcp-chat-runtime` | **F147** | send_input mailbox 写 + history tail + reset signal;reset 时 OutboundCursor `force_set(0)` + prior_offsets.clear()(V0.6.4 Bug B 防线);新 ArtifactWatcher 监 signals/reset.signal | 2 d |
+| W1-T3 `creator-bridge` | `v065-w1-creator-bridge` | **F148** + **F151** | (F148) `/ccteam-creator` SKILL.md Phase 5.6/5.9 文案改 + e2e_creator_full_path_test.rs (stub TG/claude);(F151) `cmd_remove::purge` 加 `imd/registry/<slug>/` + 优先 MCP unregister fallback fs delete | 1.5 d |
+| W1-T4 `dispatcher-sweep` | `v065-w1-dispatcher-sweep` | **F149** | `skills/ccteam/SKILL.md` 6 处 stale Wave 1 fallback 删除;intent table 描述对齐当前实状态 | 0.5 d |
+| W1-T5 `control-admin-smoke` | `v065-w1-control-admin` | **F150** | audit `skills/ccteam-control/SKILL.md` MCP 调用 + 6 个 admin_* smoke test + `docs/user-manual.md` admin 段 | 1 d |
+
+**并行**:T1 / T4 / T5 三人 day1 同时起;T2 day1 等 T1 框架定下来(共享 mcp_chat_tools.rs 文件);T3 day2 等 T1 PR merge 后启(依赖 chat_register_bot MCP)。
+
+### Wave 1 PR 合入顺序
+
+1. **T1 F146** → merge first(基础设施)
+2. **T2 F147** + **T3 F148+F151** + **T4 F149** + **T5 F150** → 并行 PR,各自 review pass 后 merge
+
+### Wave 1 验收
+
+- `cargo test --workspace --locked --no-fail-fast` ≥ **1506 / 1**(1482 + 24 新测试估算)
+- clippy `-D warnings` clean
+- F148 e2e_creator_full_path_test.rs 通过(stub adapter)
+- **真机 host-probe**(nas-box005,fresh wipe):走通 `/ccteam-creator` + TG round-trip,**手动签字** → `docs/versions/v0-6-5/wave-1-handoff.md`
+- 每 PR 描述含 `prd.md` finding 链接 + verification log + `git push -u origin <branch>`(per V0.6 学到的陷阱)
+
+### Wave 1 handoff 文档
+
+`docs/versions/v0-6-5/wave-1-handoff.md` 五段固定(per V0.6.0 4-wave 范式):
+- **Decided**:每 finding 落地决策(如:F146 chat_lifecycle 移除不留 alias)
+- **Rejected**:本 wave 不做的(如:F146 不在本版搞 multi-tenant `im_chat_ids: Vec<String>`)
+- **Risks**:发现的新风险(如:F147 reset 期 outbound 行为)
+- **Files**:本 wave 改的文件列表
+- **Remaining**:遗留给 Wave 2/3/4 的(如:F162 corpus 收 V0.6.6)
+
+---
+
+## Wave 2 — Epic F:Advise vote/parallel + Codex critic(P1)
+
+**目标**:V0.6.0 Wave 3 承诺的 `/ccteam-advise` 真路径接通;Codex auto-critic 验证 deterministic。
+
+### 工作树分配
+
+| Teammate | Branch | Findings | Briefing 重点 | Est. |
+|---|---|---|---|---|
+| W2-T1 `advise-vote` | `v065-w2-advise-vote` | **F152** | `crates/ccteam-core/src/advise.rs`(新)`advise_vote()` fn + Claude API + Codex spawn 并行 + verdict synthesizer;budget enforcement;Codex-unavailable display | 2 d |
+| W2-T2 `advise-parallel` | `v065-w2-advise-parallel` | **F153** + **F154** | (F153) `advise_parallel()` fn 共享 spawn helper;(F154) skill body 文案 sweep ── 同 wave 起,文档跟代码 | 1 d |
+| W2-T3 `codex-critic-gate` | `v065-w2-codex-critic` | **F155** + **F156** | (F155) `ccteam doctor --check-codex-auto-critic` flag + stub binary tests;(F156) `/ccteam-team` §3.5 验证 Codex critic 真路径或显式 V0.7 deferral(默认实装) | 1.5 d |
+
+### Wave 2 PR 合入顺序
+
+1. **T1 F152** → merge first(F153 复用 spawn helper)
+2. **T2 F153+F154** + **T3 F155+F156** → 并行 merge
+
+### Wave 2 验收
+
+- baseline ≥ **1524 / 1**(1506 + 18 新测试)
+- clippy clean
+- F152 真路径(Codex installed)+ Codex-unavailable path 双 e2e
+- `ccteam doctor --check-codex-auto-critic` exit code 行为正确
+- `docs/versions/v0-6-5/wave-2-handoff.md` 五段固定
+
+---
+
+## Wave 3 — Epic G:UX cohesion + F113 验收补做
+
+**目标**:零依赖 60s 体验、决策树替代架构词汇、F113 验收 #5 第一次真做。
+
+### 工作树分配
+
+| Teammate | Branch | Findings | Briefing 重点 | Est. |
+|---|---|---|---|---|
+| W3-T1 `scan-quick` | `v065-w3-scan-quick` | **F157** | `ccteam-scan --quick` mode(1 sonnet agent + 3 fixed questions, 60-90s target)+ `/ccteam` intent 5 (code-scan) 路由 + intent-corpus 加 5 条 sample | 1.5 d |
+| W3-T2 `decision-tree` | `v065-w3-decision-tree` | **F158** | 新文档 `docs/task-to-command.md` + `docs/quickstart.md` 重写第一节 + `docs/user-manual.md` 加 lead + `README.md` 英文决策树 | 1 d |
+| W3-T3 `dispatcher-hide` | `v065-w3-dispatcher-hide` | **F159** + **F161** | (F159) `/ccteam` SKILL.md hide-unimpl red line + dispatcher 4-options dynamic;(F161) cross-docs grep sweep "Wave [123]/STUB/NotImplemented" → 全 0 命中 | 0.5 d |
+| W3-T4 `intent-corpus` | `v065-w3-intent-corpus` | **F162** | `tests/intent-corpus.yaml` 50 query(7 intent 各 5-8 条,中英混合)+ `scripts/host-probe/intent-accuracy.sh` + 跑 + `docs/versions/v0-6-5/intent-accuracy.md` 归档 | 2 d |
+
+### Wave 3 PR 合入顺序
+
+全部并行,各自 PR review pass 后合入(无相互依赖)。
+
+### Wave 3 验收
+
+- baseline ≥ **1530 / 1**(1524 + 6 新测试)
+- clippy clean
+- F162 `intent-accuracy.md` 落,accuracy ≥ **0.90**(< 0.90 不阻 ship 但单独 finding 跟)
+- F157 `ccteam-scan --quick` 在 sample repo 90s 内出报告(host-probe)
+- F158 决策树 `grep -E "mode:.*chat|preset:.*chat-pocket" docs/{quickstart,user-manual}.md README.md` 0 命中
+- F161 `grep -E "Wave [123]|STUB|NotImplemented" docs/{quickstart,user-manual,recipes,troubleshooting}.md docs/advanced/*.md skills/*/SKILL.md README.md` 0 命中
+- `docs/versions/v0-6-5/wave-3-handoff.md` 五段固定
+
+---
+
+## Wave 4 — doc-syncer + host-probe + ship gate
+
+**目标**:Tier-1 docs 同步、`CLAUDE.md §一` baseline 回填、版本号 bump、tag。
+
+### 工作分配(单 teammate / 1 day)
+
+| Step | 内容 |
+|---|---|
+| 4.1 | `CLAUDE.md §一 当前状态` 表回填:HEAD / version / baseline 数 / kLOC / 当前最新版 / 上一版 / V0.6.x 候选 / V0.7 主线候选 |
+| 4.2 | `CLAUDE.md §四 Skills` 表 status 描述 sync |
+| 4.3 | `docs/tech-design.md` § (有关 chat MCP / advise MCP / auto-critic 的)同步当前 ship 状态 |
+| 4.4 | `docs/interfaces.md` MCP §(原 chat_lifecycle row 替换 chat_register_bot / chat_unregister_bot,advise tools 从 STUB 升真)|
+| 4.5 | `docs/claude-code-tool-surface.md`(如有)── MCP 工具新清单 |
+| 4.6 | 任何 V0.6.4 漏回填的(如 V0.6.4 OutboundCursor PR 当时也未回填 CLAUDE.md baseline)|
+| 4.7 | workspace version bump:`Cargo.toml` `0.6.4 → 0.6.5` + `cargo check --offline` 触发 `Cargo.lock` update |
+| 4.8 | commit message:`v0.6.5: chat MCP bridge + advise vote + UX cohesion + F113 verification (closes V0.6 promises)` |
+| 4.9 | PR 描述含全部 17 finding 链接 + ship gate clear list + verification logs |
+| 4.10 | git tag `v0.6.5`(在 PR merge 后,from `main`)|
+
+### Wave 4 ship gate(per README §5,prd.md §Ship gate)
+
+merge 前 8 项全 ✓:
+
+- [ ] cargo test ≥ 1530 / 1
+- [ ] clippy `-D warnings` clean
+- [ ] F148 host-probe(nas-box005 fresh)pass + 手动签字
+- [ ] F162 intent-accuracy.md ≥ 0.90
+- [ ] tier-1 docs grep clean
+- [ ] CLAUDE.md §一 baseline 表更新
+- [ ] `ccteam doctor` 报告 MCP "26 active, 0 stubs"
+- [ ] version bump + commit prefix `v0.6.5:`
+
+---
+
+## 估算汇总
+
+| Wave | Teammates | Calendar days | 累计 baseline 增量 |
+|---|---|---|---|
+| 0 (doc-first) | 1 | 0.5 | — |
+| 1 (Epic E) | 5 parallel | 2.5 (T1 + T2/T3 后续) | +24 测试 → 1506/1 |
+| 2 (Epic F) | 3 parallel | 2 | +18 测试 → 1524/1 |
+| 3 (Epic G) | 4 parallel | 2 | +6 测试 → 1530/1 |
+| 4 (doc-syncer) | 1 | 1 | — |
+| **总计** | 5 peak / 13 unique role | **8 calendar days** | **+48 测试** |
+
+**单线作业** estimate:9-12 天(无 worktree 并行)。
+
+---
+
+## 主仓 dirty 管控(CLAUDE.md §五 多 session 规则)
+
+每 wave 开 worktree:
+
+```bash
+git worktree add -b v065-w<N>-<finding> /tmp/ccteam-v065-w<N>-<finding> origin/main
+cd /tmp/ccteam-v065-w<N>-<finding>
+# 开干
+```
+
+完事 PR + `git worktree remove /tmp/ccteam-v065-w<N>-<finding>`。
+
+**主仓 main 不变 dirty**。跨 session 看到主仓 dirty:`git stash push -m "v065-doc-first WIP"` 再切。
+
+---
+
+## V0.6.5 ship 后
+
+1. 关闭本版所有 17 finding 的对应 issue / 内部 finding tracker
+2. CLAUDE.md `§一 V0.7 主线候选` 行更新:删除 "国内 IM 启用" 表述里跟 V0.6.5 重叠的部分(本版只关 V0.6 账,V0.7 仍以国内 IM + monorepo 为主)
+3. `docs/versions/v0-6-5/host-probe.md`(新)留作执行实证存档
+4. 通知 / 文档:用户面 Telegram 用户(如有)告知 chat-mode end-to-end onboarding 第一次真正可用

--- a/docs/versions/v0-6-5/prd.md
+++ b/docs/versions/v0-6-5/prd.md
@@ -1,0 +1,826 @@
+# V0.6.5 — PRD
+
+17 finding · 3 Epic · doc-first 完整需求。
+
+> **本 PR 范围**:本文件 + `README.md` + `dev-plan.md`(Wave 0 doc-first);代码改动全部走后续 Wave 1-3 PR。
+>
+> **Pre-v1.0 不留技术债**:实现里**不写 backward-compat shim**;`workflow.yaml` / BotRegistration schema 直接前进(no `#[serde(default)]` legacy compat unless 必要);CLI surface 直接扩(no deprecated alias);老用户的 manually-poked `~/.ccteam/imd/registry/` JSON 文件 schema 不变,因此自然兼容。
+
+---
+
+# EPIC E — MCP 桥 + creator 通路(P0)
+
+**主线**:把 V0.6.0 立项时承诺的 chat-mode end-to-end onboarding 真正接通。今晚 2026-05-23 Telegram duplicate flood 调研的 root cause 不只是 OutboundCursor race(那是另一个 bug,V0.6.4 已修),更深层是 `/ccteam-creator` Phase 5.6 注册 bot 这条桥**自 V0.6.0 就没建过**。所有看到 ccteam chat bot 工作的项目都是老用户某时手动写过 `~/.ccteam/imd/registry/<slug>/<role>.json`。
+
+## F146 — `mcp__ccteam__chat_register_bot` + `chat_list_bots` 真实现
+
+### 痛点
+
+`/ccteam-creator` Phase 5.6 documentation says "call `ccteam_imd::register_bot(slug, persona_id, vendor, im_platform, im_chat_id)`" ── Rust 函数存在,但 Claude TUI 没法直接调 Rust 函数,**MCP `chat_*` 工具全是 Wave 1 STUB**。skill 跑下来只写 `<project>/.ccteam/workflow.yaml`,**不写 BotRegistration JSON**,daemon `list_bots()` 返回空,所有 inbound 消息被 router dropped。
+
+### 现状缺口
+
+`crates/ccteam-cli/src/mcp_chat_tools.rs::dispatch()`:
+```rust
+match name {
+    "ccteam__chat_send_input"
+    | "ccteam__chat_lifecycle"
+    | "ccteam__chat_reset"
+    | "ccteam__chat_list_bots"
+    | "ccteam__chat_history" => { ... "error": "NotImplemented" ... }
+    _ => Ok(None),
+}
+```
+
+5 个 chat tool 全在 stub 分支。原 `chat_lifecycle` 设计是单工具多 action(`start` / `stop` / `reset`)── 本版**拆为原子操作**,新增 `chat_register_bot` / `chat_unregister_bot`(`chat_lifecycle` 在 F151 删除,以 atomic verbs 取代)。
+
+### 需求
+
+**新增 MCP tool `ccteam__chat_register_bot`**:
+- input schema:`{ workflow_slug: string, role: string, vendor: "claude"|"codex", im_platform: "telegram"|"slack"|"discord", im_chat_id: string, persona_id?: string }`
+- 内部调 `ccteam_imd::register_bot()`,落 `~/.ccteam/imd/registry/<slug>/<role>.json`(0644;**non-secret** ── token 在 `~/.ccteam/im/credentials.json` 0600)
+- 返回:`{ ok: true, path: "<absolute path>", workflow_slug, role }`
+- 错误:invalid vendor / role 已存在(返 `ok: false, error: "already_registered"`,daemon 不冲突写)/ slug 含非法字符 → 400 等效
+
+**新增 MCP tool `ccteam__chat_unregister_bot`**(F151 依赖):
+- input schema:`{ workflow_slug: string, role: string }`
+- 调 `ccteam_imd::unregister_bot()`
+- 返回:`{ ok: true, removed: bool }`(`removed=false` 表示 idempotent miss)
+
+**真实现 MCP tool `ccteam__chat_list_bots`**:
+- input schema:`{ workflow_slug?: string }`(可选过滤)
+- 调 `ccteam_imd::list_bots()`,可选 filter
+- 返回:`{ ok: true, bots: [{ workflow_slug, role, vendor, im_platform, im_chat_id, created_at, running: bool, last_turn_at?: string }] }`
+- `running` 字段由 `BotSupervisor::is_started()` 推断;daemon 未跑则 `running: false`、`last_turn_at` 从 `<project>/.ccteam/chat/<role>/turns.jsonl` mtime 读
+
+### 文件(预估)
+
+- `crates/ccteam-cli/src/mcp_chat_tools.rs` ── 拆 stub dispatch,新增 3 个真 dispatch 函数;chat_register_bot / chat_unregister_bot / chat_list_bots 三处
+- `crates/ccteam-cli/src/mcp_serve.rs` ── tool 注册表新增 register / unregister(`chat_lifecycle` 移除,留 schema-version note 引导用户改用新工具)
+- `crates/ccteam-imd/src/lib.rs` ── 已有 `register_bot()` / `unregister_bot()` / `list_bots()`,**不动**;新增 `bot_running_status()` helper 给 list_bots MCP 用(查 BotSupervisor registry)
+- `crates/ccteam-imd/tests/chat_register_mcp_test.rs`(新)── end-to-end:tempdir `HOME` → MCP dispatch chat_register_bot → 读 disk → assert
+- `docs/interfaces.md` ── §MCP 表 `chat_lifecycle` 行替换为 `chat_register_bot` / `chat_unregister_bot`
+
+### 验收
+
+1. `echo '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"ccteam__chat_register_bot","arguments":{"workflow_slug":"test","role":"helper","vendor":"claude","im_platform":"telegram","im_chat_id":"42"}}}' | ccteam internal mcp-stdio` → 落 `~/.ccteam/imd/registry/test/helper.json` 内容 schema-valid
+2. 同 slug+role 再调一次 → 返回 `already_registered`,文件不被 clobber(idempotent miss = false)
+3. `chat_list_bots` 不传 filter → 返回 1 行;传 `workflow_slug="other"` → 返回 0 行
+4. `chat_unregister_bot` 调一次 → 文件消失;再调 → `removed: false`(idempotent)
+5. baseline ≥ 1488 / 1(本 finding +6 测试)
+
+### 风险
+
+- **vendor 枚举 serde 大小写**:今晚踩过 ── BotRegistration `vendor: "Claude"` 大写被 daemon 拒收,只接受 `"claude"`。MCP tool 必须在 input schema 加 enum constraint(`"enum": ["claude", "codex"]`)且 dispatch 函数主动 lowercase。
+- **`bot_running_status()` 跨 crate 依赖**:`ccteam_imd::SupervisorRegistry` 是 in-process `Arc<Mutex<...>>`;MCP 工具是新进程(stdin/stdout 模式),**读不到 daemon 的内存 registry**。Workaround:走文件 heartbeat ── `~/.ccteam/imd/registry/<slug>/<role>.heartbeat`(daemon 每 5s touch;mtime 在 30s 内 → `running: true`)。需在 daemon BotSupervisor 加 heartbeat-write 路径。
+- **`chat_lifecycle` 移除是 breaking**:本 V0.6.5 sweep `/ccteam-creator` Phase 5.6 等所有 caller 同步改用 atomic verbs;old `chat_lifecycle` STUB 直接删,**不写 deprecated alias**(违反 CLAUDE.md §五 #4)。
+
+---
+
+## F147 — `mcp__ccteam__chat_send_input` + `chat_history` + `chat_reset` 真实现
+
+### 痛点
+
+剩下 3 个 `chat_*` STUB 同样阻塞外部 caller 给 chat-mode bot 发消息 / 读历史 / reset 卡死会话。F146 关掉了 register / list / unregister,本 finding 关 send / history / reset 三个。
+
+### 现状缺口
+
+同 F146 ── `mcp_chat_tools.rs::dispatch` 三个 match arm 还 return NotImplemented。
+
+### 需求
+
+**`ccteam__chat_send_input`**:
+- input:`{ workflow_slug: string, role: string, content: string, reply_to?: string }`
+- 实现:写 `<project>/.ccteam/chat/<role>/inbox/msg-<unix-ms>-<rand>.md` 文件(envelope: yaml frontmatter + content body),格式与 `daemon.rs` inbox dispatcher 期望一致
+- 写完文件后**不**触发 tmux send-keys(daemon 自己 mpsc fast-path 会读到 inotify 事件)
+- 返回:`{ ok: true, mailbox_path: "...", cid: "<cid>" }`
+
+**`ccteam__chat_history`**:
+- input:`{ workflow_slug: string, role: string, n?: number(default 20) }`
+- 实现:读 `<project>/.ccteam/chat/<role>/turns.jsonl`,tail 最后 N 行(只取 `role: "assistant"` 行,user 行可选 ── 由 input flag `include_user?: bool` 控制,default false)
+- 返回:`{ ok: true, turns: [{ turn_id, ts, role, content }] }`
+
+**`ccteam__chat_reset`**:
+- input:`{ workflow_slug: string, role: string }`
+- 实现:写 `<project>/.ccteam/chat/<role>/signals/reset.signal` 文件;daemon BotSupervisor 监听该信号,执行 `close_thread` + `start_thread`(新 sid)
+- 返回:`{ ok: true, signal_path: "..." }`(异步操作,不等 daemon 真 reset 完;用户 follow up 用 chat_list_bots 查 last_turn_at)
+
+### 文件(预估)
+
+- `crates/ccteam-cli/src/mcp_chat_tools.rs` ── 3 个新 dispatch 函数 + schema 描述真实化
+- `crates/ccteam-imd/src/supervisor.rs` ── BotSupervisor 监 reset.signal 文件(新轮询 + inotify;可借用现成 `ArtifactWatcher`)
+- `crates/ccteam-imd/tests/chat_send_input_test.rs`(新)── mailbox 文件落 + envelope 解析往返
+- `crates/ccteam-imd/tests/chat_reset_signal_test.rs`(新)── reset signal → daemon close+start 真发生(用 stub adapter 验)
+- `docs/interfaces.md` ── §MCP 表 send_input / history / reset 三行从 STUB → 真描述
+
+### 验收
+
+1. `chat_send_input` 调用 → mailbox 文件落 + daemon 5s 内 mpsc fast-path consume + tmux session 收到(stub adapter test)
+2. `chat_history` 返回 last 20 assistant turns,与 turns.jsonl 内容一致
+3. `chat_reset` 调用 → 1s 内 daemon 看到 signal → 旧 sid `close_thread` + 新 sid `start_thread` 都触发 + 旧 turns.jsonl 归档到 `<role>/archive/turns-<old-sid>.jsonl`
+4. baseline ≥ 1496 / 1(本 finding +8 测试)
+
+### 风险
+
+- **reset 期间 outbound flood 风险**:reset 触发 → 旧 tmux 关 → 新 tmux 起 → claude 重新建 session jsonl。这正是 V0.6.4 修过的 Bug B(subagent jsonl re-emit)的近亲 ── 新 sid 不在 prior_offsets 里,从 0 开始读。Mitigation:reset 时主动 `cursor.force_set(0)` + `cursor.prior_offsets.clear()`,保证 fresh start 不替老 sid 重放(F147 实现里专门写一段)。
+- **mailbox 文件名 race**:多个 MCP caller 并发调 send_input → 文件名 `msg-<unix-ms>-<rand>` 的 `<rand>` 必须用够长(8 hex char)避碰撞;`<unix-ms>` 用 `now_unix_ms()`(纳秒分辨率)。
+
+---
+
+## F148 — `/ccteam-creator` Phase 5.6 端到端跑通
+
+### 痛点
+
+`/ccteam-creator` skill 跑下来用户**以为成功了**(write 了 workflow.yaml + .claude/agents/<role>.md + 自定义 .mcp.json),但 BotRegistration 没落 → daemon `bots=0` → TG 消息全 dropped。今晚 nas-box005 调研事故的最深层 root cause。
+
+### 现状缺口
+
+`skills/ccteam-creator/SKILL.md:255`:
+
+> *"For chat presets, call `ccteam_imd::register_bot(slug, persona_id, vendor, im_platform, im_chat_id)` → `Result<PathBuf>`."*
+
+skill 是 LLM-driven 自然语言,**没有任何方式可以直接调 Rust 函数**。F146 实装 MCP 工具后这条桥才有真实现路径。
+
+### 需求
+
+`skills/ccteam-creator/SKILL.md` Phase 5.6 改写:
+- 文案从 "call `ccteam_imd::register_bot()`" 改为 "invoke `mcp__ccteam__chat_register_bot(workflow_slug, role, vendor, im_platform, im_chat_id)`"
+- 调用入参:`im_chat_id` 取自 Phase 5.1 写入 `~/.ccteam/im/credentials.json` 的 `allowed_chat_ids[0]`(creator skill 已有读凭证逻辑)
+- 错误处理:`already_registered` → skill 决策为 idempotent OK 继续,不报错 retry;其他 error → stop + 告诉用户 "registry write failed:<reason>"
+- **Phase 5.9 用户回执 + Phase 5.8 daemon ensure-running** 不变,但前者新加一行:"  Bot 注册到 ~/.ccteam/imd/registry/<slug>/<role>.json ✓"
+
+`docs/quickstart.md` "Set up Telegram bot in 5 minutes" 段同步:命令顺序 = `/ccteam-creator` → go → 等 daemon 自动起 tmux → TG 立即可用。**不再**需要任何手动 JSON 编辑。
+
+### 文件(预估)
+
+- `skills/ccteam-creator/SKILL.md` ── Phase 5.6 段 + Phase 5.9 reply 模板
+- `docs/quickstart.md` ── 5 分钟 TG bot 段(如已有则改写)
+- `tests/e2e/creator_full_path_test.rs`(新)── shell 脚本驱动:fresh tempdir HOME → ccteam-im-setup mock(预填 creds.json)→ `/ccteam-creator` 模拟 dialogue(jq 拼 MCP call)→ assert workflow.yaml + agent.md + registration JSON 全落 + 全 schema-valid
+
+### 验收
+
+1. `tests/e2e/creator_full_path_test.rs` 通过(stub Telegram + stub claude tui)
+2. **真机 host-probe**:nas-box005 fresh state(`rm -rf ~/.ccteam/ /home/rob/projects/test-creator/.ccteam/ ~/.claude/projects/-home-rob-projects-test-creator/`)→ 在 claude TUI 内跑 `/ccteam-creator "做个 TG 助理 bot"` → `go` → 不手工 touch 任何文件 → 从 TG 发 `hi` → 收到回复
+3. baseline ≥ 1498 / 1(本 finding +2 测试)
+
+### 风险
+
+- **skill 行为 LLM 依赖**:skill 文本指示 Claude 怎么决策,但实际执行还是 Claude 自由发挥。本 finding 改 skill 文本是必要不充分条件;**真验证只能靠 host-probe**(F148 验收 #2)。
+- **`mcp__ccteam__chat_register_bot` 注册时 daemon 没起**:可能场景 ── 用户先跑 `/ccteam-creator` 再起 daemon。F146 MCP 工具只写文件,daemon 后起也能从 disk 读 registry(`list_bots()` 路径)── 不冲突。
+
+---
+
+## F149 — `/ccteam` 总入口移除 Wave 2/3 fallback 提示
+
+### 痛点
+
+`skills/ccteam/SKILL.md` 还在显示 ── 
+
+- line 28:`Wave 1 实用范围 ... 三 sub-skill body 占位`
+- line 64:`Wave 2 F114 复活 ── Wave 1 fallback "请直接说 'wave2-not-ready'"`
+- line 67:`Wave 3 F112 新建 ── Wave 1 fallback 同上`
+- line 71-77:整段 "当路由目标是 Wave 2/3 才落地时,告诉用户 ..."
+- line 95:`d → 走 advise 路径(Wave 1:Wave 3 缺失说明)`
+- line 112:`Wave 2 复活后填实(目前 V0.5 砍掉态)`
+- line 118-119:`⏳ sub-skill body 由后续 Wave 填实 / ⏳ host probe 5 sub-skill 验收`
+
+V0.6.0 Wave 2/3 实际把 creator / im-setup / advise 三 sub-skill body 都写了 ── 这 6+ 处 stale 文案是 V0.6.0 doc-syncer 漏 sweep 的 drift,F146-F148 / F152-F154 ship 后这些更彻底过时,**用户看了会怀疑系统状态**。
+
+### 现状缺口
+
+文案对齐脏。skill body 早已不是 placeholder。
+
+### 需求
+
+`skills/ccteam/SKILL.md` 系统性 sweep:
+
+| 原 (line) | 改成 |
+|---|---|
+| 28 "Wave 1 实用范围" 段 | 删除整段;改 short note: "7 intents 全部对应实工 skill;不再有 placeholder fallback" |
+| 64 intent 2 "Wave 2 F114 复活" | 删 "Wave 2 F114 复活" 描述,留 `/ccteam-creator <NL>` 路由 |
+| 65 intent 3 "Wave 2 F117 新建" | 同上 |
+| 67 intent 5 "Wave 3 F112 新建" | 同上 |
+| 71-77 "Wave 1 缺失 sub-skill 处理" 整段 | 删除 |
+| 75 提示用户调 `mcp__ccteam__chat_send_input(...)` 的描述 | 留路径,删 "stub 返 NotImplemented" 注 |
+| 95 "Wave 1:Wave 3 缺失说明" | 删括号 |
+| 112 "Wave 2 复活后填实" | 删 |
+| 118-119 双 ⏳ 行 | 改 ✅ 或删除(本 PR ship 后清,F162 完成后再清 119)|
+
+Doc-syncer 角度:本 PR 落 + F146-F156 ship 后,line 119 同步删/打勾;F162 ship 后 line 118 标记 ✅。
+
+### 文件
+
+- `skills/ccteam/SKILL.md`
+
+### 验收
+
+1. `grep -E "Wave [123]|wave2-not-ready|sub-skill body 由|占位" skills/ccteam/SKILL.md` 全 0 命中
+2. baseline 不退(纯文档)
+
+### 风险
+
+无。纯文本 sweep。
+
+---
+
+## F150 — `/ccteam-control` 接 `admin_*` MCP 验证
+
+### 痛点
+
+V0.6.1 F128 ship 了 `admin_change_persona` + `admin_add_tool` 两个 MCP 工具(`crates/ccteam-cli/src/mcp_admin_tools.rs` 是真 impl),但 `/ccteam-control` skill 是否实际**调用**到了它们 ── 不确定。`/ccteam-control` 是用户管理已有项目的入口,如果 skill 还在用 V0.5 旧路径(直接 shell 调 `ccteam ctl ...` 已删除的子命令),用户会撞墙。
+
+### 现状缺口
+
+需要审 `/ccteam-control` 当前 skill body 是否引用 `mcp__ccteam__admin_*` 名字、还是引用过时 CLI 子命令。
+
+### 需求
+
+1. **Audit** `skills/ccteam-control/SKILL.md`:列出所有用到的 ccteam 操作(暂停、恢复、看费、删项目、改 persona、加 tool)→ 每条标注当前实际触发哪条路径(MCP / CLI / shell)
+2. **Bridge**:对每条 ccteam-control 操作,确保 skill 文本明确说调 MCP `admin_*` / `workflow_*` 工具(如已有);如还在用过时 CLI,改为 MCP-first(CLI 留作 fallback,标注 "if MCP not registered")
+3. **Smoke test**:每条操作各 1 个 integration test(用 stub MCP)
+4. 文档补:`docs/user-manual.md` "如何暂停 / 恢复 / 改 persona / 加工具" 段引用具体 MCP 工具名
+
+### 文件
+
+- `skills/ccteam-control/SKILL.md` ── 审 + 改
+- `crates/ccteam-cli/tests/mcp_admin_smoke_test.rs`(新)── 6 个操作各 1 smoke
+- `docs/user-manual.md` ── admin 段
+
+### 验收
+
+1. `grep -E "ccteam ctl|ccteam-ctl " skills/ccteam-control/SKILL.md` 0 命中(确认旧 CLI 路径全清)
+2. 每个 admin_* MCP 工具至少有 1 个 skill-driven smoke case 跑通
+3. baseline ≥ 1504 / 1(本 finding +6 测试)
+
+### 风险
+
+- 旧 CLI 子命令(`ccteam ctl pause` 等)在 V0.6.0 已删,但 skill 文本可能还引;改完后老 muscle memory 用户可能问"为什么没了"── `docs/user-manual.md` 单独加 migration note(指向 MCP 工具)。
+
+---
+
+## F151 — `ccteam remove --purge` 同步清 `imd/registry/`
+
+### 痛点
+
+`ccteam remove <slug> --purge` 当前清:
+- `~/.ccteam/config.yaml::projects[]` 删 slug 行
+- `~/.ccteam/progress/<slug>.jsonl`
+- `~/.ccteam/inbox/<slug>/`
+- `~/.ccteam/control/<slug>/`
+- `<project>/.ccteam/`、`<project>/.claude/agents/`、`<project>/workflow.yaml`
+
+**不清** `~/.ccteam/imd/registry/<slug>/`,导致 stale BotRegistration JSON 在 daemon `list_bots()` 还能读到,但 workflow.yaml 已删 → 路由命中后 daemon 找不到 BotSupervisor → 撞错。
+
+### 现状缺口
+
+`crates/ccteam-cli/src/commands.rs::cmd_remove()` 的 purge 路径列表里没有 `imd/registry/<slug>/`。
+
+### 需求
+
+1. `cmd_remove(..., purge=true)` 路径加一行:`rm -rf ~/.ccteam/imd/registry/<slug>/`
+2. F146 落地后,**优先**走 `chat_unregister_bot` MCP 调用(每个 role)── 触发 daemon 看到 registry 文件消失 → BotSupervisor 自动 graceful shutdown + tmux 关
+3. 如果 daemon 没起,fallback 直接 `rm -rf` ── 老 registry 自然失效
+4. `--dry-run` mode 输出多一行 `imd/registry/<slug>/ (N JSON files)` 展示给用户
+
+### 文件
+
+- `crates/ccteam-cli/src/commands.rs` ── `cmd_remove` 函数 + dry-run output
+- `crates/ccteam-cli/tests/ccteam_remove_test.rs` ── 新加 case:remove --purge 后 imd/registry/<slug>/ 不存在
+
+### 验收
+
+1. `ccteam remove dev-foo --purge --dry-run` 输出含 `imd/registry/dev-foo/ (1 JSON file)`
+2. `ccteam remove dev-foo --purge` 后 `ls ~/.ccteam/imd/registry/dev-foo/` 返回 NoSuchFileOrDir
+3. daemon 跑着时 remove --purge → 5s 内 daemon `bots=...` 数下降 + 对应 tmux session 消失
+4. baseline ≥ 1506 / 1(本 finding +2 测试)
+
+### 风险
+
+- **多 role 同 slug**:`~/.ccteam/imd/registry/<slug>/` 可能有多个 role JSON;rm -rf 一次清完。MCP unregister 路径需对每个 role 单调。
+
+---
+
+# EPIC F — Advise + Codex critic(P1)
+
+**主线**:V0.6.0 立项 F112 §A 承诺 Claude + Codex 并行 advisor,Wave 3 实际 ship 了 `CodexExecAdapter`(Rust 层 OK),但 MCP `advise_*` 工具表面留 STUB,`/ccteam-advise` skill body 调到 NotImplemented。
+
+## F152 — `mcp__ccteam__advise_vote` 真实现
+
+### 痛点
+
+`/ccteam-advise "A vs B 该选哪个"` 跑完,后台调 `mcp__ccteam__advise_vote` → NotImplemented → skill 静默退化为纯 Claude 单边回答,违反 "Codex unavailable" 必须显式提示的红线(skills/ccteam-advise/SKILL.md "Red lines" §3)。
+
+### 现状缺口
+
+`crates/ccteam-cli/src/mcp_advise_tools.rs::dispatch()`:
+```rust
+match name {
+    "ccteam__advise_vote" | "ccteam__advise_parallel" => {
+        ... "error": "NotImplemented" ...
+    }
+    _ => Ok(None),
+}
+```
+
+### 需求
+
+**`ccteam__advise_vote`**:
+- input:`{ question: string, context?: string, codex_timeout_secs?: number(default 60) }`
+- 实现:并行 spawn 两个 advisor session
+  - Claude 路径:走 in-process Claude API call(同 Task subagent 路径,sonnet,system prompt = `personas/critic.md`)
+  - Codex 路径:`crates/ccteam-core/src/execution/codex_exec.rs::CodexExecAdapter::start_thread + submit_turn` 一次性 q&a(同 mode 2 bg 但只问一题)
+- 等两边返回 → 第三次 Claude call 做 verdict synthesis(prompt:看双方 verdict 找 agreement / disagreement / suggest 1 winning approach)
+- 返回:`{ ok: true, verdict: string, claude_answer: string, codex_answer: string|null, codex_status: "ok"|"timeout"|"unavailable"|"error", agreement: "agree"|"disagree"|"partial" }`
+- **Codex 不可用** → `codex_answer: null` + `codex_status: "unavailable"`(reason: codex not in PATH / not authenticated / etc.),verdict 段必须显式说 "Codex unavailable: <reason>"(红线守)
+
+**预算**:本调用计入 `~/.ccteam/cost-budget.json::advise_today_usd`;`max_cost_usd_per_24h`(per-vendor,沿用 V0.6.0 budgets)超顶 → 拒服务返 `ok: false, error: "budget_exceeded"`。
+
+### 文件
+
+- `crates/ccteam-cli/src/mcp_advise_tools.rs` ── dispatch 真实现
+- `crates/ccteam-core/src/advise.rs`(新)── 提供 `advise_vote()` 函数,封装并行 spawn + synthesis 逻辑
+- `crates/ccteam-cli/tests/mcp_advise_vote_test.rs`(新)── stub Claude API + stub `codex exec`,跑完整 vote 路径,验 verdict 输出 + agreement 标记 + Codex unavailable 路径
+- `docs/interfaces.md` ── §MCP 表 advise_vote 从 STUB → 真描述
+
+### 验收
+
+1. 真路径(Codex installed + auth)→ verdict 包含 claude_answer 段 + codex_answer 段 + 1 段 synthesis
+2. Codex unavailable(`CCTEAM_CODEX_BIN=/bin/false`)→ verdict 显式说 "Codex unavailable: <reason>",仍返 ok: true
+3. budget 触顶 → returns budget_exceeded,**不**消耗 advisor 调用
+4. baseline ≥ 1514 / 1(本 finding +8 测试)
+
+### 风险
+
+- **Codex CLI 协议漂移**:F144 已修 vendor forward-compat 解析,本 finding 沿用 ── codex stderr / exit code / `--json` 输出新字段时不 panic
+- **并行 Claude API rate-limit**:Claude API quota 撞顶 → claude_answer:"<rate-limited>",verdict 文本必须涵盖该 case
+
+---
+
+## F153 — `mcp__ccteam__advise_parallel` 真实现
+
+### 痛点
+
+advise_vote 是 2 advisor + 1 synthesizer;advise_parallel 是 N-of-N 不合成。`/ccteam-team 3:reviewer` 这类 N-way 调用都路由到 advise_parallel,目前 STUB。
+
+### 现状缺口
+
+同 F152,dispatch arm 还是 NotImplemented。
+
+### 需求
+
+**`ccteam__advise_parallel`**:
+- input:`{ question: string, n: number(2-8), vendors?: ("claude"|"codex")[](default ["claude","codex"]), timeout_secs?: number(default 60) }`
+- 实现:fan out N parallel advisors(vendors round-robin OR explicit per-slot),不合成
+- 返回:`{ ok: true, answers: [{ vendor, answer, status }] }`(N 项数组)
+- 当 `vendors.len() < n` 时 round-robin 凑齐;`vendors.len() > n` 直接报错 invalid input
+
+### 文件
+
+- `crates/ccteam-cli/src/mcp_advise_tools.rs` ── dispatch
+- `crates/ccteam-core/src/advise.rs` ── `advise_parallel()` 函数,基础设施同 F152(共享 spawn helper)
+- `crates/ccteam-cli/tests/mcp_advise_parallel_test.rs`(新)── N=4 case 验返回 4 项 + N=8 vendors=["claude"] 全 claude 验证 + budget 触顶 case
+
+### 验收
+
+1. N=4 vendors=["claude","codex"] → 2 claude + 2 codex 答(round-robin)
+2. N=2 vendors=["claude"] → 2 claude
+3. budget 触顶 → 不消耗 advisor,err
+4. baseline ≥ 1518 / 1(本 finding +4 测试)
+
+### 风险
+
+- N 大时并行起码消耗大,Claude API rate 限制可能撞,timeout 默认 60s 后未返单条 → status `timeout`,answer 段空字符串
+
+---
+
+## F154 — `/ccteam-advise` skill body 文案修正
+
+### 痛点
+
+`skills/ccteam-advise/SKILL.md:168`:
+
+> "for N-way voting use the MCP tool `ccteam__advise_parallel` instead (**Wave 3 daemon**)."
+
+line 186 同样指向 "the daemon registers (`ccteam__advise_vote` / `ccteam__advise_parallel`)" 描述,**没说这两工具其实 STUB**。F152 + F153 ship 后这两行同步改成真路径描述。
+
+### 现状缺口
+
+skill 文本承诺的能力大于实际能力。
+
+### 需求
+
+`skills/ccteam-advise/SKILL.md` 改:
+- line 168 删 "(Wave 3 daemon)" 注 ── F152/F153 ship 后无需该注
+- §"Where to look" line 186 ── 描述准确(已是真路径,只删 "the daemon registers" 加注)
+- §"How this skill differs from ..." 段如果引用 STUB 状态 → 同步更新
+
+### 文件
+
+- `skills/ccteam-advise/SKILL.md`
+
+### 验收
+
+1. `grep -E "Wave [123]|STUB|NotImplemented" skills/ccteam-advise/SKILL.md` 0 命中
+2. baseline 不退
+
+---
+
+## F155 — `ccteam-creator` Phase 3.5 Codex auto-critic 验证
+
+### 痛点
+
+`skills/ccteam-creator/SKILL.md` Phase 3.5 (V0.6.0 Wave 3 F112 §B) 描述 ── 当 persona 是 critic-flavor 时,skill 自动跑 `codex --version && codex login status`,通了就 inject `executor: codex` 到 workflow.yaml。**但这是 skill 文本 ── Claude 决定要不要执行,没有 deterministic gate**。是否真的工作过 → 未知。
+
+### 现状缺口
+
+无测试覆盖。可能完全 broken,可能巧合工作,文档说 "real-verified on remote" 但实际证据只在 V0.6.0 host-probe.md。
+
+### 需求
+
+1. **写测试**:`crates/ccteam-core/tests/creator_codex_critic_test.rs`(新)── 模拟 critic persona(如 `code-critic`)被选中,断言 workflow.yaml 渲染时 `agents.<role>.executor: codex` 出现(当 `$CCTEAM_CODEX_BIN` 设为 stub 返成功时);unset 时不出现
+2. **加 deterministic gate**:`crates/ccteam-cli/src/commands.rs` 加 `ccteam doctor --check-codex-auto-critic` flag ── 跑同样 detection probe,exit 0 / 1 + stdout 输出 detected_state(用户和 skill 可同样 query)
+3. **skill 改**:Phase 3.5 文本明确说 "consult `ccteam doctor --check-codex-auto-critic`,subprocess output → decide" 而不是说 "subprocess inline"
+
+### 文件
+
+- `crates/ccteam-cli/src/commands.rs` ── 新 doctor flag
+- `crates/ccteam-core/src/templates/workflow_templates/` ── critic-flavor preset 模板加 `executor: codex` 占位 + tests
+- `crates/ccteam-core/tests/creator_codex_critic_test.rs`(新)
+- `skills/ccteam-creator/SKILL.md` ── Phase 3.5 段引用新 doctor flag
+
+### 验收
+
+1. `CCTEAM_CODEX_BIN=/path/to/working/codex ccteam doctor --check-codex-auto-critic` → exit 0 + stdout `{"available": true, ...}`
+2. `CCTEAM_CODEX_BIN=/bin/false ccteam doctor --check-codex-auto-critic` → exit 1 + `{"available": false, "reason": "..."}`
+3. test 覆盖:critic persona + codex_available=true → workflow.yaml 渲染含 `executor: codex`;codex_available=false → 不含
+4. baseline ≥ 1522 / 1(本 finding +4 测试)
+
+### 风险
+
+- **codex CLI 版本检测**:不同 codex 版本 stdout 格式有差异;`--version` parse 用宽松 prefix match(如 startswith "codex ")
+
+---
+
+## F156 — `/ccteam-team` §3.5 N≥3 critic auto-injection 验证
+
+### 痛点
+
+`skills/ccteam-team/SKILL.md:143`:
+
+> "When N ≥ 3 ... (`/ccteam-team 3:reviewer`) ... in V0.7) **will** route this through the daemon's `CodexExecAdapter` so the critic gets Codex evidence ..."
+
+读起来像 "Wave 3 没做,V0.7 才做"。但 V0.6.0 Wave 3 ship 了 CodexExecAdapter 完整,V0.6.5 F152 又把 advise vote 接通 ── 该把这段含糊描述要么改"真路径已通"要么明确"V0.7 计划",不能两可。
+
+### 现状缺口
+
+V0.6.0 → V0.6.5 跨 5 个 patch 没人 review 这段。
+
+### 需求
+
+1. **Audit** `skills/ccteam-team/SKILL.md` §3.5 当前真实路径:N=3 时是不是真的会路由 critic 到 Codex?如否,**显式标注 V0.7+ deferral**(参考 ccteam-im-setup skill 拒 Slack/Discord 的格式)
+2. **决策**:Codex critic auto-injection in `/ccteam-team` 是
+   - (a) **本 V0.6.5 同步实现**(加 1 个 small test + 1 段 wave-2 spawn helper)── 若 advise_vote 已接通,这条几乎免费
+   - (b) **明确 V0.7 推迟**(文案改清)
+3. 用户 choose (a) → 加测试 + 实现;choose (b) → 仅文案 sweep
+
+**决策默认 = (a)**:advise vote infra 在 F152 已 ready,team-3-reviewer 走同 helper 即可,工时小、价值大。
+
+### 文件
+
+- `skills/ccteam-team/SKILL.md` ── §3.5 文案改
+- `crates/ccteam-core/tests/team_3reviewer_codex_critic_test.rs`(新)── stub adapter 验:N=3 reviewer team + Codex available → 至少 1 role 是 codex
+- 可选:`crates/ccteam-core/src/templates/workflow_templates/team-3-reviewer.yaml` ── if Codex auto-critic injection 落进模板而非 skill 决策
+
+### 验收
+
+1. `grep "in V0\.7" skills/ccteam-team/SKILL.md` 0 命中
+2. (如选 a)stub adapter test pass
+3. baseline ≥ 1524 / 1(本 finding +2 测试,如选 a;选 b 则 +0)
+
+### 风险
+
+- 选(a)时需测试 `multi_workflow` 模板 schema 是否够灵活 ── 若需扩 schema,scope creep;选(b)保守
+
+---
+
+# EPIC G — UX cohesion + F113 收账
+
+**主线**:用户上手 30 秒看到 value;决策树替代 mode/preset/recipe 三层抽象;dispatcher 文案对齐当前真实状态;F113 验收 #5 (50-query intent classification) 第一次真做。
+
+## F157 — `ccteam-scan --quick` 60s 内出报告 + `/ccteam` 加 code-scan 入口
+
+### 痛点
+
+V0.6.2 ship 的 `ccteam-scan` 是大码库 audit(分层 CLAUDE.md / 噪声排除 / LSP / map 四项),跑全量 5-10 分钟。**新用户 30 秒内看到 value** 这条目标没有任何 ccteam 路径满足 ── quickstart 还在 lead with TG bot(需要 token / 5+ 分钟 onboard)。
+
+### 现状缺口
+
+`skills/ccteam-scan/SKILL.md` 设计目标是 audit-quality,不适合 60s zero-config 体验。
+
+### 需求
+
+1. `ccteam-scan` 加 `--quick` flag(default mode 仍是 audit)
+2. `--quick` 启用 1 个 sonnet agent + 3 个固定问题:
+   - 问 1:`ls -la` + `git ls-files | head -50` → 推断主语言 / 框架 / 入口文件
+   - 问 2:`rg "TODO|FIXME|HACK"` → top 10 热点
+   - 问 3:CLAUDE.md / README.md 存在?有则简介,无则建议初始化
+3. 输出 `<repo>/.ccteam/codebase-scan.md`(同当前 path)── 但 frontmatter 加 `quick: true` flag,后续 audit mode 跑时升级
+4. `skills/ccteam/SKILL.md` 增加第 5 个 intent(`code-scan`):"扫一下代码 / 摸底新项目 / scan code / audit codebase"
+5. `/ccteam "扫一下代码"` → route to `/ccteam-scan --quick`
+
+### 文件
+
+- `skills/ccteam-scan/SKILL.md` ── 加 `--quick` mode description
+- `skills/ccteam/SKILL.md` ── 加 intent 5 (code-scan) + 路由
+- `tests/integration/scan_quick_test.sh`(新)── tempdir + git init + 几个 fake file → 跑 `/ccteam-scan --quick` → 验落地报告 + 内容覆盖 3 问题
+
+### 验收
+
+1. 在 `/tmp/test-rust-repo`(预装一个 sample crate)跑 `/ccteam-scan --quick` ── 90 秒内出 `.ccteam/codebase-scan.md`
+2. 报告含三段(language/framework/entry, TODO hotspots, CLAUDE.md status)
+3. `/ccteam "扫一下代码"` 路由到 scan ── intent classifier 测试(F162 fixture 加 5 条对应 sample query)
+4. baseline 不变(skill 改不影响 cargo test)
+
+### 风险
+
+- **sonnet 1 agent 60-90s 不一定够**:fallback 是把 quick 改成 haiku 4.5(更快、便宜);trade-off 见 dev-plan §Epic G
+
+---
+
+## F158 — `docs/task-to-command.md` 决策树 + tier-1 docs lead 改写
+
+### 痛点
+
+`docs/orchestration-patterns.md` 讲 mode/preset/recipe 三层抽象,用户面对的真问题是 "我想做 X,用啥命令"。现状逼用户读架构文档才会用。
+
+### 现状缺口
+
+文档结构 contributor-centric,不是 user-centric。
+
+### 需求
+
+1. 新文档 `docs/task-to-command.md` ── 单屏决策树(草案见 README §Epic B):
+   ```
+   你想做的事                              → 用这个
+   ──────────────────────────────────────────────────────
+   摸底新代码库 / audit                     /ccteam-scan
+   开发 / 修 bug / 重构(全程盯着)         /ccteam-team "<task>"
+   review PR / 第二意见                     /ccteam-advise "<PR or path>"
+   做个 IM 私聊助理(长期 24/7 在线)       /ccteam-creator "做个 X 助理"
+   做个团队 IM 圆桌(多 bot 互动)          /ccteam-creator "群里几个 bot"
+   夜里跑长任务(hands-off)                /ccteam-creator "<task>,关电脑跑"
+   看 / 暂停 / 恢复 / 看花费                /ccteam-control list / pause / cost
+   配 / 改 IM token                         /ccteam-im-setup
+   不确定?用自然语言问                     /ccteam "<NL 描述>"
+   ```
+2. 嵌入 `docs/quickstart.md` 顶部第一节(覆盖原 TG bot 5 分钟段位置;TG bot 留下沉到 §2 "若你要做 IM bot")
+3. 嵌入 `docs/user-manual.md` 顶部
+4. **`README.md`(英文,root)** ── 加同样表格的英文版(根 README 必须英文 per CLAUDE.md §三)
+5. `docs/orchestration-patterns.md` 加 frontmatter `audience: contributors`(向新用户标注)
+
+### 文件
+
+- `docs/task-to-command.md`(新)
+- `docs/quickstart.md` ── 重写第一节
+- `docs/user-manual.md` ── 加 lead 段
+- `README.md` ── 加决策树(英文)
+- `docs/orchestration-patterns.md` ── frontmatter
+
+### 验收
+
+1. `grep -E "mode:.*chat|preset:.*chat-pocket" docs/quickstart.md docs/user-manual.md README.md` 0 命中(架构词汇下沉到 advanced/)
+2. 决策树 9 条全在新用户路径覆盖 7 个 skill
+3. 用户视角:`cd /any/repo && claude && /ccteam` → dispatcher 第一句话 + 决策树第一行内容一致
+
+### 风险
+
+- 翻译 ── 根 README 英文必须 native,不能机器翻译。本 finding 决策树短,翻译 effort 可控。
+
+---
+
+## F159 — `/ccteam` 对未实现 intent 直接隐藏
+
+### 痛点
+
+`/ccteam` 当前若识别 intent 落在尚未实现的路径(F146-F156 之前的 advise / chat),用户跑下来撞 NotImplemented。**用户从 dispatcher 选了一个 → 死胡同**,体验最差的 1 种。
+
+V0.6.5 ship 后 ── F146-F156 实装,advise / chat 都通。本 finding 是 forward-looking:任何后续 V0.6.6+ 引入新 intent 但还没真实现的,**dispatcher 必须直接不暴露**,不打 placeholder。
+
+### 现状缺口
+
+`skills/ccteam/SKILL.md` 历史是"暴露 + warning",现在该转"未实现就不显示"。
+
+### 需求
+
+1. `skills/ccteam/SKILL.md` 加 §"Hide 未实现 intent" red line ── 任何未 ship 的 intent 不出现在 dispatcher 4-options 里,也不出现在路由表
+2. Each new sub-skill ship 时 ── 必须先确认 MCP 工具表面 + skill body 都 ready 才能加进 `/ccteam` intent 表
+3. 文案 review:`skills/ccteam/SKILL.md` 第 1-30 行的 intent 介绍只列 ship 状态的
+
+### 文件
+
+- `skills/ccteam/SKILL.md`
+
+### 验收
+
+1. `/ccteam` 跑下来 4-options 只列已 ship 路径(V0.6.5 ship 后是 7 个 intent 全 ship,4-options 应根据 NL 推断动态选 4 个最相关)
+2. `grep "STUB|NotImplemented|placeholder|fallback.*not.*ready" skills/ccteam/SKILL.md` 0 命中
+
+### 风险
+
+- 决策点:**dispatcher 看到 ambiguous intent 仍要给用户 4 options 选**,即使一个 intent 是未来 ── 这与本 finding 冲突。妥协:V0.6.5 内,4 options 只从 7 个 ship intent 里选;V0.6.6+ 新 intent ship 后再扩。
+
+---
+
+## F160 — CLAUDE.md §一 baseline 更新 + skill 状态注释清理
+
+### 痛点
+
+`CLAUDE.md §一 当前状态(2026-05-23)` 表里:
+- `Workspace version` 行还是 `0.6.3`(V0.6.4 ship 后没回填)
+- `当前最新版` 行还是 V0.6.3
+- `测试 baseline` 行 `1471/1` 应是 1482/1(V0.6.4 后)→ V0.6.5 ship 后 ≥ 1530/1
+- §四 Skills 段 6 sub-skill 列表 ── 含 ccteam-scan(✓)+ ccteam-im-setup(F117 一次性 IM token onboarding)── status 描述要核对(F117 描述里 Slack/Discord 推 V0.7 这件事是否说清)
+
+V0.6.4 ship 之后这个 §一 表也没回填(我作为 maintainer 漏的,不只是本 V0.6.5)。
+
+### 现状缺口
+
+CLAUDE.md 是每 session 自动加载的 SoT,baseline 数字不对会让下一个接手 Claude 浪费 time 重新校对。
+
+### 需求
+
+V0.6.5 ship 后(Wave 4):
+
+| Cell | 老 | 新 |
+|---|---|---|
+| HEAD | `83f8bce`(V0.6.3) | (V0.6.5 ship commit SHA)|
+| Workspace version | `0.6.3` | `0.6.5` |
+| 测试 baseline | `1471/1` | (V0.6.5 实际数,目标 ≥1530/1)|
+| Clippy | `0 errors + 0 warnings` | 不变 |
+| 代码规模 | `~73 kLOC Rust` | 实际新增后数,大致 ~74-76 kLOC |
+| 当前最新版 | `V0.6.3` | `V0.6.5`(并加 "完整 chat onboarding ship" 一句话总结)|
+| 上一版 | V0.6.2 | V0.6.4(回填 V0.6.4 OutboundCursor 一行)|
+| V0.6.x 延期候选 | `空` | `空`(本版闭所有 retained risk)|
+| V0.7 主线候选 | (不变,或更新)| 加 "Slack/Discord onboarding"(F146/F147 实装后 V0.7 解锁)|
+
+§四 Skills 表 ── ccteam-control / ccteam-advise / ccteam-im-setup status 描述 sync 到 V0.6.5 真实状态(`/ccteam-control` 实际接 admin_* MCP;`/ccteam-advise` 实装 vote/parallel;`/ccteam-im-setup` Telegram only,Slack/Discord V0.7)。
+
+### 文件
+
+- `CLAUDE.md` ── §一 表 + §四 skills 表
+
+### 验收
+
+1. Workspace HEAD = V0.6.5 ship 后 SHA,§一 表所有数字正确
+2. §四 skills 表 status 描述 = 实际能力,无"V0.7 才落地"占位
+
+### 风险
+
+无。doc-only。
+
+---
+
+## F161 — `/ccteam` dispatcher 文案 drift sweep
+
+### 痛点
+
+详见 §F149。**本 finding 是 F149 + F154 + F156 文案 sweep 的"用户面文档"配对** ── 这些 SKILL.md 改完后,docs/{quickstart,user-manual,recipes,troubleshooting,advanced/}/*.md 里如果还有引用"Wave 2/3 才落地"/"sub-skill body 占位"/"NotImplemented stub" 这类老话术,需要同步删 / 改。
+
+### 现状缺口
+
+User-facing docs 可能有 stale 提法。
+
+### 需求
+
+跨 docs/ root + skills/ + README.md grep:
+
+```bash
+grep -rn -E "Wave [123]|wave2-not-ready|sub-skill body|占位|STUB|NotImplemented" \
+  docs/{quickstart,user-manual,recipes,troubleshooting}.md \
+  docs/advanced/*.md \
+  skills/*/SKILL.md \
+  README.md
+```
+
+每条命中必须二选一:
+- (a) 标注为 "V0.6.x ship 前" 状态 → 直接删除(这是 V0.6.5 ship 后的状态)
+- (b) 标注是真实当前限制(如 V0.7 Slack onboarding)→ 改成 "V0.7+" 而非 "Wave X"
+
+`docs/versions/v0-6-*/` 历史归档**不**动 ── 历史描述保留。
+
+### 文件
+
+- 所有 grep 命中的文件
+
+### 验收
+
+1. 上述 grep 在 tier-1 user-facing 文档 0 命中
+2. baseline 不变
+
+### 风险
+
+无。
+
+---
+
+## F162 — F113 验收 #5 补做:50-query intent classifier ≥90% accuracy
+
+### 痛点
+
+`docs/versions/v0-6-0/prd.md:61` 是 F113 ship gate #5:
+
+> "host probe:5 个 sub-skill 各 1 host test,intent classification accuracy ≥90%(基于 50 个 sample query)"
+
+V0.6.0 Wave 4 ship 时仅跑了 5 preset E2E + 3 Codex scenario(`host-probe.md` 表),**完全没碰** 50-query intent test。V0.6.1-V0.6.3 patch 也没人补。这是 ccteam 旗舰功能(NL dispatcher)的核心验收数字 ── **从未存在**。
+
+### 现状缺口
+
+仓库全 grep:`sample_queries` / `intent_classifier` / `intent-test` 0 命中。
+
+### 需求
+
+1. **写 corpus** `tests/intent-corpus.yaml`:
+   ```yaml
+   # 50 NL queries → expected intent label (per /ccteam SKILL.md routing table)
+   # 7 intent labels: start-team, create-workflow, configure-im, monitor,
+   #                  advise, status-debug, code-scan(V0.6.5 新增)
+   queries:
+     - input: "我想做个 TG 助理 bot"
+       expected: create-workflow
+     - input: "fix all TS errors"
+       expected: start-team
+     - input: "暂停 dev-foo"
+       expected: monitor
+     - input: "为啥撞 budget"
+       expected: status-debug
+     - input: "扫一下这个代码库"
+       expected: code-scan
+     - input: "Claude + Codex 都看看 A vs B"
+       expected: advise
+     # ... 共 50 条,每 intent 至少 5-8 条,涵盖中英混合 + 不同句长 + 同义词 + 错别字
+   ```
+2. **写 runner** `scripts/host-probe/intent-accuracy.sh`:
+   ```bash
+   #!/bin/bash
+   # 跑 corpus 过 /ccteam dispatcher intent classifier
+   # 输出 confusion matrix + overall accuracy + per-intent precision/recall
+   # 把结果落到 docs/versions/v0-6-5/intent-accuracy.md
+   # exit 0 if accuracy ≥ 0.90 else exit 1
+   ```
+3. **运行方式**:driver 是 claude TUI session 处理 corpus 每条 query 后输出 routed intent;runner 把 50 个 输入 喂给 Claude,从输出抓 intent label(模式 = `routed_intent: <label>` 一行,或类似机器可读约定),对比 expected。**避免 50 次真实 claude 跑得太慢/太贵** ── runner 可选 mock(stub claude `claude --print --output-format json`)模式只跑 SKILL.md 路由表静态 match,不真起 sonnet。
+4. **结果落地** `docs/versions/v0-6-5/intent-accuracy.md`:
+   - 总 accuracy 数字
+   - confusion matrix 7×7
+   - 失败 case 列(`expected vs predicted` + Why,人工归因)
+   - Ship gate:≥ 90% 通过,< 90% block ship
+
+### 文件
+
+- `tests/intent-corpus.yaml`(新)── 50 query
+- `scripts/host-probe/intent-accuracy.sh`(新)── runner
+- `docs/versions/v0-6-5/intent-accuracy.md`(新)── 结果归档
+- `crates/ccteam-cli/src/commands.rs`(可选)── `ccteam doctor --intent-accuracy` flag 调 runner,formatted output
+
+### 验收
+
+1. runner 跑完 50 条 ── overall accuracy ≥ 0.90
+2. confusion matrix 落 `intent-accuracy.md`
+3. failed case 全部人工归因(模糊 input?intent overlap?SKILL.md 路由表不准?)
+4. 任何 < 90% 的 intent → 单 finding 跟,**不**阻 V0.6.5 ship(但 ship gate doc 标注)
+5. baseline 不变(runner 是 host probe,不进 cargo test)
+
+### 风险
+
+- **真跑 50 次 claude API call 成本**:估算 sonnet 4.6 input ~50 tok x 50 = 2500 tok input;output ~50 tok x 50 = 2500 tok output;按 $3/Mtok in + $15/Mtok out → < $0.10。**可接受**,但 host-probe 模式默认 mock(静态路由表 match)+ `--real` flag 走真 LLM 验证。
+- **corpus 偏 ── 50 条可能不能代表 production**:V0.6.5 ship 后跟踪真实 user query,收集 / 扩 corpus 到 V0.6.6 / V0.7。
+
+---
+
+# 跨 finding 风险表(必读)
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| F146 `bot_running_status` 跨进程 heartbeat 文件 race | daemon + MCP 同写一个 heartbeat 路径 | daemon **只写**,MCP **只读**;mtime 30s 内 = running |
+| F146 vendor 大小写 `Claude` vs `claude` 已踩坑 | 注册失败静默 | MCP schema enum + dispatch 主动 lowercase |
+| F147 reset 期间 outbound flood 风险 | 又像 Bug B 闪现 | reset 触发时 OutboundCursor `force_set(0)` + `prior_offsets.clear()` |
+| F148 host-probe e2e 依赖 daemon 起 + tmux | 起不来 / hang | scripted health-wait 同 V0.6.1 F119 pattern;timeout 30s |
+| F151 daemon 跑着 remove --purge 行为 | tmux session 怎么干净关 | MCP unregister 先调,daemon graceful 关 tmux + delete 文件;daemon 不在则 fs 删 |
+| F152 Codex CLI 协议漂移 | advise vote 解析崩 | V0.6.3 F144 forward-compat 解析已 ship,沿用 |
+| F155 doctor `--check-codex-auto-critic` 检测假阳/阴 | creator 误判 | stub binary tests + 真机 host-probe 双管 |
+| F162 50-query corpus 偏 | accuracy 数字不代表 production | corpus 设计 review;default mock + opt-in real LLM run |
+
+---
+
+# Ship gate(同 README §5,prd 落实化)
+
+V0.6.5 → main merge 前必须:
+
+1. `cargo test --workspace --locked --no-fail-fast` ≥ **1530 / 1**
+2. `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
+3. F148 host-probe(fresh nas-box005):`/ccteam-creator "做个 TG 助理"` → `go` → 不手工 touch 任何文件 → 从 TG 发 `hi` → 收到回复,**手动签字**记入 `docs/versions/v0-6-5/host-probe.md`
+4. F162 `intent-accuracy.md` 落,accuracy ≥ 0.90
+5. tier-1 docs 文案 grep(F149/F154/F161 mandate)0 命中
+6. `CLAUDE.md §一 baseline` 表已更新(F160)
+7. `ccteam doctor` 报告 "MCP tool surface: 26 active, 0 stubs"
+8. workspace version bump `0.6.4 → 0.6.5`;commit 前缀 `v0.6.5:`
+9. git tag `v0.6.5`


### PR DESCRIPTION
## Summary

Doc-first PR for **V0.6.5** — 关 V0.6 的账. 17 findings across 3 epics, no code changes (代码走后续 Wave 1-3 PR).

V0.6.0 立项时承诺的 chat-mode end-to-end onboarding 从未真正交付. 2026-05-23 nas-box005 的 Telegram duplicate flood 调研把这条 root cause chain 暴露出来 — `/ccteam-creator` Phase 5.6 文档说 \`call ccteam_imd::register_bot()\` 但 MCP `chat_*` 全 STUB,从 V0.6.0 至今这条桥没建过. 长期被老用户手工补 registration 文件掩盖.

## Epic 概览

**Epic E — MCP 桥 + creator 通路 (P0,F146-F151)**
- F146 `mcp__ccteam__chat_register_bot` + `chat_list_bots` (拆 `chat_lifecycle` 为 atomic verbs)
- F147 `chat_send_input` + `chat_history` + `chat_reset`
- F148 `/ccteam-creator` Phase 5.6 end-to-end 跑通
- F149 `/ccteam` dispatcher 移除 Wave 2/3 fallback 文案
- F150 `/ccteam-control` 接 `admin_*` MCP 冒烟验证
- F151 `ccteam remove --purge` 同步清 `imd/registry/`

**Epic F — Advise + Codex critic (P1,F152-F156)**
- F152 `mcp__ccteam__advise_vote` 真实现 (基于已有 `CodexExecAdapter`)
- F153 `mcp__ccteam__advise_parallel` 真实现
- F154 `/ccteam-advise` skill body 文案修正
- F155 `ccteam-creator` Phase 3.5 Codex auto-critic + `ccteam doctor --check-codex-auto-critic` deterministic gate
- F156 `/ccteam-team` §3.5 N≥3 critic auto-injection 验证

**Epic G — UX cohesion + F113 收账 (P0/P1 混,F157-F162)**
- F157 `ccteam-scan --quick` 60s 体验 + `/ccteam` intent 5 (code-scan)
- F158 `docs/task-to-command.md` 决策树 + tier-1 docs lead 改写
- F159 `/ccteam` 未实现 intent 直接隐藏
- F160 `CLAUDE.md §一` baseline 更新 + skill 状态注释清理
- F161 dispatcher 文案 drift sweep (skills + docs)
- F162 F113 验收 #5 补做:**50-query intent classifier ≥90% accuracy** (V0.6.0 立项 ship gate 至今未做)

## 文档结构

```
docs/versions/v0-6-5/
├── README.md (148 行)  — epic 概览 + 痛点映射 + 红线核对 + ship gate
├── prd.md    (826 行)  — 17 finding 完整需求 (痛点 / 现状缺口 / 设计 / 文件 / 验收 / 风险)
└── dev-plan.md (197 行) — 4 Wave / worktree-per-finding 执行计划
```

## Wave 结构

| Wave | 主题 | Findings | Teammates | 估算 |
|---|---|---|---|---|
| 0 (本 PR) | doc-first | — | 1 | 0.5d |
| 1 | Epic E (MCP chat 桥) | F146-F151 | 5 parallel | 2.5d |
| 2 | Epic F (Advise + Codex critic) | F152-F156 | 3 parallel | 2d |
| 3 | Epic G (UX + F113 收账) | F157-F162 | 4 parallel | 2d |
| 4 | doc-syncer + ship gate | — | 1 | 1d |

**总计** 8 calendar days (并行) / 9-12 days (单线).

## Ship gate (V0.6.5 → main)

- [ ] `cargo test --workspace` ≥ 1530/1 (baseline 1482/1 起点)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] F148 host-probe (nas-box005 fresh wipe): `/ccteam-creator` → TG round-trip,无手工编辑 — 手动签字
- [ ] F162 `intent-accuracy.md` ≥ 0.90 accuracy
- [ ] tier-1 docs grep "Wave [123]/STUB/NotImplemented" 0 命中
- [ ] `CLAUDE.md §一 baseline` 表更新到 V0.6.5 数字
- [ ] `ccteam doctor` 报告 \"MCP tool surface: 26 active, 0 stubs\"

## Test plan

- [x] doc-only PR, no cargo changes
- [ ] User review pass + \`go\` → Wave 1 kick-off
- [ ] Each subsequent Wave PR carries its own validation suite (per finding 验收 in `prd.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)