### PR TITLE
v0.6.5 (F153+F154): advise_parallel e2e + /ccteam-advise skill sweep

### DIFF
--- a/crates/ccteam-cli/tests/mcp_advise_parallel_test.rs
+++ b/crates/ccteam-cli/tests/mcp_advise_parallel_test.rs
@@ -1,0 +1,364 @@
+//! V0.6.5 F153 — integration tests for `mcp__ccteam__advise_parallel`
+//! real implementation.
+//!
+//! These tests drive `ccteam mcp-serve` over stdio JSON-RPC, with
+//! `CCTEAM_CLAUDE_BIN` / `CCTEAM_CODEX_BIN` env vars pointed at a
+//! per-test fake script that emits a deterministic body so the
+//! assertions are hermetic (no real claude / codex binary required).
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+const CODEX_BIN_ENV: &str = "CCTEAM_CODEX_BIN";
+const CLAUDE_BIN_ENV: &str = "CCTEAM_CLAUDE_BIN";
+
+/// Build a fake binary script that echoes the supplied stdout on
+/// invocation and exits 0. Returns the (guard, path) so the caller
+/// keeps the tempdir alive for the test's duration.
+fn fake_bin(stdout: &str) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("fake.sh");
+    let mut body = String::from("#!/usr/bin/env bash\n");
+    body.push_str("cat <<'EOF'\n");
+    body.push_str(stdout);
+    if !stdout.ends_with('\n') {
+        body.push('\n');
+    }
+    body.push_str("EOF\n");
+    body.push_str("exit 0\n");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(body.as_bytes()).unwrap();
+    f.sync_all().unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    (dir, path)
+}
+
+struct McpServer {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+}
+
+impl McpServer {
+    fn spawn(
+        home: &std::path::Path,
+        projects: &std::path::Path,
+        env: &[(&str, &std::path::Path)],
+    ) -> Self {
+        let bin = env!("CARGO_BIN_EXE_ccteam");
+        let mut cmd = Command::new(bin);
+        cmd.arg("mcp-serve")
+            .env("CCTEAM_HOME", home)
+            .env("CCTEAM_PROJECTS_ROOT", projects)
+            .env("CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP", "1")
+            .env_remove("CCTEAM_DISABLE_TOOLS")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        let mut child = cmd.spawn().expect("spawn ccteam mcp-serve");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child,
+            stdin,
+            stdout,
+        }
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let mut line = serde_json::to_string(msg).unwrap();
+        line.push('\n');
+        self.stdin.write_all(line.as_bytes()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn recv(&mut self) -> Value {
+        let mut line = String::new();
+        self.stdout.read_line(&mut line).expect("read stdout");
+        serde_json::from_str(line.trim()).expect("parse JSON-RPC response")
+    }
+
+    fn call_tool(&mut self, id: u64, tool: &str, args: Value) -> Value {
+        self.send(&json!({
+            "jsonrpc": "2.0", "id": id,
+            "method": "tools/call",
+            "params": { "name": tool, "arguments": args }
+        }));
+        self.recv()
+    }
+
+    fn shutdown(mut self) {
+        drop(self.stdin);
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_secs(2) {
+            if let Ok(Some(_)) = self.child.try_wait() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        let _ = self.child.kill();
+    }
+}
+
+/// Extract the JSON body from the MCP `content[0].text` envelope.
+fn parse_tool_response(resp: &Value) -> Value {
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing content[0].text in {resp}"));
+    serde_json::from_str(text).expect("tool body parses as JSON")
+}
+
+/// Set up a fresh ccteam-root + projects dir.
+fn fresh_dirs() -> (TempDir, PathBuf, PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let projects = tmp.path().join("projects");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::create_dir_all(&projects).unwrap();
+    (tmp, home, projects)
+}
+
+/// F153 acceptance #1 — N=4 vendors=["claude","codex"] → 4 slots,
+/// round-robin to 2 claude + 2 codex; every slot returns Ok.
+#[test]
+fn advise_parallel_n4_round_robin_returns_four_answers() {
+    let (_tmp, home, projects) = fresh_dirs();
+    let (_claude_dir, claude_bin) = fake_bin("Claude says use Foobar because it is the simplest.");
+    let (_codex_dir, codex_bin) = fake_bin(
+        r#"{"type":"thread.started","thread_id":"t1"}
+{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"Codex says use Foobar for the same reason."}}
+{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}"#,
+    );
+
+    let mut srv = McpServer::spawn(
+        &home,
+        &projects,
+        &[(CLAUDE_BIN_ENV, &claude_bin), (CODEX_BIN_ENV, &codex_bin)],
+    );
+    let resp = srv.call_tool(
+        2,
+        "ccteam__advise_parallel",
+        json!({
+            "question": "Should I pick Foobar?",
+            "n": 4,
+            "vendors": ["claude", "codex"],
+        }),
+    );
+    let parsed = parse_tool_response(&resp);
+    assert_eq!(parsed["ok"], true, "got body: {parsed}");
+    let answers = parsed["answers"].as_array().expect("answers is array");
+    assert_eq!(answers.len(), 4, "expected 4 answers, got {answers:?}");
+
+    // Round-robin order: [claude, codex, claude, codex].
+    let vendors: Vec<&str> = answers
+        .iter()
+        .map(|a| a["vendor"].as_str().unwrap())
+        .collect();
+    assert_eq!(vendors, vec!["claude", "codex", "claude", "codex"]);
+    for a in answers {
+        assert_eq!(a["status"]["status"], "ok", "all slots must be ok; got {a}");
+        assert!(!a["answer"].as_str().unwrap().is_empty());
+    }
+
+    // Budget ledger: one sample per slot (4 total).
+    let ledger_path = home.join("cost-budget.json");
+    assert!(ledger_path.is_file(), "ledger file must be written");
+    let ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(&ledger_path).unwrap()).unwrap();
+    let samples = ledger["samples"].as_array().unwrap();
+    assert_eq!(samples.len(), 4, "expected 4 cost samples");
+    let claude_n = samples.iter().filter(|s| s["vendor"] == "claude").count();
+    let codex_n = samples.iter().filter(|s| s["vendor"] == "codex").count();
+    assert_eq!(claude_n, 2);
+    assert_eq!(codex_n, 2);
+
+    srv.shutdown();
+}
+
+/// F153 acceptance #2 — N=2 vendors=["claude"] → both slots claude.
+#[test]
+fn advise_parallel_n2_claude_only_returns_two_claude_answers() {
+    let (_tmp, home, projects) = fresh_dirs();
+    let (_claude_dir, claude_bin) = fake_bin("Claude advice text.");
+
+    let mut srv = McpServer::spawn(&home, &projects, &[(CLAUDE_BIN_ENV, &claude_bin)]);
+    let resp = srv.call_tool(
+        2,
+        "ccteam__advise_parallel",
+        json!({
+            "question": "Q?",
+            "n": 2,
+            "vendors": ["claude"],
+        }),
+    );
+    let parsed = parse_tool_response(&resp);
+    assert_eq!(parsed["ok"], true, "got body: {parsed}");
+    let answers = parsed["answers"].as_array().unwrap();
+    assert_eq!(answers.len(), 2);
+    for a in answers {
+        assert_eq!(a["vendor"], "claude");
+        assert_eq!(a["status"]["status"], "ok");
+    }
+
+    // 2 claude samples, no codex.
+    let ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join("cost-budget.json")).unwrap())
+            .unwrap();
+    let samples = ledger["samples"].as_array().unwrap();
+    assert_eq!(samples.len(), 2);
+    assert!(samples.iter().all(|s| s["vendor"] == "claude"));
+
+    srv.shutdown();
+}
+
+/// F153 — Codex unavailable: a mixed N=2 slot with [claude, codex]
+/// where codex binary is non-exec → the codex slot's status flips to
+/// `unavailable` but the array still has 2 rows and the call returns
+/// `ok:true`.
+#[test]
+fn advise_parallel_codex_unavailable_slot_marks_status_but_array_still_full() {
+    let (tmp, home, projects) = fresh_dirs();
+    let (_claude_dir, claude_bin) = fake_bin("Claude says A.");
+    let nonexec = tmp.path().join("notexec");
+    std::fs::write(&nonexec, b"plain text").unwrap();
+
+    let mut srv = McpServer::spawn(
+        &home,
+        &projects,
+        &[(CLAUDE_BIN_ENV, &claude_bin), (CODEX_BIN_ENV, &nonexec)],
+    );
+    let resp = srv.call_tool(
+        2,
+        "ccteam__advise_parallel",
+        json!({
+            "question": "Q?",
+            "n": 2,
+            "vendors": ["claude", "codex"],
+            "timeout_secs": 5,
+        }),
+    );
+    let parsed = parse_tool_response(&resp);
+    assert_eq!(parsed["ok"], true, "got body: {parsed}");
+
+    let answers = parsed["answers"].as_array().unwrap();
+    assert_eq!(
+        answers.len(),
+        2,
+        "N slots preserved regardless of vendor status"
+    );
+    assert_eq!(answers[0]["vendor"], "claude");
+    assert_eq!(answers[0]["status"]["status"], "ok");
+    assert_eq!(answers[1]["vendor"], "codex");
+    assert_eq!(answers[1]["status"]["status"], "unavailable");
+    let reason = answers[1]["status"]["detail"]["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("detail.reason missing in {}", answers[1]));
+    assert!(
+        reason.contains("not on PATH or not executable"),
+        "unavailable reason must call out binary problem; got: {reason}"
+    );
+    // The unavailable slot returns an empty answer body so callers can
+    // render a placeholder.
+    assert_eq!(answers[1]["answer"], "");
+
+    // Budget ledger: only the ok slot charged.
+    let ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join("cost-budget.json")).unwrap())
+            .unwrap();
+    let samples = ledger["samples"].as_array().unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0]["vendor"], "claude");
+
+    srv.shutdown();
+}
+
+/// F153 acceptance #3 — pre-call budget check refuses before spawning
+/// any advisor subprocess.
+#[test]
+fn advise_parallel_budget_exceeded_does_not_spawn_advisors() {
+    let (_tmp, home, projects) = fresh_dirs();
+    // Pre-seed the ledger past the cap.
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut samples = String::from("[");
+    for i in 0..15 {
+        if i > 0 {
+            samples.push(',');
+        }
+        samples.push_str(&format!(r#"{{"vendor":"claude","usd":0.10,"ts":"{now}"}}"#));
+    }
+    samples.push(']');
+    let body = format!(r#"{{"samples":{samples}}}"#);
+    std::fs::write(home.join("cost-budget.json"), body).unwrap();
+
+    // Explode script proves we never reached the spawn path.
+    let tmp_explode = TempDir::new().unwrap();
+    let explode = tmp_explode.path().join("explode.sh");
+    std::fs::write(
+        &explode,
+        "#!/usr/bin/env bash\necho 'spawned!' >&2\nexit 99\n",
+    )
+    .unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&explode).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&explode, perms).unwrap();
+
+    let mut srv = McpServer::spawn(&home, &projects, &[(CLAUDE_BIN_ENV, &explode)]);
+    let resp = srv.call_tool(
+        2,
+        "ccteam__advise_parallel",
+        json!({
+            "question": "Q?",
+            "n": 2,
+            "vendors": ["claude"],
+            "max_cost_usd": 0.5,
+        }),
+    );
+    let parsed = parse_tool_response(&resp);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"], "budget_exceeded");
+
+    // Budget ledger size unchanged (no advisor calls charged).
+    let ledger: Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join("cost-budget.json")).unwrap())
+            .unwrap();
+    let samples = ledger["samples"].as_array().unwrap();
+    assert_eq!(samples.len(), 15, "budget refusal must not append");
+
+    srv.shutdown();
+}
+
+/// F153 — `n` out of range is caught upstream of any spawn / budget.
+#[test]
+fn advise_parallel_n_out_of_range_returns_invalid_input() {
+    let (_tmp, home, projects) = fresh_dirs();
+    let mut srv = McpServer::spawn(
+        &home,
+        &projects,
+        &[(CLAUDE_BIN_ENV, std::path::Path::new("/tmp/does-not-exist"))],
+    );
+    let resp = srv.call_tool(
+        2,
+        "ccteam__advise_parallel",
+        json!({ "question": "Q?", "n": 9 }),
+    );
+    let parsed = parse_tool_response(&resp);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error"], "invalid_input");
+    assert!(parsed["detail"]
+        .as_str()
+        .unwrap()
+        .contains("`n` must be in 2..=8"));
+    srv.shutdown();
+}

