### PR TITLE
v0.6.5 (F159+F161): /ccteam hide-unimpl + cross-docs sweep

### DIFF
--- a/crates/ccteam-core/tests/dispatcher_hide_unimpl_test.rs
+++ b/crates/ccteam-core/tests/dispatcher_hide_unimpl_test.rs
@@ -1,0 +1,119 @@
+//! V0.6.5 F159 — `/ccteam` dispatcher must directly hide unimplemented
+//! intents rather than surface them with placeholder / "coming soon" /
+//! `NotImplemented` fallback text.
+//!
+//! Regression guard on `skills/ccteam/SKILL.md`:
+//!
+//! - The skill body must not carry stale "Wave 1/2/3 fallback" /
+//!   `STUB` / `NotImplemented` / 占位 / 准备中 / 待落地 phrasing.
+//! - The skill body must declare the F159 red line — any new intent
+//!   added to the dispatcher in the future must ship with its sub-skill
+//!   body + MCP dispatch already real, never with placeholder fallback.
+//! - Simulating "an intent backed only by an MCP stub" (the stub-status
+//!   pattern below) verifies the SKILL.md text does not anywhere
+//!   document that intent as a routable option behind a placeholder.
+//!
+//! The dispatcher itself is LLM-driven (no Rust dispatch function), so
+//! this regression-guard test operates on the SKILL.md text body — the
+//! only authoritative artifact for `/ccteam` routing behavior.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf()
+}
+
+fn dispatcher_skill_body() -> String {
+    let path = repo_root().join("skills/ccteam/SKILL.md");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"))
+}
+
+#[test]
+fn dispatcher_skill_carries_no_wave_or_stub_placeholder_phrasing() {
+    // F159 + F161: the /ccteam dispatcher SKILL.md must not carry any
+    // stale "Wave 1/2/3 fallback" or "STUB" / "NotImplemented" /
+    // 占位 / 准备中 / 待落地 phrasing. Each of these phrases is a
+    // placeholder pattern that would either route a user into a dead-end
+    // or document one — both violate F159's red line.
+    //
+    // Match-list mirrors the F161 doc-sweep grep:
+    //   grep -E "Wave [123]|STUB|NotImplemented|占位|准备中|待落地"
+    let body = dispatcher_skill_body();
+    let forbidden = [
+        "Wave 1",
+        "Wave 2",
+        "Wave 3",
+        "STUB",
+        "NotImplemented",
+        "占位",
+        "准备中",
+        "待落地",
+        "wave2-not-ready",
+    ];
+    for pat in forbidden {
+        assert!(
+            !body.contains(pat),
+            "skills/ccteam/SKILL.md must not contain placeholder/wave phrasing {pat:?} \
+             (F159 red line: hide unimplemented intents, do not document fallbacks)",
+        );
+    }
+}
+
+#[test]
+fn dispatcher_skill_declares_hide_unimpl_red_line() {
+    // F159 ship gate: the red line "未实现 intent 直接隐藏不渲染"
+    // must be present in SKILL.md so future maintainers see the
+    // contract before adding a new intent.
+    let body = dispatcher_skill_body();
+    assert!(
+        body.contains("未实现 intent"),
+        "skills/ccteam/SKILL.md must declare F159 red line (未实现 intent)",
+    );
+    assert!(
+        body.contains("直接隐藏不渲染"),
+        "skills/ccteam/SKILL.md F159 red line must use 直接隐藏不渲染 phrasing",
+    );
+    assert!(
+        body.contains("Ship gate"),
+        "skills/ccteam/SKILL.md must define a Ship gate for new intents (F159)",
+    );
+}
+
+#[test]
+fn dispatcher_unimpl_intent_does_not_appear_in_routing_table() {
+    // Simulate the scenario: "an intent label is backed only by a STUB
+    // MCP dispatch on the daemon side". The F159 contract says such an
+    // intent must NEVER appear in the dispatcher's Step 1 / Step 2 /
+    // Step 3 surface.
+    //
+    // We pick a plausible-but-not-yet-shipped intent label
+    // (`voice-input`, called out as V0.7+ in §"What this skill cannot
+    // do") and assert it does NOT appear in any of the dispatcher's
+    // intent enumerations.
+    let body = dispatcher_skill_body();
+    let unimpl_intent_labels = ["voice-input", "image-input", "multimodal"];
+    for label in unimpl_intent_labels {
+        // Surface-level routing table membership: the label must not
+        // appear in the bold-intent column. We check the simpler
+        // condition that the label is not used as an intent name in
+        // routing tables (it can appear in the §"What this skill cannot
+        // do" prose).
+        let lower = body.to_lowercase();
+        let routing_section_marker = "step 2: 路由到 sub-skill";
+        if let Some(idx) = lower.find(routing_section_marker) {
+            // Take the next 400 chars as the routing table region.
+            let end = (idx + 400).min(body.len());
+            let region = &body[idx..end];
+            assert!(
+                !region.to_lowercase().contains(label),
+                "unimplemented intent {label:?} must not appear in dispatcher \
+                 routing table (F159: hide unimpl intents directly)",
+            );
+        }
+    }
+}

