### PR TITLE
v0.6.5 (F150): /ccteam-control admin_* MCP smoke tests

### DIFF
--- a/crates/ccteam-cli/tests/mcp_admin_smoke_test.rs
+++ b/crates/ccteam-cli/tests/mcp_admin_smoke_test.rs
@@ -1,0 +1,431 @@
+//! F150 — `mcp__ccteam__admin_*` MCP smoke tests.
+//!
+//! Verifies that `/ccteam-control` admin operations route correctly
+//! through the MCP wire layer.  Each test drives the real `ccteam
+//! mcp-serve` binary via stdin/stdout JSON-RPC (same harness as
+//! `mcp_e2e_test.rs`) and confirms the expected JSON response shapes
+//! and, where applicable, file-system side-effects.
+//!
+//! Operations covered (one test each):
+//!  1. `admin_workflow_pause`    — `ccteam__workflow_pause` returns ok=true
+//!  2. `admin_workflow_resume`   — `ccteam__workflow_resume` returns ok=true
+//!  3. `admin_list_workflows`    — `ccteam__admin_ls` returns project list
+//!  4. `admin_cost_today`        — `ccteam__admin_ls` response carries cost fields
+//!  5. `admin_stop_everything`   — `ccteam__workflow_signal` stop → inbox file
+//!  6. `admin_change_persona`    — `ccteam__admin_change_persona` rewrites agent .md
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+// ─────────────────────────── test harness ───────────────────────────
+
+struct McpServer {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl McpServer {
+    fn spawn(home: &std::path::Path, projects: &std::path::Path) -> Self {
+        let bin = env!("CARGO_BIN_EXE_ccteam");
+        let mut child = Command::new(bin)
+            .arg("mcp-serve")
+            .env("CCTEAM_HOME", home)
+            .env("CCTEAM_PROJECTS_ROOT", projects)
+            .env("CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn ccteam mcp-serve");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let mut line = serde_json::to_string(msg).unwrap();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn recv(&mut self) -> Value {
+        let mut line = String::new();
+        self.stdout
+            .read_line(&mut line)
+            .expect("read mcp-serve stdout");
+        serde_json::from_str(line.trim()).expect("parse mcp-serve JSON-RPC response")
+    }
+
+    fn shutdown(mut self) {
+        drop(self.stdin);
+        let _ = self.child.wait_timeout_or_kill(Duration::from_secs(2));
+    }
+}
+
+trait WaitTimeoutOrKill {
+    fn wait_timeout_or_kill(&mut self, timeout: Duration) -> Option<std::process::ExitStatus>;
+}
+
+impl WaitTimeoutOrKill for std::process::Child {
+    fn wait_timeout_or_kill(&mut self, timeout: Duration) -> Option<std::process::ExitStatus> {
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout {
+            if let Ok(Some(status)) = self.try_wait() {
+                return Some(status);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = self.kill();
+        self.wait().ok()
+    }
+}
+
+// ──────────────────────── project bootstrap ───────────────────────────
+
+const FIXTURE_WF: &str = r#"
+name: test-workflow
+agents:
+  worker:
+    executor: claude
+    trigger: watch:.ccteam/inbox/
+    input: .ccteam/inbox/
+    output: .ccteam/output/
+"#;
+
+/// Minimal state.json required by `pause` / `resume` (ProjectState
+/// serde-defaults handle all optional fields).
+fn minimal_state_json(slug: &str) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    format!(
+        r#"{{
+  "slug": "{slug}",
+  "team": "dev",
+  "created_at": "{now}",
+  "tmux_session": "ccteam-{slug}",
+  "soft_warn_threshold_usd": 20.0,
+  "hard_kill_threshold_usd": 200.0,
+  "context_tokens_used": 0,
+  "context_reset_threshold_tokens": 600000,
+  "context_reset_count": 0,
+  "last_progress_event_at": null,
+  "last_user_interaction_at": "{now}",
+  "user_attached": false,
+  "user_pause_pending": false
+}}"#
+    )
+}
+
+/// Write the minimal project layout the MCP admin tools need.
+///
+/// Creates:
+/// - `projects/<slug>/.ccteam/workflow.yaml`
+/// - `projects/<slug>/.ccteam/state.json`       (for pause/resume)
+/// - `home/state/orchestrator.heartbeat`         (daemon-alive gate)
+/// - `projects/<slug>/.claude/agents/<bot>.md`  (for change-persona test)
+fn bootstrap(home: &std::path::Path, projects: &std::path::Path, slug: &str, bot: Option<&str>) {
+    std::fs::create_dir_all(home).unwrap();
+    std::fs::create_dir_all(projects).unwrap();
+    let ccteam_dir = projects.join(slug).join(".ccteam");
+    std::fs::create_dir_all(&ccteam_dir).unwrap();
+    std::fs::write(ccteam_dir.join("workflow.yaml"), FIXTURE_WF).unwrap();
+    std::fs::write(ccteam_dir.join("state.json"), minimal_state_json(slug)).unwrap();
+
+    // Daemon heartbeat so mutating tools don't fail the health gate.
+    let state_dir = home.join("state");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    std::fs::write(
+        state_dir.join("orchestrator.heartbeat"),
+        format!("pid: {}\nat: {}\n", std::process::id(), now),
+    )
+    .unwrap();
+
+    // Persona file for the change-persona smoke test.
+    if let Some(b) = bot {
+        let agents_dir = projects.join(slug).join(".claude").join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(
+            agents_dir.join(format!("{b}.md")),
+            format!("---\nname: {b}\ntools: Read\n---\nOriginal persona body.\n"),
+        )
+        .unwrap();
+    }
+}
+
+/// Call a tool and assert `isError=false`; return the parsed body JSON.
+fn call_tool(srv: &mut McpServer, name: &str, args: Value) -> Value {
+    srv.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": { "name": name, "arguments": args }
+    }));
+    let resp = srv.recv();
+    assert_eq!(
+        resp["result"]["isError"], false,
+        "tools/call {name} returned isError=true: {resp:?}"
+    );
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    serde_json::from_str(text).expect("parse tool body as JSON")
+}
+
+// ─────────────────────────── 1. pause ──────────────────────────────
+
+/// F150 smoke 1 — `admin_workflow_pause`:
+/// `ccteam__workflow_pause` must return `ok=true` and set
+/// `user_pause_pending=true` in the response envelope.
+#[test]
+fn admin_workflow_pause() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    bootstrap(&home, &projects, "dev-alpha", None);
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    let body = call_tool(
+        &mut srv,
+        "ccteam__workflow_pause",
+        json!({ "slug": "dev-alpha" }),
+    );
+    assert_eq!(body["ok"], true, "pause must return ok=true");
+    assert_eq!(body["slug"], "dev-alpha", "pause must echo the slug back");
+    assert_eq!(
+        body["user_pause_pending"], true,
+        "pause must set user_pause_pending=true in response"
+    );
+    srv.shutdown();
+}
+
+// ─────────────────────────── 2. resume ─────────────────────────────
+
+/// F150 smoke 2 — `admin_workflow_resume`:
+/// `ccteam__workflow_resume` must return `ok=true`.  We start from an
+/// already-paused state (pause first) so the full round-trip exercises
+/// both directions.
+#[test]
+fn admin_workflow_resume() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    bootstrap(&home, &projects, "dev-beta", None);
+
+    let mut srv = McpServer::spawn(&home, &projects);
+
+    // Pause first, then resume — exercise the full round-trip.
+    call_tool(
+        &mut srv,
+        "ccteam__workflow_pause",
+        json!({ "slug": "dev-beta" }),
+    );
+
+    let body = call_tool(
+        &mut srv,
+        "ccteam__workflow_resume",
+        json!({ "slug": "dev-beta" }),
+    );
+    assert_eq!(body["ok"], true, "resume must return ok=true");
+    assert_eq!(body["slug"], "dev-beta", "resume must echo the slug");
+    srv.shutdown();
+}
+
+// ─────────────────────────── 3. list workflows ─────────────────────
+
+/// F150 smoke 3 — `admin_list_workflows`:
+/// `ccteam__admin_ls` must enumerate existing projects and report them
+/// in a `projects` array with the correct slugs.
+#[test]
+fn admin_list_workflows() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    bootstrap(&home, &projects, "dev-gamma", None);
+    bootstrap(&home, &projects, "dev-delta", None);
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    let body = call_tool(&mut srv, "ccteam__admin_ls", json!({}));
+    let arr = body["projects"]
+        .as_array()
+        .expect("projects must be an array");
+    assert!(
+        arr.len() >= 2,
+        "must list at least the 2 bootstrapped projects; got {}",
+        arr.len()
+    );
+    let slugs: Vec<&str> = arr.iter().filter_map(|p| p["slug"].as_str()).collect();
+    assert!(
+        slugs.contains(&"dev-gamma"),
+        "dev-gamma must appear in project list; got {slugs:?}"
+    );
+    assert!(
+        slugs.contains(&"dev-delta"),
+        "dev-delta must appear in project list; got {slugs:?}"
+    );
+    srv.shutdown();
+}
+
+// ─────────────────────────── 4. cost today ─────────────────────────
+
+/// F150 smoke 4 — `admin_cost_today`:
+/// `ccteam__admin_ls` response must carry `cost_24h_usd` on every
+/// project entry — that is the data backing `/ccteam-control show-cost`
+/// and `@ccteam cost today`.
+#[test]
+fn admin_cost_today() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    bootstrap(&home, &projects, "dev-epsilon", None);
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    let body = call_tool(&mut srv, "ccteam__admin_ls", json!({}));
+    let arr = body["projects"]
+        .as_array()
+        .expect("projects must be an array");
+    // Find the project we bootstrapped.
+    let proj = arr
+        .iter()
+        .find(|p| p["slug"] == "dev-epsilon")
+        .expect("dev-epsilon must appear in listing");
+    // cost_24h_usd must be present (may be 0.0 for a fresh project).
+    assert!(
+        proj.get("cost_24h_usd").is_some(),
+        "project entry must carry cost_24h_usd; got: {proj:?}"
+    );
+    // cost_used_usd (alias, also present for backwards compat).
+    assert!(
+        proj.get("cost_used_usd").is_some(),
+        "project entry must carry cost_used_usd; got: {proj:?}"
+    );
+    // Sanity: fresh project has zero cost.
+    let cost = proj["cost_24h_usd"].as_f64().unwrap_or(-1.0);
+    assert!(
+        cost >= 0.0,
+        "cost_24h_usd must be non-negative for a fresh project; got {cost}"
+    );
+    srv.shutdown();
+}
+
+// ─────────────────────────── 5. stop everything ────────────────────
+
+/// F150 smoke 5 — `admin_stop_everything`:
+/// `ccteam__workflow_stop_agent` with no `session_id` (i.e. stop ALL
+/// sessions of a role) is the MCP primitive backing the NL admin
+/// `@ccteam stop everything` path.  We confirm a `.ccteam/stop_signal/`
+/// marker file is written and the tool returns `ok=true`.
+#[test]
+fn admin_stop_everything() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    bootstrap(&home, &projects, "dev-zeta", None);
+
+    // stop_agent is a file-system marker write — it does NOT require a
+    // live daemon (the orchestrator reads the marker on its next tick).
+    let mut srv = McpServer::spawn(&home, &projects);
+    let body = call_tool(
+        &mut srv,
+        "ccteam__workflow_stop_agent",
+        json!({
+            "slug": "dev-zeta",
+            "role": "worker",
+            // session_id omitted → stop ALL sessions of this role
+        }),
+    );
+    assert_eq!(body["ok"], true, "stop_agent must return ok=true");
+    assert_eq!(body["slug"], "dev-zeta", "response must echo slug");
+    assert_eq!(body["role"], "worker", "response must echo role");
+
+    // The marker file must be written to .ccteam/stop_signal/.
+    let stop_dir = projects.join("dev-zeta/.ccteam/stop_signal");
+    assert!(
+        stop_dir.exists(),
+        "stop_signal dir must exist after stop_agent; checked {}",
+        stop_dir.display()
+    );
+    let entries: Vec<_> = std::fs::read_dir(&stop_dir).unwrap().collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "exactly one stop_signal marker expected; found {}",
+        entries.len()
+    );
+    // The marker file should be named `worker___all__` (session omitted).
+    let marker_name = entries[0]
+        .as_ref()
+        .unwrap()
+        .file_name()
+        .into_string()
+        .unwrap();
+    assert!(
+        marker_name.starts_with("worker_"),
+        "marker file must start with role prefix `worker_`; got `{marker_name}`"
+    );
+    srv.shutdown();
+}
+
+// ─────────────────────────── 6. change persona ─────────────────────
+
+/// F150 smoke 6 — `admin_change_persona`:
+/// `ccteam__admin_change_persona` must rewrite the bot's agent .md
+/// with the provided content and return `ok=true` + `bytes_written`.
+#[test]
+fn admin_change_persona() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    bootstrap(&home, &projects, "dev-eta", Some("worker"));
+
+    let new_persona =
+        "---\nname: worker\ntools: Read, WebFetch\n---\nRevised persona: 专注于 web 研究。\n";
+
+    let mut srv = McpServer::spawn(&home, &projects);
+    let body = call_tool(
+        &mut srv,
+        "ccteam__admin_change_persona",
+        json!({
+            "slug":           "dev-eta",
+            "bot":            "worker",
+            "new_persona_md": new_persona,
+        }),
+    );
+    assert_eq!(body["ok"], true, "change_persona must return ok=true");
+    assert_eq!(body["slug"], "dev-eta");
+    assert_eq!(body["bot"], "worker");
+    let bytes = body["bytes_written"].as_u64().unwrap_or(0);
+    assert!(bytes > 0, "bytes_written must be positive; got {bytes}");
+
+    // Verify the agent .md was actually rewritten on disk.
+    let agent_md = projects
+        .join("dev-eta")
+        .join(".claude")
+        .join("agents")
+        .join("worker.md");
+    assert!(
+        agent_md.exists(),
+        "agent .md must exist after change_persona"
+    );
+    let on_disk = std::fs::read_to_string(&agent_md).unwrap();
+    assert!(
+        on_disk.contains("WebFetch"),
+        "agent .md must contain the new tools list; got: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("Revised persona"),
+        "agent .md must contain the new body; got: {on_disk}"
+    );
+    assert!(
+        !on_disk.contains("Original persona"),
+        "old persona body must be gone; got: {on_disk}"
+    );
+    srv.shutdown();
+}

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -240,7 +240,157 @@ Web **只看不操作**。所有控制走 Claude session slash 或 IM。
 
 ---
 
