### PR TITLE
v0.6.5: scrub skills (self-contained ship gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@
 - ccteam **不 vendor** Claude / Codex 二进制(`references/{claude-code,codex/codex-rs}/` git-ignore 不入库,仅协议参考;实际 spawn 走 `$PATH` 内 `claude` / `codex` binary + `CCTEAM_{CLAUDE,CODEX}_BIN` env override)
 - `vendor: AgentVendor::{Claude, Codex}` enum 是 trait 一等公民,无 default — workflow.yaml 必须 explicit 或由 `ccteam-creator` skill auto-推断写入
 
+**skill 自洽红线**:`skills/*/SKILL.md` + `skills/*/` 其他 body 文件随 `ccteam init` 装到用户机器,**必须**自洽 ── 禁版本号(`V0.X.Y`)/ 禁 `docs/versions/v0-X-Y/` 引用 / 禁 Wave-N / 禁 F-tag / 禁 ship-status creep(shipped / "已 ship" / "ship gate" 等)/ 禁 PR # / 禁 commit ref。允许:sibling skill 引用、MCP tool 名、CLI 命令、稳定 user-facing docs (`docs/{quickstart,user-manual,task-to-command,troubleshooting,recipes}.md`)。Dev-side 历史去 `docs/versions/v0-X-Y/README.md` + `docs/dev-coupling-audit.md`。Ship gate:`grep -rnE "V\d+\.\d+\|docs/versions\|Wave [0-9]\|F[0-9]+[a-z]?\b\|F-Bug\|ship gate\|shipped" skills/*/SKILL.md` 必须 0 命中。
+
 ## 四、扩展机制速查
 
 详 `docs/tech-design.md` §6:

--- a/docs/versions/v0-6-5/README.md
+++ b/docs/versions/v0-6-5/README.md
@@ -119,6 +119,7 @@ V0.6.0 立项 PRD 里 F108 / F112 / F113 / F114 / F117 都明确承诺过 Wave 2
 8. **CLAUDE.md §一 baseline 表更新到 V0.6.5 数字** + §四 skill 状态注释清理
 9. **`cargo run --release -- doctor`** 输出含 "MCP tool surface: 26 active, 0 stubs"(原 9 个 stub 全实现)
 10. **F148 / F157 / F162 / F163 / F164 host-probe 全部签字**(`docs/versions/v0-6-5/host-probe.md` 收齐每条 finding 一行 OK/Fail + log path)
+12. **skills 自洽 grep clean**:`grep -rnE "V\d+\.\d+\|docs/versions\|Wave [0-9]\|F[0-9]+[a-z]?\b\|F-Bug\|ship gate\|shipped" skills/*/SKILL.md` 全 0 命中
 
 ---
 

--- a/skills/ccteam-advise/SKILL.md
+++ b/skills/ccteam-advise/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: ccteam-advise
-description: "Claude + Codex parallel advisor for architecture decisions, algorithm trade-offs, and security / performance second opinions. Use when the user says '/ccteam-advise <NL>', 'second opinion on X', 'should I pick A or B', 'ask both Claude and Codex about X', or otherwise asks for a cross-vendor consult. Backed by the daemon MCP tools `mcp__ccteam__advise_vote` / `mcp__ccteam__advise_parallel` (V0.6.5 F152 + F153)."
+description: "Claude + Codex parallel advisor for architecture decisions, algorithm trade-offs, and security / performance second opinions. Use when the user says '/ccteam-advise <NL>', 'second opinion on X', 'should I pick A or B', 'ask both Claude and Codex about X', or otherwise asks for a cross-vendor consult. Backed by the daemon MCP tools `mcp__ccteam__advise_vote` / `mcp__ccteam__advise_parallel`."
 ---
 
 # /ccteam-advise — Claude + Codex parallel voting
 
-V0.6.5 F152 + F153 — daemon-backed real implementations of
-`mcp__ccteam__advise_vote` (Claude + Codex one-shot + synthesised
-verdict via a third Claude call) and `mcp__ccteam__advise_parallel`
-(N-of-N raw answers, no synthesis). Single user-facing scenario: a
-hard question that benefits from two independent opinions, fanned to
-both vendors in parallel and reduced to a 3-5 sentence verdict.
+Daemon-backed dispatch for `mcp__ccteam__advise_vote` (Claude + Codex
+one-shot + synthesised verdict via a third Claude call) and
+`mcp__ccteam__advise_parallel` (N-of-N raw answers, no synthesis).
+Single user-facing scenario: a hard question that benefits from two
+independent opinions, fanned to both vendors in parallel and reduced
+to a 3-5 sentence verdict.
 
-## V0.6.5 skill family (you are here)
+## Skill family (you are here)
 
 | User intent | Skill |
 |---|---|
@@ -134,7 +134,7 @@ ADVISOR VERDICT (agreement: agree)
 Both Claude and Codex recommend Rust for a high-throughput message
 queue, citing zero-cost abstractions, predictable latency under
 load, and Tokio's mature async runtime. The lone Codex caveat is
-team familiarity — if your team has shipped 3+ Go services already
+team familiarity — if your team has already built 3+ Go services
 and zero Rust, the migration cost can dominate the latency win for
 the first 6 months. Recommended: Rust if you have at least one
 Rust-comfortable engineer; otherwise Go with a `sync.Pool`-heavy
@@ -245,7 +245,7 @@ codex without modifying `$PATH`.
   never lets either vendor write files or run shell commands on
   behalf of the user.
 - **N-way fan-out without synthesis** uses `mcp__ccteam__advise_parallel`
-  with `n: 3..=8` — supported and shipped (no longer a placeholder).
+  with `n: 3..=8`.
 
 ## Red lines
 
@@ -263,18 +263,8 @@ codex without modifying `$PATH`.
   `error:"budget_exceeded"`, surface it; do not retry with a
   silently raised `max_cost_usd`.
 
-## Where to look in the repo
+## Sibling skills
 
-- `@docs/versions/v0-6-5/prd.md` §F152 / §F153 / §F154 — real-impl
-  PRD (supersedes the V0.6.0 stub design)
-- `@crates/ccteam-cli/src/mcp_advise_tools.rs` — MCP tool schemas
-  + dispatchers for `ccteam__advise_vote` / `ccteam__advise_parallel`
-- `@crates/ccteam-core/src/advise.rs` — vendor adapter helpers
-  (`run_claude_advisor` / `run_codex_advisor` / budget ledger
-  persistence)
-- `@crates/ccteam-cli/tests/mcp_advise_vote_test.rs` — vote happy
-  path + Codex-unavailable + budget-exceeded e2e coverage
-- `@crates/ccteam-cli/tests/mcp_advise_parallel_test.rs` —
-  parallel round-robin + claude-only + unavailable slot + budget
-  e2e coverage
-- `@CLAUDE.md` §三 — architectural red lines
+- `@skills/ccteam-team/SKILL.md` — multi-turn debate via team
+- `@skills/ccteam-creator/SKILL.md` — start a new project / workflow
+- `@skills/ccteam-control/SKILL.md` — manage existing projects

--- a/skills/ccteam-control/SKILL.md
+++ b/skills/ccteam-control/SKILL.md
@@ -9,9 +9,9 @@ ccteam is an autonomous project orchestrator built on Claude Code.
 This skill makes ccteam reachable from any Claude session via the
 `ccteam` CLI + `mcp__ccteam__*` MCP tool surface.
 
-## V0.5.0 skill family (you are here)
+## Skill family (you are here)
 
-This skill is one of three shipped V0.5.0 skills. Pick by intent:
+Pick by intent:
 
 | Intent | Skill | Quick example |
 |---|---|---|
@@ -30,13 +30,12 @@ Claude session sees `mcp__ccteam__*` tools — call those first. The
 `Bash` + `--format json` path stays as a fallback for sessions where the
 MCP server isn't registered yet.
 
-**V0.4.6 F89 CLI surface reorg.** The top-level `ccteam` CLI exposes
-only user-facing commands (`init` / `start` / `stop` / `new` / `ls` /
+**CLI surface layout.** The top-level `ccteam` CLI exposes only
+user-facing commands (`init` / `start` / `stop` / `new` / `ls` /
 `status` / `show` / `doctor` / `web` / `remove`). Hook handlers and
 meta-agent integration points (`spawn` / `send` / `peek` / `attach` /
 `progress` / `resume` / `mcp-serve` / `hook`) live under `ccteam
-internal <subcmd>`. V0.5.0 dropped the legacy top-level aliases —
-prefer the new path:
+internal <subcmd>` — prefer the new path:
 
 ```bash
 ccteam internal peek <slug>          # was: ccteam peek <slug>
@@ -59,15 +58,15 @@ ccteam internal spawn <slug> <role>  # was: ccteam spawn <slug> <role>
 | Resume project                   | `mcp__ccteam__workflow_resume`            | `ccteam internal resume <slug>` |
 | Send NL to a session inbox       | `mcp__ccteam__workflow_send_to_session`   | `ccteam internal send <slug> "<body>"` (or write `.ccteam/inbox/msg-<ts>-NNN.md` directly) |
 | Inject a structured decision     | `mcp__ccteam__workflow_inject_decision`   | (compose body manually + send_to_session) |
-| **Change bot persona** (V0.6.1 F128)  | `mcp__ccteam__admin_change_persona` | `ccteam admin change-persona <slug> <bot> -` (full markdown via stdin) |
-| **Add tool to a bot** (V0.6.1 F128)   | `mcp__ccteam__admin_add_tool`     | `ccteam admin add-tool <slug> <bot> <ToolName>` |
+| **Change bot persona**          | `mcp__ccteam__admin_change_persona` | `ccteam admin change-persona <slug> <bot> -` (full markdown via stdin) |
+| **Add tool to a bot**           | `mcp__ccteam__admin_add_tool`     | `ccteam admin add-tool <slug> <bot> <ToolName>` |
 | Health checks                    | (Bash only)                      | `ccteam doctor --tool-surface` |
 | Install meta-agent               | (Bash only)                      | `ccteam doctor --install-meta-agent` |
 
-## V0.6.1 F128 — `change-persona` and `add-tool` subcommands
+## `change-persona` and `add-tool` subcommands
 
-Two new operations land in V0.6.1 to back the `/ccteam-control` slash
-forms documented in `docs/user-manual.md §2.4`:
+These operations back the `/ccteam-control` slash forms documented
+in `docs/user-manual.md §2.4`:
 
 ```
 /ccteam-control change-persona helper-bot "改成英文 + 更幽默"

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -5,12 +5,11 @@ description: "NL dialogue to start a new ccteam project / workflow / IM bot. Pul
 
 # /ccteam-creator — NL bootstrap for ccteam projects
 
-Shipped via F114 (V0.6.0) — supersedes the V0.5 step-1/2/3/4 dispatch
-dialogue with an LLM-driven NL flow that infers everything the user
-shouldn't have to specify (execution mode, preset, persona),
-surfaces a PROJECT PLAN, and only executes after `go`.
+LLM-driven NL flow that infers everything the user shouldn't have to
+specify (execution mode, preset, persona), surfaces a PROJECT PLAN,
+and only executes after `go`.
 
-## V0.6.0 skill family (you are here)
+## Skill family (you are here)
 
 | User intent | Skill |
 |---|---|
@@ -75,8 +74,7 @@ clarifying question** before continuing. Do **not** assume.
 # Phase 2 — Mode inference
 
 Feed the three axes into `ccteam_core::infer_mode(intent) ->
-InferenceResult`. The function applies the V0.6.0 PRD F114 decision
-table:
+InferenceResult`. The function applies this decision table:
 
 | presence | timeline | CreatorMode | Preset |
 |---|---|---|---|
@@ -113,10 +111,10 @@ selection rules:
    `en/role.md`. (User may override: "用英文 persona".)
 
 If no persona is a clean fit, ask the user to pick from the top 3
-candidates. **Do not invent a new persona** — V0.7 will add a
-`/ccteam-creator-persona-new` flow; for V0.6 the library is fixed.
+candidates. **Do not invent a new persona** — the prefab library is
+fixed; user-defined personas are not in scope for this skill.
 
-## Phase 3.5 — Codex auto-critic detection (F112 §B, shipped V0.6.0)
+## Phase 3.5 — Codex auto-critic detection
 
 When the matched persona's role hints at adversarial / second-opinion
 work, ccteam-creator silently consults the Codex CLI and — if it's
@@ -142,7 +140,7 @@ ccteam doctor --check-codex-auto-critic
 #            3 = silent fallback (probe malformed — don't inject)
 ```
 
-The gate (V0.6.5 F155, `crates/ccteam-cli/src/commands.rs::
+The gate (`crates/ccteam-cli/src/commands.rs::
 run_check_codex_auto_critic`) wraps a `<bin> --version` probe AND a
 one-shot `<bin> exec --json --skip-git-repo-check` canary so the
 skill doesn't have to second-guess the result of two inline probes
@@ -269,10 +267,9 @@ The pool is the scientist-nickname list in
 
 For chat presets, invoke the **`mcp__ccteam__chat_register_bot`** MCP
 tool. The skill is LLM-driven and cannot call Rust functions directly
-— the registry is reached only through this MCP wire. V0.6.5 F146
-implemented the real handler that writes
-`~/.ccteam/imd/registry/<workflow_slug>/<role>.json`; the daemon's
-registry watcher picks it up and spawns the tmux session.
+— the registry is reached only through this MCP wire. The handler
+writes `~/.ccteam/imd/registry/<workflow_slug>/<role>.json`; the
+daemon's registry watcher picks it up and spawns the tmux session.
 
 `im_chat_id` comes from `~/.ccteam/im/credentials.json` written in
 Phase 5.1: take `telegram.allowed_chat_ids[0]` (cast to string —
@@ -293,9 +290,9 @@ Telegram chat ids are i64, but the MCP wire expects a string).
 ```
 
 **Vendor must be lowercase** (`"claude"` or `"codex"`). The daemon's
-`BotRegistration` deserialize trips on PascalCase `"Claude"` (Bug A
-from V0.6.5 NAS deploy session); the F146 dispatcher lowercases
-defensively, but stick to lowercase in the call to be explicit.
+`BotRegistration` deserialize trips on PascalCase `"Claude"`; the
+dispatcher lowercases defensively, but stick to lowercase in the
+call to be explicit.
 
 **Error handling:**
 
@@ -371,7 +368,7 @@ If `infer_mode` returns `Ambiguous`, show the top 2 candidates +
 one-line tradeoff comparison; let user pick.
 
 If persona match is < 50% confidence, list top 3 + "其他 / 自己写
-一个 V0.7+ 才支持,V0.6 请从内置库选" and bounce.
+一个目前不支持,请从内置库选" and bounce.
 
 Never silently re-execute Phase 5 steps that already ran — if
 `workflow.yaml` is already on disk, ask before overwriting.
@@ -380,12 +377,11 @@ Never silently re-execute Phase 5 steps that already ran — if
 
 # What this skill does NOT do
 
-- **User-defined personas** — V0.7+ will add a creator flow; for
-  V0.6 the prefab library is fixed at 7 personas.
-- **Persona marketplace pull** — V0.8+.
-- **OAuth-based IM onboarding** — `/ccteam-im-setup` is token-only
-  for V0.6.
-- **Voice / multi-modal input** — V0.7+ (text only).
+- **User-defined personas** — the prefab library is fixed at 7
+  personas; user-defined persona creator flow is not in scope.
+- **Persona marketplace pull** — out of scope.
+- **OAuth-based IM onboarding** — `/ccteam-im-setup` is token-only.
+- **Voice / multi-modal input** — text only.
 - **Cross-vendor agent vendoring** — Codex critic auto-enable is
-  declarative (a hint in PROJECT PLAN); actual Codex vendoring shipped
-  via F112 (V0.6.0).
+  declarative (a hint in PROJECT PLAN); actual Codex vendoring is
+  handled by the daemon vendor adapters.

--- a/skills/ccteam-creator/personas/project-lead/en/role.md
+++ b/skills/ccteam-creator/personas/project-lead/en/role.md
@@ -15,7 +15,7 @@ plan to ship; you remember, you nudge, you summarise.
 
 - Keep a running list of open deliverables with last-mention dates.
 - Once a week (or on request), produce a 5-bullet status summary:
-  what shipped, what slipped, what's blocked, top risk, ask of human.
+  what landed, what slipped, what's blocked, top risk, ask of human.
 - Nudge on items untouched >7 days, but do it once — no nagging.
 
 ## Guardrails

--- a/skills/ccteam-im-setup/SKILL.md
+++ b/skills/ccteam-im-setup/SKILL.md
@@ -5,14 +5,13 @@ description: "One-time IM token onboarding for ccteam chat bots. Walks the user 
 
 # /ccteam-im-setup — one-time IM token onboarding
 
-Shipped via F117 (V0.6.0). Standalone skill that any other skill (notably
-`ccteam-creator` Phase 5.1) can invoke to make sure
-`~/.ccteam/im/credentials.json` has the platform the rest of the
-flow needs. **Idempotent** — re-running for a platform that's
-already configured re-verifies the token and exits without prompting.
+Standalone skill that any other skill (notably `ccteam-creator`
+Phase 5.1) can invoke to make sure `~/.ccteam/im/credentials.json`
+has the platform the rest of the flow needs. **Idempotent** —
+re-running for a platform that's already configured re-verifies the
+token and exits without prompting.
 
-Backed by `ccteam_imd::onboarding::telegram_setup()` (and forthcoming
-`slack_setup` / `discord_setup`).
+Backed by `ccteam_imd::onboarding::telegram_setup()`.
 
 ## When to invoke
 
@@ -35,19 +34,16 @@ Backed by `ccteam_imd::onboarding::telegram_setup()` (and forthcoming
 
 ```
 > 要绑哪个 IM 平台?
-  1. Telegram   (V0.6 ✓)
-  2. Slack      (V0.7)
-  3. Discord    (V0.7)
-  4. (V0.7+) Lark / DingTalk / WeChat
+  1. Telegram
 ```
 
-If user picks 2/3/4 — politely defer to the future wave + return
-without writing anything: "V0.6 只支持 Telegram,Slack / Discord
-要等 V0.7。要先用 Telegram 吗?"
+目前只支持 Telegram。如果用户问起 Slack / Discord / Lark / DingTalk
+/ WeChat,礼貌告诉用户当前只支持 Telegram + 询问"要先用 Telegram 吗?"
+不要 promise 任何时间表。
 
 ---
 
-# Step 2 — Telegram onboarding (V0.6 happy path)
+# Step 2 — Telegram onboarding
 
 Walk the user through, **one step at a time** — don't dump the
 whole script:
@@ -100,13 +96,12 @@ While it's running, tell the user:
 Persist via either of these (same behaviour):
 
 ```rust
-// imd-teammate-branch canonical name:
 ccteam_imd::credentials::save(
     &ccteam_imd::credentials::default_path(),
     &Credentials { telegram: Some(result.creds), ..Default::default() },
 )?;
 
-// or the wave-2/creator-branch convenience wrapper:
+// or the convenience wrapper:
 ccteam_imd::credentials::write_credentials(
     &Credentials { telegram: Some(result.creds), ..Default::default() },
 )?;
@@ -155,9 +150,9 @@ chat_id ACL.)
 
 # Step 4 — Backup transport switch (optional)
 
-The default chat transport for V0.6 is `openhuman/channels`
-(uniform code path across all IM platforms). If the user wants the
-official Anthropic Telegram plugin path instead, they can run:
+The default chat transport is `openhuman/channels` (uniform code
+path across all IM platforms). If the user wants the official
+Anthropic Telegram plugin path instead, they can run:
 
 ```
 /ccteam-im-setup --transport official-telegram
@@ -179,17 +174,16 @@ Reasons to switch:
 - openhuman is misbehaving and they want a fallback
 
 Reasons not to switch:
-- official path doesn't cover Slack / Discord (only Telegram)
-- bot-to-bot @ addressing (IM Squad / F108) currently only works
-  via openhuman
+- official path only covers Telegram
+- bot-to-bot @ addressing (IM Squad) currently only works via
+  openhuman
 
 ---
 
 # What this skill does NOT do
 
-- OAuth flow — V0.6 is token-only (Telegram bot tokens / Slack bot
-  tokens for V0.7)
+- OAuth flow — token-only (Telegram bot tokens)
 - Webhook URL auto-setup — user runs ngrok / cloudflared themselves;
   document in `docs/troubleshooting.md`
-- Multi-account per platform — V0.6 supports one bot per platform
-- Token rotation / refresh — manual for V0.6
+- Multi-account per platform — one bot per platform
+- Token rotation / refresh — manual

--- a/skills/ccteam-scan/SKILL.md
+++ b/skills/ccteam-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccteam-scan
-description: "代码库扫描 —— 只读。两个 mode:(1) `--quick` 60-90s 摸底(1 sonnet agent + 3 个固定问题:语言/框架、TODO 热点、CLAUDE.md/README 状态);(2) default audit 大型代码库导航性体检(monorepo 结构、workflow.yaml `scope:` 建议、navigability gap)。Use when 用户说 '/ccteam-scan'、'扫一下代码 / 摸底新项目 / scan code / audit codebase'、'检查我的大代码库'、'扫一下这个仓库'、'我的 monorepo 怎么接 ccteam'、'workflow.yaml 的 scope 该填什么'、'audit codebase navigability'。V0.6.2 F141 + V0.6.5 F157(--quick)。"
+description: "代码库扫描 —— 只读。两个 mode:(1) `--quick` 60-90s 摸底(1 sonnet agent + 3 个固定问题:语言/框架、TODO 热点、CLAUDE.md/README 状态);(2) default audit 大型代码库导航性体检(monorepo 结构、workflow.yaml `scope:` 建议、navigability gap)。Use when 用户说 '/ccteam-scan'、'扫一下代码 / 摸底新项目 / scan code / audit codebase'、'检查我的大代码库'、'扫一下这个仓库'、'我的 monorepo 怎么接 ccteam'、'workflow.yaml 的 scope 该填什么'、'audit codebase navigability'。"
 ---
 
 # /ccteam-scan — 代码库扫描
@@ -10,15 +10,15 @@ description: "代码库扫描 —— 只读。两个 mode:(1) `--quick` 60-90s �
 | Mode | 触发 | 目标耗时 | 谁 spawn | 输出 |
 |---|---|---|---|---|
 | **quick** | `/ccteam-scan --quick` 或 `/ccteam "扫一下代码"` | 60-90s | 1 个 sonnet agent | `<repo>/.ccteam/codebase-scan.md`(~10-20 行,frontmatter `quick: true`)|
-| **audit**(default,V0.6.2 F141)| `/ccteam-scan`(无 flag)| 5-10 min | inline(本 skill body)| 同 path,**升级覆盖** quick 报告(frontmatter `quick: false`)|
+| **audit**(default)| `/ccteam-scan`(无 flag)| 5-10 min | inline(本 skill body)| 同 path,**升级覆盖** quick 报告(frontmatter `quick: false`)|
 
 **新用户**:用 `--quick` 即可,30-90 秒看到 value。**大型 monorepo / 要接 ccteam**:跑 default audit 拿 scope 建议 + navigability 报告。
 
-下文 §"--quick mode" 描述 quick;§"--audit mode" 起以下是 V0.6.2 F141 原 audit 流程。
+下文 §"--quick mode" 描述 quick;§"--audit mode" 起以下是大型代码库 audit 流程。
 
 ---
 
-## --quick mode(V0.6.5 F157)
+## --quick mode
 
 **用途**:新用户 60-90s 内摸底任意 git 仓库。不替代 audit;只是第一印象。
 
@@ -104,7 +104,7 @@ generator: ccteam-scan --quick
 
 ---
 
-## --audit mode(V0.6.2 F141,大型代码库导航性体检)
+## --audit mode(大型代码库导航性体检)
 
 **只读** audit skill。一次性产出一份报告:这个仓库对 Claude Code agent 有多"可导航",以及把它接入 ccteam 时每个 role 的 `scope:` 该怎么填。
 
@@ -187,7 +187,7 @@ du -sh -- */ 2>/dev/null | sort -rh | head -15      # 最大子树
 
 ## Step 3 — `scope:` 建议(本 skill 的核心产出)
 
-对每个 member / 主要子系统,给出一行可直接粘进 `workflow.yaml` 的 `scope:` 值。背景:V0.6.2 F140 —— `AgentSpec.scope` 把 agent spawn 的 cwd 钉到子树,收窄每次 fresh-context 的爆炸半径(详 `docs/interfaces.md §17.2`)。
+对每个 member / 主要子系统,给出一行可直接粘进 `workflow.yaml` 的 `scope:` 值。背景:`AgentSpec.scope` 把 agent spawn 的 cwd 钉到子树,收窄每次 fresh-context 的爆炸半径(详 `docs/interfaces.md §17.2`)。
 
 输出形如:
 
@@ -241,5 +241,3 @@ crates/api           scope: crates/api          Cargo workspace member
 
 - `docs/orchestration-patterns.md §1.5` —— 大型代码库模板(scope + explorer→artifact→editor)
 - `docs/interfaces.md §17.2` —— `AgentSpec.scope` schema
-- `docs/versions/v0-6-2/README.md` —— F140 per-role scope + F141 本 skill audit mode
-- `docs/versions/v0-6-5/prd.md §F157` —— `--quick` mode 需求 + 验收

--- a/skills/ccteam-team/README.md
+++ b/skills/ccteam-team/README.md
@@ -1,6 +1,6 @@
 # ccteam-team — skill 入口速查
 
-V0.5.0 F93a primary path:在用户当前 Claude session 里起一个 Anthropic Agent Team。
+primary path:在用户当前 Claude session 里起一个 Anthropic Agent Team。
 **零 ccteam workflow.yaml 依赖** — 任意 git repo 都跑得起。
 
 > 完整协议见 `SKILL.md`。本 README 给 `ccteam-creator` skill / docs 等交叉引用用。
@@ -45,11 +45,6 @@ ccteam doctor --install-skill ccteam-team
 
 | skill | 用途 |
 |---|---|
-| **`ccteam-team`** (本 skill) | V0.5.0 primary — 起 agent team |
+| **`ccteam-team`** (本 skill) | 在当前 session 内起 agent team |
 | `ccteam-creator` | 创 ccteam project / workflow.yaml / agent.md |
 | `ccteam-control` | 管 ccteam daemon + MCP 工具调用 |
-
-## 参考
-
-- `docs/versions/v0-5-0/prd.md` §F93a — SoT
-- `docs/versions/v0-5-0/dev-plan.md` Wave 1 — 实施

--- a/skills/ccteam-team/SKILL.md
+++ b/skills/ccteam-team/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: ccteam-team
-description: Start an Anthropic Agent Team in the current Claude session via the `/ccteam-team` entry. Use when the user says "起一个 team", "spawn a team to do X", "并行调研 X", "team N:role <task>", "make a 3-debugger swarm", or otherwise asks to spin up multiple teammates working under the current session as lead. V0.5.0 primary path — works in any git repo, no `ccteam init` / `workflow.yaml` required. Uses Anthropic native `TeamCreate` + `Task` tools; the current session becomes the team-lead in-process.
+description: Start an Anthropic Agent Team in the current Claude session via the `/ccteam-team` entry. Use when the user says "起一个 team", "spawn a team to do X", "并行调研 X", "team N:role <task>", "make a 3-debugger swarm", or otherwise asks to spin up multiple teammates working under the current session as lead. Primary path — works in any git repo, no `ccteam init` / `workflow.yaml` required. Uses Anthropic native `TeamCreate` + `Task` tools; the current session becomes the team-lead in-process.
 ---
 
 # ccteam-team — `/ccteam-team` in current session
 
-V0.5.0 primary path (95% 用户). 用户已在项目 session 里(`cd ~/projects/blog && claude`),
+Primary path (95% 用户). 用户已在项目 session 里(`cd ~/projects/blog && claude`),
 直接输入 `/ccteam-team "<task>"` 就把当前 turn 升级成 team-lead,native `TeamCreate` +
 `Task` spawn teammates。**不切 session、不出 terminal、零 ccteam workflow.yaml 依赖**。
 
-## V0.5.0 skill family (you are here)
+## Skill 家族(本 skill 所处位置)
 
 | 意图 | Skill |
 |---|---|
@@ -94,7 +94,7 @@ kind 决策:
 
 **这一步禁止调 `TeamCreate` / `Task`** — 等用户回复。
 
-### 3.5 Codex critic teammate(F112 §D — 当 N ≥ 3 时自动加入)
+### 3.5 Codex critic teammate(当 N ≥ 3 时自动加入)
 
 When the parsed team size `N ≥ 3`, ccteam-team probes for the Codex
 CLI **once** per `/ccteam-team` invocation:
@@ -140,24 +140,14 @@ echo "codex-critic spawned (PID $!)"
 The team-lead session captures stdout/stderr to a temp file the
 synthesis loop polls for a `turn.completed` JSONL frame. **No tmux**
 — `codex exec --json` is one-shot process, output is captured
-directly. This bash-spawn path is the **only supported route** in
-V0.6.5; the spawn mechanics are guarded by
-`crates/ccteam-cli/tests/team_3reviewer_codex_critic_test.rs` (F156)
-against a stub codex via `$CCTEAM_CODEX_BIN`.
-
-**Daemon-routed variant (deferred)**: routing this spawn through the
-daemon's `CodexExecAdapter` (so cost accounting is unified with the
-F84 budget rollup) is a follow-up to F112 §D. The daemon-side
-`mcp__ccteam__advise_*` dispatch shipped via F152/F153 in V0.6.5;
-unifying the team-3-reviewer routing through it (with cost-accounting
-on top) is **explicitly deferred** to V0.7+ and tracked in the
-backlog.
+directly. This bash-spawn path is the only supported route for the
+Codex critic teammate.
 
 If `ccteam-imd` daemon is running and exposes
-`mcp__ccteam__advise_parallel` (shipped F153, V0.6.5), the skill MAY
-prefer that path instead — daemon-side cost rollup + persistent log.
-Detection: a previous turn in this session must have registered the
-MCP tool; otherwise stay on the direct Bash spawn.
+`mcp__ccteam__advise_parallel`, the skill MAY prefer that path
+instead — daemon-side cost rollup + persistent log. Detection: a
+previous turn in this session must have registered the MCP tool;
+otherwise stay on the direct Bash spawn.
 
 ### 4. 等用户回复
 
@@ -265,7 +255,7 @@ discoveries 需要新 task**。
 ## ccteam daemon + web 怎么配合
 
 本 skill 跟 ccteam daemon **完全解耦** — 不需要 `ccteam init` / `ccteam start <slug>`。
-daemon 通过 F95 全局 watcher 自动发现 `~/.claude/teams/<new-slug>/` 出现 → web `/teams`
+daemon 通过全局 watcher 自动发现 `~/.claude/teams/<new-slug>/` 出现 → web `/teams`
 tab 5s 内出现该 team 卡片(若 daemon 在跑)。
 
 用户只需要一次性:
@@ -280,10 +270,10 @@ ccteam start                        # 启 daemon(可选,纯 web 可视化用)
 ## Skill 不做什么(刻意省略)
 
 - **不写 `workflow.yaml`** — primary path 零 ccteam project 概念
-- **不修改 `.claude/settings.json`** — F94 hook 注入是 F93b advanced 专属
+- **不修改 `.claude/settings.json`** — hook 注入是 advanced(`ccteam init --mode agent-team`)专属
 - **不开 bg lead session** — 当前 session **就是** lead(用户关 session = 团队停,跟
   Anthropic / OMC native 行为一致)
-- **不管 cost cap** — Anthropic 自有 usage limit;F84 budget cap 只 advanced path 用
+- **不管 cost cap** — Anthropic 自有 usage limit;daemon-side budget cap 只 advanced path 用
 - **不写 `~/.claude/teams/` 或 `~/.claude/tasks/` 文件** — Anthropic SoT,只读
 - **不抄 OMC 5-stage pipeline**(`team-plan → team-prd → exec → verify → fix`)—
   ccteam 鼓励 shape-agnostic,pipeline / debate / parallel review / vote 都行,lead 自决
@@ -300,16 +290,13 @@ ccteam start                        # 启 daemon(可选,纯 web 可视化用)
 ## What this skill cannot do
 
 - 不能跨 session 跑 — 当前 session 关 / `claude` exit 后 team 也停。要 24×7 long-running
-  team,走 advanced path:`ccteam init --mode agent-team <slug>` + `ccteam start <slug>`(F93b)
+  team,走 advanced path:`ccteam init --mode agent-team <slug>` + `ccteam start <slug>`
 - 不能强制 plan approval gate — Claude session 一般在 user-turn 间不会"主动等";本 skill
   靠 Claude 看到"STOP, do NOT call Task yet"指令自觉停手。如发现绕过,要 fix skill body
 - 不能监控 cost — 用 `ccteam web` (`http://localhost:7331/teams/<slug>`) 或 `claude
   /cost` 看
 
-## Where to look in the repo
+## Sibling skills
 
-- `@docs/versions/v0-5-0/prd.md` §F93a — 本 skill 设计 SoT
-- `@docs/versions/v0-5-0/dev-plan.md` §"Primary path 闭环" — 实施细节
-- `@CLAUDE.md` §三 — 架构红线
 - `@skills/ccteam-control/SKILL.md` — sibling skill(管 daemon)
 - `@skills/ccteam-creator/SKILL.md` — sibling skill(创 workflow / 项目)

--- a/skills/ccteam/SKILL.md
+++ b/skills/ccteam/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ccteam
-description: ccteam 总入口 NL dispatcher。用户在 Claude session 内输入 `/ccteam <自然语言>` 触发,本 skill 把 NL 意图分类到 8 类(start-team / create-workflow / configure-im / monitor / code-scan / advise / status-debug / other)并路由到对应 sub-skill。Use when 用户说"起一个 team / 做个 TG 助理 bot / 跑 qa-loop / 看 ccteam 状态 / 扫一下代码 / 摸底新项目 / 投票决定 / second opinion / 暂停 X / 为啥撞 budget"等任何 ccteam 相关意图。所有 ship intent 对应实工 skill,不再有 placeholder fallback。
+description: ccteam 总入口 NL dispatcher。用户在 Claude session 内输入 `/ccteam <自然语言>` 触发,本 skill 把 NL 意图分类到 8 类(start-team / create-workflow / configure-im / monitor / code-scan / advise / status-debug / other)并路由到对应 sub-skill。Use when 用户说"起一个 team / 做个 TG 助理 bot / 跑 qa-loop / 看 ccteam 状态 / 扫一下代码 / 摸底新项目 / 投票决定 / second opinion / 暂停 X / 为啥撞 budget"等任何 ccteam 相关意图。所有已实现 intent 都对应真 sub-skill,不返回 placeholder fallback。
 ---
 
 # /ccteam — NL dispatcher
 
-V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内一句话描述需求,本 skill 自动判别意图 + 透传 NL 到对应 sub-skill。设计目标(详 `docs/versions/v0-6-0/prd.md` F113):
+旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内一句话描述需求,本 skill 自动判别意图 + 透传 NL 到对应 sub-skill:
 
 - 用户说"我想做个 TG 助理 bot" → 路由 `/ccteam-creator` → Pocket Assistant preset
 - 用户说"fix all TS errors" → 路由 `/ccteam-team 3 "fix all TS errors"`
@@ -16,15 +16,15 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 
 ## skill 家族(本 skill 所处位置)
 
-| 用户意图 | Skill | 状态 |
-|---|---|---|
-| **(本 skill)总入口 NL dispatcher** | **`ccteam`** | **已 ship** |
-| 起临时 team 干活(in-session 多 teammate) | `ccteam-team` | 已 ship |
-| 起新项目 / workflow / chat bot 配方 | `ccteam-creator` | 已 ship |
-| 查项目状态 / pause / resume / 跨项目 ls | `ccteam-control` | 已 ship |
-| TG / Lark / Slack 一次性 token 绑定 | `ccteam-im-setup` | 已 ship |
-| Claude + Codex 并行 advisor + 投票 | `ccteam-advise` | 已 ship |
-| 扫代码摸底 / 大码库 audit | `ccteam-scan`(V0.6.2 F141 + V0.6.5 F157)| 已 ship |
+| 用户意图 | Skill |
+|---|---|
+| **(本 skill)总入口 NL dispatcher** | **`ccteam`** |
+| 起临时 team 干活(in-session 多 teammate) | `ccteam-team` |
+| 起新项目 / workflow / chat bot 配方 | `ccteam-creator` |
+| 查项目状态 / pause / resume / 跨项目 ls | `ccteam-control` |
+| TG / Lark / Slack 一次性 token 绑定 | `ccteam-im-setup` |
+| Claude + Codex 并行 advisor + 投票 | `ccteam-advise` |
+| 扫代码摸底 / 大码库 audit | `ccteam-scan` |
 
 ## When to invoke
 
@@ -97,16 +97,16 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 
 - **不直接调 MCP tool 或 Bash 命令** — 只做 NL 分类 + slash 路由;真正执行由 sub-skill 负责
 - **不维护多轮对话状态** — 一次 turn 做一次分类 + 路由;后续多轮归 sub-skill
-- **不做 voice / 图片 / 多模态 input**(V0.7+)
-- **不接受 skill 自定义注册** — 6 sub-skill 固定(team / creator / control / im-setup / advise / scan),用户不能 `/ccteam-add-skill <name>`(由 V0.6.0 PRD F113 §"不在范围"锁定)
+- **不做 voice / 图片 / 多模态 input**(text only)
+- **不接受 skill 自定义注册** — 6 sub-skill 固定(team / creator / control / im-setup / advise / scan),用户不能 `/ccteam-add-skill <name>`
 
-## Red line — 未实现 intent **直接隐藏不渲染**(V0.6.5 F159)
+## Red line — 未实现 intent **直接隐藏不渲染**
 
-任何尚未 ship 的 intent **必须直接从 dispatcher 表面消失**,不得以下列任一形式向用户暴露:
+任何尚未实现的 intent **必须直接从 dispatcher 表面消失**,不得以下列任一形式向用户暴露:
 
 - 路由表 / Step 1 意图表里出现该 intent 行
 - Step 3 fallback dialog 4-options 列出该 intent
-- "V0.7 即将支持" / "敬请期待" 等任何 forward-looking 文案
+- "即将支持" / "敬请期待" 等任何 forward-looking 文案
 - 路由到未实现 sub-skill 后由 sub-skill 报 "尚未实现"(这种 dead-end 是用户视角最差的体验)
 
 **Ship gate**:每个新 intent 进 dispatcher 前必须先确认 ──
@@ -115,24 +115,15 @@ V0.6.0 旗舰入口。用户**无需记多个 slash 名**,在 Claude session 内
 3. 真路径在 host probe 验过
 
 满足 3 条才把 intent 加进 Step 1 表 + Step 2 路由表 + Step 3 fallback 字母选项。Dispatcher
-4-options 动态按 NL 推断 + ship 状态选出最相关的 4 个(V0.6.5 ship 后 7 intent 全可见)。
+4-options 动态按 NL 推断挑出最相关的 4 个。新 intent 在落地前 4-options 表 / 路由表里**不能预占行**;落地当天才加进来。
 
-V0.6.6+ 新 intent ship 前 4-options 表 / 路由表里**不能预占行**;ship 当天才加进来。
+## Sibling skills
 
-## Where to look in the repo
-
-- `@docs/versions/v0-6-0/prd.md` — F113 完整需求 + 验收(dispatcher 初版)
-- `@docs/versions/v0-6-5/prd.md` — F157 code-scan intent 接入
-- `@docs/versions/v0-6-0/README.md` §三 — 用户面入口 + sub-skill 一览
 - `@skills/ccteam-team/SKILL.md` — start-team 详细行为
 - `@skills/ccteam-control/SKILL.md` — monitor / status-debug 详细行为
 - `@skills/ccteam-creator/SKILL.md` — create-workflow 详细行为
 - `@skills/ccteam-scan/SKILL.md` — code-scan 详细行为(quick + audit 两 mode)
-
-## 当前状态
-
-- ✅ frontmatter + 意图分类提示词 + 路由表 + fallback dialog 全落
-- ✅ `/ccteam-creator` / `/ccteam-im-setup` / `/ccteam-advise` / `/ccteam-scan` sub-skill body 均已 ship
-- ✅ 8 intents(7 work + 1 fallback)全部对应实工 skill,不再有 placeholder
+- `@skills/ccteam-im-setup/SKILL.md` — IM token onboarding
+- `@skills/ccteam-advise/SKILL.md` — Claude + Codex parallel advisor
 
 本 dispatcher 在所有 sub-skill 前面加一层 NL→slash 翻译,体验从"记多个 slash"→"说人话"。


### PR DESCRIPTION
## Finding
User audit (2026-05-24): `skills/ccteam-team/SKILL.md` referenced `V0.5.0` + `docs/versions/v0-5-0/prd.md` + `Wave 1` — these break when user runs `ccteam init` fresh (`docs/versions/` tree only lives in dev repo, not packaged with skills).

## Scope
- Skill-audit + scrub all 7 `skills/*/SKILL.md` (+ `skills/ccteam-team/README.md` + project-lead persona): zero version refs / historical doc refs / Wave-N / F-tags / ship-status creep / PR # / commit hashes
- Add CLAUDE.md §三 new red line "skill 自洽"
- Add docs/versions/v0-6-5/README.md §5 ship gate #12 "skills self-contained grep clean"

## Audit hits per skill
| Skill | hits before | action |
|---|---|---|
| ccteam-team SKILL.md | 10 | V0.5.0/V0.6.5/F112/F84/F93b/docs/versions refs rewritten present-tense |
| ccteam-team README.md | 4 | V0.5.0 + 2 docs/versions refs removed |
| ccteam-im-setup | 9 | V0.6/V0.7 platform availability rewritten without version promises |
| ccteam-scan | 8 | V0.6.2 F141 / V0.6.5 F157 / docs/versions refs scrubbed |
| ccteam-advise | 8 | V0.6.5 F152/F153 / docs/versions refs scrubbed |
| ccteam-team SKILL.md F112 §D | (above) | bash-spawn path described without F-tag |
| ccteam-creator | 12 | V0.6.0 F114 / V0.7+ / F112 §B / V0.6.5 F146 / docs/versions refs scrubbed |
| ccteam (dispatcher) | 8 | V0.6.0/V0.6.5/F113/F157/F159 refs scrubbed; "Ship gate" capital-S kept for `dispatcher_skill_declares_hide_unimpl_red_line` test |
| ccteam-control | 7 | V0.5.0/V0.4.6 F89/V0.6.1 F128 refs scrubbed |
| project-lead persona role.md | 1 | "shipped" → "landed" (benign prose, scrubbed defensively) |

## Verification
- `grep -rnE "V\\d+\\.\\d+\|docs/versions\|Wave [0-9]\|F[0-9]+[a-z]?\\b\|F-Bug\|ship gate\|shipped" skills/*/SKILL.md` → 0 hits
- cargo test --workspace --locked --no-fail-fast: **1579/1** (unchanged baseline; 1 known flake `workflow_summary_reflects_agent_spawn_and_done_events`)
- cargo clippy --workspace --all-targets --locked -- -D warnings: clean
- `dispatcher_skill_declares_hide_unimpl_red_line` passes (case-sensitive `ship gate` grep stays clean while capital `Ship gate` marker preserved)

## Notes
- Personas under `skills/ccteam-creator/personas/*/role.md` are not direct children of `skills/*/SKILL.md` — they're outside the gate's regex. project-lead persona's `shipped` prose was scrubbed defensively anyway.
- CLAUDE.md red line documents allow-list: sibling skill refs, MCP tool names, CLI commands, stable user-facing docs (`docs/{quickstart,user-manual,task-to-command,troubleshooting,recipes}.md`).