--- a/skills/ccteam-advise/SKILL.md
+++ b/skills/ccteam-advise/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: ccteam-advise
-description: "Claude + Codex parallel advisor for architecture decisions, algorithm trade-offs, and security / performance second opinions. Use when the user says '/ccteam-advise <NL>', 'second opinion on X', 'should I pick A or B', 'ask both Claude and Codex about X', or otherwise asks for a cross-vendor consult. V0.6.0 Wave 3 (F112 §A)."
+description: "Claude + Codex parallel advisor for architecture decisions, algorithm trade-offs, and security / performance second opinions. Use when the user says '/ccteam-advise <NL>', 'second opinion on X', 'should I pick A or B', 'ask both Claude and Codex about X', or otherwise asks for a cross-vendor consult. Backed by the daemon MCP tools `mcp__ccteam__advise_vote` / `mcp__ccteam__advise_parallel` (V0.6.5 F152 + F153)."
 ---
 
 # /ccteam-advise — Claude + Codex parallel voting
 
-V0.6.0 Wave 3 — F112 §A. Single user-facing scenario: a hard
-question that benefits from two independent opinions. The skill
-fans the same question to **Claude** (via a `general-purpose`
-subagent) and **Codex** (via `codex exec --json` on PATH), then
-synthesises a verdict the user can act on without reading both
-transcripts in full.
+V0.6.5 F152 + F153 — daemon-backed real implementations of
+`mcp__ccteam__advise_vote` (Claude + Codex one-shot + synthesised
+verdict via a third Claude call) and `mcp__ccteam__advise_parallel`
+(N-of-N raw answers, no synthesis). Single user-facing scenario: a
+hard question that benefits from two independent opinions, fanned to
+both vendors in parallel and reduced to a 3-5 sentence verdict.
 
