### PR TITLE
v0.6.5 (F157): ccteam-scan --quick + intent route

### DIFF
--- a/skills/ccteam-scan/SKILL.md
+++ b/skills/ccteam-scan/SKILL.md
@@ -1,11 +1,112 @@
 ---
 name: ccteam-scan
-description: "大型代码库导航性体检 —— 只读 audit。探测 monorepo 结构、为每个子系统建议 workflow.yaml 的 `scope:` 值、报告 navigability gap(分层 CLAUDE.md / permissions.deny 噪声排除 / LSP 缺失)。Use when 用户说 '/ccteam-scan'、'检查我的大代码库'、'扫一下这个仓库'、'我的 monorepo 怎么接 ccteam'、'workflow.yaml 的 scope 该填什么'、'audit codebase navigability'。V0.6.2 F141。"
+description: "代码库扫描 —— 只读。两个 mode:(1) `--quick` 60-90s 摸底(1 sonnet agent + 3 个固定问题:语言/框架、TODO 热点、CLAUDE.md/README 状态);(2) default audit 大型代码库导航性体检(monorepo 结构、workflow.yaml `scope:` 建议、navigability gap)。Use when 用户说 '/ccteam-scan'、'扫一下代码 / 摸底新项目 / scan code / audit codebase'、'检查我的大代码库'、'扫一下这个仓库'、'我的 monorepo 怎么接 ccteam'、'workflow.yaml 的 scope 该填什么'、'audit codebase navigability'。V0.6.2 F141 + V0.6.5 F157(--quick)。"
 ---
 
-# /ccteam-scan — 大型代码库导航性体检
+# /ccteam-scan — 代码库扫描
 
