### PR TITLE
docs(v0.6.5): Epic H (运维健壮性) + dev-kickoff prompt — 19 findings final

### DIFF
--- a/docs/versions/v0-6-5/README.md
+++ b/docs/versions/v0-6-5/README.md
@@ -1,10 +1,10 @@
-# ccteam V0.6.5 — V0.6 收尾:MCP 桥补全 + advise 落地 + UX cohesion + F113 验收补做
+# ccteam V0.6.5 — V0.6 收尾:MCP 桥补全 + advise 落地 + UX cohesion + 运维健壮性
 
-> **状态:doc-first / Wave 0**(本 PR 范围 = `README.md` + `prd.md` + `dev-plan.md`,代码 PR 走后续 Wave 1-3)。
-> **主题:** **关 V0.6 的账**。V0.6.0 立项时承诺的 chat-mode end-to-end onboarding(从 `/ccteam-creator` 跑下来到 TG 收回复)从未真正通过 ── 长期被「老用户手工补 registration 文件」掩盖,2026-05-23 nas-box005 的 Telegram duplicate flood 调研把 chain of root causes 全暴露出来。本版把 V0.6.0 Wave 2/3 应交未交的 MCP `chat_*` / `advise_*` 表面 + creator 注册桥 + advise vote + UX 决策树 + F113 验收 #5 (50-query intent test)一次合上。
+> **状态:doc-first / Wave 0**(本 PR 范围 = `README.md` + `prd.md` + `dev-plan.md` + `dev-kickoff.md`,代码 PR 走后续 Wave 1-4)。
+> **主题:** **关 V0.6 的账 + 关运维实战发现的账**。V0.6.0 立项时承诺的 chat-mode end-to-end onboarding(从 `/ccteam-creator` 跑下来到 TG 收回复)从未真正通过 ── 长期被「老用户手工补 registration 文件」掩盖,2026-05-23 nas-box005 的 Telegram duplicate flood 调研把整条 root-cause chain 全暴露出来,顺带发现 daemon 不响应 SIGINT/SIGTERM、claude-tui adapter 无法重附接已存在 tmux session 两个运维 blocker。本版把 V0.6.0 Wave 2/3 应交未交的 MCP `chat_*` / `advise_*` 表面 + creator 注册桥 + advise vote + UX 决策树 + F113 验收 #5 (50-query intent test) + 运维 robustness 双 finding 一次性合上。**所有 wave 必须在本版内完成,不留任何遗留给未来版本。**
 > **基线起点:** workspace `0.6.4` / test `1482 / 1`(V0.6.4 ship 数 + 那次 OutboundCursor PR 的 7 新测试)/ clippy `-D warnings` clean。
-> **基线目标:** workspace `0.6.5` / test ≥ `1530 / 1`(+48 估算,见各 Epic 验收)/ clippy `-D warnings` clean。
-> **痛点对应:** 13 用户痛点中 ── 痛点 4 (零摩擦上手)、痛点 5 (能否真正在 IM 闭环)、痛点 6 (跨 vendor 第二意见)、痛点 11 (Skill / 入口可发现性)。
+> **基线目标:** workspace `0.6.5` / test ≥ `1540 / 1`(+58 估算,见各 Epic 验收)/ clippy `-D warnings` clean。
+> **痛点对应:** 13 用户痛点中 ── 痛点 4 (零摩擦上手)、痛点 5 (能否真正在 IM 闭环)、痛点 6 (跨 vendor 第二意见)、痛点 9 (24/7 daemon 真能被运维)、痛点 11 (Skill / 入口可发现性)、痛点 14 (长跑可靠性)。
 
 ---
 
@@ -29,8 +29,10 @@
 |  | **F160** | CLAUDE.md §一 baseline 更新 + skill 状态注释清理 | S |
 |  | **F161** | `/ccteam` dispatcher 文案 drift sweep(6 处 stale Wave 1 fallback)| XS |
 |  | **F162** | F113 验收 #5 补做:50-query intent classifier accuracy test ≥90% | M |
+| **H — 运维健壮性**(P1,2026-05-23 实战发现)| **F163** | `ccteam start` 优雅响应 SIGINT/SIGTERM(关闭 tokio runtime + 清理 pidfile + 释放 web port + 关 tmux 子进程)| S |
+|  | **F164** | `claude-tui::start_thread` 自动重附接已存在 `ccteam-chat-<slug>-<role>` tmux session(daemon 重启不必人工 kill-session)| M |
 
-**总计** 17 finding · 3 Epic · 估算 9-12 工作日(单线作业)或 4-5 天(并行 worktree)。
+**总计** 19 finding · 4 Epic · 估算 10-13 工作日(单线作业)或 5 天(并行 worktree)。
 
 ---
 
@@ -40,10 +42,13 @@ V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2
 
 - F113 验收 #5 "50-query intent classification ≥90%" 在 v0-6-0 PRD line 61 是 ship gate,Wave 4 doc-syncer 时没补、V0.6.1-V0.6.3 三个 patch 也都没补 ── 这是 V0.6.0 的欠债。
 - `/ccteam-creator` Phase 5.6 说 "call `ccteam_imd::register_bot(...)`" ── Rust 函数存在但**没人能从 Claude TUI 外部调到它**(没 MCP / 没 CLI 子命令)。这条桥从 V0.6.0 立项以来就是断的。
+- V0.6.4 OutboundCursor PR ship + nas-box005 真机部署过程中**实战发现**两个运维 blocker(F163 / F164):daemon 不响应任何 graceful shutdown 信号(只能 SIGKILL,丢 in-memory state、留孤儿 pidfile),`claude-tui::start_thread` 看到已存在的 ccteam tmux session 直接报错而不是 reattach(daemon 重启周期里 bot 永久失能,必须人工 `tmux kill-session`)。这些不是 V0.6.0 PRD 承诺的 ── 是 ship 后**首次真生产部署**才出现的。但运维不通,用户面 chat onboarding(F148)就无法完整 ship。
 
-把这些归到 V0.7.0 等于把"V0.6 闭环"主题往后推一个 minor。V0.6.5 单独 ship 这 17 条,让 V0.6 真正闭环,V0.7.0 才能干净地开新主题(国内 IM / monorepo `.mcp.json` / chat memory sync / 第 4 mode HumanApproval 深化)。
+把这些归到 V0.7.0 等于把"V0.6 闭环"主题往后推一个 minor。V0.6.5 单独 ship 这 19 条,让 V0.6 真正闭环,V0.7.0 才能干净地开新主题(国内 IM / monorepo `.mcp.json` / chat memory sync / 第 4 mode HumanApproval 深化)。
 
 **与 CLAUDE.md §五 "pre-v1.0 不留技术债" 原则一致** ── 不写 backward-compat shim、不留 deprecated alias;workflow.yaml / registry schema 直接前进。
+
+**Strict no-wave-leftover 规矩**(本版自我加严):Wave 1-4 任何 finding 验收不过 → block 本版 ship,不允许 "下版本再补"。要么 finding 在本版做完,要么 finding 主动 EOL 删除。
 
 ---
 