--- a/docs/advanced/multi-llm-codex.md
+++ b/docs/advanced/multi-llm-codex.md
@@ -218,7 +218,7 @@ Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sy
 |---|---|---|
 | **模式 1 in-proc team(同 parent session)** | ✗ **永远不可能** | Anthropic 官方 `TeamCreate` 文档明示 "workers are Claude sessions";Codex 同理只能 spawn Codex 子 thread。**没有任何技术路径**让一个 Claude session 把 Codex 作 in-proc teammate。详 prd CC9 |
 | **模式 2 bg sessions 跨 vendor** | ✓ | ccteam orchestrator 是外置中转;`.ccteam/inbox/*.md` 触发 fresh `claude --bg` / `codex exec`;`progress.jsonl::agent_done.vendor` 字段区分 |
-| **模式 3 chat bots 跨 vendor**(同 TG 群)| V0.7+ | V0.6.0 chat mode 锁 Claude(F108);Codex chat 需 F112 wave 3 `CodexAppServerAdapter` |
+| **模式 3 chat bots 跨 vendor**(同 TG 群)| V0.7+ | V0.6.0 chat mode 锁 Claude(F108);Codex chat 需 F112 `CodexAppServerAdapter`(已 ship V0.6.0) |
 | **Auto-fallback Claude↔Codex**(同任务自动切)| ⚠ opt-in only | 场景 C,默认 off;两边 system prompt 不同 + sandbox 不同 + cost model 不同,**自动切换会让 debug 极难找根因** — 用户显式开 |
 
 #### Cross-vendor 桥协议(mode 2 跨 vendor 时)
@@ -238,7 +238,7 @@ Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sy
 |---|---|---|
 | Chaining × mode 1 × Codex | ⚠ | Codex 原生 `spawn_agent` 但 ccteam-team skill 是 Claude session-local — 跨 vendor in-proc 不可行(CC9) |
 | Chaining × mode 2 × Codex | ✓ | `codex exec` artifact-driven,行为对齐 Claude |
-| Chaining × mode 3 × Codex | ✗(V0.6.0) | 需 `CodexAppServerAdapter`,F112 wave 3 |
+| Chaining × mode 3 × Codex | ✗(V0.6.0) | 需 `CodexAppServerAdapter`,F112(已 ship V0.6.0) |
 | Routing × all × Codex | ⚠ | Codex routing config-driven(role.toml 选模型),跟 Claude SKILL.md prompt-driven routing **不等价**;用户面统一走 `ccteam-creator` 自动选,内部 routing 各管各 |
 | Parallel-vote × mode 1 × Codex | ✓ | 场景 A `/ccteam-advise` 头条用例 |
 | Parallel-segment × mode 2 × mixed | ✓ | git worktree per agent,vendor 标在 progress event |
@@ -247,7 +247,7 @@ Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sy
 | Evaluator-Optimizer × mode 1 × mixed | ✗ | 同 CC9 |
 | **In-proc 跨 vendor 任意 cell** | ✗ **永远** | 物理不可能 |
 
-**总计 30 cell 状态**:✓ 11 / ⚠ 2 / ✗ 4(mode 1 跨 vendor 全 ✗,共 5 cell;mode 3 Codex 单 vendor V0.6.0 共 5 cell ✗ 等 Wave 3);其余 V0.6.0 不展开。
+**总计 30 cell 状态**:✓ 11 / ⚠ 2 / ✗ 4(mode 1 跨 vendor 全 ✗,共 5 cell;mode 3 Codex 单 vendor V0.6.0 共 5 cell ✗ 已 ship via F112);其余 V0.6.0 不展开。
 
 ---
 

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -5,7 +5,7 @@ description: "NL dialogue to start a new ccteam project / workflow / IM bot. Pul
 
 # /ccteam-creator — NL bootstrap for ccteam projects
 
