### PR TITLE
v0.6.5 (F163 retro): real-machine graceful shutdown fix

### DIFF
--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -1446,12 +1446,12 @@ fn run_start(
     // We need the paths twice (for orchestrator construction + final
     // pidfile cleanup), so clone before the move into Orchestrator::new.
     let cleanup_paths = paths.clone();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build tokio runtime")?;
     let result = (|| -> Result<()> {
         let orchestrator = std::sync::Arc::new(Orchestrator::new(paths, config)?);
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("build tokio runtime")?;
         runtime.block_on(async move {
             // V0.4.1 simplification: orchestrator + web share one
             // shutdown signal (Ctrl-C or SIGTERM). The watch::channel
@@ -1471,27 +1471,39 @@ fn run_start(
 
             // V0.5.0 F95 — global `~/.claude/teams/` watcher mirrors 5
             // `team_*` events into `~/.ccteam/teams-progress.jsonl` for
-            // the web `/teams` tab to consume. Fire-and-forget: the task
-            // owns its notify watcher, exits on runtime shutdown.
-            let _agent_teams_watcher_task = match ccteam_core::AgentTeamsWatcherConfig::from_env() {
-                Ok(cfg) => match ccteam_core::AgentTeamsWatcher::new(cfg) {
-                    Ok(watcher) => Some(watcher.start()),
+            // the web `/teams` tab to consume. The watcher runs inside
+            // `spawn_blocking` and never sees its outbound sender drop
+            // (the sender is owned by the same blocking task), so the
+            // only way to terminate it is to flip its `cancel` AtomicBool.
+            // F163 retro — without this wiring, the blocking thread sits
+            // in `recv_timeout(60s)` until the next discovery tick, and
+            // `Runtime::drop` → `BlockingPool::shutdown(None)` blocks
+            // the process for the full discovery interval (host probe
+            // observed >60s hang requiring SIGKILL).
+            let agent_teams_cancel: Option<std::sync::Arc<std::sync::atomic::AtomicBool>> =
+                match ccteam_core::AgentTeamsWatcherConfig::from_env() {
+                    Ok(cfg) => match ccteam_core::AgentTeamsWatcher::new(cfg) {
+                        Ok(watcher) => {
+                            let cancel = watcher.cancel_handle();
+                            let _join = watcher.start();
+                            Some(cancel)
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                ?err,
+                                "F95 AgentTeamsWatcher::new failed; team-events disabled",
+                            );
+                            None
+                        }
+                    },
                     Err(err) => {
                         tracing::warn!(
                             ?err,
-                            "F95 AgentTeamsWatcher::new failed; team-events disabled",
+                            "F95 AgentTeamsWatcherConfig::from_env failed; team-events disabled",
                         );
                         None
                     }
-                },
-                Err(err) => {
-                    tracing::warn!(
-                        ?err,
-                        "F95 AgentTeamsWatcherConfig::from_env failed; team-events disabled",
-                    );
-                    None
-                }
-            };
+                };
 
             let web_handle = if web.disabled {
                 None
@@ -1583,6 +1595,16 @@ fn run_start(
             signal_task.abort();
             unroster_task.abort();
 
+            // F163 retro — flip the AgentTeamsWatcher cancel flag so its
+            // `spawn_blocking` thread exits within `WATCHER_SHUTDOWN_POLL`
+            // (500ms) instead of holding `BlockingPool::shutdown` for up
+            // to a full `TEAMS_DISCOVERY_INTERVAL` (60s) at process tear-
+            // down. Paired with the explicit `runtime.shutdown_timeout`
+            // outside this `block_on` for defense in depth.
+            if let Some(cancel) = agent_teams_cancel {
+                cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+            }
+
             // F163 — explicit log: tmux sessions are intentionally left
             // running. Daemon stop ≠ bot session stop (CLAUDE.md §三 red
             // line: 永不主动 kill 长 session).
@@ -1594,6 +1616,17 @@ fn run_start(
             orch_result
         })
     })();
+    // F163 retro — explicit bounded shutdown of the tokio blocking pool.
+    // `Runtime::drop` calls `BlockingPool::shutdown(None)` which waits
+    // **forever** for every `spawn_blocking` task to return. The
+    // AgentTeamsWatcher cancel above takes care of the long-poll
+    // watcher loop, but any straggler (workflow_watcher tx-is_closed
+    // race, per-project ArtifactWatcher mid-syscall, transient claude
+    // GC sweep) could still hold the pool. A 5s ceiling matches the
+    // per-task drain timeout used inside `block_on` and keeps total
+    // worst-case shutdown at ≤ 30s orch + 5s web + 5s imd + 5s pool =
+    // 45s well under the user-observed >60s hang.
+    runtime.shutdown_timeout(Duration::from_secs(5));
     ccteam_core::remove_pidfile(&cleanup_paths);
     result
 }

--- a/crates/ccteam-cli/tests/graceful_shutdown_test.rs
+++ b/crates/ccteam-cli/tests/graceful_shutdown_test.rs
@@ -24,11 +24,32 @@ fn ccteam_bin() -> &'static str {
 /// Spawn a minimal `ccteam start` daemon in an isolated tempdir.
 /// Returns (child, ccteam_home, pidfile_path).
 fn spawn_test_daemon(tmp_dir: &tempfile::TempDir) -> (std::process::Child, PathBuf, PathBuf) {
+    spawn_test_daemon_with(
+        tmp_dir,
+        /* with_agent_teams_root = */ false,
+        Stdio::null,
+    )
+}
+
+/// Spawn helper with explicit toggles. `with_agent_teams_root=true`
+/// pre-creates `<HOME>/.claude/teams/` so the F95 AgentTeamsWatcher
+/// installs its inotify watch + runs the full discovery loop — this is
+/// the production code path that V0.6.5 F163 retro fixes (`spawn_blocking`
+/// task held BlockingPool::shutdown for the full TEAMS_DISCOVERY_INTERVAL
+/// at process exit).
+fn spawn_test_daemon_with(
+    tmp_dir: &tempfile::TempDir,
+    with_agent_teams_root: bool,
+    stderr_factory: fn() -> Stdio,
+) -> (std::process::Child, PathBuf, PathBuf) {
     let fake_home = tmp_dir.path();
     let ccteam_home = fake_home.join(".ccteam");
     std::fs::create_dir_all(ccteam_home.join("phases")).unwrap();
     std::fs::create_dir_all(ccteam_home.join("state")).unwrap();
     std::fs::create_dir_all(fake_home.join("projects")).unwrap();
+    if with_agent_teams_root {
+        std::fs::create_dir_all(fake_home.join(".claude").join("teams")).unwrap();
+    }
     let pidfile = ccteam_home.join("state").join("orchestrator.pid");
 
     let child = Command::new(ccteam_bin())
@@ -38,7 +59,7 @@ fn spawn_test_daemon(tmp_dir: &tempfile::TempDir) -> (std::process::Child, PathB
         .env("CCTEAM_PROJECTS_ROOT", fake_home.join("projects"))
         .env("RUST_LOG", "warn")
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(stderr_factory())
         .spawn()
         .expect("spawn ccteam start");
 
@@ -303,4 +324,242 @@ fn shutdown_does_not_kill_tmux_sessions() {
 fn ccteam_core_pid_alive(pid: u32) -> bool {
     let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
     ret == 0
+}
+
+/// F163 retro case 5 — SIGTERM exits within 5s **even when the
+/// AgentTeamsWatcher path is fully wired** (`~/.claude/teams/`
+/// present, so the F95 watcher installs its inotify watch + spawns
+/// the blocking discovery loop).
+///
+/// Before the retro fix, this configuration triggered the
+/// `BlockingPool::shutdown(None)` hang: the AgentTeamsWatcher's
+/// `spawn_blocking` thread blocked inside `recv_timeout(60s)` and
+/// never noticed runtime tear-down, so `Runtime::drop` waited a full
+/// TEAMS_DISCOVERY_INTERVAL (>60s) and the process required SIGKILL.
+///
+/// Acceptance: process exits within 6s of SIGTERM (5s pool ceiling +
+/// 1s wall-clock slack for the orchestrator/web/imd drain dance + OS
+/// scheduling jitter). The unit-test deadline is intentionally tighter
+/// than the user-facing 10s contract so a regression that re-introduces
+/// even a partial hang surfaces here loudly.
+#[test]
+#[cfg(unix)]
+fn sigterm_exits_within_5s_with_agent_teams_watcher_active() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (mut child, _ccteam_home, pidfile) =
+        spawn_test_daemon_with(&tmp, /* with_agent_teams_root = */ true, Stdio::null);
+
+    let pidfile_deadline = Instant::now() + Duration::from_secs(10);
+    let daemon_pid = match wait_for_pidfile(&pidfile, pidfile_deadline) {
+        Ok(pid) => pid,
+        Err(msg) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("F163 retro: {msg}");
+        }
+    };
+
+    let signal_sent_at = Instant::now();
+    send_signal(daemon_pid, libc::SIGTERM).expect("send SIGTERM");
+
+    // 6s ceiling — tighter than the 10s user-facing contract to catch
+    // any regression that re-introduces a partial BlockingPool hang.
+    let exit_deadline = signal_sent_at + Duration::from_secs(6);
+    let exited = wait_for_exit(&mut child, exit_deadline);
+    let exit_elapsed = signal_sent_at.elapsed();
+
+    if exited.is_err() {
+        let _ = child.kill();
+    }
+    let _ = child.wait();
+
+    assert!(
+        exited.is_ok(),
+        "F163 retro: daemon with active AgentTeamsWatcher should exit within 6s of SIGTERM; \
+         elapsed={:?} (was the cancel-handle wiring removed?)",
+        exit_elapsed,
+    );
+
+    assert!(
+        !pidfile.exists(),
+        "F163 retro: pidfile {} should be removed even when the BlockingPool path was exercised",
+        pidfile.display()
+    );
+}
+
+/// F163 retro case 6 — five consecutive `start → SIGTERM` cycles all
+/// exit within 6s, with the AgentTeamsWatcher wired. Catches any
+/// non-deterministic shutdown flake (e.g. a race where the cancel
+/// flag flip lands AFTER the discovery thread already entered
+/// recv_timeout for the next 60s window).
+///
+/// This is the unit-test analog of the F163 NAS re-probe acceptance
+/// loop (`for run in 1..5; do ccteam start & sleep 5; kill -TERM; ...`).
+#[test]
+#[cfg(unix)]
+fn sigterm_exits_fast_across_five_consecutive_runs() {
+    for run in 1..=5 {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (mut child, _ccteam_home, pidfile) =
+            spawn_test_daemon_with(&tmp, /* with_agent_teams_root = */ true, Stdio::null);
+
+        let pidfile_deadline = Instant::now() + Duration::from_secs(10);
+        let daemon_pid = match wait_for_pidfile(&pidfile, pidfile_deadline) {
+            Ok(pid) => pid,
+            Err(msg) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("F163 retro run #{run}: {msg}");
+            }
+        };
+
+        let signal_sent_at = Instant::now();
+        send_signal(daemon_pid, libc::SIGTERM).expect("send SIGTERM");
+
+        let exit_deadline = signal_sent_at + Duration::from_secs(6);
+        let exited = wait_for_exit(&mut child, exit_deadline);
+        let exit_elapsed = signal_sent_at.elapsed();
+
+        if exited.is_err() {
+            let _ = child.kill();
+        }
+        let _ = child.wait();
+
+        assert!(
+            exited.is_ok(),
+            "F163 retro run #{run}: daemon should exit within 6s of SIGTERM; elapsed={:?}",
+            exit_elapsed,
+        );
+        assert!(
+            !pidfile.exists(),
+            "F163 retro run #{run}: pidfile {} should be removed",
+            pidfile.display()
+        );
+    }
+}
+
+/// F163 retro case 7 — daemon logs the expected shutdown
+/// signal-handling lines BEFORE exit. Asserts the in-process telemetry
+/// chain (signal handler observed → graceful shutdown begin → graceful
+/// shutdown complete) actually executes, not just "process exited".
+/// A future regression that bypasses the orchestrator drain (e.g. by
+/// short-circuiting on a race or hard-aborting) would still satisfy
+/// "exited within 6s" but break this assertion.
+///
+/// Captures both stdout and stderr because the tracing subscriber's
+/// default writer (stdout) is asymmetric with the bin's banner
+/// `eprintln!` (stderr); merging both keeps the assertion robust to a
+/// future writer swap.
+#[test]
+#[cfg(unix)]
+fn sigterm_emits_full_graceful_shutdown_telemetry() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fake_home = tmp.path();
+    let ccteam_home = fake_home.join(".ccteam");
+    std::fs::create_dir_all(ccteam_home.join("phases")).unwrap();
+    std::fs::create_dir_all(ccteam_home.join("state")).unwrap();
+    std::fs::create_dir_all(fake_home.join("projects")).unwrap();
+    std::fs::create_dir_all(fake_home.join(".claude").join("teams")).unwrap();
+    let pidfile = ccteam_home.join("state").join("orchestrator.pid");
+
+    let mut child = Command::new(ccteam_bin())
+        .args(["start", "--no-web", "--no-imd", "--tick-seconds", "1"])
+        .env("HOME", fake_home)
+        .env("CCTEAM_HOME", &ccteam_home)
+        .env("CCTEAM_PROJECTS_ROOT", fake_home.join("projects"))
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ccteam start");
+
+    let pidfile_deadline = Instant::now() + Duration::from_secs(10);
+    let daemon_pid = match wait_for_pidfile(&pidfile, pidfile_deadline) {
+        Ok(pid) => pid,
+        Err(msg) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("F163 retro telemetry: {msg}");
+        }
+    };
+
+    send_signal(daemon_pid, libc::SIGTERM).expect("send SIGTERM");
+
+    let exit_deadline = Instant::now() + Duration::from_secs(6);
+    let exited = wait_for_exit(&mut child, exit_deadline);
+    let output = child.wait_with_output().expect("wait_with_output");
+    let stdout_text = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr_text = String::from_utf8_lossy(&output.stderr).to_string();
+    let merged = format!("STDOUT:\n{stdout_text}\nSTDERR:\n{stderr_text}");
+
+    assert!(
+        exited.is_ok(),
+        "F163 retro telemetry: daemon must exit within 6s of SIGTERM; \
+         output-so-far:\n{merged}",
+    );
+
+    // The orchestrator graceful drain must execute. Without it we'd be
+    // tearing down state non-cooperatively — a CLAUDE.md §三 violation
+    // adjacent to "永不主动 kill 长 session".
+    assert!(
+        merged.contains("SIGTERM received"),
+        "F163 retro telemetry: expected 'SIGTERM received' line; got:\n{merged}",
+    );
+    assert!(
+        merged.contains("graceful shutdown complete"),
+        "F163 retro telemetry: expected 'graceful shutdown complete' line; got:\n{merged}",
+    );
+
+    assert!(
+        !pidfile.exists(),
+        "F163 retro telemetry: pidfile {} should be removed",
+        pidfile.display()
+    );
+}
+
+/// F163 retro case 8 — `AgentTeamsWatcher::cancel_handle()` flipping
+/// drives the blocking discovery loop to exit within the 500ms
+/// `WATCHER_SHUTDOWN_POLL` floor (well under the 60s
+/// `TEAMS_DISCOVERY_INTERVAL`). Direct unit test of the
+/// crate-internal contract the daemon path relies on — a regression
+/// that loses the cancel wiring inside `AgentTeamsWatcher::start` would
+/// pass the SIGTERM tests above only via the defense-in-depth
+/// `runtime.shutdown_timeout(5s)` fallback, but fail this one within
+/// 600ms (no pool teardown involved).
+#[tokio::test(flavor = "current_thread")]
+async fn agent_teams_watcher_cancel_handle_stops_blocking_loop_fast() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let teams_root = tmp.path().join("teams");
+    let tasks_root = tmp.path().join("tasks");
+    let progress_path = tmp.path().join("progress.jsonl");
+    std::fs::create_dir_all(&teams_root).unwrap();
+
+    let cfg = ccteam_core::AgentTeamsWatcherConfig {
+        teams_root,
+        tasks_root,
+        progress_path,
+        discovery_interval: Duration::from_secs(60),
+    };
+    let watcher = ccteam_core::AgentTeamsWatcher::new(cfg).expect("new watcher");
+    let cancel = watcher.cancel_handle();
+    let handle = watcher.start();
+
+    // Let the discovery loop reach its recv_timeout sleep.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let cancel_at = Instant::now();
+    cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+
+    // Join via blocking with a tight deadline. The loop polls cancel
+    // each `WATCHER_SHUTDOWN_POLL` (500ms), so a generous 1500ms
+    // ceiling catches any regression that bumps the poll interval or
+    // moves the cancel check below recv_timeout.
+    let join_res = tokio::time::timeout(Duration::from_millis(1500), handle).await;
+    let elapsed = cancel_at.elapsed();
+    assert!(
+        join_res.is_ok(),
+        "F163 retro: AgentTeamsWatcher blocking loop did not exit within 1500ms of cancel; \
+         elapsed={:?}",
+        elapsed,
+    );
 }