-## V0.6.0 skill family (you are here)
+## V0.6.5 skill family (you are here)
 
 | User intent | Skill |
 |---|---|
@@ -28,6 +28,9 @@ transcripts in full.
 Trigger phrases (LLM matching — no regex needed):
 
 - `/ccteam-advise <question>` — explicit slash entry
+- `/ccteam-advise vote <question>` — same, routes to `mcp__ccteam__advise_vote`
+- `/ccteam-advise parallel <question>` — routes to `mcp__ccteam__advise_parallel`
+  (N raw answers, no verdict; user wants to read both rather than a synthesis)
 - "second opinion on X"
 - "ask both Claude and Codex about X"
 - "should I pick A or B" / "X vs Y trade-off"
@@ -43,30 +46,151 @@ If the user's question is < 1 sentence ("which is better?"), ask
 one clarifying question before the dispatch — vague prompts produce
 generic answers from both vendors.
 
-## Pre-flight: is Codex available?
+## Step 1: Pick the route (vote vs parallel)
 
-Before spawning the parallel advisors:
+| Intent | Route | Output shape |
+|---|---|---|
+| "Give me one consolidated recommendation" | `mcp__ccteam__advise_vote` | `verdict` (3-5 sentence prose) + both raw answers + `agreement` (agree / partial / disagree / unknown) |
+| "Give me both answers, I'll decide" | `mcp__ccteam__advise_parallel` | `answers: [{vendor, answer, status}, ...]` (N rows, no synth) |
+| Default (ambiguous user intent) | `mcp__ccteam__advise_vote` | synthesised verdict is the safer default |
 