-## §4 Cost 透明
+## §4 Admin 操作参考(`mcp__ccteam__admin_*` + `mcp__ccteam__workflow_*`)
+
+> 所有 admin 操作的首选路径是 **MCP 工具**(`mcp__ccteam__*`)。如果 MCP 未注册(尚未跑 `ccteam doctor --install-mcp`),可用对应的 Bash fallback。
+
+### §4.1 暂停 / 恢复 workflow
+
+**暂停**(停止自动派任务,但不 kill tmux session):
+
+```
+/ccteam-control pause <slug>
+```
+
+底层调用:
+
+| MCP 工具 | Bash fallback |
+|---|---|
+| `mcp__ccteam__workflow_pause { "slug": "<slug>" }` | `ccteam pause <slug>` |
+
+返回:`{ "ok": true, "slug": "...", "user_pause_pending": true }`
+
+**恢复**(清除暂停,下一个 orchestrator tick 重启派任务):
+
+```
+/ccteam-control resume <slug>
+```
+
+| MCP 工具 | Bash fallback |
+|---|---|
+| `mcp__ccteam__workflow_resume { "slug": "<slug>" }` | `ccteam internal resume <slug>` |
+
+返回:`{ "ok": true, "slug": "..." }`
+
+---
+
+### §4.2 列出所有 workflow(查看状态)
+
+```
+/ccteam-control list
+```
+
+| MCP 工具 | Bash fallback |
+|---|---|
+| `mcp__ccteam__admin_ls {}` | `ccteam ls --format json` |
+
+返回示例:
+
+```json
+{
+  "projects": [
+    {
+      "slug": "dev-helper",
+      "team": "dev",
+      "phase_state": "idle",
+      "cost_used_usd": 0.83,
+      "cost_24h_usd": 0.83,
+      "cost_active_usd": 0.0
+    }
+  ],
+  "orchestrator": {
+    "daemon_health": { "status": "healthy", "age_secs": 12 }
+  }
+}
+```
+
+---
+
+### §4.3 今日 Cost(`@ccteam cost today`)
+
+**Claude session**:
+
+```
+/ccteam-control show-cost
+```
+
+**IM 端**:
+
+```
+@ccteam cost today
+```
+
+底层都调 `mcp__ccteam__admin_ls`,从响应里读每个 project 的 `cost_24h_usd`。  
+`cost_24h_usd` = 最近 24h 内的 token 花费;`cost_used_usd` = 项目生命周期累计。
+
+---
+
+### §4.4 紧急停止 workflow(`@ccteam stop everything`)
+
+**单个 role 全停**:
+
+```
+/ccteam-control stop <slug> <role>
+```
+
+| MCP 工具 | Bash fallback |
+|---|---|
+| `mcp__ccteam__workflow_stop_agent { "slug": "...", "role": "..." }` | `ccteam internal stop <slug> <role>` |
+
+`session_id` 省略 = 停该 role 下所有 session。  
+底层写 `.ccteam/stop_signal/<role>___all__` 标记文件,orchestrator 在下一 tick 拆除 session。
+
+**IM 端 stop everything**(需 CONFIRM 二次确认,防误触):
+
+```
+@ccteam stop everything
+# bot 回: "Are you sure? Reply CONFIRM to stop all."
+CONFIRM
+```
+
+---
+
+### §4.5 修改 bot Persona(`change-persona`)
+
+修改某个 chat-mode bot 的行为、语言、工具集:
+
+```
+/ccteam-control change-persona <bot> "<NL 描述你想改什么>"
+```
+
+skill 会:
+1. 读 `<project>/.claude/agents/<bot>.md`(当前 persona)
+2. 把你的 NL 合并进 persona body
+3. 调 MCP 工具写回:
+
+| MCP 工具 | Bash fallback |
+|---|---|
+| `mcp__ccteam__admin_change_persona { "slug": "...", "bot": "...", "new_persona_md": "<完整 md>" }` | `ccteam admin change-persona <slug> <bot> -`(full markdown via stdin)|
+
+**`new_persona_md` 必须是完整文件内容**(YAML frontmatter + body),skill 负责组装;MCP 工具直接写文件,不做 NL parse。
+
+成功后 `progress.jsonl` 追加 `persona_changed` 事件,bot 下次 turn 自动 pick up 新 persona。
+
+---
+
+### §4.6 给 bot 加工具(`add-tool`)
+
+```
+/ccteam-control add-tool <bot> "<NL 描述能力>"
+```
+
+skill 把 NL 翻译成 Claude Code 工具名(如 `WebFetch`、`Bash`)后调:
+
+| MCP 工具 | Bash fallback |
+|---|---|
+| `mcp__ccteam__admin_add_tool { "slug": "...", "bot": "...", "tool_descriptor": "WebFetch" }` | `ccteam admin add-tool <slug> <bot> WebFetch` |
+
+操作是幂等的 — 重复加同一工具不报错(返回 `already_present: true`)。  
+成功后 `progress.jsonl` 追加 `tool_added` 事件。
+
+---
+
+## §5 Cost 透明
 
 ccteam 默认每个 workflow 有 24h cost cap(creator 起项目时问你)。
 