-V0.6.2 F141。**只读** audit skill。一次性产出一份报告:这个仓库对 Claude Code agent 有多"可导航",以及把它接入 ccteam 时每个 role 的 `scope:` 该怎么填。
+两个 mode:
+
+| Mode | 触发 | 目标耗时 | 谁 spawn | 输出 |
+|---|---|---|---|---|
+| **quick** | `/ccteam-scan --quick` 或 `/ccteam "扫一下代码"` | 60-90s | 1 个 sonnet agent | `<repo>/.ccteam/codebase-scan.md`(~10-20 行,frontmatter `quick: true`)|
+| **audit**(default,V0.6.2 F141)| `/ccteam-scan`(无 flag)| 5-10 min | inline(本 skill body)| 同 path,**升级覆盖** quick 报告(frontmatter `quick: false`)|
+
+**新用户**:用 `--quick` 即可,30-90 秒看到 value。**大型 monorepo / 要接 ccteam**:跑 default audit 拿 scope 建议 + navigability 报告。
+
+下文 §"--quick mode" 描述 quick;§"--audit mode" 起以下是 V0.6.2 F141 原 audit 流程。
+
+---
+
+## --quick mode(V0.6.5 F157)
+
+**用途**:新用户 60-90s 内摸底任意 git 仓库。不替代 audit;只是第一印象。
+
+**实现**:本 skill body 不 inline 跑(quick 必须 spawn 一个 fresh sonnet agent,理由:Sonnet 4.5 工具调用快,语义抽取强,与主 session 隔离 context)。
+
+### 步骤
+
+1. **环境检查**(skill body 同步跑,< 1s):
+   - `pwd && git rev-parse --show-toplevel` —— 锁定仓库根
+   - 若不是 git 仓库 → 报错退出:"`--quick` 需要 git 仓库;在仓库根再跑"
+   - 若 `<repo>/.ccteam/codebase-scan.md` 已存在且 < 24h → 直接展示已有报告 + 提示"已有最近报告,如需重扫加 `--force`"
+2. **spawn 1 个 sonnet agent**(用户 ad-hoc Task tool,subagent_type 选 `general-purpose` 或项目内已 ln -sf 的 sonnet-default 子 agent;无项目子 agent 则 `general-purpose`):
+   - **model**: `claude-sonnet-4-5`(快,本 mode 不需要 opus 智能;若 opus quota 紧,fallback haiku-4-5)
+   - **briefing**: 见 §Quick agent briefing
+   - **target**:60-90s 出完整报告
+3. **agent 写报告** → `<repo>/.ccteam/codebase-scan.md` —— skill body 不再处理,agent 完即 done
+4. **skill body 给用户 ≤ 5 行摘要**:报告 path + 3 个 question 的 1-line 答案;问"要不要跑 full audit?(`/ccteam-scan`)"
+
+### Quick agent briefing(直接粘进 Task tool prompt)
+
+```
+你是 ccteam-scan --quick mode 的一次性 agent。60-90 秒内摸底当前 git 仓库,产一份短报告。
+
+仓库根:<pwd 锁定的路径>
+
+回答 3 个固定问题(每问限 5-8 行,允许 ≤ 3 个 bash 命令探测):
+
+## Q1 — 主语言 / 框架 / 入口
+- `ls -la` + `git ls-files | head -50` + 检查 `Cargo.toml` / `package.json` / `go.mod` / `pyproject.toml` / `pom.xml` 等 build 文件
+- 输出:主语言(top 1-2)、framework(若可见)、入口文件(`main.rs` / `index.ts` / `app.py` 等)、build 工具
+- ≤ 5 行
+
+## Q2 — TODO / FIXME / HACK 热点
+- `rg -i "TODO|FIXME|HACK" --no-heading -c | sort -t: -k2 -rn | head -10`(每文件 count)
+- 输出:top 10 热点文件 + 总数;若 < 5 个 hit → "干净,无明显 tech debt 标记"
+- ≤ 8 行
+
+## Q3 — CLAUDE.md / README 状态
+- 检查 root `CLAUDE.md` / `README.md` / `AGENTS.md` 存在性 + 大小(行数)
+- 若 root README 存在:用 `head -20` 抽出 project description 1-2 行
+- 若 root CLAUDE.md 存在:抽出 1-line summary(它是给 Claude Code 的 project memory)
+- 若两者皆无:建议初始化(`claude /init` 或 `ccteam init`)
+- ≤ 7 行
+
+落地报告到 `<repo>/.ccteam/codebase-scan.md`(若 `.ccteam/` 不存在先 `mkdir -p`),格式:
+
+---
+quick: true
+generated: <ISO 8601 timestamp>
+generator: ccteam-scan --quick
+---
+
+# Codebase quick scan — <repo basename>
+
+## Q1 — language / framework / entry
+<5 行>
+
+## Q2 — TODO hotspots
+<8 行>
+
+## Q3 — CLAUDE.md / README status
+<7 行>
+
+## Next steps
+- 大型 monorepo 要接 ccteam → 跑 full audit:`/ccteam-scan`(无 --quick)
+- 起 team 干活 → `/ccteam-team "<task>"`
+- 配 IM bot → `/ccteam-creator "做个 X 助理"`
+
+---
+
+**红线**:
+- 只读 —— 除报告文件外零写动作。不改 CLAUDE.md / README / 任何源码
+- 不 spawn 子 agent(本 mode 一层 sonnet 就到底)
+- 不调 MCP `mcp__ccteam__*`(quick 是 zero-config 体验,不依赖 ccteam project 状态)
+- 60-90s 内出报告;超时则截断(已答几问就答几问),不无限拉长
+```
+
+### 与 audit mode 的关系
+
+- quick 落 `quick: true` frontmatter;audit 落 `quick: false`,**覆盖**同 path
+- audit mode 不读 quick 报告 —— 两次扫描独立,不增量
+- 用户先 quick 后 audit 是常见路径:quick 给即时反馈,audit 给 production-grade 建议
+
+---
+
+## --audit mode(V0.6.2 F141,大型代码库导航性体检)
+
+**只读** audit skill。一次性产出一份报告:这个仓库对 Claude Code agent 有多"可导航",以及把它接入 ccteam 时每个 role 的 `scope:` 该怎么填。
 
 灵感来源:Anthropic《How Claude Code works in large codebases》—— "Claude 的能力 = 找到正确 context 的能力;太多则退化,太少则盲目"。本 skill 是 `docs/orchestration-patterns.md §1.5` explorer→artifact→editor 模板里 `explorer` role 的一次性交互版。
 
