### PR TITLE
v0.6.5 (F158): task-to-command decision tree + tier-1 docs lead 改写

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,63 @@
 # ccteam
 
-> **A multi-agent orchestrator on top of Claude Code** — one tool, three tiers: in-proc temporary helpers / bg long-running workflows / IM bots running 24/7.
+> **A multi-agent orchestrator on top of Claude Code** — describe what you want, ccteam picks the command. No YAML. No CLI flags to memorize.
 
 ![demo](docs/versions/v0-6-0/demos/30s-tg-bot-team.gif)
 
-## Three runtime modes (the core of ccteam)
+## What do you want to do?
 
-ccteam adds **three multi-agent runtime modes** to Claude Code, each for a different cadence:
+Pick the row that matches your goal. The right column is the command — copy-paste into any Claude session.
 
-| # | Mode | How it's hosted | Typical use |
-|---|---|---|---|
-| **1** | **Lightweight (in-proc)** | Inside an existing Claude session; ccteam acts as a plugin/skill that spawns temporary teammates via the native `Task` tool, sharing the session lifecycle | Summoning helpers while coding / a quick 3–5 agent burst |
-| **2** | **bg workflow orchestration** | Multiple `claude --bg --agent <role>` sessions collaborating through a `workflow.yaml` of triggers; file artifacts pass the baton; the ccteam Rust daemon runs long while bg jobs come and go | Power users running long workflows in a domain (qa-loop: test-fix-release / self-driving builds) |
-| **3** | **IM bots (tmux-resident)** | Long-running tmux + `claude` TUI sessions, one per agent bot, always on; bots talk to each other in an IM group by @-mentioning | Chatting privately with an AI assistant on your phone / a multi-bot team collaborating across devices in an IM group |
+```
+You want to do                                 → Run this
+──────────────────────────────────────────────────────────────────────
+Get a feel for a new codebase / repo audit      /ccteam-scan
+Build / fix / refactor (watching it work)       /ccteam-team "<task>"
+Review a PR / get a second opinion              /ccteam-advise "<PR or path>"
+A private IM assistant (24/7, always on)        /ccteam-creator "build me a <X> assistant"
+A multi-bot IM round-table                      /ccteam-creator "a few bots in a group"
+Run a long task overnight (hands-off)           /ccteam-creator "<task>, run while I sleep"
+List / pause / resume / check spending          /ccteam-control list | pause | cost
+Wire up an IM token (Telegram / Slack / Discord)  /ccteam-im-setup
+Not sure? Just describe it in natural language  /ccteam "<what you want>"
+```
 
-The three modes are fixed at the bottom; **the application layer on top is open** — the five presets below ship as a starter set, and the `ccteam-creator` skill can generate new scenarios from a natural-language description.
+> Each command is a Claude Code slash command. Type it in a `claude` session — `/ccteam <NL>` is the universal entry; the others let you skip the router when you already know the path.
 
-## 5-minute quickstart (pick an entry point by mode)
+## Get started
 
 ```bash
-# 0. Install Claude Code + the ccteam plugin first.
-# https://code.claude.com/docs/install
+# 0. Install Claude Code first: https://code.claude.com/docs/install
 claude
 /plugin install ccteam
 
-# === Mode 1: summon a temporary helper inside an existing session ===
-/ccteam "clean up all the TypeScript errors here"
-# Or burst a few agents in parallel:
-/ccteam-team 3 "refactor the src/auth submodule"
-
-# === Mode 2: kick off a bg long-running workflow ===
-/ccteam-creator "overnight qa-loop: run tests on every commit, auto-fix on failure"
-
-# === Mode 3: hook up IM bots ===
-/ccteam-im-setup                            # one-time bind for TG/Slack/Discord
-/ccteam-creator "build me a TG DM assistant that helps manage my email"
+# 1. Try the universal entry — describe what you want in any language:
+/ccteam "scan this repo and tell me what it does"
+/ccteam "fix the TypeScript errors in src/"
+/ccteam "build a Telegram bot that summarizes my GitHub PRs at 7am"
 ```
 