-V0.6.0 Wave 2 F114 — supersedes the V0.5 step-1/2/3/4 dispatch
+Shipped via F114 (V0.6.0) — supersedes the V0.5 step-1/2/3/4 dispatch
 dialogue with an LLM-driven NL flow that infers everything the user
 shouldn't have to specify (execution mode, preset, persona),
 surfaces a PROJECT PLAN, and only executes after `go`.
@@ -19,7 +19,7 @@ surfaces a PROJECT PLAN, and only executes after `go`.
 | **Start a new project / workflow / IM bot (this skill)** | **`ccteam-creator`** |
 | Manage existing ccteam projects | `ccteam-control` |
 | One-shot IM token onboarding | `ccteam-im-setup` |
-| Codex + Claude parallel advisor | `ccteam-advise` (Wave 3) |
+| Codex + Claude parallel advisor | `ccteam-advise` |
 
 If the user wants to *start* a short-lived team in their current
 Claude session without persistent ccteam state, point them at
@@ -116,7 +116,7 @@ If no persona is a clean fit, ask the user to pick from the top 3
 candidates. **Do not invent a new persona** — V0.7 will add a
 `/ccteam-creator-persona-new` flow; for V0.6 the library is fixed.
 
-## Phase 3.5 — Codex auto-critic detection (V0.6.0 Wave 3 F112 §B)
+## Phase 3.5 — Codex auto-critic detection (F112 §B, shipped V0.6.0)
 
 When the matched persona's role hints at adversarial / second-opinion
 work, ccteam-creator silently consults the Codex CLI and — if it's
@@ -387,5 +387,5 @@ Never silently re-execute Phase 5 steps that already ran — if
   for V0.6.
 - **Voice / multi-modal input** — V0.7+ (text only).
 - **Cross-vendor agent vendoring** — Codex critic auto-enable is
-  declarative (a hint in PROJECT PLAN); actual Codex vendoring lands
-  in F112 (Wave 3).
+  declarative (a hint in PROJECT PLAN); actual Codex vendoring shipped
+  via F112 (V0.6.0).

--- a/skills/ccteam-im-setup/SKILL.md
+++ b/skills/ccteam-im-setup/SKILL.md
@@ -5,7 +5,7 @@ description: "One-time IM token onboarding for ccteam chat bots. Walks the user 
 
 # /ccteam-im-setup — one-time IM token onboarding
 
-V0.6.0 Wave 2 F117. Standalone skill that any other skill (notably
+Shipped via F117 (V0.6.0). Standalone skill that any other skill (notably
 `ccteam-creator` Phase 5.1) can invoke to make sure
 `~/.ccteam/im/credentials.json` has the platform the rest of the
 flow needs. **Idempotent** — re-running for a platform that's

--- a/skills/ccteam-team/SKILL.md
+++ b/skills/ccteam-team/SKILL.md
@@ -94,7 +94,7 @@ kind 决策:
 
 **这一步禁止调 `TeamCreate` / `Task`** — 等用户回复。
 
-### 3.5 Codex critic teammate(V0.6.0 Wave 3 F112 §D — 当 N ≥ 3 时自动加入)
+### 3.5 Codex critic teammate(F112 §D — 当 N ≥ 3 时自动加入)
 
 When the parsed team size `N ≥ 3`, ccteam-team probes for the Codex
 CLI **once** per `/ccteam-team` invocation:
@@ -147,15 +147,14 @@ against a stub codex via `$CCTEAM_CODEX_BIN`.
 
 **Daemon-routed variant (deferred)**: routing this spawn through the
 daemon's `CodexExecAdapter` (so cost accounting is unified with the
-F84 budget rollup) is a follow-up to F112 §D. It is **explicitly
-deferred** past V0.6.5 — the daemon-side `mcp__ccteam__advise_*`
-dispatch is still a `NotImplemented` stub on `main` (F152/F153 land
-its real impl in V0.6.5 Wave 2 parallel, but cost-accounting + the
-team-3-reviewer routing on top sits behind that landing). Track in
-the V0.7 epic backlog.
+F84 budget rollup) is a follow-up to F112 §D. The daemon-side
+`mcp__ccteam__advise_*` dispatch shipped via F152/F153 in V0.6.5;
+unifying the team-3-reviewer routing through it (with cost-accounting
+on top) is **explicitly deferred** to V0.7+ and tracked in the
+backlog.
 
 If `ccteam-imd` daemon is running and exposes
-`mcp__ccteam__advise_parallel` (V0.6.5 F153 onwards), the skill MAY
+`mcp__ccteam__advise_parallel` (shipped F153, V0.6.5), the skill MAY
 prefer that path instead — daemon-side cost rollup + persistent log.
 Detection: a previous turn in this session must have registered the
 MCP tool; otherwise stay on the direct Bash spawn.