@@ -25,15 +126,22 @@ V0.6.2 F141。**只读** audit skill。一次性产出一份报告:这个仓库�
 
 触发短语(LLM 语义匹配,无需 regex):
 
-- `/ccteam-scan [路径]` — 显式 slash 入口(路径省略 = 当前 git 仓库根)
+**quick mode** —— 优先匹配:
+- `/ccteam-scan --quick` — 显式 quick
+- "扫一下代码 / 摸底 / 看看这个仓库 / scan code / quick scan"
+- 用户刚 `cd` 进新仓库 + 问"这是个啥项目 / 用了啥技术"
+- 通过 `/ccteam` dispatcher intent 5(code-scan)路由进来
+
+**audit mode** —— default:
+- `/ccteam-scan [路径]` — 显式 slash 入口(无 `--quick`,路径省略 = 当前 git 仓库根)
 - "检查 / 扫一下我的大代码库"、"这个 monorepo 怎么接 ccteam"
 - "workflow.yaml 的 `scope:` 该填什么"
 - "我的仓库对 agent 友好吗 / navigability audit"
 
 不要在以下场景触发:
 
-- 用户要的是代码 review / bug 排查 —— 那是普通编码任务,不是导航性体检
-- 仓库很小(`git ls-files | wc -l` < ~200)—— 直接告诉用户"小仓库不需要 scan,一份 root CLAUDE.md 足够",不跑完整流程
+- 用户要的是代码 review / bug 排查 —— 那是普通编码任务,不是导航性体检(转 `/ccteam-team` 或普通编码)
+- 仓库很小(`git ls-files | wc -l` < ~200)+ 用户要 audit —— 告诉用户"小仓库不需要 audit,跑 `--quick` 30 秒摸底足够";若要 audit 仍可继续
 
 ## 核心原则 —— 只读 advisory
 
@@ -120,7 +228,7 @@ crates/api           scope: crates/api          Cargo workspace member
 
 - 不改任何源码 / 配置 / workflow.yaml —— 只读 + 只写 `.ccteam/codebase-scan.md` 报告
 - 不代写 `CLAUDE.md` 内容、不装 LSP —— 那是 inner harness / 项目仓库职责
-- 不跑 agent、不 spawn session —— 纯一次性 audit
+- audit mode 不 spawn 长 session(纯一次性 audit);quick mode spawn 1 个 sonnet agent 单次回答 3 问后即结束(也非长 session)
 - 不做代码质量 / 安全 review —— 那是别的 skill / team 的事
 
 ## Red lines
@@ -133,4 +241,5 @@ crates/api           scope: crates/api          Cargo workspace member
 
 - `docs/orchestration-patterns.md §1.5` —— 大型代码库模板(scope + explorer→artifact→editor)
 - `docs/interfaces.md §17.2` —— `AgentSpec.scope` schema
-- `docs/versions/v0-6-2/README.md` —— F140 per-role scope + F141 本 skill
+- `docs/versions/v0-6-2/README.md` —— F140 per-role scope + F141 本 skill audit mode
+- `docs/versions/v0-6-5/prd.md §F157` —— `--quick` mode 需求 + 验收

--- a/skills/ccteam/SKILL.md
+++ b/skills/ccteam/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccteam
-description: ccteam 总入口 NL dispatcher。用户在 Claude session 内输入 `/ccteam <自然语言>` 触发,本 skill 把 NL 意图分类到 7 类(start-team / create-workflow / configure-im / monitor / advise / status-debug / other)并路由到对应 sub-skill。Use when 用户说"起一个 team / 做个 TG 助理 bot / 跑 qa-loop / 看 ccteam 状态 / 投票决定 / second opinion / 暂停 X / 为啥撞 budget"等任何 ccteam 相关意图。7 intents 全部对应实工 skill,不再有 placeholder fallback。
+description: ccteam 总入口 NL dispatcher。用户在 Claude session 内输入 `/ccteam <自然语言>` 触发,本 skill 把 NL 意图分类到 8 类(start-team / create-workflow / configure-im / monitor / code-scan / advise / status-debug / other)并路由到对应 sub-skill。Use when 用户说"起一个 team / 做个 TG 助理 bot / 跑 qa-loop / 看 ccteam 状态 / 扫一下代码 / 摸底新项目 / 投票决定 / second opinion / 暂停 X / 为啥撞 budget"等任何 ccteam 相关意图。所有 ship intent 对应实工 skill,不再有 placeholder fallback。
 ---
 
 # /ccteam — NL dispatcher
