### PR TITLE
v0.6.5 (F148+F151): creator bridge + remove --purge cleans imd/registry

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -2889,8 +2889,7 @@ fn render_migrate_hook_commands_report(paths: &CcteamPaths, dry_run: bool) -> Re
             hook_sh.display(),
         ));
     }
-    let reports =
-        scan_project_settings_for_hook_rewrite(&paths.projects_root, &hook_sh, dry_run)?;
+    let reports = scan_project_settings_for_hook_rewrite(&paths.projects_root, &hook_sh, dry_run)?;
     if reports.is_empty() {
         out.push_str("  no project `settings.json` files found.\n\n");
         return Ok(out);
@@ -2915,9 +2914,7 @@ fn render_migrate_hook_commands_report(paths: &CcteamPaths, dry_run: bool) -> Re
             "\n  {touched} settings.json file(s) would be rewritten — re-run without --dry-run to apply.\n",
         ));
     } else {
-        out.push_str(&format!(
-            "\n  {touched} settings.json file(s) rewritten.\n",
-        ));
+        out.push_str(&format!("\n  {touched} settings.json file(s) rewritten.\n",));
     }
     out.push('\n');
     Ok(out)
@@ -4213,9 +4210,108 @@ pub fn run_remove(paths: &CcteamPaths, slug: &str, opts: RemoveOptions) -> Resul
     // 6. Optional `--purge`: project-local ccteam-managed paths.
     if opts.purge {
         purge_project_managed_paths(&project_dir, opts.dry_run, &mut report)?;
+        // V0.6.5 F151 — also clean `~/.ccteam/imd/registry/<slug>/`. The
+        // F146 registry is the daemon's bot lifecycle SoT, so without
+        // this cleanup `list_bots()` still surfaces stale BotRegistration
+        // entries after the workflow.yaml is gone → daemon can spawn an
+        // orphan tmux session.
+        purge_imd_registry_for_slug(&paths.root, slug, opts.dry_run, &mut report)?;
     }
 
     Ok(report)
+}
+
+/// V0.6.5 F151 — purge `~/.ccteam/imd/registry/<slug>/`.
+///
+/// **Strategy:** for each registered role under the slug, call
+/// [`ccteam_imd::unregister_bot_in`] first — this is the in-process
+/// equivalent of the `chat_unregister_bot` MCP tool. It deletes the
+/// `<role>.json` registry file *and* the `<role>.heartbeat` sidecar,
+/// which is exactly what the daemon's registry watcher observes to
+/// close the tmux session gracefully. After all roles are unregistered
+/// (or if the registry dir is empty / malformed), `rm -rf` the
+/// `<slug>/` dir to clean any leftover files (e.g. stale heartbeats
+/// from a previous unregister/re-register cycle that left a sidecar
+/// orphan).
+///
+/// Works whether the daemon is running or not — `unregister_bot_in`
+/// is pure file IO, no daemon RPC.
+fn purge_imd_registry_for_slug(
+    ccteam_root: &std::path::Path,
+    slug: &str,
+    dry_run: bool,
+    report: &mut RemoveReport,
+) -> Result<()> {
+    let slug_dir = ccteam_imd::registry_root_in(ccteam_root).join(slug);
+    if !slug_dir.exists() {
+        // Nothing to clean — non-chat slug or already pristine. Stay
+        // silent (don't add a "nothing to do" step row that clutters
+        // dry-run output).
+        return Ok(());
+    }
+
+    // Enumerate roles via list_bots_in (so we route through the F146
+    // MCP-equivalent surface). Falls back to empty list on parse errors;
+    // the final rm -rf still catches whatever remains.
+    let bots = ccteam_imd::list_bots_in(ccteam_root, Some(slug)).unwrap_or_default();
+    let role_count = bots.len();
+
+    if dry_run {
+        // Count JSON files even if list_bots_in skipped malformed rows.
+        let json_count = std::fs::read_dir(&slug_dir)
+            .map(|it| {
+                it.filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("json"))
+                    .count()
+            })
+            .unwrap_or(0);
+        let noun = if json_count == 1 {
+            "JSON file"
+        } else {
+            "JSON files"
+        };
+        report.steps.push(format!(
+            "would purge imd/registry/{slug}/ ({json_count} {noun})"
+        ));
+        return Ok(());
+    }
+
+    // Step 6a — per-role unregister (MCP-equivalent in-process call).
+    // Idempotent miss is fine; just records the path that *was* there.
+    for reg in bots {
+        match ccteam_imd::unregister_bot_in(ccteam_root, &reg.workflow_slug, &reg.role) {
+            Ok((removed, path)) => {
+                if removed {
+                    report.steps.push(format!(
+                        "unregistered bot `{}` (deleted {})",
+                        reg.role,
+                        path.display()
+                    ));
+                }
+            }
+            Err(err) => {
+                // Don't bail — the rm -rf below is the fallback.
+                report.steps.push(format!(
+                    "unregister bot `{}` failed ({err}); will fall back to rm -rf",
+                    reg.role
+                ));
+            }
+        }
+    }
+
+    // Step 6b — final sweep. Catches: heartbeat sidecars whose
+    // registration JSON was already gone, malformed registration
+    // files list_bots_in skipped, or the empty slug dir itself.
+    if slug_dir.exists() {
+        std::fs::remove_dir_all(&slug_dir)
+            .with_context(|| format!("rm -rf {}", slug_dir.display()))?;
+        report.steps.push(format!(
+            "purged imd/registry/{slug}/ ({role_count} role{} cleared)",
+            if role_count == 1 { "" } else { "s" }
+        ));
+    }
+
+    Ok(())
 }
 
 /// Helper for `run_remove --purge` — walks each ccteam-managed path