-→ See [quickstart](docs/quickstart.md) for the full walkthrough.
-
-## 5 presets, pick whichever fits
-
-Each preset is a recommended "mode × orchestration pattern × persona" recipe; `ccteam-creator` wires it up through NL dialogue:
-
-| Preset | One-line scenario | How to launch | Mode |
-|---|---|---|---|
-| **Solo Sidekick** | Summon a single helper while coding with Claude | `/ccteam <natural language>` | 1 |
-| **Team Sprint** | A few-hour burst with 3–5 agents in parallel | `/ccteam-team 3 "<task>"` | 1 |
-| **Overnight Builder** | Drop a task and go to sleep; runs for hours to days | `/ccteam-creator "overnight ..."` | 2 |
-| **Pocket Assistant** ⭐ | A private AI assistant in your phone IM | `/ccteam-creator "build a TG assistant"` | 3 |
-| **IM Squad** ⭐ | Multiple bots in an IM group @-mentioning each other | `/ccteam-creator "build a multi-bot TG team"` | 3 |
-
-⭐ flagship scenarios. Mode 3 brings your AI team into IM, working on your behalf across devices 24/7 — the difference vs. ChatGPT / Cursor / Devin: the bots run **on your computer**, can touch your files, run your commands, read your code; your phone is just the entry point.
+The 5-minute walkthrough for "private IM assistant" (the flagship use case) lives in [docs/quickstart.md](docs/quickstart.md).
 
 ## Three ways to talk to ccteam
 
-- 🟢 **Inside a Claude session**: `/ccteam <natural language>` is the universal entry point (works for modes 1/2/3)
-- 🟢 **From IM** (mode 3): DM a bot, or `@ccteam <NL admin>` in a group
-- 🟡 **Web dashboard** (modes 2/3): `http://localhost:7331` (read-only)
+- **Inside a Claude session** — `/ccteam <NL>` is the universal entry; the per-task slash commands above are shortcuts.
+- **From IM** — DM your bot directly, or `@ccteam <NL admin>` inside a group for control (`pause`, `cost`, `list`, `stop everything`, …).
+- **Web dashboard** (read-only) — `http://localhost:7331` to watch workflows, transcripts, and 24h spend.
 
-> You **do not** need to learn CLI commands, and you **do not** need to write any YAML. All setup happens through dialogue inside a Claude session.
+The AI runs on **your computer** — it can read your files, run your commands, touch your code. Your phone / IM is just the entry point; close the laptop lid and the workflow keeps running.
 
 ## Docs
 
 | What you want | Read this |
 |---|---|
-| Get the first preset running in 5 minutes | [docs/quickstart.md](docs/quickstart.md) |
-| Full 3-mode + 5-preset user manual | [docs/user-manual.md](docs/user-manual.md) |
+| Decision tree — task to command (with examples) | [docs/task-to-command.md](docs/task-to-command.md) |
+| 5-minute walkthrough for the flagship IM-bot use case | [docs/quickstart.md](docs/quickstart.md) |
+| Full user manual (every scenario, every flag) | [docs/user-manual.md](docs/user-manual.md) |
 | Copy-paste a ready-made use case | [docs/recipes.md](docs/recipes.md) |
-| Something broke and you cannot find it | [docs/troubleshooting.md](docs/troubleshooting.md) |
+| Something broke | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Advanced customization / Codex integration | [docs/advanced/](docs/advanced/) |
 
 ## License & acknowledgements
 