--- a/crates/ccteam-core/src/artifact_watcher.rs
+++ b/crates/ccteam-core/src/artifact_watcher.rs
@@ -580,11 +580,25 @@ impl AgentTeamsWatcher {
                     return;
                 }
                 // Bounded wait: either we get an inotify event, or
-                // we time out and rerun discovery if due.
-                let timeout = config
+                // we time out and rerun discovery if due. V0.6.5 F163
+                // retro — the wait is **capped** at
+                // `WATCHER_SHUTDOWN_POLL` (500ms) so the cancel-flag
+                // check at the top of the loop fires within half a
+                // second of graceful shutdown. The earlier code used
+                // `.max(WATCHER_SHUTDOWN_POLL)` which made the floor
+                // `WATCHER_SHUTDOWN_POLL` but left the ceiling at the
+                // full `discovery_interval` (60s), so a daemon SIGTERM
+                // could sit blocked inside `recv_timeout` for up to a
+                // full minute — long enough that
+                // `BlockingPool::shutdown(None)` blocked the process
+                // past the operator's SIGKILL patience. Discovery still
+                // happens at `discovery_interval` cadence via the
+                // `last_discovery.elapsed() >= discovery_interval`
+                // check below; we just sample more often.
+                let remaining = config
                     .discovery_interval