@@ -54,7 +59,9 @@ V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2
 | 4 (零摩擦上手) | F157 / F158 / F159 | `ccteam-scan --quick` 是新用户 60 秒看到 value 的零依赖路径;决策树替代 mode/preset/recipe 三层认知 |
 | 5 (IM 闭环) | F146 / F147 / F148 / F151 | chat MCP 桥补全后,**从未跑通**的 `/ccteam-creator → daemon → TG` end-to-end 第一次真正可重现 |
 | 6 (跨 vendor 第二意见) | F152 / F153 / F154 / F155 | advise vote / parallel MCP 真实现,Codex auto-critic 验证 |
+| 9 (24/7 daemon 可运维) | F163 / F164 | SIGINT/SIGTERM 优雅退出;daemon 重启自动 reattach tmux,无需人工 `tmux kill-session` |
 | 11 (Skill / 入口可发现性) | F149 / F158 / F160 / F161 | 用户面文档 + dispatcher 文案对齐当前真实状态;F113 验收 #5 补做让"分类准"有数字 |
+| 14 (长跑可靠性) | F163 / F164 / F162 | 配合 9:graceful restart 让 chat bot 真能 7x24 跑;intent 准确度有 baseline 数字 |
 
 ---
 
@@ -66,8 +73,8 @@ V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2
 | `progress.jsonl` 是唯一 state SoT | F146-F151 不写 progress | bot lifecycle 事件由 BotSupervisor 自己写 progress,MCP 工具不直接写 |
 | No prompt injection | F147 `chat_send_input` 写 mailbox 文件 | mailbox 是已有路径,与 inbox 同级别处理;不向 tmux pane 直接 send-keys system prompt |
 | 每次 spawn = fresh 1M context(bg 模式) | 不触及 | chat 模式 spawn 复用 context 是 feature(CLAUDE.md §三 原文) |
-| 永不主动 kill 长 session | F146-F151 不 kill | `chat_lifecycle.stop` 走 graceful `close_thread`;`chat_reset` 同 |
-| 不解析 tmux 终端输出 | 不触及 | F147 走 mailbox 写文件,不 scrape |
+| 永不主动 kill 长 session | F146-F151 不 kill;**F163 graceful shutdown 也守** | `chat_lifecycle.stop` / `chat_reset` 走 graceful `close_thread`;F163 SIGTERM handler 走 watch::channel cancel + 等 task graceful drop,**不直接 kill tmux**(tmux session 由 user 决定;daemon stop ≠ bot session stop)|
+| 不解析 tmux 终端输出 | 不触及 | F147 走 mailbox 写文件;**F164 reattach 用 `tmux has-session -t <name>` 退出码探测,不读 pane content** |
 | fix-loop 撞 3 次必 escalate | 不触及 | 本版无 fix-loop 改 |
 | `ccteam-core` 零 team 名字面量 | 不触及 | 本版 ccteam-core 改动仅在 cli / imd / mcp 层 |
 | 跨项目记忆走官方接口 | 不触及 | 本版不改 `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` 处理 |
@@ -100,15 +107,18 @@ V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2
 
 ## 5. Ship gate(V0.6.5 → main)
 