-```bash
-codex --version 2>/dev/null && codex login status 2>/dev/null
+Both tools enforce the same rolling 24h budget cap in
+`<ccteam_root>/cost-budget.json` (default 0.50 USD/24h, override via
+`max_cost_usd`). Over-cap → tool returns `ok:false, error:"budget_exceeded"`
+without spawning any advisor; surface that to the user verbatim.
+
+## Step 2: Invoke the MCP tool
+
+Preferred path — one MCP tool call per consult:
+
+```json
+// advise_vote
+{
+  "name": "mcp__ccteam__advise_vote",
+  "arguments": {
+    "question": "Should the orchestrator gate writes via inotify or a polling watcher?",
+    "context": "Target: 200ms latency cap; cross-platform (linux + macOS).",
+    "codex_timeout_secs": 60,
+    "max_cost_usd": 0.50
+  }
+}
 ```
 
-- Both succeed → run the full dual-vendor dispatch (§Step 1–§Step 2)
-- Either fails → fall back to **Claude-only single advisor**, print
-  a one-line note: `Codex unavailable (reason); running Claude-only
-  advisor.` Then dispatch the single Task and skip the verdict
-  synthesis (just print Claude's answer).
+```json
+// advise_parallel
+{
+  "name": "mcp__ccteam__advise_parallel",
+  "arguments": {
+    "question": "Should the orchestrator gate writes via inotify or a polling watcher?",
+    "n": 4,
+    "vendors": ["claude", "codex"],
+    "timeout_secs": 60
+  }
+}
+```
 
-**Test override**: when `$CCTEAM_CODEX_BIN` is set, treat that path
-as the codex binary instead of probing PATH. Lets unit / e2e tests
-inject a fake codex without modifying `$PATH`.
+The daemon spawns both vendors in parallel (`claude -p ...` + `codex
+exec --json -`), aggregates the result, and returns a single MCP
+response. Cost is accounted into `<ccteam_root>/cost-budget.json`
+on the daemon side — no client-side bookkeeping needed.
 
-## Step 1: Parallel dispatch
+### Codex unavailable
 
-Issue **two tool calls in the same assistant turn** so they run
+When the codex binary is missing from `$PATH` (or
+`$CCTEAM_CODEX_BIN` points at a non-executable file), the daemon
+returns the result with the Codex slot marked
+`status:"unavailable"` and the verdict (advise_vote) explicitly
+includes the line `Codex unavailable: <reason>`. The call is still
+`ok:true`. Surface the unavailability note to the user verbatim —
+never silently fall through to a "Claude-only" output without
+flagging it.
+
+### Daemon not running
+
+If `mcp__ccteam__advise_vote` is not registered in this session (no
+daemon running, or daemon-side `CCTEAM_DISABLE_TOOLS=advise`), fall
+back to the **manual fan-out** below.
+
+## Step 3: Render the verdict
+
+For `advise_vote`, the daemon already returns a synthesised
+`verdict` string. Render it as-is, then optionally show the two raw
+answers under collapsible headings if the user asks ("show me both
+sides").
+
+For `advise_parallel`, render each `answers[i]` row as its own
+section — do not synthesise yourself.
+
+### Example output (advise_vote)
+
+User: `/ccteam-advise vote should I write the new persistence layer in Rust or Go for a high-throughput message queue?`
+
+Daemon returns (paraphrased shape — actual JSON fields are
+`verdict` / `claude_answer` / `codex_answer` / `agreement` / `budget`):
+
+```
+ADVISOR VERDICT (agreement: agree)
+==================================
+Both Claude and Codex recommend Rust for a high-throughput message
+queue, citing zero-cost abstractions, predictable latency under
+load, and Tokio's mature async runtime. The lone Codex caveat is
+team familiarity — if your team has shipped 3+ Go services already
+and zero Rust, the migration cost can dominate the latency win for
+the first 6 months. Recommended: Rust if you have at least one
+Rust-comfortable engineer; otherwise Go with a `sync.Pool`-heavy
+hot path is acceptable for ~50% of Rust's throughput ceiling.
+
+Claude's answer:    [collapsed — expand with "show Claude's reply"]
+Codex's answer:     [collapsed — expand with "show Codex's reply"]
+
+Budget: 0.015 / 0.500 USD used today.
+```
+
+Synthesis rules (the daemon already follows these for
+`advise_vote`; replicate them only if you fall back to manual mode):
+
+- **Both agree** → "Both agree: <X>. Reasons: ..." Pick the
+  recommendation as the verdict.
+- **Conflict** → "Claude says <X> because <r1>; Codex says <Y>
+  because <r2>. Recommended: <Z> because <why>." If the conflict
+  is irreducible (e.g. matter of taste), say so explicitly and let
+  the user pick.
+- **One vendor strongly objects** (e.g. dealbreaker risk) → that
+  vendor's veto carries unless the user explicitly overrides.
+
+Don't pad the verdict — under 250 words total.
+
+## Output language
+
+Match the user's input language. If the user wrote in Chinese, the
+verdict labels stay as `Claude:` / `Codex:` / `合成:` / `分歧度:`
+(those are already mixed). If the user wrote in English, swap
+`合成` → `Synthesis`, `分歧度` → `Divergence`.
+
+## Cost / budget hint
+
+Each `mcp__ccteam__advise_vote` call:
+
+- 1 Claude advisor call (`claude -p ...`, ~250-word cap) ≈ $0.005
+- 1 Codex `exec` call (`codex exec --json -`, same cap) ≈ $0.005
+- 1 Claude verdict synth call ≈ $0.005
+
+Total ≈ $0.015 per `advise_vote` consult; `advise_parallel` is
+`N × $0.005` (no synth step). The daemon enforces a default rolling
+24h cap of $0.50 (≈ 33 vote consults / 100 parallel slots).
+
+If the user calls `/ccteam-advise` > 20× in one session, surface a
+soft reminder: "You've asked the parallel advisor 20+ times;
+consider using `/ccteam-team 3:reviewer` for an extended debate
+instead — same cost, deeper exploration."
+
+## Manual fallback (no daemon)
+
+If the daemon isn't running or the advise group is disabled, issue
+**two tool calls in the same assistant turn** so they run
 concurrently:
 
-1. Claude advisor:
+1. Claude advisor (via the Task tool):
 
    ```
    Task({
@@ -78,8 +202,7 @@ concurrently:
    })
    ```
 
-2. Codex advisor (via Bash since the Task tool can't target
-   Codex directly):
+2. Codex advisor (via Bash):
 
    ```bash
    CODEX_BIN="${CCTEAM_CODEX_BIN:-codex}"