@@ -14,7 +14,7 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 
 灵感来源:OMC `README:231` "No commands to memorize, just describe what you want" 已市场验证。
 
-## V0.6.0 skill 家族(本 skill 所处位置)
+## skill 家族(本 skill 所处位置)
 
 | 用户意图 | Skill | 状态 |
 |---|---|---|
@@ -24,6 +24,7 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 | 查项目状态 / pause / resume / 跨项目 ls | `ccteam-control` | 已 ship |
 | TG / Lark / Slack 一次性 token 绑定 | `ccteam-im-setup` | 已 ship |
 | Claude + Codex 并行 advisor + 投票 | `ccteam-advise` | 已 ship |
+| 扫代码摸底 / 大码库 audit | `ccteam-scan`(V0.6.2 F141 + V0.6.5 F157)| 已 ship |
 
 ## When to invoke
 
@@ -38,7 +39,7 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 
 ## Step 1: 意图分类
 
-对收到的 NL,落 7 类之一(优先级从上到下,匹配第一条即停):
+对收到的 NL,落 8 类之一(优先级从上到下,匹配第一条即停):
 
 | # | 意图 | 触发关键词 / 模式 | 示例 |
 |---|---|---|---|
@@ -46,13 +47,16 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 | 2 | **create-workflow** | "做个 bot" / "做个 IM 助理" / "夜里跑 X" / "长跑监控 X" / "建 workflow" / "Pocket Assistant" / "Overnight" / "做个 TG 群多 bot" | `/ccteam "做个 TG 助理 bot"` |
 | 3 | **configure-im** | "绑 TG token" / "换 Slack" / "我的 chat_id" / "IM 设置" / "怎么对接 Lark" | `/ccteam "绑 TG token"` |
 | 4 | **monitor** | "我的项目状态" / "ls all" / "跑得怎样" / "看 X 项目" / "现在哪些 team 在跑" | `/ccteam "我哪些项目还活着"` |
-| 5 | **advise** | "second opinion" / "投票决定" / "Codex + Claude 各给" / "两边都问下" / "advise X" | `/ccteam "Claude + Codex 各给一个方案"` |
-| 6 | **status-debug** | "为啥撞 budget" / "看 log" / "stop X" / "pause X" / "resume X" / "X 卡住了" | `/ccteam "为啥撞 budget"` |
-| 7 | **other** | 不在以上 6 类 | "你好 / ccteam 是什么 / hi" |
+| 5 | **code-scan** | "扫一下代码" / "摸底新项目" / "scan code" / "audit codebase" / "这仓库是个啥" / "看看这代码用了啥" / "navigability audit" / "我的 monorepo 怎么接 ccteam" / "workflow.yaml 的 scope 该填什么" | `/ccteam "扫一下代码"` |
+| 6 | **advise** | "second opinion" / "投票决定" / "Codex + Claude 各给" / "两边都问下" / "advise X" | `/ccteam "Claude + Codex 各给一个方案"` |
+| 7 | **status-debug** | "为啥撞 budget" / "看 log" / "stop X" / "pause X" / "resume X" / "X 卡住了" | `/ccteam "为啥撞 budget"` |
+| 8 | **other** | 不在以上 7 类 | "你好 / ccteam 是什么 / hi" |
 
 歧义启发式:
 - 同时匹配 start-team + create-workflow:看是否提到"持久 / 长跑 / IM / bot" → create-workflow;否则 → start-team
 - 同时匹配 monitor + status-debug:有具体 slug 提及 → status-debug;泛指 → monitor