-                    .saturating_sub(last_discovery.elapsed())
-                    .max(WATCHER_SHUTDOWN_POLL);
+                    .saturating_sub(last_discovery.elapsed());
+                let timeout = remaining.min(WATCHER_SHUTDOWN_POLL);
                 let recv = event_rx.recv_timeout(timeout);
                 match recv {
                     Ok(Ok(ev)) => {

--- a/docs/versions/v0-6-5/host-probe.md
+++ b/docs/versions/v0-6-5/host-probe.md
@@ -14,10 +14,10 @@
 | **F148** `/ccteam-creator` → TG round-trip | **PASS** | Fresh-state `/ccteam-creator "做个 TG 助理 bot"` → `go` → bot registered + tmux supervisor started + 3 real Telegram messages delivered (tg_msg_id 1896/1897/1898 to recipient 339498819) within ~25s of `go` confirmation. See "F148 details" below. |
 | **F157** `ccteam-scan --quick` <= 90s | **PASS** | Real run on `/home/rob/nasworkspace/ccteam` (89 kLOC Rust workspace): wall-clock **33s** (well under 90s). `.ccteam/codebase-scan.md` written (42 lines, frontmatter `quick: true`, all 3 Q's answered). |
 | **F162** `intent-accuracy.sh --real` | **PASS** | 50/50 = **1.0000** accuracy. Per-intent precision/recall all 1.000. Wall-clock 5:27. Report at `docs/versions/v0-6-5/intent-accuracy.md` (mode=`real`). Ship gate >= 0.90 cleared with margin. |
-| **F163** SIGTERM graceful (<= 5s) | **FAIL** | SIGTERM sent to two separate daemon instances (PID 1773722 and PID 1776891). Both stayed alive >60s after SIGTERM; pidfile not unlinked; required SIGKILL. **Port 7331 IS released** within ~1s of SIGTERM (web server tokio task does respond to shutdown), but the main process does not exit. Partial graceful shutdown — handler accepts SIGTERM but blocks somewhere before runtime drop. |
+| **F163** SIGTERM graceful (<= 5s) | **PASS** (after F163 retro fix) | Original W1-T6 PR #96 (`TASK_DRAIN_TIMEOUT` 5s wrap on web/imd handles) was insufficient. F163 retro PR re-probed nas-box005 5/5 runs: SIGTERM → process exit in **~1019ms** (range 1016-1019ms), pidfile unlinked every cycle, tmux session `ccteam-chat-tech-helper-tg-tech-helper` survives all 5 SIGTERM cycles (created 09:14:27 UTC, still alive after probe). See "F163 retro details" below. |
 | **F164** tmux reattach across restart | **PASS** | Bot tmux session_id `$1` (`ccteam-chat-tech-helper-tg-tech-helper`) survived daemon kill + restart. Daemon log explicitly emits `claude-tui: reattached to existing tmux session (pane claude process alive) event="session_reattached" pane_pid=Some(1775109)`. Post-restart MCP `chat_send_input` → bot pane → real Telegram delivery (tg_msg_id 1899 to recipient 339498819) confirmed. |
 
-**4 of 5 gates pass. F163 fails.**
+**Initial run: 4 of 5 gates pass. F163 retro PR re-probed nas-box005 — all 5 gates now PASS.**
 
 ---
 
@@ -89,7 +89,7 @@ Note: NAS `/usr/bin/python3` is permission-denied for user `rob` (Synology defau
 
 ---
 
-## F163 details — FAIL
+## F163 details — initial FAIL
 
 Two independent SIGTERM attempts, both stuck:
 
@@ -115,7 +115,65 @@ Both runs: pidfile NOT auto-unlinked, but port 7331 freed within ~1s.
 
 **Interpretation:** the daemon does have *some* signal handler (web server tokio task exits + binds port), but the main process hangs on a non-cancellable task — possibly an outstanding tokio runtime task (claude_jobs gc / artifact_watcher polling / supervisor thread join). This is consistent with F163's PRD description identifying this as a known V0.6.4 ship blocker.
 
-**Implication for V0.6.5 ship gate #5** (`docs/versions/v0-6-5/README.md` §5 #5): the ship gate is **not** met. Either (a) defer F163 explicitly with a `docs/versions/v0-6-6/` plan, or (b) treat current daemon shutdown semantics as "SIGTERM releases port + frees daemon-level resources but does not exit process; operators must `kill -9` after SIGTERM if they need the PID slot" and document accordingly. Recommend escalating to main session for ship/no-ship decision.
+---
+
+## F163 retro details — PASS (deep-fix follow-up)
+
+**Root cause** (identified 2026-05-24 09:14 UTC via deep-debug with
+`eu-stack` thread dumps + tracing-instrumented daemon log):
+
+1. `AgentTeamsWatcher::start` spawns a `tokio::task::spawn_blocking`
+   discovery loop. Its only exit conditions are (a) cancel flag set,
+   (b) inotify mpsc `Disconnected`. The mpsc sender is owned by the
+   same blocking task (held inside the `notify::Watcher` closure moved
+   into the spawn_blocking body), so (b) never fires while the task is
+   alive — self-pinning deadlock. Production daemon never flipped (a)
+   on shutdown.
+2. The loop's `recv_timeout` used
+   `discovery_interval.saturating_sub(elapsed).max(WATCHER_SHUTDOWN_POLL)`
+   which made `WATCHER_SHUTDOWN_POLL` a **floor** not a **ceiling**. The
+   thread sat in `recv_timeout` for up to a full
+   `TEAMS_DISCOVERY_INTERVAL` (60s) before sampling the cancel flag.
+3. `Runtime::drop` → `BlockingPool::shutdown(None)` blocks the process
+   indefinitely waiting for every `spawn_blocking` thread to return.
+   Combined with #1+#2 this held the main thread in `futex_wait` past
+   the operator's SIGKILL patience.
+
+**Fix** (PR `v065-f163-deep-fix`, commit 8906a79):
+- `AgentTeamsWatcher` loop now uses `remaining.min(WATCHER_SHUTDOWN_POLL)`
+  so cancel sampled every 500ms regardless of discovery interval.
+- `ccteam start` captures `watcher.cancel_handle()` before `.start()` and
+  flips it after graceful shutdown propagates.
+- Defense in depth: after `block_on` returns, explicit
+  `runtime.shutdown_timeout(Duration::from_secs(5))` bounds any
+  straggler spawn_blocking task at 5s.
+
+**Re-probe** (5 consecutive runs, 2026-05-24 09:37 UTC):
+```
+run 1: PID=1798958: gone in 1019ms PASS
+run 2: PID=1798994: gone in 1018ms PASS
+run 3: PID=1799027: gone in 1016ms PASS
+run 4: PID=1799102: gone in 1016ms PASS
+run 5: PID=1799138: gone in 1018ms PASS
+=== all 5 runs PASS ===
+```
+
+Each run: SIGTERM → exit in ~1.02s, pidfile unlinked every cycle. Daemon
+log emits full graceful shutdown chain (`SIGTERM received` → `graceful
+shutdown begin` → `graceful shutdown clean` → `graceful shutdown
+complete`). Existing tmux session `ccteam-chat-tech-helper-tg-tech-helper`
+(created at 09:14:27 UTC) **survives all 5 SIGTERM cycles**, confirming
+the F164 reattach contract is preserved (CLAUDE.md §三 red line: 永不主动
+kill 长 session — daemon stop ≠ bot session stop).
+
+**Unit-test coverage added** (`crates/ccteam-cli/tests/graceful_shutdown_test.rs`):
+- `sigterm_exits_within_5s_with_agent_teams_watcher_active`
+- `sigterm_exits_fast_across_five_consecutive_runs`
+- `sigterm_emits_full_graceful_shutdown_telemetry`
+- `agent_teams_watcher_cancel_handle_stops_blocking_loop_fast`
+
+Workspace baseline after fix: **1583 passed / 1 pre-existing flake**
+(`workflow_summary_reflects_agent_spawn_and_done_events`), clippy clean.
 
 ---
 
@@ -162,6 +220,6 @@ NAS left in clean state (no daemon, no tmux sessions, registry intact for future
 
 | | |
 |---|---|
-| **Overall** | **4/5 gates PASS** (F148 / F157 / F162 / F164) + **1 FAIL** (F163) |
-| **Recommend** | escalate F163 to main session for ship/no-ship decision; F164 minor inbox-on-startup-sweep wrinkle is V0.6.6 candidate |
-| **Run duration** | ~30 min (07:00 - 07:30 UTC, 2026-05-24); blocked once on python3 PATH issue (5 min troubleshoot) |
+| **Overall** | Initial probe: **4/5 gates PASS** (F148 / F157 / F162 / F164) + **1 FAIL** (F163). After F163 retro PR: **5/5 gates PASS** (re-probe 5/5 SIGTERM cycles all exit in ~1s with pidfile unlinked + tmux session preserved). |
+| **Recommend** | Ship V0.6.5 — all gates green. F164 minor inbox-on-startup-sweep wrinkle remains a V0.6.6 candidate. |
+| **Run duration** | Initial probe ~30 min (07:00 - 07:30 UTC, 2026-05-24); F163 deep-debug + retro fix + re-probe ~2.5h (09:00 - 11:30 UTC, 2026-05-24). |


### PR DESCRIPTION
## Finding

F163 retro — W1-T6 PR #96's `TASK_DRAIN_TIMEOUT` (5s wrap on web/imd handles) passed unit tests but real NAS host hung >60s on SIGTERM (Wave 4b host-probe). Required SIGKILL; pidfile not unlinked.

## Root cause

Deep-debug on nas-box005 (eu-stack thread dumps + tracing-instrumented daemon log) identified two compounding defects in the `AgentTeamsWatcher` path:

1. `AgentTeamsWatcher::start` spawns a `tokio::task::spawn_blocking` discovery loop. Its only exit conditions are (a) cancel flag set, (b) inotify mpsc `Disconnected`. The mpsc sender is owned by the same blocking task (held inside the `notify::Watcher` closure moved into the spawn_blocking body), so (b) never fires while the task is alive — self-pinning deadlock. Production daemon never flipped (a).
2. The loop's `recv_timeout` used `discovery_interval.saturating_sub(elapsed).max(WATCHER_SHUTDOWN_POLL)` which made `WATCHER_SHUTDOWN_POLL` a **floor** not a **ceiling**. The thread sat up to 60s in `recv_timeout` before sampling the cancel flag.
3. `Runtime::drop` → `BlockingPool::shutdown(None)` blocks forever waiting for every `spawn_blocking` thread to return; combined with #1+#2, the main thread blocked indefinitely in `futex_wait` past the operator's SIGKILL patience.

## Fix

- `AgentTeamsWatcher` loop now uses `remaining.min(WATCHER_SHUTDOWN_POLL)` so the cancel flag is sampled every 500ms regardless of discovery interval.
- `ccteam start` captures `watcher.cancel_handle()` before `.start()` and flips it after graceful shutdown propagates.
- Defense in depth: after `block_on` returns, explicit `runtime.shutdown_timeout(Duration::from_secs(5))` bounds any straggler `spawn_blocking` task at 5s (workflow_watcher race, per-project ArtifactWatcher mid-syscall, claude GC sweep).

Strictly better than the original W1-T6 design because:
- Original `TASK_DRAIN_TIMEOUT` only bounded the **async** `web_handle.await` + `imd_handle.await` — it never touched the **blocking** pool which is what actually held the process.
- The cancel-handle wiring is cooperative (drives clean exit ~500ms); the runtime timeout is defense-in-depth (5s ceiling on anything that didn't cooperate).

## Verification

- **cargo test --workspace**: 1583 passed / 1 pre-existing flake (`workflow_summary_reflects_agent_spawn_and_done_events`).
- **clippy --workspace --all-targets -D warnings**: clean.
- **NAS re-probe** (nas-box005, 2026-05-24 09:37 UTC): 5/5 consecutive SIGTERM cycles all exit in **~1.02s** (range 1016-1019ms), pidfile unlinks every cycle, tmux session `ccteam-chat-tech-helper-tg-tech-helper` survives all 5 cycles (F164 reattach contract preserved).
- **host-probe.md** F163 row updated ✗ → ✓ with full re-probe evidence + sign-off block.

### New unit-test coverage (`graceful_shutdown_test.rs`)

| Test | What it pins |
|---|---|
| `sigterm_exits_within_5s_with_agent_teams_watcher_active` | Exercises production path (`~/.claude/teams/` pre-created so F95 watcher arms inotify + spawn_blocking loop); asserts SIGTERM → exit within 6s. |
| `sigterm_exits_fast_across_five_consecutive_runs` | Unit-test analog of the NAS 5-cycle re-probe — catches non-deterministic flakes. |
| `sigterm_emits_full_graceful_shutdown_telemetry` | Asserts the signal-handler → graceful drain → shutdown-complete trace fires; a future regression that satisfies "exit within 6s" via hard-abort still fails this. |
| `agent_teams_watcher_cancel_handle_stops_blocking_loop_fast` | Direct unit test of the crate-internal contract: cancel flip drives the blocking discovery loop to exit within `WATCHER_SHUTDOWN_POLL` (500ms). |

## Red lines preserved

- **No proactive kill of tmux long sessions** (CLAUDE.md §三): Both the cancel-handle flip and `runtime.shutdown_timeout` act only on the daemon's own tokio runtime. Re-probe confirms tmux session `ccteam-chat-tech-helper-tg-tech-helper` (created 09:14:27 UTC) survives all 5 SIGTERM cycles.
- **No `std::process::exit()` bypass of pidfile cleanup**: cleanup still flows through the `let result = (|| -> Result<()> { ... })(); remove_pidfile(...); result` path — moved the `runtime` binding outside the IIFE so `runtime.shutdown_timeout` runs **before** pidfile removal.

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast` → 1583/1
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` → clean
- [x] NAS 5-cycle re-probe → 5/5 PASS, avg 1018ms
- [x] tmux session preserved across all 5 cycles
- [x] Pidfile unlinked every cycle
- [x] `docs/versions/v0-6-5/host-probe.md` F163 row ✗ → ✓ with sign-off block updated