@@ -265,7 +415,7 @@ qa-loop          $4.12    $5.00     ↘ -3%      ⚠ 82% of cap
 
 ---
 
-## §5 从 V0.5 升级到 V0.6 — 0 用户操作
+## §6 从 V0.5 升级到 V0.6 — 0 用户操作
 
 V0.6 升级**完全无感**:
 
@@ -278,7 +428,7 @@ V0.6 升级**完全无感**:
 
 ---
 
-## §6 接下来去哪
+## §7 接下来去哪
 
 | 想干什么 | 读这个 |
 |---|---|


### PR DESCRIPTION
## Finding
F150 — `/ccteam-control` 接 `admin_*` MCP 验证

## Changes
- **`crates/ccteam-cli/tests/mcp_admin_smoke_test.rs`** (new): 6 integration smoke tests driving `ccteam mcp-serve` subprocess via JSON-RPC:
  - `admin_workflow_pause` — `ccteam__workflow_pause` returns ok=true + user_pause_pending=true
  - `admin_workflow_resume` — `ccteam__workflow_resume` returns ok=true after pause round-trip
  - `admin_list_workflows` — `ccteam__admin_ls` enumerates bootstrapped projects
  - `admin_cost_today` — `ccteam__admin_ls` carries cost_24h_usd + cost_used_usd fields
  - `admin_stop_everything` — `ccteam__workflow_stop_agent` writes stop_signal marker
  - `admin_change_persona` — `ccteam__admin_change_persona` rewrites agent .md on disk
- **`docs/user-manual.md`**: new §4 Admin 操作参考 with per-operation MCP tool name, Bash fallback, and response examples for all 6 admin operations
- `skills/ccteam-control/SKILL.md`: confirmed 0 legacy `ccteam ctl` hits (already MCP-first)

## Verification
- `cargo test --workspace`: 1488 passed / 1 failed (baseline was 1482; +6 new tests)
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 errors, 0 warnings
- `grep -E "ccteam ctl|ccteam-ctl " skills/ccteam-control/SKILL.md`: 0 hits

## Acceptance Checklist
- [x] 0 legacy `ccteam ctl` paths in SKILL.md
- [x] 6 admin_* smoke tests all pass
- [x] baseline >= 1488/1
- [x] user-manual §4 references concrete MCP tool names for every admin op