+- 同时匹配 code-scan + start-team:动词是"扫 / 看 / 摸底 / audit"(只读)→ code-scan;动词是"改 / 修 / 重构 / fix"(写)→ start-team
+- code-scan default 走 `--quick`(60-90s 摸底);用户明说"大码库 / monorepo / scope / navigability / 完整 audit" → 不带 `--quick`,走 audit mode
 
 ## Step 2: 路由到 sub-skill
 
@@ -62,9 +66,10 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 | 2 create-workflow | `/ccteam-creator <NL>` | 原 NL 原样 |
 | 3 configure-im | `/ccteam-im-setup` | 透传 token / IM 平台 hint |
 | 4 monitor | `/ccteam-control <NL>` | 原 NL,如有 slug 提取 |
-| 5 advise | `/ccteam-advise <NL>` | 原 NL 原样 |
-| 6 status-debug | `/ccteam-control <NL>` | 提取 slug + 动作 |
-| 7 other | Step 3 fallback dialog | — |
+| 5 code-scan | `/ccteam-scan --quick` (default) 或 `/ccteam-scan` (用户明说大码库 / audit) | 仓库路径(默认当前 cwd) |
+| 6 advise | `/ccteam-advise <NL>` | 原 NL 原样 |
+| 7 status-debug | `/ccteam-control <NL>` | 提取 slug + 动作 |
+| 8 other | Step 3 fallback dialog | — |
 
 ## Step 3: Fallback dialog(意图分类失败 / 用户 NL 含糊)
 
@@ -75,14 +80,16 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 > (b) 做个 IM bot 助理(私聊 / 群内多 bot)
 > (c) 看 ccteam 项目状态 / 暂停 / 恢复
 > (d) Claude + Codex 双方咨询(advise / second opinion)
+> (e) 摸底新代码库 / 扫一下代码(快速 60-90s 报告)
 >
-> 选个字母回我(`a` / `b` / `c` / `d`),或重新描述一下你想做啥。
+> 选个字母回我(`a` / `b` / `c` / `d` / `e`),或重新描述一下你想做啥。
 
 收到字母:
 - `a` → 走 start-team 路径,问"具体要 team 干啥?(描述任务)"
 - `b` → 走 create-workflow 路径
 - `c` → 走 monitor 路径
 - `d` → 走 advise 路径
+- `e` → 走 code-scan 路径(`/ccteam-scan --quick`)
 
 收到完整重述 → 重跑 Step 1。
 
@@ -91,20 +98,22 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 - **不直接调 MCP tool 或 Bash 命令** — 只做 NL 分类 + slash 路由;真正执行由 sub-skill 负责
 - **不维护多轮对话状态** — 一次 turn 做一次分类 + 路由;后续多轮归 sub-skill
 - **不做 voice / 图片 / 多模态 input**(V0.7+)
-- **不接受 skill 自定义注册** — 5 sub-skill 固定,用户不能 `/ccteam-add-skill <name>`(由 V0.6.0 PRD F113 §"不在范围"锁定)
+- **不接受 skill 自定义注册** — 6 sub-skill 固定(team / creator / control / im-setup / advise / scan),用户不能 `/ccteam-add-skill <name>`(由 V0.6.0 PRD F113 §"不在范围"锁定)
 
 ## Where to look in the repo
 
-- `@docs/versions/v0-6-0/prd.md` — F113 完整需求 + 验收
-- `@docs/versions/v0-6-0/README.md` §三 — 用户面入口 + 5 sub-skill 一览
+- `@docs/versions/v0-6-0/prd.md` — F113 完整需求 + 验收(dispatcher 初版)
+- `@docs/versions/v0-6-5/prd.md` — F157 code-scan intent 接入
+- `@docs/versions/v0-6-0/README.md` §三 — 用户面入口 + sub-skill 一览
 - `@skills/ccteam-team/SKILL.md` — start-team 详细行为
 - `@skills/ccteam-control/SKILL.md` — monitor / status-debug 详细行为
 - `@skills/ccteam-creator/SKILL.md` — create-workflow 详细行为