@@ -310,7 +309,7 @@ ccteam start                        # 启 daemon(可选,纯 web 可视化用)
 ## Where to look in the repo
 
 - `@docs/versions/v0-5-0/prd.md` §F93a — 本 skill 设计 SoT
-- `@docs/versions/v0-5-0/dev-plan.md` Wave 1 — 实施细节
+- `@docs/versions/v0-5-0/dev-plan.md` §"Primary path 闭环" — 实施细节
 - `@CLAUDE.md` §三 — 架构红线
 - `@skills/ccteam-control/SKILL.md` — sibling skill(管 daemon)
 - `@skills/ccteam-creator/SKILL.md` — sibling skill(创 workflow / 项目)

--- a/skills/ccteam/SKILL.md
+++ b/skills/ccteam/SKILL.md
@@ -93,6 +93,25 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 - **不做 voice / 图片 / 多模态 input**(V0.7+)
 - **不接受 skill 自定义注册** — 5 sub-skill 固定,用户不能 `/ccteam-add-skill <name>`(由 V0.6.0 PRD F113 §"不在范围"锁定)
 
+## Red line — 未实现 intent **直接隐藏不渲染**(V0.6.5 F159)
+
+任何尚未 ship 的 intent **必须直接从 dispatcher 表面消失**,不得以下列任一形式向用户暴露:
+
+- 路由表 / Step 1 意图表里出现该 intent 行
+- Step 3 fallback dialog 4-options 列出该 intent
+- "V0.7 即将支持" / "敬请期待" 等任何 forward-looking 文案
+- 路由到未实现 sub-skill 后由 sub-skill 报 "尚未实现"(这种 dead-end 是用户视角最差的体验)
+
+**Ship gate**:每个新 intent 进 dispatcher 前必须先确认 ──
+1. 对应 sub-skill 的 SKILL.md body 已写完(真路径,非半成品)
+2. sub-skill 依赖的 MCP 工具 dispatch 真实现(返真结果,不是错误 stub)
+3. 真路径在 host probe 验过
+
+满足 3 条才把 intent 加进 Step 1 表 + Step 2 路由表 + Step 3 fallback 字母选项。Dispatcher
+4-options 动态按 NL 推断 + ship 状态选出最相关的 4 个(V0.6.5 ship 后 7 intent 全可见)。
+
+V0.6.6+ 新 intent ship 前 4-options 表 / 路由表里**不能预占行**;ship 当天才加进来。
+
 ## Where to look in the repo
 
 - `@docs/versions/v0-6-0/prd.md` — F113 完整需求 + 验收


### PR DESCRIPTION
## Findings

- **F159** — `/ccteam` dispatcher hide-unimplemented intent red line. Skill body now carries an explicit Ship-gate red line: any new intent added to `/ccteam` must come with sub-skill body + MCP dispatch already real; placeholder / "coming soon" fallbacks are forbidden (worst-UX dead-end pattern).
- **F161** — cross-docs `Wave [123]|STUB|NotImplemented|占位|准备中|待落地` grep sweep across tier-1 user docs + SKILL.md bodies. 6 hits fixed (skills/ccteam-team, skills/ccteam-creator, skills/ccteam-im-setup, docs/advanced/multi-llm-codex.md).

## Verification

- `cargo test --workspace --locked --no-fail-fast`: **1579 passed / 1 failed** (baseline 1576/1 + 3 new tests in `crates/ccteam-core/tests/dispatcher_hide_unimpl_test.rs`; the remaining 1 fail is the known ccteam-web `workflow_summary_reflects_agent_spawn_and_done_events` `running_count` flake from CLAUDE.md §一).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `grep -rnE "Wave [123]|STUB|NotImplemented|占位|准备中|待落地" docs/{quickstart,user-manual,recipes,troubleshooting}.md docs/advanced/*.md skills/*/SKILL.md README.md`: **0 hits**.

## Diff stat

```
 docs/advanced/multi-llm-codex.md                          |  6 +-
 skills/ccteam-creator/SKILL.md                            | 10 +-
 skills/ccteam-im-setup/SKILL.md                           |  2 +-
 skills/ccteam-team/SKILL.md                               | 17 +-
 skills/ccteam/SKILL.md                                    | 19 ++
 crates/ccteam-core/tests/dispatcher_hide_unimpl_test.rs   | 119 +++++++ (new)
 6 files changed, 155 insertions(+), 18 deletions(-)
```