--- a/crates/ccteam-cli/tests/e2e_creator_full_path_test.rs
+++ b/crates/ccteam-cli/tests/e2e_creator_full_path_test.rs
@@ -1,0 +1,393 @@
+//! V0.6.5 F148 — end-to-end wire test for `/ccteam-creator` Phase 5.6.
+//!
+//! Background — F148 fixes the deepest root cause of the nas-box005
+//! deploy fiasco: `skills/ccteam-creator/SKILL.md` Phase 5.6 used to
+//! tell the LLM to "call `ccteam_imd::register_bot(...)`" — a Rust
+//! function the LLM has no way to invoke. The result: workflow.yaml
+//! landed, .claude/agents/<role>.md landed, .mcp.json landed — but
+//! `~/.ccteam/imd/registry/<slug>/<role>.json` was never written,
+//! so the daemon's `list_bots()` returned 0 → every Telegram message
+//! got dropped without ever reaching a tmux session.
+//!
+//! V0.6.5 F146 made `mcp__ccteam__chat_register_bot` a real MCP tool;
+//! F148 rewrites Phase 5.6 to tell the LLM to invoke that tool. The
+//! skill body is markdown read by the LLM, not code we can execute
+//! in a test — so these tests verify two things instead:
+//!
+//! 1. **Wire contract** — driving `ccteam mcp-serve` with the exact
+//!    JSON args the rewritten Phase 5.6 documents lands the
+//!    registration file at the path `list_bots()` reads. This catches
+//!    regressions where the MCP tool's arg names / vendor casing /
+//!    path layout drifts away from what the skill instructs.
+//!
+//! 2. **Skill text guard** — `skills/ccteam-creator/SKILL.md` Phase
+//!    5.6 mentions `mcp__ccteam__chat_register_bot` (the F148 contract)
+//!    and **not** the legacy `ccteam_imd::register_bot` Rust call.
+//!    This prevents a future SKILL.md edit from reverting to the
+//!    pre-F148 stub text.
+//!
+//! These tests stub the IM provider + the claude-tui adapter (neither
+//! is exercised) — the **real** end-to-end "TG message → bot reply"
+//! verification is Wave 4 host-probe on nas-box005.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+// ─────────────────────────── MCP test harness ───────────────────────────
+
+struct McpServer {
+    child: std::process::Child,
+    stdin: std::process::ChildStdin,
+    stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl McpServer {
+    fn spawn(home: &Path, projects: &Path) -> Self {
+        let bin = env!("CARGO_BIN_EXE_ccteam");
+        let mut child = Command::new(bin)
+            .arg("mcp-serve")
+            .env("CCTEAM_HOME", home)
+            .env("CCTEAM_PROJECTS_ROOT", projects)
+            .env("CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP", "1")
+            // Quiet the tracing fmt layer — by default `init_tracing`
+            // writes INFO to stdout, which would interleave with the
+            // JSON-RPC frame on the same channel. `ccteam_imd::register_bot_checked_in`
+            // emits an info log on every successful registration, so
+            // without this filter the very first call returns garbage.
+            .env("RUST_LOG", "error")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn ccteam mcp-serve");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let mut line = serde_json::to_string(msg).unwrap();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn recv(&mut self) -> Value {
+        let mut line = String::new();
+        let n = self
+            .stdout
+            .read_line(&mut line)
+            .expect("read mcp-serve stdout");
+        assert!(
+            n > 0,
+            "mcp-serve closed stdout without responding (line={line:?})",
+        );
+        serde_json::from_str(line.trim())
+            .unwrap_or_else(|e| panic!("parse JSON-RPC response: {e}; got line: {line:?}"))
+    }
+
+    fn call_tool(&mut self, name: &str, args: Value) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": name, "arguments": args }
+        }));
+        let resp = self.recv();
+        assert_eq!(
+            resp["result"]["isError"], false,
+            "tools/call {name} reported isError=true; resp={resp:?}",
+        );
+        let text = resp["result"]["content"][0]["text"]
+            .as_str()
+            .expect("content[0].text");
+        serde_json::from_str(text).expect("parse tool body as JSON")
+    }
+
+    fn shutdown(mut self) {
+        drop(self.stdin);
+        let _ = self.child.wait_timeout_or_kill(Duration::from_secs(2));
+    }
+}
+
+trait WaitTimeoutOrKill {
+    fn wait_timeout_or_kill(&mut self, timeout: Duration) -> Option<std::process::ExitStatus>;
+}
+
+impl WaitTimeoutOrKill for std::process::Child {
+    fn wait_timeout_or_kill(&mut self, timeout: Duration) -> Option<std::process::ExitStatus> {
+        let start = std::time::Instant::now();
+        while start.elapsed() < timeout {
+            if let Ok(Some(status)) = self.try_wait() {
+                return Some(status);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = self.kill();
+        self.wait().ok()
+    }
+}
+
+// ─────────────────────────── creator-flow fixture ───────────────────────────
+
+/// Simulates what `/ccteam-creator` Phase 5.1 leaves on disk: a fresh
+/// `HOME` with `.ccteam/im/credentials.json` containing a Telegram
+/// block whose `allowed_chat_ids[0]` is the value Phase 5.6 passes
+/// to `chat_register_bot` as `im_chat_id`.
+struct CreatorFixture {
+    _tmp: TempDir,
+    ccteam_home: PathBuf,
+    projects_root: PathBuf,
+}
+
+impl CreatorFixture {
+    /// Stub IM credentials so the "creator just finished Phase 5.1" state
+    /// is what the MCP server sees.
+    fn fresh_with_telegram_chat(chat_id: &str) -> Self {
+        let tmp = TempDir::new().unwrap();
+        let ccteam_home = tmp.path().join("ccteam-home");
+        let projects_root = tmp.path().join("projects");
+        std::fs::create_dir_all(ccteam_home.join("im")).unwrap();
+        std::fs::create_dir_all(&projects_root).unwrap();
+
+        // Phase 5.1 output — Telegram credentials.json with one chat id.
+        let creds = json!({
+            "telegram": {
+                "bot_token": "STUB-TG-TOKEN-12345",
+                "allowed_chat_ids": [chat_id],
+            }
+        });
+        std::fs::write(
+            ccteam_home.join("im").join("credentials.json"),
+            serde_json::to_string_pretty(&creds).unwrap(),
+        )
+        .unwrap();
+
+        Self {
+            _tmp: tmp,
+            ccteam_home,
+            projects_root,
+        }
+    }
+
+    /// Mirror what Phase 5.3 (`render_workflow_template`) writes:
+    /// `<project>/.ccteam/workflow.yaml`. Body is a minimal chat-mode
+    /// stub so the daemon's loader is happy.
+    fn seed_workflow_yaml(&self, slug: &str, role: &str, bot_handle: &str) -> PathBuf {
+        let project_dir = self.projects_root.join(slug);
+        let ccteam = project_dir.join(".ccteam");
+        std::fs::create_dir_all(&ccteam).unwrap();
+        let body = format!(
+            r#"name: {slug}
+agents:
+  {role}:
+    executor: claude
+    mode: chat
+    trigger: chat
+chat:
+  bot_name: "{bot_handle}"
+"#
+        );
+        let path = ccteam.join("workflow.yaml");
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// Phase 5.4 — drop persona body into `<project>/.claude/agents/<role>.md`.
+    fn seed_persona_md(&self, slug: &str, role: &str) -> PathBuf {
+        let dir = self.projects_root.join(slug).join(".claude").join("agents");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{role}.md"));
+        let body = format!(
+            "---\nname: {role}\ndescription: stub persona for F148 test\n---\n# {role}\n\nstub body\n",
+        );
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+}
+
+// ───────────────────────────── tests ─────────────────────────────
+
+/// F148 acceptance — driving the rewritten Phase 5.6 MCP call against
+/// `ccteam mcp-serve` lands the registration JSON exactly where
+/// `list_bots()` reads from, with the lowercase vendor canonical form
+/// the daemon's `BotRegistration` deserialize requires.
+///
+/// This is the wire-contract proof that the SKILL.md text (which the
+/// LLM follows) is reachable end-to-end. Stubs the IM provider + the
+/// claude-tui adapter; real "TG → bot reply" verification is the
+/// Wave 4 nas-box005 host-probe.
+#[test]
+fn t_creator_phase_5_6_mcp_call_lands_registration_with_lowercase_vendor() {
+    let chat_id = "987654321";
+    let slug = "tg-helper";
+    let role = "tech-helper";
+    let bot_handle = "@my_helper_bot";
+
+    let fx = CreatorFixture::fresh_with_telegram_chat(chat_id);
+    // Phases 5.3 + 5.4 prep — workflow.yaml + persona .md on disk so
+    // the daemon's eventual roster pass has something to consume.
+    let workflow_yaml = fx.seed_workflow_yaml(slug, role, bot_handle);
+    let persona_md = fx.seed_persona_md(slug, role);
+
+    // Sanity — Phase 5.1 stub left credentials.json behind.
+    let creds_path = fx.ccteam_home.join("im").join("credentials.json");
+    assert!(
+        creds_path.exists(),
+        "Phase 5.1 stub credentials.json missing"
+    );
+
+    // Phase 5.6 wire call — exact arg shape the SKILL.md docs.
+    let mut srv = McpServer::spawn(&fx.ccteam_home, &fx.projects_root);
+    let body = srv.call_tool(
+        "ccteam__chat_register_bot",
+        json!({
+            "workflow_slug": slug,
+            "role": role,
+            "vendor": "claude",
+            "im_platform": "telegram",
+            "im_chat_id": chat_id,
+            "persona_id": role,
+        }),
+    );
+
+    // Response shape — { ok: true, path: "..." } per F146 contract.
+    assert_eq!(
+        body["ok"], true,
+        "Phase 5.6 MCP call must succeed; body={body:?}"
+    );
+    assert_eq!(body["workflow_slug"], slug);
+    assert_eq!(body["role"], role);
+    let path_str = body["path"].as_str().expect("path field");
+    let registration_path = PathBuf::from(path_str);
+
+    // Acceptance gate — registration file lands where list_bots reads.
+    assert!(
+        registration_path.exists(),
+        "registration JSON must land on disk at {}",
+        registration_path.display(),
+    );
+    // Layout assertion — ccteam-imd::registration_path_in canonical form.
+    let expected = ccteam_imd::registration_path_in(&fx.ccteam_home, slug, role);
+    assert_eq!(
+        registration_path.canonicalize().unwrap(),
+        expected.canonicalize().unwrap(),
+        "registration must land at <ccteam_root>/imd/registry/<slug>/<role>.json",
+    );
+
+    // On-disk content gate — lowercase vendor (Bug A防线 from nas-box005).
+    let on_disk: Value =
+        serde_json::from_str(&std::fs::read_to_string(&registration_path).unwrap()).unwrap();
+    assert_eq!(
+        on_disk["vendor"], "claude",
+        "vendor on disk MUST be lowercase to keep daemon's BotRegistration deserialize happy",
+    );
+    assert_eq!(on_disk["workflow_slug"], slug);
+    assert_eq!(on_disk["role"], role);
+    assert_eq!(on_disk["im_platform"], "telegram");
+    assert_eq!(on_disk["im_chat_id"], chat_id);
+    assert_eq!(on_disk["persona_id"], role);
+
+    // Round-trip via list_bots_in — this is the *daemon's* consumption
+    // path; if this returns 1 row, the registry watcher will too.
+    let bots = ccteam_imd::list_bots_in(&fx.ccteam_home, Some(slug)).unwrap();
+    assert_eq!(
+        bots.len(),
+        1,
+        "daemon-side list_bots must surface the registration exactly once",
+    );
+    assert_eq!(bots[0].workflow_slug, slug);
+    assert_eq!(bots[0].role, role);
+    assert_eq!(bots[0].im_platform, "telegram");
+    assert_eq!(bots[0].im_chat_id, chat_id);
+
+    // Earlier-phase artifacts must still be on disk (Phase 5.6 only
+    // touches the registry; it doesn't disturb 5.3 / 5.4 outputs).
+    assert!(
+        workflow_yaml.exists(),
+        "Phase 5.3 workflow.yaml should be intact"
+    );
+    assert!(
+        persona_md.exists(),
+        "Phase 5.4 persona .md should be intact"
+    );
+
+    srv.shutdown();
+}
+
+/// F148 SKILL.md text guard — `Phase 5.6` must mention the MCP tool by
+/// name and must NOT still claim the LLM should call the Rust function
+/// `ccteam_imd::register_bot` (the pre-F148 stub instruction).
+///
+/// This is a regression test against doc drift — the skill body is
+/// LLM-consumed, so the only way to keep the wire contract honest is
+/// to gate the text it surfaces.
+#[test]
+fn t_creator_skill_phase_5_6_documents_mcp_tool_not_rust_function() {
+    // Locate the skill from the repo root (CARGO_MANIFEST_DIR is the
+    // crate dir; the workspace root is two levels up).
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("ccteam-cli crate must sit two levels deep in workspace");
+    let skill_path = workspace_root
+        .join("skills")
+        .join("ccteam-creator")
+        .join("SKILL.md");
+    let body = std::fs::read_to_string(&skill_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", skill_path.display()));
+
+    // Locate the Phase 5.6 section.
+    let phase_5_6 = body
+        .split("## 5.6")
+        .nth(1)
+        .expect("SKILL.md must have a `## 5.6` Phase 5.6 section");
+    // Section ends at the next `## ` heading.
+    let phase_5_6_body = phase_5_6.split("\n## ").next().unwrap_or(phase_5_6);
+
+    // F148 contract — must instruct invoking the MCP tool.
+    assert!(
+        phase_5_6_body.contains("mcp__ccteam__chat_register_bot"),
+        "Phase 5.6 must instruct the LLM to invoke `mcp__ccteam__chat_register_bot`; got: {phase_5_6_body}",
+    );
+    // F148 contract — must NOT still tell the LLM to call the Rust fn
+    // (the pre-F148 stub instruction the LLM physically cannot follow).
+    assert!(
+        !phase_5_6_body.contains("ccteam_imd::register_bot("),
+        "Phase 5.6 must not still tell the LLM to call the Rust function `ccteam_imd::register_bot(...)`; that was the pre-F148 bug. Got:\n{phase_5_6_body}",
+    );
+    // F148 contract — lowercase vendor must be called out explicitly
+    // (Bug A防线 — daemon BotRegistration deserialize trips on PascalCase).
+    assert!(
+        phase_5_6_body.contains("lowercase"),
+        "Phase 5.6 must call out the lowercase vendor requirement (Bug A); got: {phase_5_6_body}",
+    );
+    // F148 contract — error handling must distinguish already_registered
+    // (idempotent OK) from other errors (stop).
+    assert!(
+        phase_5_6_body.contains("already_registered"),
+        "Phase 5.6 must document the `already_registered` idempotent-OK branch; got: {phase_5_6_body}",
+    );
+
+    // Phase 5.9 reply template must mention the registry path so the
+    // user sees the bot actually landed somewhere.
+    let phase_5_9 = body
+        .split("## 5.9")
+        .nth(1)
+        .expect("SKILL.md must have a `## 5.9` Phase 5.9 section");
+    let phase_5_9_body = phase_5_9.split("\n## ").next().unwrap_or(phase_5_9);
+    assert!(
+        phase_5_9_body.contains("imd/registry/"),
+        "Phase 5.9 reply must mention `imd/registry/<slug>/<role>.json` so the user sees the bot was registered; got: {phase_5_9_body}",
+    );
+}

--- a/crates/ccteam-cli/tests/remove_test.rs
+++ b/crates/ccteam-cli/tests/remove_test.rs
@@ -493,3 +493,164 @@ fn t06_force_overrides_refusal() {
         "config.yaml::projects must drop the slug under --force",
     );
 }
+
+// ─────────────────────────── V0.6.5 F151 ────────────────────────────
+//
+// `ccteam remove <slug> --purge` must also clean
+// `~/.ccteam/imd/registry/<slug>/` (registration JSON + heartbeat
+// sidecars). Without `--purge` the registry stays put so a re-init
+// of the same slug can resume the existing chat bots.
+
+/// Seed an imd/registry/<slug>/<role>.json + matching heartbeat
+/// sidecar — mirrors the on-disk shape F146's `register_bot_checked_in`
+/// produces.
+fn seed_imd_registry(fx: &Fixture, role: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    use ccteam_core::harness::AgentVendor;
+    let outcome = ccteam_imd::register_bot_checked_in(
+        &fx.ccteam_home,
+        &fx.slug,
+        role,
+        AgentVendor::Claude,
+        "telegram",
+        "42",
+        Some(role),
+    )
+    .expect("seed registry");
+    let reg_path = match outcome {
+        ccteam_imd::RegisterOutcome::Registered(p) => p,
+        ccteam_imd::RegisterOutcome::AlreadyRegistered(p) => p,
+    };
+    // Drop a heartbeat sidecar so we can assert it gets cleaned too.
+    let hb = ccteam_imd::bot_heartbeat_path_in(&fx.ccteam_home, &fx.slug, role);
+    std::fs::write(&hb, chrono::Utc::now().to_rfc3339()).unwrap();
+    assert!(reg_path.exists(), "fixture: registration JSON seeded");
+    assert!(hb.exists(), "fixture: heartbeat seeded");
+    (reg_path, hb)
+}
+
+#[test]
+fn t09_purge_cleans_imd_registry_dir() {
+    let fx = Fixture::new("dex-bot");
+    fx.seed_closed_progress();
+    // Seed two roles under the slug — proves the per-role unregister
+    // loop + final rm -rf both work.
+    let (reg_a, hb_a) = seed_imd_registry(&fx, "helper");
+    let (reg_b, hb_b) = seed_imd_registry(&fx, "critic");
+    let slug_dir = ccteam_imd::registry_root_in(&fx.ccteam_home).join(&fx.slug);
+    assert!(slug_dir.is_dir(), "fixture: imd/registry/<slug>/ seeded");
+
+    let out = fx
+        .cmd()
+        .args(["remove", &fx.slug, "--purge"])
+        .output()
+        .expect("spawn ccteam remove --purge");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "remove --purge should succeed; stderr: {stderr}; stdout: {stdout}",
+    );
+
+    // Every role file + heartbeat gone.
+    assert!(
+        !reg_a.exists(),
+        "imd/registry/<slug>/helper.json should be purged"
+    );
+    assert!(
+        !reg_b.exists(),
+        "imd/registry/<slug>/critic.json should be purged"
+    );
+    assert!(
+        !hb_a.exists(),
+        "imd/registry/<slug>/helper.heartbeat should be purged"
+    );
+    assert!(
+        !hb_b.exists(),
+        "imd/registry/<slug>/critic.heartbeat should be purged"
+    );
+    // The slug dir itself gone.
+    assert!(
+        !slug_dir.exists(),
+        "imd/registry/<slug>/ dir should be purged; still at {}",
+        slug_dir.display()
+    );
+    // Progress log mentions the purge so the user can see what happened.
+    assert!(
+        stdout.contains("imd/registry/dex-bot/"),
+        "purge step must be reported; got: {stdout}",
+    );
+}
+
+#[test]
+fn t10_remove_without_purge_keeps_imd_registry() {
+    let fx = Fixture::new("dex-bot");
+    fx.seed_closed_progress();
+    let (reg_path, hb_path) = seed_imd_registry(&fx, "helper");
+    let slug_dir = ccteam_imd::registry_root_in(&fx.ccteam_home).join(&fx.slug);
+
+    let out = fx
+        .cmd()
+        .args(["remove", &fx.slug])
+        .output()
+        .expect("spawn ccteam remove");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "remove (no --purge) should succeed; stderr: {stderr}; stdout: {stdout}",
+    );
+
+    // Without --purge the imd/registry/<slug>/ tree must survive so a
+    // re-`ccteam init` of the same slug picks up where it left off.
+    assert!(
+        reg_path.exists(),
+        "imd/registry/<slug>/helper.json must survive without --purge",
+    );
+    assert!(
+        hb_path.exists(),
+        "imd/registry/<slug>/helper.heartbeat must survive without --purge",
+    );
+    assert!(
+        slug_dir.is_dir(),
+        "imd/registry/<slug>/ must survive without --purge",
+    );
+    // Step list must NOT mention the imd/registry purge step.
+    assert!(
+        !stdout.contains("imd/registry/"),
+        "non-purge run must not touch imd/registry/; got: {stdout}",
+    );
+}
+
+#[test]
+fn t11_purge_dry_run_reports_imd_registry_count() {
+    let fx = Fixture::new("dex-bot");
+    fx.seed_closed_progress();
+    let (reg_path, hb_path) = seed_imd_registry(&fx, "helper");
+
+    let out = fx
+        .cmd()
+        .args(["remove", &fx.slug, "--purge", "--dry-run"])
+        .output()
+        .expect("spawn ccteam remove --purge --dry-run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "dry-run --purge should succeed; stderr: {stderr}; stdout: {stdout}",
+    );
+
+    // Filesystem untouched under --dry-run.
+    assert!(
+        reg_path.exists(),
+        "dry-run must not delete registration JSON"
+    );
+    assert!(
+        hb_path.exists(),
+        "dry-run must not delete heartbeat sidecar"
+    );
+    // PRD §F151 acceptance #1 — output names the dir + JSON count.
+    assert!(
+        stdout.contains("would purge imd/registry/dex-bot/") && stdout.contains("1 JSON file"),
+        "dry-run must preview imd/registry/<slug>/ with count; got: {stdout}",
+    );
+}

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -252,14 +252,54 @@ The pool is the scientist-nickname list in
 
 ## 5.6  Register the bot
 
-For chat presets, call `ccteam_imd::register_bot(slug, persona_id,
-vendor, im_platform, im_chat_id)` → `Result<PathBuf>`. `im_chat_id`
-comes from the `TelegramCredentials::owner_chat_id()` helper on the
-credential record persisted in 5.1. The `bot_handle` is **not**
-returned from this call — it's resolved by the daemon-side router
-from the rendered `workflow.yaml`'s `chat.bot_name` field at the
-next registry-watcher tick. Embed the minted handle (from 5.5) into
-the `chat.bot_name` slot of the YAML before writing it out in 5.3.
+For chat presets, invoke the **`mcp__ccteam__chat_register_bot`** MCP
+tool. The skill is LLM-driven and cannot call Rust functions directly
+— the registry is reached only through this MCP wire. V0.6.5 F146
+implemented the real handler that writes
+`~/.ccteam/imd/registry/<workflow_slug>/<role>.json`; the daemon's
+registry watcher picks it up and spawns the tmux session.
+
+`im_chat_id` comes from `~/.ccteam/im/credentials.json` written in
+Phase 5.1: take `telegram.allowed_chat_ids[0]` (cast to string —
+Telegram chat ids are i64, but the MCP wire expects a string).
+
+```json
+{
+  "name": "mcp__ccteam__chat_register_bot",
+  "arguments": {
+    "workflow_slug": "<slug from 5.2>",
+    "role": "<persona_id from Phase 3>",
+    "vendor": "claude",
+    "im_platform": "telegram",
+    "im_chat_id": "<allowed_chat_ids[0]>",
+    "persona_id": "<persona_id from Phase 3>"
+  }
+}
+```
+
+**Vendor must be lowercase** (`"claude"` or `"codex"`). The daemon's
+`BotRegistration` deserialize trips on PascalCase `"Claude"` (Bug A
+from V0.6.5 NAS deploy session); the F146 dispatcher lowercases
+defensively, but stick to lowercase in the call to be explicit.
+
+**Error handling:**
+
+- Response `{"ok": true, "path": "..."}` → continue to Phase 5.7.
+- Response `{"ok": false, "error": "already_registered", "path": "..."}`
+  → **idempotent OK**, this is a re-run of the same creator dialogue;
+  log the line `Bot already registered at <path>; reusing` and
+  continue. **Do not** call `chat_unregister_bot` to retry — that
+  would race the daemon's tmux session.
+- Any other error (validation, IO) → **STOP**. Surface to user:
+  `"registry write failed: <error from response>"`. Do not proceed
+  to Phase 5.7 / 5.8 — leaving a half-installed bot with workflow.yaml
+  but no registration is worse than failing the dialogue.
+
+The `bot_handle` is **not** an input to this call — it's resolved by
+the daemon-side router from the rendered `workflow.yaml`'s
+`chat.bot_name` field at the next registry-watcher tick. Embed the
+minted handle (from 5.5) into the `chat.bot_name` slot of the YAML
+before writing it out in 5.3.
 
 ## 5.7  Project-level `.mcp.json`
 
@@ -285,9 +325,14 @@ will roster the new workflow.
   Slug:   <slug>
   Mode:   <preset>
   Persona: <label>
+  Bot 注册到 ~/.ccteam/imd/registry/<slug>/<role>.json ✓
 
 在 <IM platform> 私聊 <@handle> 就能开聊。要看状态:
   /ccteam-control show <slug>
+
+要卸载这个 bot:
+  invoke mcp__ccteam__chat_unregister_bot{workflow_slug: <slug>, role: <role>}
+  (or `ccteam remove <slug> --purge` to wipe everything for the slug)
 ```
 
 (English equivalent if the user wrote in English.)


### PR DESCRIPTION
## Findings

- [F148](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-5/prd.md#f148) — `/ccteam-creator` Phase 5.6 真调 `chat_register_bot` MCP (替代 LLM 物理无法调用的 Rust `ccteam_imd::register_bot()` stub)
- [F151](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-5/prd.md#f151) — `ccteam remove --purge` 也清 `~/.ccteam/imd/registry/<slug>/`(registration JSON + heartbeat sidecar)

## Verification

- `cargo test --workspace --locked --no-fail-fast`: **1518 passed / 1 failed** (baseline 1513/1 + 5 new tests: F148 +2 e2e + F151 +3 incl. dry-run preview)
  - 1 fail = pre-existing flake `workflow_summary_reflects_agent_spawn_and_done_events` per CLAUDE.md §一 baseline
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: **0 errors / 0 warnings**
- `rustfmt --check --edition 2021` on touched files: clean

## Acceptance (prd §F148)

1. `e2e_creator_full_path_test.rs` passes (stub TG + stub claude-tui) ✓
2. nas-box005 host-probe fresh state → `/ccteam-creator` → `go` → TG `hi` → reply — **Wave 4 host-probe** (per prd risk note: "真验证只能靠 host-probe")
3. baseline ≥ 1498/1 ✓ (1518/1, +20 over prd floor)

## Acceptance (prd §F151)

1. `ccteam remove dev-foo --purge --dry-run` outputs `would purge imd/registry/dev-foo/ (1 JSON file)` ✓ (`t11_purge_dry_run_reports_imd_registry_count`)
2. `ccteam remove dev-foo --purge` → `ls ~/.ccteam/imd/registry/dev-foo/` returns NoSuchFileOrDir ✓ (`t09_purge_cleans_imd_registry_dir`)
3. daemon live + remove --purge → bot supervisor shuts down — implicit via existing `t07_remove_writes_unroster_trigger_when_daemon_alive` + per-role `unregister_bot_in` triggering registry watcher (live-daemon round-trip is Wave 4 host-probe)
4. baseline ≥ 1506/1 ✓

## Implementation notes

**F148**: SKILL.md Phase 5.6 rewritten with:
- explicit `mcp__ccteam__chat_register_bot` invocation (vs. ungrokkable Rust call)
- lowercase vendor requirement called out (Bug A防线 from nas-box005)
- example JSON args block showing the wire shape
- `already_registered` → idempotent OK / other errors → STOP error matrix
- Phase 5.9 reply now includes `Bot 注册到 ~/.ccteam/imd/registry/<slug>/<role>.json ✓` line so user sees the bot actually landed

Test stubs IM provider + claude-tui adapter (true e2e is Wave 4 host-probe). The text-guard test prevents future SKILL.md edits from reverting to the pre-F148 stub.

**F151**: `purge_imd_registry_for_slug()` enumerates roles via `list_bots_in(Some(slug))` first (MCP-equivalent surface — same code path the `chat_unregister_bot` MCP tool uses), per-role `unregister_bot_in` (deletes JSON + heartbeat sidecar), then `rm -rf` the slug dir as final sweep for stale leftovers. Daemon-down case: `unregister_bot_in` is pure file IO, no RPC, so it works either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)