### PR TITLE
chore(docs): CLAUDE.md §七 — drop cargo fmt, use rustfmt direct

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,9 @@ V0.6.0 走通的 4-wave 流程,V0.6.x patch + V0.7 minor 起点直接复用:
 
 `rustfmt.toml` pin stable rustfmt(`max_width = 100` / `tab_spaces = 4` / `use_field_init_shorthand`):
 
-- **新文件 / 大改文件:`cargo fmt -- <files>` 必跑**(commit 前)
-- **小改 drifted 文件:不 fmt-sweep**(本仓存量 fmt drift ~4-5 kLOC;全仓 `cargo fmt --all` 会爆 PR diff)
+- **不用 `cargo fmt`**(含 `cargo fmt -- <files>` 形式)── cargo fmt **silently 忽略文件参数**,会全 workspace 跑,把存量 ~4-5 kLOC fmt drift 拉进你的 PR diff(2026-05-24 V0.6.5 W1-T3 实战踩坑)
+- **新文件 / 大改文件:`rustfmt --edition 2021 <files>` 直调**(commit 前;原地写回)
+- **dry-run probe:**`rustfmt --check --edition 2021 <files>`
+- **小改 drifted 文件:不 fmt-sweep**(让 drift 维持现状,别动)
 - **不上 workspace-wide CI fmt gate**(drift 清零后才指望)
 - **drift 清理走独立 chore PR**,按模块拆,一次一个 crate


### PR DESCRIPTION
## Change
CLAUDE.md §七 Rust formatting convention updated:
- ❌ `cargo fmt -- <files>` (silently ignores file args, runs whole workspace)
- ✅ `rustfmt --edition 2021 <files>` (true file-scoped formatting)

## Why
2026-05-24 V0.6.5 W1-T3 (F148+F151) subagent ran `cargo fmt -- <3 files>`, expecting scoped formatting per the old §七 direction. cargo fmt formatted ~40 unrelated drifted files. Had to revert via `git checkout`.

## Scope
- CLAUDE.md §七 only (4 +/2 -)
- No code changes
- No baseline impact