+- `@skills/ccteam-scan/SKILL.md` — code-scan 详细行为(quick + audit 两 mode)
 
 ## 当前状态
 
 - ✅ frontmatter + 意图分类提示词 + 路由表 + fallback dialog 全落
-- ✅ `/ccteam-creator` / `/ccteam-im-setup` / `/ccteam-advise` sub-skill body 已 ship
-- ✅ 7 intents 全部对应实工 skill,不再有 placeholder fallback
+- ✅ `/ccteam-creator` / `/ccteam-im-setup` / `/ccteam-advise` / `/ccteam-scan` sub-skill body 均已 ship
+- ✅ 8 intents(7 work + 1 fallback)全部对应实工 skill,不再有 placeholder
 
 本 dispatcher 在所有 sub-skill 前面加一层 NL→slash 翻译,体验从"记多个 slash"→"说人话"。


### PR DESCRIPTION
## Finding

**F157** — `ccteam-scan --quick` 60-90s zero-config 摸底 + `/ccteam` 加 code-scan intent。
PRD: `docs/versions/v0-6-5/prd.md` §F157(L510-L547)。

## Changes

- `skills/ccteam-scan/SKILL.md`
  - frontmatter description 改双 mode 描述(quick + audit)
  - 新章节 `--quick mode (V0.6.5 F157)`:1 sonnet agent + 3 fixed question(语言/框架/入口、TODO 热点、CLAUDE.md/README 状态)+ Quick agent briefing(可直粘 Task tool 的 prompt)
  - `--audit mode (V0.6.2 F141)` 章节 = 原 F141 流程不动
  - 触发短语区分 quick / audit
- `skills/ccteam/SKILL.md`
  - intent 表从 7 类扩到 8 类:code-scan 插入为 #5,advise→#6, status-debug→#7, other→#8
  - 路由表:code-scan → `/ccteam-scan --quick`(default)/ `/ccteam-scan`(用户明说大码库 audit)
  - 歧义启发式补两条:(a) 同时匹 code-scan + start-team → 看动词读 / 写;(b) 用户明说大码库 / scope → audit mode
  - fallback dialog 加 `(e) 摸底新代码库 / 扫一下代码`
  - skill 家族表加 ccteam-scan 行;footer current status 改 8 intents / 6 sub-skill

## Verification

- baseline: **1576 / 1**(skill-only diff,Rust 零改 → 无新增 test;PRD 验收 #4 "baseline 不变" 满足)
- clippy: 0 warnings(`cargo clippy --workspace --all-targets --locked -- -D warnings`)
- skill 文档长度:scan 245 行 / dispatcher 119 行(后者 < CLAUDE.md §六 "≤200 行" 红线;前者是工具 skill,不入 cache 反复)
- diff stat: 2 files / +141 / -23
- 真机 90s wall-clock 验证 deferred 到 Wave 4 host-probe(per dev-plan.md L162)

## Acceptance checklist (per PRD §F157)

- [x] #1 `--quick` flag 加到 ccteam-scan ── 通过 mode 表 + 新章节落地
- [x] #2 1 sonnet agent + 3 个固定问题 ── Quick agent briefing § Q1/Q2/Q3
- [x] #3 输出 `<repo>/.ccteam/codebase-scan.md` + frontmatter `quick: true` ── briefing 模板规定
- [x] #4 `/ccteam` intent 5 (code-scan) ── intent 表 + 路由表 + fallback dialog 三处同步
- [x] #5 `/ccteam "扫一下代码"` → `/ccteam-scan --quick` ── 路由表锁定
- [x] PRD 验收 #4 baseline 不变 ── 1576/1 confirmed
- [ ] PRD 验收 #1/#2 真机 90s wall-clock ── Wave 4 host-probe 验

## Out of scope

- intent-corpus.yaml 50-query sample(F162 = W3-T4 worktree,本 PR 不动)
- audit mode 不读 quick 报告(两次扫描独立)── 已在 §"与 audit mode 的关系" 写明