-See [LICENSE](LICENSE). Built on [Claude Code](https://code.claude.com/) (the runtime) and [openhuman/channels](https://github.com/openhuman/channels) (14+ IM platforms in Rust); orchestration taxonomy from Anthropic's *Building Effective Agents*; mode-3 IM bot pattern (tmux + send-keys + transcript polling) inspired by `ccgram` and `oh-my-claudecode`.
-
----
-
-See [docs/versions/v0-6-1/README.md](docs/versions/v0-6-1/README.md) for current release notes.
+See [LICENSE](LICENSE). Built on [Claude Code](https://code.claude.com/) (the runtime) and [openhuman/channels](https://github.com/openhuman/channels) (14+ IM platforms in Rust); orchestration taxonomy from Anthropic's *Building Effective Agents*; IM-bot pattern (tmux + send-keys + transcript polling) inspired by `ccgram` and `oh-my-claudecode`.

--- a/docs/orchestration-patterns.md
+++ b/docs/orchestration-patterns.md
@@ -1,6 +1,12 @@
+---
+audience: contributors
+---
+
 # 编排模式 —— 拆分哲学 + 5 模式目录(ccteam 设计依据)
 
-> **角色**:tier-1 全局文档。ccteam 后续所有 workflow 设计、agent 拓扑、自动化迭代**都基于本文的 5 模式 + 拆分哲学**;新加 workflow 模板 / 重做 fix-loop / 拓展非编程领域 team 都先回到本文校准。
+> **角色**:tier-1 全局文档,**面向 contributor**(ccteam 维护者 / 新 workflow 设计者)。日常**用户**用 ccteam 不需要读本文 —— 用户面入口是 [task-to-command.md](task-to-command.md)(决策树)+ [quickstart.md](quickstart.md) + [user-manual.md](user-manual.md)。
+>
+> ccteam 后续所有 workflow 设计、agent 拓扑、自动化迭代**都基于本文的 5 模式 + 拆分哲学**;新加 workflow 模板 / 重做 fix-loop / 拓展非编程领域 team 都先回到本文校准。
 >
 > **回答两个核心问题**:
 > 1. **什么时候该拆 agent?**(§一 设计哲学 — "按上下文拆,不按角色拆")

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,38 @@
-# Quickstart — 5 分钟在 TG 收到你第一个 AI 助理的回话
+# Quickstart
 
-> 本文档单一目标:从 0 到 **你手机 TG 收到 bot 第一条回话**,5 步,5 分钟。
+> **第一节先看决策树** ── 你想做的事 → 直接对应一个命令,不必先理解架构。
+>
+> 第二节起是 "我要做 IM bot" 这条路的 5 分钟走通流程(从 0 到 **你手机 TG 收到 bot 第一条回话**)。其他路径详见 [task-to-command.md](task-to-command.md) + [user-manual.md](user-manual.md)。
 >
 > 卡住任何一步?跳到 [troubleshooting.md](troubleshooting.md) 搜对应章节。
 
-## 你需要
+---
+
+## §1 我该用哪个命令?(决策树)
+
+```
+你想做的事                                  → 用这个
+──────────────────────────────────────────────────────────────────
+摸底新代码库 / 仓库 audit                    /ccteam-scan
+开发 / 修 bug / 重构(全程盯着干)            /ccteam-team "<task>"
+review PR / 第二意见 / 对答案                /ccteam-advise "<PR 或 path>"
+做个 IM 私聊助理(长期 24/7 在线)            /ccteam-creator "做个 X 助理"  ↓ §2 详跑通
+做个团队 IM 圆桌(多 bot 互动)               /ccteam-creator "群里几个 bot"
+夜里跑长任务(hands-off / 关电脑)            /ccteam-creator "<task>,睡前跑"
+看 / 暂停 / 恢复 / 看花费                    /ccteam-control list / pause / cost
+配 / 改 IM token(TG / Slack / Discord)      /ccteam-im-setup
+不确定?用自然语言问                          /ccteam "<NL 描述>"
+```
+
+每条详解 + 例子见 [task-to-command.md](task-to-command.md)。
+
+---
+
+## §2 走通 "IM 私聊助理" 这条路(5 分钟)
+
+下面是 ccteam **最有代表性的** 一条路 —— 起一个 Telegram 私聊 bot 当你的 AI 助理。
+
+**你需要**:
 
 - Claude Code(`claude` CLI),装好登好。没装看 [code.claude.com/docs/install](https://code.claude.com/docs/install)。
 - Telegram 账号 + 手机装 Telegram app。macOS / Linux 主机(Windows 走 WSL2)。
@@ -113,6 +141,7 @@ You:     go
 
 ## 接下来读什么
 
+- 想跑别的命令(不是 IM bot)?→ [task-to-command.md](task-to-command.md)(决策树详解)
 - 想跑别的 use case?→ [recipes.md](recipes.md)(代码审查 bot / 翻译 bot / 日报助手等 10 个现成模板)
 - 想了解全部 5 种用法?→ [user-manual.md](user-manual.md)
 - 想给 bot 换 persona / 加能力?→ [user-manual.md](user-manual.md) §2.4 Pocket Assistant

--- a/docs/task-to-command.md
+++ b/docs/task-to-command.md
@@ -1,0 +1,162 @@
+---
+audience: users
+---
+
+# Task → Command 决策树
+
+> 一屏看完。你想做的事 → 直接对应一个 ccteam 命令,不必先理解 mode / preset / orchestration 概念。
+>
+> 不确定?最后一行总是对的:用自然语言问 `/ccteam`,它替你路由。
+
+---
+
+## 决策树(单屏)
+
+```
+你想做的事                                  → 用这个
+──────────────────────────────────────────────────────────────────
+摸底新代码库 / 仓库 audit                    /ccteam-scan
+开发 / 修 bug / 重构(全程盯着干)            /ccteam-team "<task>"
+review PR / 第二意见 / 对答案                /ccteam-advise "<PR 或 path>"
+做个 IM 私聊助理(长期 24/7 在线)            /ccteam-creator "做个 X 助理"
+做个团队 IM 圆桌(多 bot 互动)               /ccteam-creator "群里几个 bot"
+夜里跑长任务(hands-off / 关电脑)            /ccteam-creator "<task>,睡前跑"
+看 / 暂停 / 恢复 / 看花费                    /ccteam-control list / pause / cost
+配 / 改 IM token(TG / Slack / Discord)      /ccteam-im-setup
+不确定?用自然语言问                          /ccteam "<NL 描述>"
+```
+
+---
+
+## 每条详解(用一行场景 + 一个最常见例子)
+
+### `/ccteam-scan` —— 摸底新代码库
+
+**啥时用**:刚 clone 一个仓库,想 30 秒知道:语言 / 框架 / 入口 / 主要 TODO / 有没有 CLAUDE.md。
+
+```
+cd path/to/repo
+claude
+/ccteam-scan
+```
+
+**输出**:三段报告(language/framework/entry · TODO hotspots · CLAUDE.md status)+ 建议下一步该跑哪个 ccteam 命令。
+
+---
+
+### `/ccteam-team "<task>"` —— 开发 / 修 bug / 重构
+
+**啥时用**:你有个 1-3 小时能干完的工程任务,想要几个 agent 并行帮你干,**全程盯着** = 当前 Claude session 看实时通信。
+
+```
+/ccteam-team 3 "fix all TypeScript errors in src/"
+/ccteam-team 5:reviewer "review the new auth design"
+```
+
+`<N>` 是 teammate 数(可省,默认 3)。`<task>` 是自然语言任务描述。
+
+---
+
+### `/ccteam-advise "<PR 或 path>"` —— 第二意见 / 对答案
+
+**啥时用**:你拿不准一段代码 / 设计 / PR 是不是对的,想要 Claude + Codex 两个 LLM 并行各给一份分析,你看 diff 拿主意。
+
+```
+/ccteam-advise "PR #1234"
+/ccteam-advise "src/auth/sso.rs 这个设计哪里有问题"
+```
+
+**前置条件**:装了 Codex(否则只有 Claude 单视角,失去 "双 LLM" 价值)。
+
+---
+
+### `/ccteam-creator "做个 X 助理"` —— IM 私聊助理(长跑)
+
+**啥时用**:你想要一个 **手机 IM 里随时找它说话** 的私人 AI 助理。它跑在你电脑上(读文件 / 跑命令 / 推送),手机只是入口。
+
+```
+/ccteam-im-setup                                # 第一次,绑 TG bot token
+/ccteam-creator "做个 TG 私聊助理:管邮件 + 早 7 点推 GitHub PR 摘要"
+```
+
+向导问 2-3 个问题(persona / 24h cost cap)后起 daemon,关电脑也继续跑。详 [quickstart.md](quickstart.md)。
+
+---
+
+### `/ccteam-creator "群里几个 bot"` —— IM 圆桌(多 bot)
+
+**啥时用**:你想要个 IM 群,2-5 个 bot 各持职责(架构师 + 评审 + 文档 + 测试),你 @ 一个 bot 开局,bot 之间 @ 对方协作,群里给你共识。
+
+```
+/ccteam-creator "做个 TG 多 bot 团队:架构师 + 评审员 + 写手,讨论我贴的设计文档"
+```
+
+Creator 自动起群 / 配多 bot persona / 配 @ 路由 / 限 3 层 @ 链防 ping-pong。
+
+---
+
+### `/ccteam-creator "<task>,睡前跑"` —— 夜里长任务
+
+**啥时用**:任务需长跑几小时到几天(test-fix-test 循环 / 全栈搭 todo app / 跨周做依赖升级),你 hands-off,关电脑去睡。
+
+```
+/ccteam-creator "夜里给我跑 qa-loop:测试失败自动 fix,每 fix 一轮 commit,直到 24h 或 $5 cap"
+```
+
+撞 cost cap 自动停,撞失败 N 次自动 TG 推送叫醒你。早上看摘要。
+
+---
+
+### `/ccteam-control list / pause / cost` —— 管已跑的 workflow
+
+**啥时用**:你已经起了一些 workflow / bot,想看状态 / 暂停 / 恢复 / 查 cost / 改 persona / 加工具。
+
+```
+/ccteam-control list                    # 看所有在跑的 workflow
+/ccteam-control pause helper-bot        # 暂停某个
+/ccteam-control resume helper-bot
+/ccteam-control show-cost               # 今日所有 workflow 花费
+/ccteam-control change-persona helper-bot "改成英文 + 更幽默"
+/ccteam-control add-tool helper-bot "WebFetch"
+```
+
+或在 IM 群里 `@ccteam pause helper-bot` / `@ccteam cost today` / `@ccteam stop everything`。
+
+---
+
+### `/ccteam-im-setup` —— 配 / 改 IM token
+
+**啥时用**:第一次绑 TG(/Slack/Discord)bot,或换 token / 加新平台。
+
+```
+/ccteam-im-setup
+```
+
+向导自动开浏览器到 BotFather → 拿 token → 抓 chat_id → 起 daemon。详 [quickstart.md](quickstart.md) §Step 2。
+
+> Slack / Discord onboarding 在 V0.7 ship(V0.6.x 仅 Telegram 端到端走通)。
+
+---
+
+### `/ccteam "<NL 描述>"` —— 不确定?自然语言问
+
+**啥时用**:不知道该用上面哪个 sub-skill,或想一句话搞定。
+
+```
+/ccteam 帮我扫一下这个仓库            # 路由到 /ccteam-scan
+/ccteam 修一下 TS 报错                # 路由到 /ccteam-team
+/ccteam 我想要个 TG bot 帮我管邮件    # 路由到 /ccteam-creator
+/ccteam 这个 PR 有问题么              # 路由到 /ccteam-advise
+```
+
+`/ccteam` 是**总入口 NL dispatcher**,它分析你的话路由到上面任一 sub-skill。万能,但比直接调 sub-skill 多 1-2 秒推理。**懒得记 sub-skill 名就用它**。
+
+---
+
+## 接下来读什么
+
+- 跑通第一个 bot(5 分钟)→ [quickstart.md](quickstart.md)
+- 全部 5 种用法详细手册 → [user-manual.md](user-manual.md)
+- 抄一份现成 use case → [recipes.md](recipes.md)
+- 想理解架构(mode / preset / orchestration pattern)→ [orchestration-patterns.md](orchestration-patterns.md)(面向 contributor)
+- 出错 → [troubleshooting.md](troubleshooting.md)

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1,8 +1,30 @@
 # ccteam User Manual
 
-> ccteam 让你**用一句中文/英文召唤一个 AI 团队**,跑在你电脑上、接进你的 IM。本手册带你跑通 5 种典型场景,5 分钟见效。
+> ccteam 让你**用一句中文/英文召唤一个 AI 团队**,跑在你电脑上、接进你的 IM。本手册带你跑通典型场景。
 >
 > **零 yaml,零 CLI 命令记忆,零术语**。你只需要会用 Claude Code session 输入 slash 命令 + 自然语言。
+
+---
+
+## §0 我该用哪个命令?(决策树速查)
+
+**先看决策树**,挑一条路再下读对应章节。完整决策树详解见 [task-to-command.md](task-to-command.md)。
+
+```
+你想做的事                                  → 用这个              → 本手册章节
+─────────────────────────────────────────────────────────────────────────────
+摸底新代码库 / 仓库 audit                    /ccteam-scan          §2.0
+开发 / 修 bug / 重构(全程盯着干)            /ccteam-team          §2.2 Team Sprint
+review PR / 第二意见 / 对答案                /ccteam-advise        §2.6 Advise
+IM 私聊助理(长跑)                          /ccteam-creator       §2.4 Pocket Assistant
+IM 圆桌(多 bot)                            /ccteam-creator       §2.5 IM Squad
+夜里跑长任务(hands-off)                    /ccteam-creator       §2.3 Overnight Builder
+看 / 暂停 / 改 persona / 加工具              /ccteam-control       §4 Admin 操作
+配 / 改 IM token                             /ccteam-im-setup      §2.4 + quickstart
+不确定?用自然语言问                          /ccteam "<NL>"        §3.1
+```
+
+> §1 介绍 ccteam 是什么 / 三种对话入口;§2 详跑每个场景;§3 是入口手册;§4 是 admin 操作参考;§5 cost。**只想用,跳到 §2 对应小节即可**。
 
 ---
 


### PR DESCRIPTION
## Finding

F158 — `docs/task-to-command.md` 决策树替代 mode/preset/recipe 三层认知作为用户面 lead。
PRD: `docs/versions/v0-6-5/prd.md` §F158.

## Changes

- **New `docs/task-to-command.md`** (CN, `audience: users`): single-screen decision tree mapping user intent → ccteam command (9 rows), each with a per-row explanation + canonical example.
- **`docs/quickstart.md`**: §1 rewritten with decision tree as lead; existing TG-bot 5-minute walkthrough demoted to §2 as the flagship-path walkthrough.
- **`docs/user-manual.md`**: adds §0 quick-jump decision tree at top, cross-linking to §2 sub-sections.
- **`README.md`** (English, root): replaces 3-mode + 5-preset table lead with the task-to-command decision tree (English); drops `Status` / version-info / release-notes link footer per CLAUDE.md §三 README red lines.
- **`docs/orchestration-patterns.md`**: adds `audience: contributors` frontmatter — flags it as architecture-doc audience, not user-facing.

## Verification

- `cargo test --workspace --locked --no-fail-fast` → **1576 passed / 1 failed** (baseline preserved — docs-only PR).
- `cargo clippy --workspace --all-targets --locked -- -D warnings` → **clean** (Finished, 0 warnings).
- `grep -nE "mode:.*chat|preset:.*chat-pocket" docs/quickstart.md docs/user-manual.md README.md` → **0 hits** ✓
- README.md is **English** (0 Chinese chars verified; non-ASCII are em-dashes / smart quotes / box-drawing in the decision tree only).
- README.md contains **no version number, no shipping date, no baseline** ✓ (per CLAUDE.md §三 root README red line).

## Decision-tree shape

9 rows covering 7 sub-skills:
1. `/ccteam-scan` (audit /摸底)
2. `/ccteam-team` (build / fix / refactor)
3. `/ccteam-advise` (PR review / second opinion)
4. `/ccteam-creator` 3 paths — pocket assistant / IM squad / overnight builder
5. `/ccteam-control` (list / pause / cost)
6. `/ccteam-im-setup` (IM token wire-up)
7. `/ccteam <NL>` (fallback NL dispatcher)