-1. **baseline**:`cargo test --workspace --locked --no-fail-fast` ≥ **1530 / 1**(1482 起点 + 各 finding 验收测试)
+1. **baseline**:`cargo test --workspace --locked --no-fail-fast` ≥ **1540 / 1**(1482 起点 + 各 finding 验收测试)
 2. **clippy**:`cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
 3. **`/ccteam-creator` end-to-end**:fresh machine + 零手工写文件 → `/ccteam-creator "做个 TG 助理"` → `go` → daemon 起 → TG 双向通(测试人确认)
 4. **F113 验收 #5 数字**:`scripts/host-probe/intent-accuracy.sh` 输出 ≥ 90% accuracy + confusion matrix 落 `docs/versions/v0-6-5/intent-accuracy.md`
-5. **tier-1 docs 文案 grep**:
+5. **F163 graceful shutdown 验证**:`ccteam start` 收 SIGTERM → 5s 内退出(进程消失)+ pidfile 自动 unlink + web port 7331 立即释放 + 无 zombie 子进程;**有自动化 test 覆盖**(`crates/ccteam-cli/tests/graceful_shutdown_test.rs`)
+6. **F164 tmux reattach 验证**:create 一个 `ccteam-chat-foo-bar` tmux session,跑 `start_thread(slug=foo, role=bar)` → 不报错 + 复用同 session pid(`tmux list-sessions -F "#{session_id}"` 前后一致)
+7. **tier-1 docs 文案 grep**:
    - `grep -rn "Wave [123]\|wave2-not-ready\|Wave 3.*未落地" skills/*/SKILL.md` 全 0 命中
    - `grep -rn "mode:.*chat\|preset:.*chat-pocket" docs/{quickstart,user-manual}.md README.md` 全 0 命中(决策树取代,内部架构词汇下沉到 docs/advanced/)
-6. **CLAUDE.md §一 baseline 表更新到 V0.6.5 数字** + §四 skill 状态注释清理
-7. **`cargo run --release -- doctor`** 输出含 "MCP tool surface: 26 active, 0 stubs"(原 9 个 stub 全实现)
+8. **CLAUDE.md §一 baseline 表更新到 V0.6.5 数字** + §四 skill 状态注释清理
+9. **`cargo run --release -- doctor`** 输出含 "MCP tool surface: 26 active, 0 stubs"(原 9 个 stub 全实现)
+10. **F148 / F157 / F162 / F163 / F164 host-probe 全部签字**(`docs/versions/v0-6-5/host-probe.md` 收齐每条 finding 一行 OK/Fail + log path)
 
 ---
 
@@ -119,30 +129,37 @@ V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2
 ```
 Wave 0  doc-first(本 PR)
         ├── README.md           ← 本文件
-        ├── prd.md              ← 17 finding 完整需求
-        └── dev-plan.md         ← worktree-per-epic + acceptance gate
+        ├── prd.md              ← 19 finding 完整需求
+        ├── dev-plan.md         ← worktree-per-finding + acceptance gate
+        └── dev-kickoff.md      ← 新会话开发提示词(主会话 agent-team / subagent 模式)
 
-Wave 1  Epic E(MCP chat 桥 + creator)── P0 解今晚 flood 真因
-        worktree-per-finding F146-F151,串行依赖 F146 → F148
+Wave 1  Epic E(MCP chat 桥 + creator)+ Epic H(运维健壮性)── P0
+        worktree-per-finding F146-F151 + F163 + F164,7 个 worktree 并行
+        串行依赖:F146 → F148;F163/F164 独立可并行
 
-Wave 2  Epic F(advise + Codex critic)── 并行
+Wave 2  Epic F(advise + Codex critic)
         worktree-per-finding F152-F156,F152/F153 可并行
 
 Wave 3  Epic G(UX cohesion + F113 验收)
-        F157-F160 并行;F161 文案 sweep;F162 intent fixture + 跑 + 报告
+        F157-F162 全并行
 
 Wave 4  doc-syncer + host-probe + ship gate
         CLAUDE.md baseline 回填 + tier-1 docs 同步 + version bump 0.6.4 → 0.6.5
+        nas-box005 真机跑 F148/F157/F162/F163/F164 host-probe,签字落
+        docs/versions/v0-6-5/host-probe.md
 ```
 
 每 Wave PR 必须 baseline ≥ 上 Wave 数字 + clippy 0 警告,否则不发。
+
+**Strict no-wave-leftover**:本版**不允许**把任何 finding 推到 V0.6.6 / V0.7。验收不过的 finding → 主会话 escalate 给用户 → 当场决策(继续做 / 主动 EOL 删除),不写 "TODO ship in V0.6.6"。
 
 ---
 
 ## 7. Doc-first 完成判据(本 PR 验收)
 
 - [ ] `README.md`(本文件)落
-- [ ] `prd.md` 17 finding 各章节完整(痛点 / 现状缺口 / 设计 / 文件 / 验收 / 风险)
+- [ ] `prd.md` 19 finding 各章节完整(痛点 / 现状缺口 / 设计 / 文件 / 验收 / 风险)
 - [ ] `dev-plan.md` 含 4 Wave + worktree 分配 + acceptance gate
+- [ ] `dev-kickoff.md` ── 新会话开发提示词,要求用 agent-team / subagent 防主会话 context 膨胀
 - [ ] CLAUDE.md `§一 当前状态` 表 `当前最新版` 行**暂不动**(代码 ship 后回填)
-- [ ] 用户 review pass → merge → Wave 1 kick-off
+- [ ] 用户 review pass → merge → 新会话执行 Wave 1-4

--- a/docs/versions/v0-6-5/dev-kickoff.md
+++ b/docs/versions/v0-6-5/dev-kickoff.md
@@ -1,0 +1,157 @@
+# V0.6.5 — 新会话开发提示词
+
+> 把下面整段(从 `=== START ===` 到 `=== END ===`)**整体**粘到新 Claude session 第一条消息里。
+>
+> 设计目标:**主会话 context 不膨胀**。主会话只做 (1) 读 PRD,(2) 派 worktree 给 subagent,(3) 验 acceptance gate。Worktree 内代码细节 / 测试输出 / 文件 diff 全部留在 subagent 上下文里,主会话只看一句摘要。
+>
+> 模型选 **Opus 4.7 (1M)** 或 **Sonnet 4.6**(可选 Opus 主会话 + Sonnet subagent)。
+
+---
+
+```
+=== START ===
+
+你是 V0.6.5 release 的主会话 orchestrator。当前位置:/home/rob/workplace/agents/ccteam(main 分支)。
+
+## 上下文(必读 3 份文档,顺序)
+
+1. `@CLAUDE.md` ── 项目红线 + 当前版本基线
+2. `@docs/versions/v0-6-5/README.md` ── 19 finding 4 Epic 全景
+3. `@docs/versions/v0-6-5/prd.md` ── 19 finding 完整需求(only read when dispatching a specific worktree;不要一次读完)
+4. `@docs/versions/v0-6-5/dev-plan.md` ── Wave 1-4 worktree 分配 + 验收 gate
+
+## 你的工作
+
+V0.6.5 共 4 wave,19 finding。**你必须在本会话内完成全部 ── 不允许把 wave 推到 V0.6.6 / V0.7。** 验收不过的 finding,中断 + 问用户 escalate(继续做 / 主动 EOL 删除),不写 "TODO V0.6.6"。
+
+你**不亲自**实现任何 finding。你的执行模型:
+
+```
+主会话(你)
+  ├── 读 PRD 找到当下 wave 的 worktree 列表
+  ├── 起 git worktree
+  ├── Task subagent 派工(per worktree,各自 briefing)
+  ├── 等 subagent 回报 acceptance gate (cargo test / clippy / 验收 checklist)
+  ├── 拉 subagent diff stat + 验证 commit message + PR push
+  ├── PR auto-merge
+  └── wave handoff doc 落 + 进下一 wave
+```
+
+## 关键 hard rules
+
+1. **主会话 context 紧抠**:不读 worktree 内 .rs 文件。Subagent 干完拿回 verification log + diff stat 就 OK。你看不懂的 rust 细节就让 subagent 解释,不要自己读源码。
+2. **worktree 标准**:每个 finding 独立 git worktree,路径 `/tmp/ccteam-v065-w<N>-<name>`,branch `v065-w<N>-<name>`。完事 `git worktree remove`。**主仓 main 永远 clean**。
+3. **不能跳过 acceptance gate**:每 finding 的 prd.md §"验收" 是 hard gate。任何一项不过 → 不让 subagent 继续 → 不 PR。
+4. **PR 流程**(每个 worktree):
+   - `git push -u "https://${GH_TOKEN}@github.com/firstintent/ccteam.git" <branch>:<branch>`(SSH push 经常失败,直接 HTTPS + token)
+   - `gh pr create --base main ...`
+   - `gh pr merge <N> --auto --squash`
+5. **wave 顺序**:Wave 1 → 2 → 3 → 4。**不允许并行跨 wave**(每 wave 必须 baseline ≥ 上 wave 数字 + clippy 0 警告才能下一 wave)。
+6. **wave 内部并行**:dev-plan.md 标"独立"的 worktree 同时派出去;有依赖关系的(如 F148 依赖 F146)等前置 merge 后派工。
+7. **Strict no-leftover**:wave 结束 handoff doc 五段固定(Decided / Rejected / Risks / Files / Remaining);Remaining 段**只能写当 wave 真发现的下版本候选,不能写"本版欠的 finding"**。任何欠的 finding ── 中断主流程 escalate 给我(用户)。
+
+## 派工模板(每 worktree)
+
+调用 `Task` 工具(subagent_type=general-purpose 或 code-simplifier 取决于工作性质),prompt 大致:
+
+```
+你是 V0.6.5 Wave <N> worktree <T-id> 的实现者。
+
+任务:实现 finding <F-N>(在 docs/versions/v0-6-5/prd.md 找完整 spec)。
+
+设置:
+1. git worktree add -b v065-w<N>-<name> /tmp/ccteam-v065-w<N>-<name> origin/main
+2. cd /tmp/ccteam-v065-w<N>-<name>
+3. 读 @docs/versions/v0-6-5/prd.md §<F-N> 完整 spec
+4. 实现(按 prd 设计 / 文件 / 验收)
+5. cargo test --workspace --locked --no-fail-fast — baseline 必须 ≥ <wave 累计目标>
+6. cargo clippy --workspace --all-targets --locked -- -D warnings — 0 warning
+7. cargo fmt -- <仅你改的 .rs 文件>(不要 fmt sweep 整个 workspace,会爆 PR diff)
+8. git commit + push via HTTPS token + gh pr create + auto-merge
+
+回报给主会话:
+- 一行 "F<N> done baseline X/Y clippy clean PR #<N> merged"
+- 验收 checklist 每项 ✓ / ✗
+- diff stat 行数 (+a -b 几文件)
+- 任何对 prd 设计的偏离(必须 escalate,不要自由发挥)
+
+不要回报:
+- .rs 实现细节
+- 完整 cargo test 输出(只回报 numbers)
+- 完整文件 listing
+```
+
+## Wave 1 → Wave 4 高层流程
+
+**Wave 1** (Epic E + Epic H,7 worktree)
+- T1 `mcp-chat-register` (F146) — 先派,merge 后再派 T2/T3
+- 同时派 T4 (F149) / T5 (F150) / T6 (F163) / T7 (F164) — 不依赖 T1
+- T1 merge 后派 T2 (F147) + T3 (F148+F151)
+- 全 merge + baseline ≥ 1516/1 → 落 wave-1-handoff.md → Wave 2
+
+**Wave 2** (Epic F,3 worktree)
+- T1 (F152) 先派,T2/T3 等 advise.rs 落
+- 同时派 T3 (F155+F156) — 不依赖
+- baseline ≥ 1534/1 → wave-2-handoff.md → Wave 3
+
+**Wave 3** (Epic G,4 worktree,全并行)
+- T1 (F157) / T2 (F158) / T3 (F159+F161) / T4 (F162) 同时派
+- baseline ≥ 1540/1 → wave-3-handoff.md → Wave 4
+
+**Wave 4** (doc-syncer + host-probe + ship,单 worktree)
+- CLAUDE.md §一 baseline 表回填 + §四 skill 状态注释清
+- tech-design.md / interfaces.md / claude-code-tool-surface.md sync
+- workspace version 0.6.4 → 0.6.5 bump
+- nas-box005 真机跑 F148 / F157 / F162 / F163 / F164 host-probe → host-probe.md 签字落
+- ship gate 11 项全 ✓ → PR + tag v0.6.5
+
+## 真机 host-probe(Wave 4)
+
+ssh `rob@192.168.1.19`,代码在 `/home/rob/nasworkspace/ccteam`。Wave 4 派一个 host-probe 专属 subagent,只跑 nas-box005 不写代码,签字回报。
+
+按需 wipe `~/.ccteam/ /home/rob/projects/<slug>/.ccteam/ ~/.claude/projects/-home-rob-projects-<slug>/`(`docs/versions/v0-6-5/README.md §5 Ship gate` 列出具体场景);F148 host-probe 严格要 fresh wipe(不能用任何老 registry 蒙混)。
+
+## 失败模式
+
+任何下列情况 → **立即中断 + escalate 给我**:
+1. 任何 finding 的验收 checklist 有一项过不去
+2. baseline 退步(任何 wave 后 cargo test pass count 降)
+3. clippy 0 warning gate 破
+4. 任何 wave handoff 的 Remaining 段出现 "TODO 留 V0.6.6"
+5. nas-box005 真机 host-probe 失败(F148 fresh wipe 走不通,或 F163 graceful shutdown 5s 不出,或 F164 reattach 报错)
+6. SSH push 失败(改 HTTPS,见 prd.md §"GitHub push fallback")
+7. PR 上有 mergeable=false / mergeStateStatus=DIRTY(rebase 解 conflict)
+
+## 关于上下文经济
+
+最 token-省的策略:
+- 主会话本身只 read README.md / dev-plan.md / 当下要派的 finding 那一段 prd.md
+- prd.md 全 826+ 行,**不要一次全读**;按 finding 按需读
+- subagent 看完 cargo test 几千行输出,只回 "1540/1 clean" 一行
+- 用 TaskGet 看 subagent 状态,不要重复发指令
+- 每个 worktree 派出去就让它自己跑到 PR 自动合,不来回 ping 状态
+
+## 启动
+
+1. 读 @CLAUDE.md
+2. 读 @docs/versions/v0-6-5/README.md
+3. 读 @docs/versions/v0-6-5/dev-plan.md
+4. 给我(用户)简短回报:"V0.6.5 Wave 1 即将派 7 worktree,F146 先行;无需等待 review,直接开始?"
+5. 我回 "go" → 派 Wave 1
+
+如有任何 spec 模糊处 ── 先问我,不要 freelance。
+
+=== END ===
+```
+
+---
+
+## 备注:为啥要这么做
+
+**V0.6.5 体量比一般 patch 大**(19 finding · 4 Epic · +58 测试 · 估 8 calendar days 并行)。如果主会话亲自实现每条:
+- prd.md 826 行 + 各 finding 实现文件代码 + cargo test 输出 + clippy 输出 + PR review pass + ... 主会话 context **必撞** 1M 上限
+- 撞了上限触发 auto-compaction,丢失主线策略,后期 wave 失去前期决策连续性
+
+**Agent-team / subagent 派工**让 worktree 各自烧 context,主会话只持有"调度 + 验收"心智模型,~80% context 一直空着备用 escalation/decision。这是 ccteam 设计哲学本身:**meta-harness 不亲自动手,套上去的 sub-harness 干活**。我们自己 dogfood。
+
+**Strict no-wave-leftover** 是这一版的纪律 ── 之前 V0.6.0 → V0.6.4 五个 patch 累积留账(MCP STUB / F113 验收 / 5.6 桥)就是 wave 留尾的恶果。V0.6.5 必须自己刹住这个习惯。

--- a/docs/versions/v0-6-5/dev-plan.md
+++ b/docs/versions/v0-6-5/dev-plan.md
@@ -1,8 +1,10 @@
-# V0.6.5 — Dev Plan(4 Wave / worktree-per-finding)
+# V0.6.5 — Dev Plan(4 Wave / worktree-per-finding · 19 finding · 4 Epic)
 
-> **Plan-first 原则**(CLAUDE.md §五):本文件 + `README.md` + `prd.md` user review pass 后才进 Wave 1。
+> **Plan-first 原则**(CLAUDE.md §五):本文件 + `README.md` + `prd.md` + `dev-kickoff.md` user review pass 后才进 Wave 1。
 > **Pre-v1.0 不留技术债**:`workflow.yaml` / BotRegistration / MCP tool schema 直接前进;移除 `chat_lifecycle` STUB 时**不留 deprecated alias**;旧 user 手工 poke 的 registry JSON 文件 schema 不变,自然兼容。
 > **多 session 并行**:worktree-per-finding,主仓 `main` 不变 dirty;每 Wave 完成 PR 提交后再开下 Wave。
+> **Strict no-wave-leftover**:任何 finding 验收不过 ── 主会话 escalate 给用户 → 当场决策(继续做 / 主动 EOL 删除),**禁止**写 "TODO ship in V0.6.6 / V0.7"。本版收账,不开新账。
+> **执行模型**:主会话用 agent-team / Task subagent 派工各 worktree,主会话只做 dispatch + acceptance gate 验,不读各 worktree 实现细节,防 context 膨胀。详 `dev-kickoff.md`。
 
 ---
 
@@ -15,9 +17,9 @@
 
 ---
 
-## Wave 1 — Epic E:MCP chat 桥 + creator 通路(P0)
+## Wave 1 — Epic E(MCP chat 桥 + creator)+ Epic H(运维健壮性)(P0)
 
-**目标**:V0.6.0 立项就承诺、从未真正交付的 `/ccteam-creator` end-to-end onboarding 这次走通。今晚 2026-05-23 Telegram duplicate flood 的最深 root cause 关上。Wave 1 完成后第一次:fresh machine + 零手工编辑 → `/ccteam-creator` → daemon → TG 收回复。
+**目标**:V0.6.0 立项就承诺、从未真正交付的 `/ccteam-creator` end-to-end onboarding 这次走通,同时关掉 2026-05-23 nas-box005 实战发现的两条运维 blocker(SIGTERM 不响应 + tmux session 不 reattach)。Wave 1 完成后第一次:fresh machine + 零手工编辑 → `/ccteam-creator` → daemon → TG 收回复;daemon restart 周期里 bot 自动 reattach 老 tmux 不失能。
 
 ### 串行 + 并行依赖
 
@@ -27,9 +29,11 @@ F146 (register/list/unregister MCP)
 F148 (creator Phase 5.6 真调 F146)  ──┐
 F151 (remove --purge 也清 registry)  ──┴── 各自 worktree,F148/F151 可并行
   ↓
-F147 (send_input/history/reset MCP)  ── 独立 worktree(可与 F148/F151 并行)
+F147 (send_input/history/reset MCP)  ── 独立(可与 F148/F151 并行)
 F149 (/ccteam dispatcher 文案 sweep) ── 独立(F146 ship 后才动)
 F150 (/ccteam-control 接 admin_*)    ── 独立(全 wave 任何时点都可启)
+F163 (SIGINT/SIGTERM graceful)       ── 独立(完全不动 chat 路径)
+F164 (claude-tui reattach)           ── 独立(完全不动 MCP 路径)
 ```
 
 ### 工作树分配
@@ -41,20 +45,25 @@ F150 (/ccteam-control 接 admin_*)    ── 独立(全 wave 任何时点都可�
 | W1-T3 `creator-bridge` | `v065-w1-creator-bridge` | **F148** + **F151** | (F148) `/ccteam-creator` SKILL.md Phase 5.6/5.9 文案改 + e2e_creator_full_path_test.rs (stub TG/claude);(F151) `cmd_remove::purge` 加 `imd/registry/<slug>/` + 优先 MCP unregister fallback fs delete | 1.5 d |
 | W1-T4 `dispatcher-sweep` | `v065-w1-dispatcher-sweep` | **F149** | `skills/ccteam/SKILL.md` 6 处 stale Wave 1 fallback 删除;intent table 描述对齐当前实状态 | 0.5 d |
 | W1-T5 `control-admin-smoke` | `v065-w1-control-admin` | **F150** | audit `skills/ccteam-control/SKILL.md` MCP 调用 + 6 个 admin_* smoke test + `docs/user-manual.md` admin 段 | 1 d |
+| W1-T6 `graceful-shutdown` | `v065-w1-graceful-shutdown` | **F163** | `run_start` 加 `tokio::signal::ctrl_c()` + SIGTERM listener + watch::channel cancel + 5s timeout abort + pidfile unlink + 不 kill tmux 子进程;`graceful_shutdown_test.rs` 子进程 spawn + kill -TERM + 5s 验 ps clear | 1 d |
+| W1-T7 `tmux-reattach` | `v065-w1-tmux-reattach` | **F164** | `claude_tui::start_thread` 加 "session exists → 健康检查 → reattach OR recreate dead";`TmuxSession::list_pane_pids()` + `kill()` helpers;两个 test case(alive reattach / dead recreate);**不**改 `resume_thread` | 1.5 d |
 
-**并行**:T1 / T4 / T5 三人 day1 同时起;T2 day1 等 T1 框架定下来(共享 mcp_chat_tools.rs 文件);T3 day2 等 T1 PR merge 后启(依赖 chat_register_bot MCP)。
+**并行**:T1 / T4 / T5 / T6 / T7 day1 同时起;T2 day1 等 T1 框架定下来(共享 mcp_chat_tools.rs 文件);T3 day2 等 T1 PR merge 后启(依赖 chat_register_bot MCP)。
 
 ### Wave 1 PR 合入顺序
 
-1. **T1 F146** → merge first(基础设施)
-2. **T2 F147** + **T3 F148+F151** + **T4 F149** + **T5 F150** → 并行 PR,各自 review pass 后 merge
+1. **T1 F146** → merge first(基础设施,F147/F148/F151 都依赖)
+2. **T6 F163** + **T7 F164** + **T4 F149** + **T5 F150** → 并行 PR,各自 review pass 后 merge(都不依赖 T1)
+3. **T2 F147** + **T3 F148+F151** → 并行 PR(F148 依赖 T1)
 
 ### Wave 1 验收
 
-- `cargo test --workspace --locked --no-fail-fast` ≥ **1506 / 1**(1482 + 24 新测试估算)
+- `cargo test --workspace --locked --no-fail-fast` ≥ **1516 / 1**(1482 + 34 新测试:F146 +6 / F147 +8 / F148 +2 / F150 +6 / F151 +2 / F163 +4 / F164 +6)
 - clippy `-D warnings` clean
-- F148 e2e_creator_full_path_test.rs 通过(stub adapter)
-- **真机 host-probe**(nas-box005,fresh wipe):走通 `/ccteam-creator` + TG round-trip,**手动签字** → `docs/versions/v0-6-5/wave-1-handoff.md`
+- F148 `e2e_creator_full_path_test.rs` 通过(stub adapter)
+- F163 `graceful_shutdown_test.rs` 通过
+- F164 `claude_tui_reattach_test.rs`(alive + dead 双 case)通过
+- **真机 host-probe**(nas-box005,fresh wipe):走通 `/ccteam-creator` + TG round-trip + SIGTERM graceful + tmux reattach,**手动签字** → `docs/versions/v0-6-5/wave-1-handoff.md`
 - 每 PR 描述含 `prd.md` finding 链接 + verification log + `git push -u origin <branch>`(per V0.6 学到的陷阱)
 
 ### Wave 1 handoff 文档
@@ -87,7 +96,7 @@ F150 (/ccteam-control 接 admin_*)    ── 独立(全 wave 任何时点都可�
 
 ### Wave 2 验收
 
-- baseline ≥ **1524 / 1**(1506 + 18 新测试)
+- baseline ≥ **1534 / 1**(1516 + 18 新测试)
 - clippy clean
 - F152 真路径(Codex installed)+ Codex-unavailable path 双 e2e
 - `ccteam doctor --check-codex-auto-critic` exit code 行为正确
@@ -114,7 +123,7 @@ F150 (/ccteam-control 接 admin_*)    ── 独立(全 wave 任何时点都可�
 
 ### Wave 3 验收
 
-- baseline ≥ **1530 / 1**(1524 + 6 新测试)
+- baseline ≥ **1540 / 1**(1534 + 6 新测试)
 - clippy clean
 - F162 `intent-accuracy.md` 落,accuracy ≥ **0.90**(< 0.90 不阻 ship 但单独 finding 跟)
 - F157 `ccteam-scan --quick` 在 sample repo 90s 内出报告(host-probe)
@@ -145,12 +154,15 @@ F150 (/ccteam-control 接 admin_*)    ── 独立(全 wave 任何时点都可�
 
 ### Wave 4 ship gate(per README §5,prd.md §Ship gate)
 
-merge 前 8 项全 ✓:
+merge 前 11 项全 ✓:
 
-- [ ] cargo test ≥ 1530 / 1
+- [ ] cargo test ≥ **1540 / 1**
 - [ ] clippy `-D warnings` clean
 - [ ] F148 host-probe(nas-box005 fresh)pass + 手动签字
+- [ ] F157 host-probe(`scan --quick` ≤90s 出报告)pass + 手动签字
 - [ ] F162 intent-accuracy.md ≥ 0.90
+- [ ] F163 host-probe(`kill -TERM` 5s graceful)pass + 手动签字
+- [ ] F164 host-probe(daemon restart reattach)pass + 手动签字
 - [ ] tier-1 docs grep clean
 - [ ] CLAUDE.md §一 baseline 表更新
 - [ ] `ccteam doctor` 报告 MCP "26 active, 0 stubs"
@@ -163,13 +175,14 @@ merge 前 8 项全 ✓:
 | Wave | Teammates | Calendar days | 累计 baseline 增量 |
 |---|---|---|---|
 | 0 (doc-first) | 1 | 0.5 | — |
-| 1 (Epic E) | 5 parallel | 2.5 (T1 + T2/T3 后续) | +24 测试 → 1506/1 |
-| 2 (Epic F) | 3 parallel | 2 | +18 测试 → 1524/1 |
-| 3 (Epic G) | 4 parallel | 2 | +6 测试 → 1530/1 |
-| 4 (doc-syncer) | 1 | 1 | — |
-| **总计** | 5 peak / 13 unique role | **8 calendar days** | **+48 测试** |
+| 1 (Epic E + Epic H) | 7 parallel | 2.5 (T1 + T2/T3 后续) | +34 测试 → 1516/1 |
+| 2 (Epic F) | 3 parallel | 2 | +18 测试 → 1534/1 |
+| 3 (Epic G) | 4 parallel | 2 | +6 测试 → 1540/1 |
+| 4 (doc-syncer + host-probe) | 1 | 1 | — |
+| **总计** | 7 peak / 15 unique worktree role | **8 calendar days** | **+58 测试** |
 
-**单线作业** estimate:9-12 天(无 worktree 并行)。
+**单线作业** estimate:10-13 天(无 worktree 并行)。
+**主会话 + agent-team 并行 estimate**:5 calendar days(主会话不读 worktree 实现,只 dispatch + verify)。
 
 ---
 

--- a/docs/versions/v0-6-5/prd.md
+++ b/docs/versions/v0-6-5/prd.md
@@ -792,7 +792,130 @@ V0.6.0 Wave 4 ship 时仅跑了 5 preset E2E + 3 Codex scenario(`host-probe.md` 
 ### 风险
 
 - **真跑 50 次 claude API call 成本**:估算 sonnet 4.6 input ~50 tok x 50 = 2500 tok input;output ~50 tok x 50 = 2500 tok output;按 $3/Mtok in + $15/Mtok out → < $0.10。**可接受**,但 host-probe 模式默认 mock(静态路由表 match)+ `--real` flag 走真 LLM 验证。
-- **corpus 偏 ── 50 条可能不能代表 production**:V0.6.5 ship 后跟踪真实 user query,收集 / 扩 corpus 到 V0.6.6 / V0.7。
+- **corpus 偏 ── 50 条可能不能代表 production**:V0.6.5 ship 后跟踪真实 user query,**本版 50 条由 corpus reviewer audit pass 即可** ── 不能用"以后再扩"当绕过 90% gate 的借口。
+
+---
+
+# EPIC H — 运维健壮性(P1,2026-05-23 实战发现)
+
+**主线**:V0.6.4 OutboundCursor PR ship + nas-box005 真机首次部署过程中**实战发现**两个运维 blocker。这两条不是 V0.6.0 PRD 承诺的(是 ship 后才暴露的 production 痛),但**不修运维不通就无法签 F148 host-probe**(F148 验收要求 "fresh wipe → daemon → TG round-trip"),所以与 V0.6 收账主题强耦合,合并入 V0.6.5。
+
+## F163 — `ccteam start` 优雅响应 SIGINT/SIGTERM
+
+### 痛点
+
+2026-05-23 nas-box005 实战:`kill -INT <pid>` 等 10s 无响应,`kill -TERM <pid>` 等 10s 也无响应,**只能 SIGKILL**。这导致:
+- in-memory state 全丢(orchestrator 内部 watch::channel 没机会发 cancel,subtasks 不知道要 graceful drop)
+- pidfile `~/.ccteam/state/orchestrator.pid` 留 stale → 下次启动需 "stale pidfile reclaimed" warn 路径才能起来
+- web 端口 7331 释放靠 OS reaper(SIGKILL 也行,但若 fd 有 in-flight 写可能 leak)
+- 子进程 tmux session 不收任何信号 → 永久存活成孤儿(F164 治那个,但 F163 是 daemon 这一层的 graceful)
+
+### 现状缺口
+
+`crates/ccteam-cli/src/commands.rs::run_start` 主循环只 select 业务事件 + max-runtime watchdog,**没有 `tokio::signal::ctrl_c()` 或 `tokio::signal::unix::signal(SignalKind::terminate())` 监听**。`grep "signal\|SIGINT\|SIGTERM\|ctrl_c" crates/ccteam-cli/src/commands.rs` 0 命中(2026-05-23 实测)。
+
+`ccteam stop` 子命令是用户主动 CLI → 写 stop signal 文件 → daemon 看文件触发 shutdown 路径。但这条 file-trigger 路径**不响应 process signal**。
+
+### 需求
+
+`run_start` 主 loop 加 signal 监听:
+
+```rust
+let mut sigterm = tokio::signal::unix::signal(
+    tokio::signal::unix::SignalKind::terminate()
+).ok();
+let mut sigint = tokio::signal::ctrl_c();
+
+tokio::select! {
+    // 现有业务事件 arms
+    _ = sigint => { tracing::info!("SIGINT received, graceful shutdown"); break; }
+    _ = async { if let Some(s) = sigterm.as_mut() { s.recv().await; } } => {
+        tracing::info!("SIGTERM received, graceful shutdown");
+        break;
+    }
+}
+```
+
+Shutdown 路径(打破主 loop 后):
+1. **取消 watch::channel** → 所有 spawned tokio task(web / imd / orchestrator)看到 cancel 后自己 cleanup
+2. **等 task join**(设 5s timeout 防 hang;超时则 abort)
+3. **unlink pidfile + heartbeat 文件**:`~/.ccteam/state/orchestrator.pid` / `~/.ccteam/state/orchestrator.heartbeat` / `~/.ccteam/state/imd.heartbeat`
+4. **绝不直接 kill tmux 子进程** ── tmux session 是 bot 的 long-running,跟 daemon 生命周期解耦(red line:永不主动 kill 长 session);仅写一行 log 提示用户 "N tmux sessions left running (intentional)"
+5. **退出码** 0(graceful)/ 1(timeout reaping)
+
+### 文件(预估)
+
+- `crates/ccteam-cli/src/commands.rs::run_start` ── signal handler + shutdown sequence
+- `crates/ccteam-cli/tests/graceful_shutdown_test.rs`(新)── spawn `ccteam start --max-runtime 30s` 子进程 + 1s 后发 SIGTERM + 等 5s + 断言进程退出 + pidfile 不存在 + 端口 7331 释放
+- `docs/interfaces.md` ── §CLI lifecycle 注 "SIGTERM = graceful;SIGKILL = lossy(避免)"
+
+### 验收
+
+1. `cargo test -p ccteam-cli graceful_shutdown_test` pass(local + CI)
+2. 真机:nas-box005 `kill -TERM <pid>` → 5s 内 ps 看不到 + pidfile gone + `lsof -i :7331` empty
+3. SIGINT 同样行为
+4. baseline ≥ 1530 / 1 + 4 测试 → ≥ **1534 / 1**
+
+### 风险
+
+- **kill -9 强杀仍不响应**(SIGKILL 不能被捕获):预期行为,文档说清"SIGKILL 不 graceful,会留 stale pidfile,下次启动自动 reclaim"
+- **child task 不响应 cancel**(rust async task 不 cancellation-safe):cancel + 5s timeout 后 `tokio::task::JoinHandle::abort()` 兜底
+- **tmux 子进程在 SIGTERM 时收到 SIGHUP**(因为 daemon 是它们的 parent 经过 setsid 后变为孤儿,reparent 到 init,不会 SIGHUP):验证 nas 实测当前 ps 显示 tmux session ppid=1,所以 daemon 死不带它们。R(永不 kill 长 session)守。
+
+---
+
+## F164 — `claude-tui::start_thread` 自动重附接已存在 tmux session
+
+### 痛点
+
+2026-05-23 nas-box005 实战:daemon 重启后,看到老 tmux session `ccteam-chat-pocket-bot-assistant`(自 5/20 起,PPID=1)还在跑;调 `BotSupervisor::ensure_started → start_thread` → claude-tui adapter `tmux new-session -d` 因 session name 冲突报错 → `apply_action failed` 5s 一次 log 刷屏 → bot 永久失能;**必须人工 `tmux kill-session -t ccteam-chat-...`** 让 daemon 重新建。
+
+### 现状缺口
+
+`crates/ccteam-core/src/execution/claude_tui.rs::start_thread` 当前行为(2026-05-23 grep):
+
+```rust
+let session_name = chat_session_name(&ctx.slug, &spec.role);
+let session = TmuxSession::from_name(session_name.clone());
+if session.exists() {
+    return Err(HarnessError::SpawnFailed(format!(
+        "tmux session already exists: {session_name} (call resume_thread instead)"
+    )));
+}
+```
+
+它指 caller 走 `resume_thread`,但 `BotSupervisor::ensure_started` 路径从来不 call `resume_thread` ── 看到 supervisor 没起 thread 就调 `start_thread`,撞 SpawnFailed 一次次重试。
+
+### 需求
+
+`start_thread` 增加 "session 已存在 → 健康度判断 → reattach OR recreate":
+
+1. `if session.exists()`:
+   - **健康判断**:`tmux list-panes -t <session> -F "#{pane_pid}"` 拿 pane pid;`kill -0 <pid>` + `ps -p <pid> -o comm=` 看进程名包不包 `claude`
+   - **活的 → reattach**:不 spawn 新 process,只装/更新 hook 设置(`ensure_chat_hooks_installed`)+ ensure chat dir + 返回 ThreadHandle(identity 用既有 sid 或合成 "reattached-<session_name>")
+   - **死的(pid 不在 / 不是 claude)→ recreate**:`tmux kill-session -t <name>`(daemon 自己刚检测到的死 session,清理这一个 session **不违反** R6 "永不主动 kill 长 session" ── 那条 R 守的是"活的 bot 不被 daemon 主动 kill",死的 session 是孤儿不算)+ 走原来的 `tmux new-session` 创建路径
+2. log:`session reattached` vs `session recreated (dead pane)` 用 INFO 级别 + slug/role/老 pane pid 字段
+3. **不**改 `resume_thread` ── 它走 transcript-resume + 历史 sid 加载路径,不是 start_thread 该做的;F164 只让 `start_thread` 自闭环
+
+### 文件(预估)
+
+- `crates/ccteam-core/src/execution/claude_tui.rs::start_thread` ── 改逻辑;extract `is_pane_alive_with_claude(session) -> bool` helper
+- `crates/ccteam-core/src/tmux.rs` ── 加 `TmuxSession::list_pane_pids() -> Vec<u32>` + `TmuxSession::kill()` helpers(`tmux kill-session -t <name>`)
+- `crates/ccteam-core/tests/claude_tui_reattach_test.rs`(新)── tempdir + 起 fake tmux session + 跑 start_thread 断言 reattach;另一 case 模拟 dead pane(用 `tmux send-keys "exit" Enter` 让 pane 退出)断言 recreate
+- `docs/tech-design.md` § HarnessAdapter — start_thread 行为补 reattach 描述
+
+### 验收
+
+1. test: existing-alive-session → start_thread 成功 + session_id 不变(`tmux display-message -p "#{session_id}"` 前后一致)
+2. test: existing-dead-session → start_thread 成功 + session 被 recreate(pane pid 改变)
+3. 真机:nas-box005 daemon stop → daemon start → 老 `ccteam-chat-pocket-bot-tech-helper` session 自动 reattach + 5s 内 log `bot supervisor started thread` + bot 可正常收消息
+4. baseline ≥ 1534 / 1 + 6 测试 → ≥ **1540 / 1**
+
+### 风险
+
+- **pane "活" 判断假阳/阴**:claude 短暂 init / `/compact` 中,pane pid 是 claude 但暂时不响应输入。仅依 pid + comm name 判断,**不依赖 pane content scrape**(R 守)。"活的就 reattach" 是 over-eager 而非 over-conservative,代价是 reattach 到一个正在 /compact 的 session 时,下个 turn submit 可能要等 ── 可接受
+- **reattach 后 transcript-cursor 状态**:transcript-cursor.json 已有 V0.6.4 per-sid `prior_offsets` 机制(已 ship),reattach 一个 sid 不会 replay 历史(无 oscillation,因为 `discover_active_session` 仍按 mtime + subagent filter 选最新)。F164 不破坏 V0.6.4 修复
+- **race**:daemon 重启短窗口内,另一 daemon 实例同 slug/role 也 start_thread?── ccteam orchestrator pidfile 已防多实例,但若 user 强 SIGKILL old daemon + 立即 start new daemon 中间 pidfile lock 失败 ── 这是 F163 graceful shutdown 的 cleanup 路径覆盖范围
 
 ---
 
@@ -808,6 +931,10 @@ V0.6.0 Wave 4 ship 时仅跑了 5 preset E2E + 3 Codex scenario(`host-probe.md` 
 | F152 Codex CLI 协议漂移 | advise vote 解析崩 | V0.6.3 F144 forward-compat 解析已 ship,沿用 |
 | F155 doctor `--check-codex-auto-critic` 检测假阳/阴 | creator 误判 | stub binary tests + 真机 host-probe 双管 |
 | F162 50-query corpus 偏 | accuracy 数字不代表 production | corpus 设计 review;default mock + opt-in real LLM run |
+| F163 SIGKILL 仍不 graceful | stale pidfile,但**不能修** | 文档 + `ccteam start` 启动时的 "stale pidfile reclaimed" 路径已有(V0.6.1 ship);F163 只让 -INT/-TERM 不再走那个 reclaim 路径 |
+| F163 child task 不 cancel-safe | 5s timeout abort | `tokio::JoinHandle::abort()` 兜底;documentation 注 "shutdown 5s 内出" |
+| F164 reattach 到 /compact 中的 session | next turn submit 等更久 | 可接受;tmux 不被 scrape,行为正确 |
+| F164 daemon 跑着时 user 手工 tmux kill-session | 下个 tick `is_pane_alive_with_claude` 返 false → recreate | 这是正确路径;F164 自闭环 |
 
 ---
 
@@ -815,12 +942,15 @@ V0.6.0 Wave 4 ship 时仅跑了 5 preset E2E + 3 Codex scenario(`host-probe.md` 
 
 V0.6.5 → main merge 前必须:
 
-1. `cargo test --workspace --locked --no-fail-fast` ≥ **1530 / 1**
+1. `cargo test --workspace --locked --no-fail-fast` ≥ **1540 / 1**
 2. `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
 3. F148 host-probe(fresh nas-box005):`/ccteam-creator "做个 TG 助理"` → `go` → 不手工 touch 任何文件 → 从 TG 发 `hi` → 收到回复,**手动签字**记入 `docs/versions/v0-6-5/host-probe.md`
 4. F162 `intent-accuracy.md` 落,accuracy ≥ 0.90
-5. tier-1 docs 文案 grep(F149/F154/F161 mandate)0 命中
-6. `CLAUDE.md §一 baseline` 表已更新(F160)
-7. `ccteam doctor` 报告 "MCP tool surface: 26 active, 0 stubs"
-8. workspace version bump `0.6.4 → 0.6.5`;commit 前缀 `v0.6.5:`
-9. git tag `v0.6.5`
+5. F163 graceful shutdown 真机签字:nas-box005 `kill -TERM <pid>` → 5s 内 ps clear + pidfile gone + lsof :7331 clear,落 `host-probe.md`
+6. F164 reattach 真机签字:nas-box005 daemon restart → 老 tmux session 自动复用 + bot 立即可用 + 无 `apply_action failed` 日志,落 `host-probe.md`
+7. F157 host-probe:fresh repo `/ccteam-scan --quick` ≤ 90s 出报告,落 `host-probe.md`
+8. tier-1 docs 文案 grep(F149/F154/F161 mandate)0 命中
+9. `CLAUDE.md §一 baseline` 表已更新(F160)
+10. `ccteam doctor` 报告 "MCP tool surface: 26 active, 0 stubs"
+11. workspace version bump `0.6.4 → 0.6.5`;commit 前缀 `v0.6.5:`
+12. git tag `v0.6.5`


### PR DESCRIPTION
## Summary

Per user direction (option A from earlier discussion): add Epic H — operational robustness (F163 + F164) into V0.6.5 scope. **All work must complete in V0.6.5; no wave leftover to future versions.**

Adds 2 findings + 1 new doc on top of merged V0.6.5 PRD (#92).

## Epic H — 运维健壮性 (P1, 2026-05-23 实战发现)

| Finding | 一句话 |
|---|---|
| **F163** | `ccteam start` 优雅响应 SIGINT/SIGTERM (tokio::signal listener + watch::channel cancel + 5s timeout abort + pidfile unlink, **不直接 kill tmux 子进程**) |
| **F164** | `claude-tui::start_thread` 自动重附接已存在 \`ccteam-chat-<slug>-<role>\` tmux session (pid + comm name 健康检查,**不 scrape pane content**) |

Both are 2026-05-23 nas-box005 first-deployment 实战发现的运维 blocker. F163 means daemon needs SIGKILL today (loses in-memory state, stale pidfile); F164 means daemon restart leaves bot permanently broken until human \`tmux kill-session\`. Not in V0.6.0 PRD — but \`F148 host-probe end-to-end\` cannot pass without these two, so they must ship in V0.6.5.

## 新文档:dev-kickoff.md

\`docs/versions/v0-6-5/dev-kickoff.md\` (157 行) — 新会话开发提示词.

Per user mandate (\"开发要求用 agent team 或 subagent 来减少主会话上下文膨胀\"):
- 主会话不读 worktree 实现细节,只读 PRD + 派工 + 验 acceptance gate
- 每个 finding 独立 git worktree + Task subagent 实现 + PR auto-merge
- Subagent 回报压缩到 "F<N> done baseline X/Y clippy clean PR #N merged" 一行
- 估 8 calendar days 并行完成 (主会话 + subagent),vs 10-13 days 单线

## Strict no-wave-leftover (写入所有 3 个 doc)

Per user mandate (\"不要把 wave 留在未来版本，必须在当前版本全部完成\"):

> 本版**不允许**把任何 finding 推到 V0.6.6 / V0.7。验收不过 → escalate 给用户 → 当场决策 (继续做 / 主动 EOL 删除),**禁止** 写 \"TODO ship in V0.6.6\"。本版收账,不开新账。

## 全 V0.6.5 范围 (含本 PR)

19 finding · 4 Epic · +58 测试 · baseline 1482/1 → 1540/1

| Epic | Findings | 主题 |
|---|---|---|
| E | F146-F151 | MCP chat 桥 + creator 端到端 |
| F | F152-F156 | Advise + Codex critic |
| G | F157-F162 | UX cohesion + F113 验收补做 |
| **H (本 PR 新加)** | **F163-F164** | **运维健壮性** |

## Ship gate (11 项)

merge 前必须 ✓:
- [ ] cargo test ≥ 1540/1
- [ ] clippy \`-D warnings\` clean
- [ ] F148 host-probe (nas-box005 fresh) pass + 签字
- [ ] F157 host-probe (scan --quick ≤90s) pass + 签字
- [ ] F162 intent-accuracy.md ≥ 0.90
- [ ] **F163 host-probe (\`kill -TERM\` 5s graceful) pass + 签字**
- [ ] **F164 host-probe (daemon restart reattach) pass + 签字**
- [ ] tier-1 docs grep clean
- [ ] CLAUDE.md §一 baseline 表更新
- [ ] \`ccteam doctor\` 报告 MCP \"26 active, 0 stubs\"
- [ ] version bump 0.6.4 → 0.6.5

## 文件改动

- \`docs/versions/v0-6-5/README.md\` (+17 行): Epic H table rows + ship gate + wave structure
- \`docs/versions/v0-6-5/prd.md\` (+130 行): F163 + F164 detailed specs + risk table + ship gate
- \`docs/versions/v0-6-5/dev-plan.md\` (+13 行): Wave 1 expanded to 7 worktrees (T6 F163 + T7 F164) + baseline targets bumped
- \`docs/versions/v0-6-5/dev-kickoff.md\` (新, 157 行): new-session orchestrator prompt

## Test plan

- [x] doc-only PR, no cargo changes
- [ ] User review pass → \`go\` → 新会话 (Opus 4.7 1M) 接手用 \`dev-kickoff.md\` 启动 Wave 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)