@@ -91,99 +214,67 @@ concurrently:
    PROMPT
    ```
 
-   Parse the JSONL output, take the final assistant message body.
+   Parse the JSONL output, take the final `agent_message` body.
    On non-zero exit / parse failure, treat as `Codex error: <stderr
-   one-liner>` and continue with Claude-only verdict synthesis.
+   one-liner>` and continue with a Claude-only verdict synthesis.
 
-If the daemon is running and exposes `ccteam__advise_vote` via MCP,
-the skill MAY use that tool instead of the manual fan-out — same
-result with daemon-side cost accounting. Detection: a previous turn
-in this session must have seen `mcp__ccteam__advise_vote` registered;
-otherwise stick to the direct dispatch.
+Pre-flight Codex availability check:
 
-## Step 2: Verdict synthesis
-
-After both advisors return, produce ONE final verdict in the
-prescribed format. Do not echo either advisor's raw reply verbatim
-— summarise.
-
-```
-ADVISOR VERDICT
-===============
-Claude: <100-word summary of Claude's recommendation + key reasons>
-Codex:  <100-word summary of Codex's recommendation + key reasons>
-
-合成:    <150-word final recommendation>
-分歧度:  <0-5>   # 0 = both agree, 5 = full opposition
-
-Notes (optional):
-  - <any dealbreaker either vendor raised>
-  - <any caveat the user should be aware of>
+```bash
+codex --version 2>/dev/null && codex login status 2>/dev/null
 ```
 
-Synthesis rules:
+- Both succeed → run the full dual-vendor dispatch
+- Either fails → fall back to **Claude-only single advisor**, print
+  a one-line note: `Codex unavailable (reason); running Claude-only
+  advisor.` Then dispatch the single Task and skip the verdict
+  synthesis (just print Claude's answer).
 
-- **Both agree** → "Both agree: <X>. Reasons: ..." Pick the
-  recommendation as the verdict.
-- **Conflict** → "Claude says <X> because <r1>; Codex says <Y>
-  because <r2>. Recommended: <Z> because <why>." If the conflict
-  is irreducible (e.g. matter of taste), say so explicitly and let
-  the user pick.
-- **One vendor strongly objects** (e.g. dealbreaker risk) → that
-  vendor's veto carries unless the user explicitly overrides.
-
-Don't pad the verdict — under 250 words total including all the
-sections above.
-
-## Output language
-
-Match the user's input language. If the user wrote in Chinese, the
-verdict labels stay as `Claude:` / `Codex:` / `合成:` / `分歧度:`
-(those are already mixed). If the user wrote in English, swap
-`合成` → `Synthesis`, `分歧度` → `Divergence`.
-
-## Cost / budget hint
-
-Each `/ccteam-advise` invocation is roughly:
-
-- 1 Claude Task (Sonnet 4.5, ~10k context, ~1k output) ≈ $0.04
-- 1 Codex `exec` (gpt-5-codex, ~10k context, ~1k output) ≈ $0.05
-
-Total ≈ $0.10 per consult. If the user calls `/ccteam-advise`
-> 20× in one session, surface a soft reminder:
-"You've asked the parallel advisor 20+ times; consider using
-`/ccteam-team 3:reviewer` for an extended debate instead — same
-cost, deeper exploration."
+**Test override**: when `$CCTEAM_CODEX_BIN` is set, both the daemon
+adapter and the manual fallback treat that path as the codex binary
+instead of probing `$PATH`. Lets unit / e2e tests inject a fake
+codex without modifying `$PATH`.
 
 ## What this skill does NOT do
 
 - **No iterative debate** — single round of voting + one verdict.
   Use `/ccteam-team 3:reviewer` for multi-turn debate.
-- **No retention** — verdicts are session-local; nothing is written
-  to `~/.ccteam/`.
+- **No retention** — verdicts are session-local; only the cost
+  ledger persists to `<ccteam_root>/cost-budget.json`.
 - **No tool execution** — advisors return text only; the skill
   never lets either vendor write files or run shell commands on
   behalf of the user.
-- **No 3+ vendor fan-out** — for N-way voting use the MCP tool
-  `ccteam__advise_parallel` instead (Wave 3 daemon).
+- **N-way fan-out without synthesis** uses `mcp__ccteam__advise_parallel`
+  with `n: 3..=8` — supported and shipped (no longer a placeholder).
 
 ## Red lines
 
 - **Never run the two advisors sequentially** — defeats the point
-  of parallel voting. Single assistant turn with both tool calls.
+  of parallel voting. The daemon already parallelises; in manual
+  fallback, issue both tool calls in a single assistant turn.
 - **Never quote an entire advisor reply** — synthesise. The user
   asked for a verdict, not two essays.
 - **Never silently fall through to Claude-only** — if Codex is
   unavailable, print the one-line `Codex unavailable: <reason>`
-  marker before the verdict.
+  marker before the verdict (daemon path already does this).
 - **Never invoke `/ccteam-advise` recursively** — if mid-synthesis
   you find you need more facts, ask the user, don't fan out again.
+- **Never bypass the budget cap** — if the daemon returns
+  `error:"budget_exceeded"`, surface it; do not retry with a
+  silently raised `max_cost_usd`.
 
 ## Where to look in the repo
 
-- `@docs/versions/v0-6-0/prd.md` §F112 §A — skill design SoT
-- `@crates/ccteam-cli/src/mcp_advise_tools.rs` — MCP tools the
-  daemon registers (`ccteam__advise_vote` / `ccteam__advise_parallel`)
-- `@crates/ccteam-core/src/execution/codex_exec.rs` — the
-  CodexExecAdapter the daemon route uses for the same primitive
+- `@docs/versions/v0-6-5/prd.md` §F152 / §F153 / §F154 — real-impl
+  PRD (supersedes the V0.6.0 stub design)
+- `@crates/ccteam-cli/src/mcp_advise_tools.rs` — MCP tool schemas
+  + dispatchers for `ccteam__advise_vote` / `ccteam__advise_parallel`
+- `@crates/ccteam-core/src/advise.rs` — vendor adapter helpers
+  (`run_claude_advisor` / `run_codex_advisor` / budget ledger
+  persistence)
+- `@crates/ccteam-cli/tests/mcp_advise_vote_test.rs` — vote happy
+  path + Codex-unavailable + budget-exceeded e2e coverage
+- `@crates/ccteam-cli/tests/mcp_advise_parallel_test.rs` —
+  parallel round-robin + claude-only + unavailable slot + budget
+  e2e coverage
 - `@CLAUDE.md` §三 — architectural red lines


### PR DESCRIPTION
## Findings

- **F153** `mcp__ccteam__advise_parallel` — module fn + MCP wiring already landed in PR #105 (F152 sibling). This PR adds the missing 5 hermetic e2e tests through `ccteam mcp-serve` stdio.
- **F154** `/ccteam-advise` SKILL.md body sweep — drop all "Wave 1/2/3" / "Wave 3 daemon" / "STUB" placeholder language; reframe MCP path as the primary flow with sample verdict output and Manual fallback as the no-daemon backup.

## Verification

- `cargo test --workspace --locked --no-fail-fast`: **1576 / 1** (baseline was 1571 / 1; +5 new F153 e2e tests; the 1 failure is the pre-existing `workflow_summary_reflects_agent_spawn_and_done_events` flake noted in CLAUDE.md §一).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- F153 reuses F152 helpers (`run_claude_advisor` / `run_codex_advisor` / `append_budget_sample`) — no duplicate spawn code.
- F154 grep gate: `grep -E "Wave [123]|STUB|NotImplemented|占位|准备中" skills/ccteam-advise/SKILL.md` → **0 hits**.

## Diff stat

```
crates/ccteam-cli/tests/mcp_advise_parallel_test.rs | 364 ++++++++++++++++++++ (new)
skills/ccteam-advise/SKILL.md                       | 273 +++++++++++-------- (rewrite)
2 files changed, 546 insertions(+), 91 deletions(-)
```

## F153 tests (all hermetic, no real claude/codex binary)

1. `advise_parallel_n4_round_robin_returns_four_answers` — N=4 vendors=[claude,codex] → 4 slots, round-robin to [claude,codex,claude,codex], 4 budget samples (2 claude + 2 codex).
2. `advise_parallel_n2_claude_only_returns_two_claude_answers` — N=2 vendors=[claude] → both slots claude.
3. `advise_parallel_codex_unavailable_slot_marks_status_but_array_still_full` — codex non-exec → status=unavailable + empty answer, N preserved, only claude charged.
4. `advise_parallel_budget_exceeded_does_not_spawn_advisors` — pre-call ledger past cap → ok:false + ledger unchanged.
5. `advise_parallel_n_out_of_range_returns_invalid_input` — n=9 caught upstream of any spawn.

## F154 SKILL.md highlights

- §"When to invoke" now includes `/ccteam-advise vote` and `/ccteam-advise parallel` explicit trigger forms.
- §"Pick the route (vote vs parallel)" table maps user intent → MCP tool name → output shape.
- §"Invoke the MCP tool" gives concrete JSON tool-call payloads for both `advise_vote` and `advise_parallel` with realistic arguments.
- §"Render the verdict" includes a sample `advise_vote` agreement-case rendered output (≤200 words).
- §"Codex unavailable" explicitly documents the daemon's automatic `Codex unavailable: <reason>` red-line behaviour.
- §"Manual fallback" preserved for "no daemon" scenarios but clearly framed as backup, not primary.
- §"Where to look" repoints to F152/F153 PRD + the real test files.