### PR TITLE
v0.6.5: integrate new capabilities into user-facing docs (ship gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 |---|---|
 | 主分支 main HEAD | 以 `git rev-parse origin/main` 为准 |
 | Workspace version | **`0.6.5`** |
-| 测试 baseline | **`1579/1`**(`cargo test --workspace --locked --no-fail-fast`,1 fail 是 ccteam-web `workflow_summary_reflects_agent_spawn_and_done_events` running_count flake;另零星观察到 `daemon_wires_mock_channel_to_supervisor_inbox` / `daemon_dm_no_at_mention_auto_routes_to_single_bot` 等单次性 flake,均不计入 baseline)|
+| 测试 baseline | **`1583/1`**(`cargo test --workspace --locked --no-fail-fast`,1 fail 是 ccteam-web `workflow_summary_reflects_agent_spawn_and_done_events` running_count flake;另零星观察到 `daemon_wires_mock_channel_to_supervisor_inbox` / `daemon_dm_no_at_mention_auto_routes_to_single_bot` 等单次性 flake,均不计入 baseline;F163 retro PR #116 加 4 unit tests 覆盖 BlockingPool / AgentTeamsWatcher graceful drain)|
 | Clippy | **0 errors + 0 warnings**(`-D warnings` clean)|
 | 代码规模 | ~89 kLOC Rust(workspace,~62 kLOC src + ~27 kLOC tests,不含 references)|
 | 当前最新版 | **V0.6.5**(F146-F165 共 20 finding:Epic E MCP chat 桥 + Epic F advise/Codex critic + Epic G UX cohesion + Epic H 运维健壮性 + 中途 F165 mcp-serve tracing→stderr — 关 V0.6 立项时承诺但 Wave 2/3 留 STUB 的账)— 详 `docs/versions/v0-6-5/README.md` |

--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 > **A multi-agent orchestrator on top of Claude Code** — describe what you want, ccteam picks the command. No YAML. No CLI flags to memorize.
 
-![demo](docs/versions/v0-6-0/demos/30s-tg-bot-team.gif)
-
 ## What do you want to do?
 
 Pick the row that matches your goal. The right column is the command — copy-paste into any Claude session.
 
 ```
-You want to do                                 → Run this
+You want to do                                  → Run this
 ──────────────────────────────────────────────────────────────────────
-Get a feel for a new codebase / repo audit      /ccteam-scan
-Build / fix / refactor (watching it work)       /ccteam-team "<task>"
-Review a PR / get a second opinion              /ccteam-advise "<PR or path>"
-A private IM assistant (24/7, always on)        /ccteam-creator "build me a <X> assistant"
-A multi-bot IM round-table                      /ccteam-creator "a few bots in a group"
-Run a long task overnight (hands-off)           /ccteam-creator "<task>, run while I sleep"
-List / pause / resume / check spending          /ccteam-control list | pause | cost
-Wire up an IM token (Telegram / Slack / Discord)  /ccteam-im-setup
-Not sure? Just describe it in natural language  /ccteam "<what you want>"
+Get a feel for a new codebase (60 s, zero deps)  /ccteam-scan --quick
+Audit a codebase navigability / large monorepo   /ccteam-scan
+Build / fix / refactor (watching it work)        /ccteam-team "<task>"
+Cross-vendor second opinion on a hard call       /ccteam-advise "<question>"
+A private IM assistant (24/7, always on)         /ccteam-creator "build me a <X> assistant"
+A multi-bot IM round-table                       /ccteam-creator "a few bots in a group"
+Run a long task overnight (hands-off)            /ccteam-creator "<task>, run while I sleep"
+List / pause / resume / check spending           /ccteam-control list | pause | cost
+Wire up an IM token (Telegram / Slack / Discord) /ccteam-im-setup
+Verify your install / check Codex auto-critic    ccteam doctor [--check-codex-auto-critic]
+Not sure? Just describe it in natural language   /ccteam "<what you want>"
 ```
 
 > Each command is a Claude Code slash command. Type it in a `claude` session — `/ccteam <NL>` is the universal entry; the others let you skip the router when you already know the path.
@@ -41,11 +41,21 @@ The 5-minute walkthrough for "private IM assistant" (the flagship use case) live
 
 ## Three ways to talk to ccteam
 
-- **Inside a Claude session** — `/ccteam <NL>` is the universal entry; the per-task slash commands above are shortcuts.
+- **Inside a Claude session** — `/ccteam <NL>` is the universal entry; the per-task slash commands above are shortcuts. MCP tools (`mcp__ccteam__chat_*`, `mcp__ccteam__advise_*`, `mcp__ccteam__admin_*`) are the programmatic path for anything a sub-skill does.
 - **From IM** — DM your bot directly, or `@ccteam <NL admin>` inside a group for control (`pause`, `cost`, `list`, `stop everything`, …).
 - **Web dashboard** (read-only) — `http://localhost:7331` to watch workflows, transcripts, and 24h spend.
 
 The AI runs on **your computer** — it can read your files, run your commands, touch your code. Your phone / IM is just the entry point; close the laptop lid and the workflow keeps running.
+
+## Run as a daemon
+
+`ccteam start` runs the orchestrator in the foreground (or as a detached process). To stop it cleanly:
+
+```bash
+kill -TERM $(cat ~/.ccteam/ccteam.pid)   # or just Ctrl+C in the foreground terminal
+```
+
+It drains within 5 seconds, releases the web port, and unlinks its pidfile automatically. Long-running tmux chat sessions survive a daemon restart and are re-attached on the next `ccteam start` — upgrading ccteam does not lose your bot's context.
 
 ## Docs
 

--- a/docs/advanced/customize-workflow.md
+++ b/docs/advanced/customize-workflow.md
@@ -13,24 +13,24 @@
 | 加 reviewer / critic | `/ccteam-creator` 重跑(中断式)|
 | 改 budget cap | `/ccteam-control set-budget` |
 | **加新 mode / vendor / trigger** | **vim yaml**(本文)|
-| **写 V0.7+ 新 preset PR** | **vim yaml + 加 template**(本文)|
+| **写新 preset PR** | **vim yaml + 加 template**(本文)|
 
-## 二、workflow.yaml 完整 schema(V0.6)
+## 二、workflow.yaml 完整 schema
 
-位置:`<project>/.ccteam/workflow.yaml`(F83 canonical;旧 `<project>/workflow.yaml` 仅 fallback)。
+位置:`<project>/.ccteam/workflow.yaml`(canonical;旧 `<project>/workflow.yaml` 仅 fallback)。
 
 ```yaml
 version: "0.6"                       # 必;迁移时 doctor 警告
 mode: chat                           # 必,{ in_proc | bg | chat }(serde tagged enum)
                                      # 决定 HarnessAdapter 路径 + mode-specific 字段集
-enabled: true                        # F82,default true
+enabled: true                        # default true
 
-budgets:                             # F107 + F112 vendor 拆分
+budgets:                             # vendor 拆分
   claude:
     max_cost_usd_per_24h: 5.00       # 撞顶 → budget_exceeded + auto-disable
     max_agent_spawns_per_hour: 100
     max_tokens_per_turn: 200000      # chat 必填,防 100k history 烧穿
-    max_cost_per_hour: 1.50          # spike 防,F84 24h cap 不够
+    max_cost_per_hour: 1.50          # spike 防
   codex:
     max_cost_usd_per_24h: 2.00
     max_tokens_per_turn: 100000
@@ -39,22 +39,22 @@ agents:
   - role: helpful-bot                # 必,匹配 .claude/agents/<role>.md
     vendor: claude                   # default claude;{ claude | codex }(严格小写枚举)
     model: opus-4-7                  # vendor-specific(claude:opus-4-7|sonnet-4-7|haiku;codex:o4|o4-mini)
-    trigger: manual                  # { manual | watch:<path> }(V0.6.0 仅这两类)
+    trigger: manual                  # { manual | watch:<path> | schedule:<cron> | webhook:<id> }
     parallelism: 1                   # 仅 watch 有意义;manual 强制 1
     timeout: 30m
     on_timeout: escalate             # { escalate | retry | skip }
-    max_spawn_depth: 5               # F112 recursion bomb guard;default 5
+    max_spawn_depth: 5               # recursion bomb guard;default 5
     # mode: chat 专用字段(其他 mode 写了 ignore + serde warn)
-    bot_name: "@helpful_assistant"   # IM handle(F109);default 从 F112 agent_naming 池取
-    hop_limit: 3                     # bot-to-bot @ 链路上限(R6);default 3
+    bot_name: "@helpful_assistant"   # IM handle;default 从 agent_naming 池取
+    hop_limit: 3                     # bot-to-bot @ 链路上限;default 3
     compact_every_turns: 50          # default 50,0 = 禁
     compact_every_tokens: 100000     # 双触发,default 100k
 
 artifact_dirs:                       # mode: bg 专用;mode: chat 完全忽略
   - .ccteam/fix-requests/
 
-im_channels:                         # mode: chat 专用;F109 openhuman/channels
-  - kind: telegram                   # { telegram | slack | discord | email | lark | ... (V0.7+ feature) }
+im_channels:                         # mode: chat 专用;走 openhuman/channels
+  - kind: telegram                   # { telegram | slack | discord | email | lark | ... (国内 IM 在 backlog) }
     credentials_ref: default         # ~/.ccteam/im/credentials.json 内 key
     chat_kind: dm                    # { dm | group }
     acl:                             # production must-have
@@ -66,7 +66,7 @@ im_channels:                         # mode: chat 专用;F109 openhuman/channels
 
 ## 三、5 preset 的 yaml diff(从 ccteam-creator 默认产物出发)
 
-`ccteam-creator` 模板在 `crates/ccteam-core/src/templates/workflow_templates/{pocket,squad,sprint,builder,solo}.yaml`(F114)。
+`ccteam-creator` 模板在 `crates/ccteam-core/src/templates/workflow_templates/{pocket,squad,sprint,builder,solo}.yaml`。
 
 ### Pocket → IM Squad(单 bot → 多 bot 群组)
 
@@ -74,7 +74,7 @@ im_channels:                         # mode: chat 专用;F109 openhuman/channels
  agents:
    - role: helpful-bot
 +  - role: critic-bot
-+    vendor: codex                    # F112 §D auto-critic
++    vendor: codex                    # auto-critic 路径自动设置(creator Phase 3.5)
 +    bot_name: "@critic_newton"       # 自动从 agent_naming 池
  im_channels:
    - kind: telegram
@@ -120,7 +120,7 @@ im_channels:                         # mode: chat 专用;F109 openhuman/channels
 
 `/ccteam doctor --check-codex` 验装 + auth;缺则报错,不静默 fallback。
 
-## 四、`.claude/agents/<role>.md` frontmatter(V0.6 加 `vendor`)
+## 四、`.claude/agents/<role>.md` frontmatter
 
 ```markdown
 ---
@@ -128,7 +128,7 @@ name: helpful-bot                    # 必,匹配 workflow.yaml::agents.role
 description: 中文技术助手,Claude Code best practices 范围内答问
 tools: [Read, Grep, Edit, Bash]      # Claude Code subagent 白名单;漏写 = 用不上
 model: opus-4-7
-vendor: claude                       # V0.6 新;与 workflow.yaml::vendor 必须一致(doctor warn)
+vendor: claude                       # 与 workflow.yaml::vendor 必须一致(doctor warn)
 tone: 礼貌、技术准、不啰嗦
 guardrails:
   - 拒绝 rm -rf / curl 管道 sudo 类高危命令
@@ -142,7 +142,7 @@ guardrails:
 
 ## 五、自定义 persona(从 prefab 改)
 
-prefab 在 `skills/ccteam-creator/personas/<name>/`(F114),目录结构:
+prefab 在 `skills/ccteam-creator/personas/<name>/`,目录结构:
 
 ```
 personas/tech-assistant-zh/
@@ -160,18 +160,18 @@ vim skills/ccteam-creator/personas/my-custom-bot/{agent.md.tmpl,meta.toml}
 # 不需要改 Rust — skill 启动扫 personas/* 自动 pick
 ```
 
-**用户自定义 persona 不入 V0.6.0**(F114 §不在范围)— 本节是 contributor 加内置 prefab 路径;V0.7+ 才支持 user-defined。
+**用户自定义 persona 在 backlog** — 本节是 contributor 加内置 prefab 路径;用户写 markdown persona 是未来 feature。
 
-## 六、Trigger 类型(V0.6.0 仅 2 类)
+## 六、Trigger 类型
 
 | Trigger | 语义 | 并发 |
 |---|---|---|
-| `manual` | `mcp__ct__workflow_spawn_agent` / chat user 触发 | 强制 1 |
+| `manual` | `mcp__ccteam__workflow_spawn_agent` / chat user 触发 | 强制 1 |
 | `watch:<path>` | inotify(Linux) / fsevents(macOS),**项目相对路径** | `parallelism` 上限内并发 |
+| `schedule:<cron>` | tokio_cron_scheduler;cron string(5 / 6 字段)| `parallelism` 上限内 |
+| `webhook:<id>` | HTTP POST ingress(daemon 内 axum 路由 `/webhook/<id>`)| `parallelism` 上限内 |
 
-旧 `schedule` / `gate` 在 V0.6 schema error(no shim,CLAUDE.md §五);`ccteam doctor --migrate-workflow` 自动 rewrite。
-
-## 七、Handoff 模板自定义(F115)
+## 七、Handoff 模板自定义
 
 每 stage / fix-loop iteration 完,hook prompt 当前 agent 落 `.ccteam/handoffs/<workflow-slug>/stage-<N>-<role>.md`(10-30 行);后续 spawn prompt 自动 `{{include_prev_handoffs}}` 注入。
 
@@ -214,9 +214,9 @@ ccteam start my-bots
 3. **`vendor` 严格小写枚举** — `vendor: openai` ✗ / `vendor: anthropic` ✗;只 `{ claude | codex }`。
 4. **`vendor` agent.md vs workflow.yaml 不一致** — doctor warn 不 error;运行时**按 workflow.yaml 走**,agent.md 字段静默 ignore。
 5. **`watch:<path>` 是项目相对路径**(F78 修过)— `watch:/abs/path` schema error。
-6. **`tools:` 列 `mcp__ct__*` 无效** — 该工具组给 meta-agent;普通 bot 无 permission。F111 反向 `CCTEAM_DISABLE_TOOLS` 才是禁用入口。
+6. **`tools:` 列 `mcp__ccteam__*` 无效** — 该工具组给 meta-agent;普通 bot 无 permission。反向 `CCTEAM_DISABLE_TOOLS` env(group enum)才是禁用入口。
 7. **`max_spawn_depth: 0` ≠ 无限,是禁 spawn** — 想"无限"删字段走 default 5,或 `u32::MAX`。
-8. **`compact_every_tokens` 不含 cached input** — cumulative input + output,**不算** cached(F108 实现细节)。
+8. **`compact_every_tokens` 不含 cached input** — cumulative input + output,**不算** cached(implementation detail)。
 9. **Trait 接口契约不能突破** — yaml schema 只是 `HarnessAdapter` trait 的 surface 投影;trait 不支持的字段(eg. mode 1 in_proc 写 `im_channels`)加了也是死字段。改 yaml 不能让 `submit_turn` 跳过 `start_thread`、不能让 `events()` 无 `ThreadStarted`。
 
 ## 十、看实际跑的是什么
@@ -227,4 +227,4 @@ cat ~/projects/<team>-<slug>/.ccteam/workflow.yaml
 tail -f ~/projects/<team>-<slug>/.ccteam/progress.jsonl | jq 'select(.event=="agent_spawn") | {role, vendor, mode}'
 ```
 
-任何 yaml 改动 daemon **不需重启**(F82 热加载);下次 spawn 即生效。**已在跑的 thread 不受影响**(R3 永不主动 kill);要应用到现有 chat bot,显式 `/ccteam-control restart-bot <role>`。
+任何 yaml 改动 daemon **不需重启**(热加载);下次 spawn 即生效。**已在跑的 thread 不受影响**(红线:永不主动 kill);要应用到现有 chat bot,显式 `/ccteam-control restart-bot <role>`。

--- a/docs/advanced/multi-llm-codex.md
+++ b/docs/advanced/multi-llm-codex.md
@@ -1,12 +1,10 @@
 # Multi-LLM with Codex — Advanced Guide
 
-> **Audience**:已用过 V0.5.x ccteam,想理解 V0.6.0 引入的 Codex 集成怎么工作 + 怎么定制 / 双 vendor workflow 调优 / cross-vendor 限制的高级用户。新手不必读这篇 — Codex 在默认场景下对你**完全透明**。
->
-> **Source of truth**:`docs/versions/v0-6-0/{README,prd}.md` §F107 / F108 / F112。本文是消化版,优先以 prd 为准。
+> **Audience**:已经会用 ccteam,想理解 Codex 集成怎么工作 + 怎么定制 / 双 vendor workflow 调优 / cross-vendor 限制的 power user。新手不必读 — Codex 在默认场景下对你**完全透明**。
 
 ---
 
-## 1. Codex 在 V0.6.0 的定位:advanced 隐藏开关
+## 1. Codex 的定位:advanced 隐藏开关
 
 ccteam 的"低门槛 / Claude-Code-native UX"原则要求**用户从不直接选 vendor**。Codex 不是 first-class user-facing executor,而是**在 4 个明显占优场景静默接入**;其他场景默认全 Claude。
 
@@ -14,24 +12,26 @@ ccteam 的"低门槛 / Claude-Code-native UX"原则要求**用户从不直接选
 
 | 场景 | 入口(用户面)| Codex 角色 | degrade |
 |---|---|---|---|
-| **A. Parallel voting** | `/ccteam-advise <hard question>` skill | Claude + Codex 同 prompt 并发跑 advisor,合成 verdict | codex 缺 / quota → 静默 Claude-only,**不报错** |
-| **B. Auto-critic** | `ccteam-creator` skill phase 内 | 当 role ∈ {critic, reviewer, architect, code-reviewer} 且 codex 可用 → 自动赋 `vendor: codex`(yaml 内部) | codex 不可用 → 全 Claude,yaml 不写 vendor 字段 |
+| **A. Parallel voting** | `/ccteam-advise vote\|parallel "<question>"` skill(`mcp__ccteam__advise_vote` / `advise_parallel`)| Claude + Codex 同 prompt 并发跑 advisor,合成 verdict(vote)或 raw dump(parallel)| codex 缺 / quota → 静默 Claude-only,verdict prose 说 "Codex unavailable: <reason>",**不报错** |
+| **B. Auto-critic** | `ccteam-creator` skill phase 内 | 当 role ∈ {critic, reviewer, architect, code-reviewer} 且 `ccteam doctor --check-codex-auto-critic` 返回 exit 0 → 自动赋 `vendor: codex`(yaml 内部) | codex 不可用 → 全 Claude,yaml 不写 vendor 字段 |
 | **C. Quota fallback** | `~/.ccteam/preferences.toml` `fallback.on_claude_quota = "codex"` | Claude 报 quota / 5xx → 同 turn 重试 Codex 一次 | 默认 off;meta-agent 在用户抱怨 quota 时主动提议 opt-in |
 | **D. `/ccteam-team` second-opinion** | `/ccteam-team N "task ..."` skill | in-proc team 自动加 1 个 Codex critic teammate(if codex 可用) | codex 不可用 → 全 Claude,team size 不变 |
 
 **所有其他场景**(qa-loop / autonomous-orchestrator / chat-bot / 通用 executor / planner / fixer)默认 Claude。Codex 不出场。
 
+**实现路径**:advise 场景由 `crates/ccteam-core/src/advise.rs` 实现 `advise_vote` / `advise_parallel` 两个公开 fn,各自并行 spawn 一个 advisor per vendor(Claude 走 claude-tui adapter / Codex 走 `CodexExecAdapter`),合成器读 `<ccteam_root>/cost-budget.json` 做 per-vendor cap enforcement。auto-critic 场景由 `ccteam-creator` Phase 3.5 调 `ccteam doctor --check-codex-auto-critic` 子进程(exit 0/2/3 三态)决定是否写入 vendor 字段。
+
 ---
 
 ## 2. 什么时候用 Codex / Claude / 混用
 
-V0.6.0 ccteam-creator skill 内部按下表自动决策。手编 `workflow.yaml` 的高级用户可参考:
+ccteam-creator skill 内部按下表自动决策。手编 `workflow.yaml` 的高级用户可参考:
 
 | 场景 | 推荐 vendor | 理由 |
 |---|---|---|
 | 长链 reasoning(architect / planner / hard debug)| **Codex** o-series / gpt-5.2-codex | `reasoning_output_tokens` 单独计费,长 CoT 强项;sandbox 默认严格 |
 | 编辑大量代码(executor / fixer / multi-file edit)| **Claude** Opus 4.x / Sonnet | tool use 稳定性 + ephemeral 1h cache 显著省 token |
-| 长跑 chat bot(mode 3)| **Claude** | `claude -p --resume` stream-json + cache hit turn 2 起,V0.6.0 Codex chat 走 V0.7 |
+| 长跑 chat bot(mode 3)| **Claude**(目前) | `claude -p --resume` stream-json + cache hit turn 2 起;Codex chat 在 backlog |
 | Multi-advisor 投票(同 prompt 多视角)| **混合** | Claude + Codex 各跑一次,合成"双方同意 / 冲突 + 选谁"— 见场景 A |
 | 严格 sandbox + approval workflow | **Codex** | sandbox + approval_policy 是 first-class config;Claude 只能靠 hook 模拟 |
 | Critic / code-reviewer / architect role | **Codex**(自动)| 长链 reasoning 强,二阶意见更有价值 |
@@ -69,22 +69,27 @@ ccteam 内部跑 codex 用 `--profile ccteam-default` 引这套;**用户不必�
 默认 doctor 不强求 codex(全 Claude workflow 不 nag)。显式查:
 
 ```bash
-ccteam doctor --check-codex-version    # 报告 binary 版本 / 是否 ≥0.45
-ccteam doctor --check-codex-auth       # codex account 探活
-ccteam doctor --install-codex-profile  # 落 ~/.codex/config.toml [profiles.ccteam-default]
+ccteam doctor --check-codex                  # binary 存在 + auth ok
+ccteam doctor --check-codex-auto-critic      # 跑一次 codex exec --json canary,验 auto-critic 路径可用
+ccteam doctor --install-codex-profile        # 落 ~/.codex/config.toml [profiles.ccteam-default]
 ```
+
+`--check-codex-auto-critic` 退出码:
+- **0** = codex 可用 + canary 输出格式良好(`turn.completed` JSONL 解析通过)→ `ccteam-creator` 给 critic role 自动注入 `vendor: codex`
+- **2** = binary 缺 / 版本探测失败 → 不注入,纯 Claude
+- **3** = output 格式异常(codex 升级后协议漂移)→ silent fallback,不注入
 
 doctor 输出语义:
 
 ```
 [ok]   claude --version: 2.0.x
-[ok]   codex --version: 0.45.x         ← --check-codex-version
-[ok]   codex auth: user@example.com    ← --check-codex-auth
+[ok]   codex --version: 0.45.x
+[ok]   codex auth: user@example.com
 [ok]   ~/.codex/config.toml profile ccteam-default present
 [info] workflow.yaml: 2/5 agent vendor=codex (auto-assigned by ccteam-creator)
 ```
 
-workflow 含 `vendor: codex` 但 codex auth 缺 → **启动前**报错,不等到 spawn 才挂(F112 验收 §4)。
+workflow 含 `vendor: codex` 但 codex auth 缺 → **启动前**报错,不等到 spawn 才挂。
 
 ---
 
@@ -164,8 +169,9 @@ agents:
 | `crates/ccteam-cost/pricing/anthropic.toml` | Claude 各 tier 定价(`opus-4-7` / `sonnet-4-5` / `haiku-4-5`),含 `cache_creation_input_tokens` / `cache_read_input_tokens` 写入价 + 命中价 |
 | `crates/ccteam-cost/pricing/openai.toml` | Codex 各 tier 定价(`gpt-5.2-codex` / `o3` / `o3-mini`),含 `reasoning_output_tokens` 单独计费 |
 | `crates/ccteam-cost/src/budget.rs` | `UnifiedTokenUsage` enum + per-vendor budget cap |
+| `<ccteam_root>/cost-budget.json` | advise.rs 的 per-vendor ledger(48h 自动 GC,atomic-rename 写入)|
 
-`UnifiedTokenUsage`(详 prd F107 §D)是 superset,容两边字段;`progress.jsonl::agent_done.usage` 序列化此结构。
+`UnifiedTokenUsage` 是 superset,容两边字段;`progress.jsonl::agent_done.usage` 序列化此结构。
 
 #### Per-vendor budget cap
 
@@ -178,7 +184,7 @@ budgets:
     max_cost_usd_per_24h: 2.0
 ```
 
-**触底行为**:任一 vendor 触底 → workflow 整体 `enabled: false`(F84 红线),emit `vendor_budget_exhausted { vendor }` event;**不**自动切另一 vendor(避免行为漂移)。
+**触底行为**:任一 vendor 触底 → workflow 整体 `enabled: false`(红线),emit `vendor_budget_exhausted { vendor }` event;**不**自动切另一 vendor(避免行为漂移)。advise 场景例外:某 vendor 撞 cap → 静默跳过该 vendor 跑其余,verdict 标注 `budget_exhausted`。
 
 #### 用户面展示(MCP `workflow_show_cost`)
 
@@ -208,7 +214,7 @@ ln -s CLAUDE.md AGENTS.md         # ccteam init 默认行为(Linux / macOS)
 
 Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sync-agents-md.sh`)。doctor 检测 drift,落 finding。
 
-**用户改 CLAUDE.md 自动反映到 AGENTS.md**(symlink),Codex bot 看到同一份项目规则。R8 红线(跨项目记忆走官方接口)扩到 "两边官方路径,ccteam 不写第三份"。
+**用户改 CLAUDE.md 自动反映到 AGENTS.md**(symlink),Codex bot 看到同一份项目规则。"跨项目记忆走官方接口"红线扩到"两边官方路径,ccteam 不写第三份"。
 
 ---
 
@@ -216,9 +222,9 @@ Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sy
 
 | 跨 vendor 场景 | 可行性 | 原因 |
 |---|---|---|
-| **模式 1 in-proc team(同 parent session)** | ✗ **永远不可能** | Anthropic 官方 `TeamCreate` 文档明示 "workers are Claude sessions";Codex 同理只能 spawn Codex 子 thread。**没有任何技术路径**让一个 Claude session 把 Codex 作 in-proc teammate。详 prd CC9 |
+| **模式 1 in-proc team(同 parent session)** | ✗ **永远不可能** | Anthropic 官方 `TeamCreate` 文档明示 "workers are Claude sessions";Codex 同理只能 spawn Codex 子 thread。**没有任何技术路径**让一个 Claude session 把 Codex 作 in-proc teammate |
 | **模式 2 bg sessions 跨 vendor** | ✓ | ccteam orchestrator 是外置中转;`.ccteam/inbox/*.md` 触发 fresh `claude --bg` / `codex exec`;`progress.jsonl::agent_done.vendor` 字段区分 |
-| **模式 3 chat bots 跨 vendor**(同 TG 群)| V0.7+ | V0.6.0 chat mode 锁 Claude(F108);Codex chat 需 F112 `CodexAppServerAdapter`(已 ship V0.6.0) |
+| **模式 3 chat bots 跨 vendor**(同 TG 群)| ✓ | `ClaudeStreamJsonAdapter` + `CodexAppServerAdapter` 各管各 bot;Codex chat bot 已可启用 |
 | **Auto-fallback Claude↔Codex**(同任务自动切)| ⚠ opt-in only | 场景 C,默认 off;两边 system prompt 不同 + sandbox 不同 + cost model 不同,**自动切换会让 debug 极难找根因** — 用户显式开 |
 
 #### Cross-vendor 桥协议(mode 2 跨 vendor 时)
@@ -236,18 +242,16 @@ Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sy
 
 | Cell | Codex 列 | 注 |
 |---|---|---|
-| Chaining × mode 1 × Codex | ⚠ | Codex 原生 `spawn_agent` 但 ccteam-team skill 是 Claude session-local — 跨 vendor in-proc 不可行(CC9) |
+| Chaining × mode 1 × Codex | ⚠ | Codex 原生 `spawn_agent` 但 ccteam-team skill 是 Claude session-local — 跨 vendor in-proc 不可行 |
 | Chaining × mode 2 × Codex | ✓ | `codex exec` artifact-driven,行为对齐 Claude |
-| Chaining × mode 3 × Codex | ✗(V0.6.0) | 需 `CodexAppServerAdapter`,F112(已 ship V0.6.0) |
+| Chaining × mode 3 × Codex | ✓ | `CodexAppServerAdapter` UDS bridge |
 | Routing × all × Codex | ⚠ | Codex routing config-driven(role.toml 选模型),跟 Claude SKILL.md prompt-driven routing **不等价**;用户面统一走 `ccteam-creator` 自动选,内部 routing 各管各 |
 | Parallel-vote × mode 1 × Codex | ✓ | 场景 A `/ccteam-advise` 头条用例 |
 | Parallel-segment × mode 2 × mixed | ✓ | git worktree per agent,vendor 标在 progress event |
-| Orchestrator-Worker × mode 3 × Codex | ✗(V0.6.0) | 同 chaining mode 3 |
+| Orchestrator-Worker × mode 3 × Codex | ✓ | 同 chaining mode 3 |
 | Evaluator-Optimizer × mode 2 × Codex | ✓ | critic 角色自动接 Codex(场景 B) |
-| Evaluator-Optimizer × mode 1 × mixed | ✗ | 同 CC9 |
+| Evaluator-Optimizer × mode 1 × mixed | ✗ | in-proc 跨 vendor 物理不可能 |
 | **In-proc 跨 vendor 任意 cell** | ✗ **永远** | 物理不可能 |
-
-**总计 30 cell 状态**:✓ 11 / ⚠ 2 / ✗ 4(mode 1 跨 vendor 全 ✗,共 5 cell;mode 3 Codex 单 vendor V0.6.0 共 5 cell ✗ 已 ship via F112);其余 V0.6.0 不展开。
 
 ---
 
@@ -258,16 +262,16 @@ Windows 无 POSIX symlink → 副本 + git pre-commit hook 守同步(`scripts/sy
 | **Codex sandbox 默认 read-only** | bot 想写文件失败 "permission denied",静默 | workflow.yaml 显式 `codex_sandbox: workspace-write`;Claude 的 `--dangerously-skip-permissions` **无 Codex 等价** — 必须配 sandbox + approval=never 才同效果 |
 | **`reasoning_output_tokens` 单独计费** | `gpt-5.2-codex` o-series 跑 fix-loop 3 次 bill 看起来比 Claude 贵 3x | `medium` reasoning effort 已是默认;`high` 只在 architect role 用,不在 executor;监控 `progress.jsonl::*.usage.reasoning_output_tokens` 比 input/output 还大就是 effort 配错 |
 | **AGENTS.md 不读 → bot 行为漂移** | Codex bot 不知道项目规则,Claude bot 知道 | doctor 检测 `<repo>/AGENTS.md` 存在且 symlink 到 CLAUDE.md;CI 加 trufflehog 扫 AGENTS.md / CLAUDE.md drift |
-| **Codex CLI 形态漂移激进** | `codex exec` 升级后 flag 改、`--experimental-json` API 变 | `CCTEAM_CODEX_BIN` env override(同 `CCTEAM_CLAUDE_BIN`);prd pin `codex >= 0.45`,V0.6.x 任何 codex breaking 升 ccteam patch 版兜底 |
+| **Codex CLI 形态漂移激进** | `codex exec` 升级后 flag 改、`--experimental-json` API 变 | `CCTEAM_CODEX_BIN` env override(同 `CCTEAM_CLAUDE_BIN`);pin `codex >= 0.45`,任何 codex breaking 升 ccteam patch 版兜底 |
 | **OpenAI auth 比 Anthropic 复杂** | `codex login` 4 路(ChatGPT plan / API key / device code / access token)首次失败率高 | doctor 强制 `codex account` 探活;workflow.yaml validate `vendor: codex` 但 auth 缺 → 启动前 abort |
-| **session-id 命名空间冲突** | Claude bot 和 Codex bot 同 workflow,session-id 文件互覆盖 | 内部路径 `~/.ccteam/im/<workflow>/<bot>/<vendor>/session-id` 强制 vendor 段;此 path V0.6.0 已固化(prd F112) |
-| **cross-vendor in-proc 期望** | 用户问"为啥 `/ccteam-team` 不能起 Claude + Codex 混合 in-proc 队伍" | 解释 CC9 物理限制:跨进程通过 mode 2 `.ccteam/inbox/` 桥可实现近似效果,但 in-proc(同 session)永不可能 |
+| **session-id 命名空间冲突** | Claude bot 和 Codex bot 同 workflow,session-id 文件互覆盖 | 内部路径 `~/.ccteam/im/<workflow>/<bot>/<vendor>/session-id` 强制 vendor 段 |
+| **cross-vendor in-proc 期望** | 用户问"为啥 `/ccteam-team` 不能起 Claude + Codex 混合 in-proc 队伍" | 物理限制:跨进程通过 mode 2 `.ccteam/inbox/` 桥可实现近似效果,但 in-proc(同 session)永不可能 |
 
 ---
 
 ## See also
 
-- `docs/versions/v0-6-0/prd.md` §F107 / F108 / F112 — 完整 finding 设计
 - `docs/orchestration-patterns.md` §五 — 5 拓扑 × 3 执行模式适用矩阵全表
-- `docs/versions/v0-6-0/README.md` §4.3 — Codex 4 用户可见场景的 UX 决策记录
-- `CLAUDE.md` §三 红线表 — R3 / R4 / R6 / R8 在模式 × vendor 下的措辞
+- `docs/tech-design.md` §2.1 / §3.3 — HarnessAdapter trait + vendor enum
+- `docs/interfaces.md` — workflow.yaml schema + MCP tool surface + CLI lifecycle
+- `CLAUDE.md` §三 红线表 — 模式 × vendor 下的措辞

--- a/docs/advanced/presets-reference.md
+++ b/docs/advanced/presets-reference.md
@@ -164,7 +164,7 @@ turns_jsonl: <project>/.ccteam/chat/<bot>/turns.jsonl    # ccteam-owned conversa
 {"turn_id":"...","ts":"...","user":"...","assistant":"...","usage":{"input_tokens":...,"output_tokens":...,"cache_read_input_tokens":...},"tool_calls":[...],"vendor":"claude"}
 ```
 
-`session_id_persist` 文件丢失 / Anthropic 内部 jsonl 改格式 → fail-open + 从 `turns_jsonl` last-N turn 重建 conversation(详 F118)。
+`session_id_persist` 文件丢失 / Anthropic 内部 jsonl 改格式 → fail-open + 从 `turns_jsonl` last-N turn 重建 conversation。
 
 ---
 
@@ -209,8 +209,8 @@ budgets:
 
 `bot_to_bot.routing` 选项:
 - `at_mention` — 只有显式 @ 才转发(默认)
-- `keyword` — agent prompt 内置关键词触发(进阶,V0.7+)
-- `pubsub` — 任何 bot 发言所有其他 bot 都看到(危险,V0.7+ 仅小群组)
+- `keyword` — agent prompt 内置关键词触发(在 backlog)
+- `pubsub` — 任何 bot 发言所有其他 bot 都看到(在 backlog,且限小群组)
 
 `hop_escalate_to`:`user` / `lead` / `none`(撞 limit 自动停)
 
@@ -236,9 +236,9 @@ budgets:
 
 `im.transport` 字段:
 
-| 值 | 形态 | provider 支持(V0.6.0) |
+| 值 | 形态 | provider 支持 |
 |---|---|---|
-| `openhuman`(default)| `ccteam-imd` daemon + `openhuman/channels` crate | Telegram / Slack / Discord(V0.6.0);Lark / DingTalk / QQ feature gate(V0.7 启用) |
+| `openhuman`(default)| `ccteam-imd` daemon + `openhuman/channels` crate | Telegram(stable);Slack / Discord(provider Rust 就位,onboarding skill 在 backlog);Lark / DingTalk / QQ / WeChat(feature gate,onboarding 在 backlog)|
 | `official-telegram` | `claude --channels plugin:telegram@claude-plugins-official` | Telegram only |
 
 切换走 `/ccteam-im-setup --transport <name>`,不让用户编辑 yaml。两 path 互斥(同 bot token 不可同时绑两条)。
@@ -303,4 +303,4 @@ agents:
 - 5 preset 用户文档:[user-manual.md](../user-manual.md)
 - 自定义改造:[advanced/customize-workflow.md](customize-workflow.md)
 - Codex 集成深拆:[advanced/multi-llm-codex.md](multi-llm-codex.md)
-- 架构权威:`docs/tech-design.md` + `docs/interfaces.md` + `docs/architecture/orchestration-patterns.md`(V0.6.0 重组后路径)
+- 架构权威:`docs/tech-design.md` + `docs/interfaces.md` + `docs/orchestration-patterns.md`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,18 +13,57 @@
 ```
 你想做的事                                  → 用这个
 ──────────────────────────────────────────────────────────────────
-摸底新代码库 / 仓库 audit                    /ccteam-scan
+摸底新代码库(60s 零依赖,首选)              /ccteam-scan --quick     ↓ §1.5 详跑
+仓库 navigability 体检 / 大型 monorepo audit  /ccteam-scan
 开发 / 修 bug / 重构(全程盯着干)            /ccteam-team "<task>"
-review PR / 第二意见 / 对答案                /ccteam-advise "<PR 或 path>"
+跨 vendor 第二意见(Claude + Codex)          /ccteam-advise "<问题>"   ↓ §4 详跑
 做个 IM 私聊助理(长期 24/7 在线)            /ccteam-creator "做个 X 助理"  ↓ §2 详跑通
 做个团队 IM 圆桌(多 bot 互动)               /ccteam-creator "群里几个 bot"
 夜里跑长任务(hands-off / 关电脑)            /ccteam-creator "<task>,睡前跑"
+程序化起 bot / 看历史 / 重置 session         mcp__ccteam__chat_*      ↓ §5 详跑
 看 / 暂停 / 恢复 / 看花费                    /ccteam-control list / pause / cost
 配 / 改 IM token(TG / Slack / Discord)      /ccteam-im-setup
+验证安装 / 验 Codex auto-critic              ccteam doctor [--check-codex-auto-critic]
 不确定?用自然语言问                          /ccteam "<NL 描述>"
 ```
 
 每条详解 + 例子见 [task-to-command.md](task-to-command.md)。
+
+---
+
+## §1.5 60 秒上手:`/ccteam-scan --quick`(零依赖,首选)
+
+第一次摸 ccteam,如果你不打算立刻起 bot,**最低门槛的体验**就是 `--quick` 扫一个本地仓库:无需 IM token、无需 daemon、无需 Codex,只调一次 Sonnet,1 分钟内给你三段报告(主语言/框架/入口 · TODO 热点 · `CLAUDE.md` / `AGENTS.md` 状态)+ 一句建议你下一步该跑哪个 ccteam 命令。
+
+```bash
+cd path/to/any-repo
+claude
+```
+
+session 里:
+
+```
+/ccteam-scan --quick
+```
+
+输出大致这样:
+
+```
+ccteam-scan (quick) → <repo>/.ccteam/codebase-scan.md
+
+[1/3] Language / framework / entry
+  Rust workspace · tokio + axum · entry crates/ccteam-cli/src/main.rs
+
+[2/3] TODO / FIXME hotspots
+  crates/ccteam-imd/src/outbound.rs: 4 TODO
+  docs/troubleshooting.md: 2 FIXME
+
+[3/3] CLAUDE.md / README / AGENTS.md status
+  CLAUDE.md ✓ (180 lines, current) · README.md ✓ (English) · AGENTS.md → CLAUDE.md symlink ✓
+  建议下一步:用 /ccteam-team 处理 TODO,或 /ccteam-creator 起一个长跑 bot 监控这堆 hotspot
+```
+
+24h 内复跑会直接显示上次报告(`--force` 强制重扫)。**不**写 git / 不开 daemon / 不动 `~/.ccteam/`。
 
 ---
 
@@ -56,10 +95,12 @@ $ claude
 预期输出:
 
 ```
-✓ Installed ccteam@0.6.0
-  • 5 slash commands registered: /ccteam, /ccteam-team, /ccteam-creator, /ccteam-control, /ccteam-im-setup
-  • mcp__ccteam__* tools available
+✓ Installed ccteam
+  • slash commands registered: /ccteam, /ccteam-team, /ccteam-creator, /ccteam-control, /ccteam-im-setup, /ccteam-scan, /ccteam-advise
+  • mcp__ccteam__* tools available (workflow_* / chat_* / advise_* / admin_* / screenshot_*)
 ```
+
+跑 `ccteam doctor` 验装(claude CLI / MCP / tmux / pidfile 路径都查一遍);加 `--check-codex-auto-critic` 验证 Codex 二审是否能开。
 
 → 卡了?见 [troubleshooting.md](troubleshooting.md) "plugin install 失败"。
 
@@ -136,6 +177,45 @@ You:     go
 ## Step 5 — 跨设备试试(可选)
 
 笔记本继续开着,掏手机走开,继续在 TG 跟 bot 聊。bot 仍然回。bot 跑在**你电脑上**(能动文件 / 跑命令),手机只是入口 — 这是跟 ChatGPT app 拉开差异的关键。
+
+---
+
+## §4 跨 vendor 第二意见:`/ccteam-advise`(可选)
+
+碰到拿不准的设计 / PR / 代码片段,想要 Claude + Codex 两边各给一个答案再自己拍板:
+
+```
+/ccteam-advise vote "这段 SSO 设计的 token-refresh 路径有没有竞态?"
+```
+
+ccteam 并行调用 Claude + Codex 两个 advisor,合成 verdict(majority / unanimous / split),附每个 vendor 的原始答复 + 估算 cost。`parallel` 模式不合成,直接给两份 raw answer 让你自己读:
+
+```
+/ccteam-advise parallel "重构这段 auth 中间件有几种方式?"
+```
+
+**前置**:Codex 装好(`codex --version`)+ `codex login` 跑过。没装 ccteam 会 graceful 降级跑单 Claude advisor,verdict prose 说 "Codex unavailable: <reason>",**不报错**。两个 vendor 各自走 24h cost cap(`<ccteam_root>/cost-budget.json`,撞顶自动跳过该 vendor)。
+
+底层 MCP 工具:`mcp__ccteam__advise_vote` / `mcp__ccteam__advise_parallel`。
+
+---
+
+## §5 程序化起 bot:chat MCP 工具(可选)
+
+`/ccteam-creator` 是新手 onboarding 通路;**已经懂 ccteam** 之后,从 Claude session 内直接调 MCP 工具更快:
+
+```
+mcp__ccteam__chat_register_bot { "slug": "helper", "role": "main", "vendor": "claude", "im_chat_id": "123456789" }
+mcp__ccteam__chat_list_bots {}
+mcp__ccteam__chat_send_input { "slug": "helper", "role": "main", "text": "summarize today's PRs" }
+mcp__ccteam__chat_history { "slug": "helper", "role": "main", "limit": 10 }
+mcp__ccteam__chat_reset { "slug": "helper", "role": "main" }
+mcp__ccteam__chat_unregister_bot { "slug": "helper", "role": "main" }
+```
+
+6 个工具组成完整生命周期:register → list / send_input / history → reset → unregister。`chat_reset` 归档 `turns.jsonl` 到 `archive/turns-<ts>.jsonl` + 清 outbound cursor + 清 transcript cursor(daemon 内存与磁盘同步重置)。`vendor` 字段严格小写枚举:`claude` 或 `codex`。
+
+适合场景:CI 编排起多个 bot 做 batch / 给已跑 bot 推一个程序化指令 / 抓 bot 历史做 audit。**仍然守红线**:per-bot tmux session、`progress.jsonl` 是 state SoT、不写 prompt。
 
 ---
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,4 +1,4 @@
-# Recipes — 8 个 ready-to-go 配方
+# Recipes — ready-to-go 配方
 
 > 这是一份"照菜单点"的快速起手册。每个配方告诉你 **一句话怎么起、起出来是啥、每天大约花多少钱**。
 >
@@ -362,7 +362,7 @@ final 输出 → 你点 reaction 表示接受 / 让某个 bot 重做一段
 
 ### 适合谁
 
-任何"我要 V0.6.0 一上来就玩 Codex 集成"的早期采用者;严肃多模块改动场景。
+想从 day-1 用 Codex 集成的早期采用者;严肃多模块改动场景。
 
 ### 起步
 
@@ -437,7 +437,7 @@ ccteam-creator 推断:**混合** — Overnight Builder 跑长任务 + Pocket Ass
 ```
 PROJECT PLAN
 ============
-Type:           Pocket Assistant + Overnight Builder(混合配方,V0.6.0 验证项)
+Type:           Pocket Assistant + Overnight Builder(混合配方)
 Bot:            @project_lead(persona: 项目监工 中文版)
 白天角色:        TG 私聊回答进度问题、收新需求、整理 backlog
 夜里角色:        跑 test → fix bug → 生成晨报
@@ -477,6 +477,161 @@ Reply 'go' 启动。
 ### 想改?
 
 [进阶定制 — 调白天 / 夜里时段 / 改通知策略 / 加多人协作](advanced/customize-workflow.md#hybrid-project-lead)
+
+---
+
+## 配方 9 — 60s 摸底新开源项目(零 token,零依赖)
+
+### 场景
+
+> "我刚 clone 一个开源项目,想 60 秒知道它是干啥的 / TODO 集中在哪 / 文档齐不齐,再决定要不要深读。"
+
+### 适合谁
+
+任何刚 clone 仓库的人 / 评估一个候选依赖 / 给团队做 due-diligence 的 lead。**第一次接触 ccteam 也用这条** — 不开 daemon、不绑 IM、不需 Codex,纯单 Sonnet 调用看价值。
+
+### 起步
+
+```bash
+cd path/to/repo
+claude
+```
+
+session 里:
+
+```
+/ccteam-scan --quick
+```
+
+### 用法
+
+约 60 秒后,报告写到 `<repo>/.ccteam/codebase-scan.md`,session 内直接渲染:
+
+```
+[1/3] Language / framework / entry
+  Rust workspace · tokio + axum · entry crates/foo-cli/src/main.rs
+
+[2/3] TODO / FIXME hotspots
+  crates/foo-core/src/worker.rs: 7 TODO / 2 FIXME
+  docs/architecture.md: 3 TODO
+
+[3/3] CLAUDE.md / README / AGENTS.md status
+  CLAUDE.md ✗ (建议 claude /init)· README.md ✓ (English) · AGENTS.md 缺
+  建议下一步:跑 claude /init 写一份 CLAUDE.md;或 /ccteam-team 干掉 worker.rs 那 7 个 TODO
+```
+
+24h 内复跑直接显示上次报告(`--force` 强制重扫)。
+
+### 预期 cost
+
+每次 ≈ $0.01-0.03(单 Sonnet 调用,小中型仓库)。
+
+---
+
+## 配方 10 — Claude + Codex 双 vendor 二审一个设计决策
+
+### 场景
+
+> "我在拿不准的设计决策上想要 Claude 和 Codex 两边各给一份分析,看两边同不同意,再自己拍板。"
+
+### 适合谁
+
+任何"拿不准"场景:架构选型、PR 评审、棘手 bug 根因、性能优化路径选择。
+
+### 起步
+
+前置:`codex login` 跑过(可用 `ccteam doctor --check-codex-auto-critic` 一条命令验)。
+
+```
+/ccteam-advise vote "我们的 SSO token refresh 路径,放 redis 缓存还是走 DB 行锁?各自的故障模式有哪些?"
+```
+
+### 用法
+
+ccteam 并行调 Claude + Codex 两个 advisor,合成一份 verdict:
+
+```
+VERDICT: split
+Claude (Opus): 推荐 redis,理由 (1) 延迟低 (2) 失效自动... [完整答复 ~500 字]
+Codex (gpt-5.2-codex): 推荐 DB 行锁,理由 (1) 强一致 (2) 不依赖独立组件...
+
+差异点:
+  - 一致性 vs 延迟 trade-off 选不同
+  - Claude 假设 redis 高可用;Codex 假设 redis 是 SPOF
+
+Cost: Claude $0.02 + Codex $0.03 = $0.05
+```
+
+`parallel` 模式不合成,直接给两份 raw answer 让你自己读:
+
+```
+/ccteam-advise parallel "重构这段 auth 中间件有几种方式?"
+```
+
+### 生成什么
+
+无文件落盘(单次跑完即用)。两 vendor 各自走 24h cost cap(记账 `<ccteam_root>/cost-budget.json`,48h 自动 GC)。某 vendor 撞顶 → 静默跳过,verdict 标 `budget_exhausted`。
+
+### 预期 cost
+
+- 单次 vote ≈ **$0.01-0.05**(两 vendor 各跑一次)
+- 单次 parallel 同上
+
+### 想改?
+
+[Codex 集成进阶](advanced/multi-llm-codex.md):自定义 Codex sandbox / reasoning effort / 切默认 vendor。
+
+---
+
+## 配方 11 — 程序化起一个长跑 IM bot(MCP 路径)
+
+### 场景
+
+> "我已经懂 ccteam,想从 Claude session 内一句 MCP call 起 / 改 / 重置一个 chat bot,不走 /ccteam-creator 向导。"
+
+### 适合谁
+
+CI 编排 / 批量起多个 bot / power user 想跳过向导 / 自动化测试 / 给已跑 bot 推程序化指令。
+
+### 起步
+
+前置:`ccteam-im-setup` 跑过(token 落 `~/.ccteam/im/credentials.json`)。session 里直接调 MCP:
+
+```json
+{ "name": "mcp__ccteam__chat_register_bot",
+  "args": { "slug": "helper", "role": "main", "vendor": "claude", "im_chat_id": "123456789" } }
+```
+
+### 用法
+
+```json
+mcp__ccteam__chat_list_bots {}
+→ { "bots": [ { "slug": "helper", "role": "main", "running": true, "heartbeat_age_secs": 7 } ] }
+
+mcp__ccteam__chat_send_input { "slug": "helper", "role": "main", "text": "summarize today's PRs" }
+
+mcp__ccteam__chat_history { "slug": "helper", "role": "main", "limit": 5 }
+→ { "turns": [ {"turn_id":"...", "user":"...", "assistant":"..."} ] }
+
+mcp__ccteam__chat_reset { "slug": "helper", "role": "main" }
+→ { "ok": true, "archived": "archive/turns-1716527890123.jsonl" }
+
+mcp__ccteam__chat_unregister_bot { "slug": "helper", "role": "main" }
+```
+
+### 生成什么
+
+`<ccteam_root>/imd/registry/<slug>/<role>.json` + `<role>.heartbeat`(daemon 自维护)。`vendor` 字段严格小写枚举(`claude` / `codex`),3 层校验(schema enum / dispatch `to_lowercase()` / serde `rename_all`)。
+
+`chat_reset` 归档 `turns.jsonl` 到 `archive/turns-<unix-ms>.jsonl` + 清 outbound cursor + 清 transcript cursor(daemon 内存 + 磁盘同步重置 — 不留 race)。
+
+### 预期 cost
+
+MCP 工具本身 0 cost(纯文件操作 + daemon coordination);bot 跑起来后按 turn 计费。
+
+### 想改?
+
+[进阶定制](advanced/customize-workflow.md):workflow.yaml 字段 / multi-bot per slug / cross-vendor squad。
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,10 +1,8 @@
 # ccteam 故障排查手册
 
-> V0.6.1 起。主入口都在 Claude session 内:`/ccteam-control`(运行时)、`/ccteam-creator`(新建项目)、`/ccteam-team`(临时 team)、`/ccteam-im-setup`(TG 配置)、`/ccteam-advise`(双 LLM 投票)+ 总入口 `/ccteam <NL>`。**诊断**走 **CLI**:在任意终端跑 `ccteam doctor`(详细诊断,80% 卡点它自动检出);Claude session 内可以 `Bash("ccteam doctor")` 一键调用。还卡再查本手册。
+> 主入口都在 Claude session 内:`/ccteam`(总入口)、`/ccteam-scan`(摸底)、`/ccteam-team`(临时 team)、`/ccteam-creator`(新建项目)、`/ccteam-control`(运行时)、`/ccteam-im-setup`(TG 配置)、`/ccteam-advise`(双 LLM 投票)。**诊断**走 **CLI**:在任意终端跑 `ccteam doctor`(详细诊断,80% 卡点它自动检出);Claude session 内可以 `Bash("ccteam doctor")` 一键调用。还卡再查本手册。
 >
-> **V0.6.1 ship policy 提示**:本手册示例以 `ccteam doctor` 命令行为准;V0.6.0 早期文档曾写 `/ccteam-doctor` slash 形式,**该 slash 不存在**(F127 manual-prover sweep 校正)。
->
-> 进阶 fix path:`docs/versions/v0-6-1/prd.md` 找 F-finding,`docs/claude-code-tool-surface.md` 看平台原语,`docs/orchestration-patterns.md` 看拓扑选择。
+> 进阶 fix:`docs/claude-code-tool-surface.md` 看平台原语,`docs/orchestration-patterns.md` 看拓扑选择,`docs/tech-design.md` 看架构权威。
 
 ---
 
@@ -16,7 +14,7 @@
 **相关**:A2(版本过低)。
 
 ### A2. `ccteam doctor` 报 "claude version too old, need ≥ 2.1.139"
-**原因**:V0.6.0+ 依赖 agent-view / `--bg` 等新特性,旧版没有。
+**原因**:ccteam 依赖 agent-view / `--bg` 等较新特性,旧版没有。
 **修复**:`claude update` 升 stable → 重启 Claude session → 重跑 `ccteam doctor`。
 **相关**:A1。
 
@@ -42,8 +40,8 @@
 
 ### A7. `/ccteam-creator` 起新项目报 "Team already exists"
 **原因**:上次新建留下的 `~/.claude/teams/<name>/` 残留,或 `~/projects/<slug>/` 已存在。
-**修复**:1) 重选另一个 slug;2) 想用同名:手动 `rm -rf ~/.claude/teams/<name> ~/projects/<slug>` 后重起。
-**相关**:`docs/versions/v0-5-1/` troubleshoot 同类。
+**修复**:1) 重选另一个 slug;2) 想用同名:手动 `rm -rf ~/.claude/teams/<name> ~/projects/<slug>` 后重起,或 `ccteam remove <slug> --purge` 一并清 `imd/registry/`。
+**相关**:A11。
 
 ### A8. 跟 BotFather 要 TG bot token 拿不到
 **原因**:TG 没注册 / @BotFather 没回 / 超出 20 bot 上限。
@@ -61,8 +59,8 @@
 **相关**:A8。
 
 ### A11. 想跑 `ccteam new ...` shell 命令,提示 command not found
-**原因**:V0.6.0 推荐**不走 shell**,所有创建在 Claude session 里 `/ccteam-creator` 完成。
-**修复**:在 Claude session 内 `/ccteam-creator`,跟向导走完即可。**不需要装 ccteam 二进制**。
+**原因**:推荐**不走 shell**,所有创建在 Claude session 里 `/ccteam-creator` 完成。
+**修复**:在 Claude session 内 `/ccteam-creator`,跟向导走完即可。**不需要装 ccteam 二进制**(除非你要跑 `ccteam start` daemon)。
 **相关**:A3。
 
 ### A12. 项目 `.mcp.json` 跟其他 MCP server 冲突
@@ -120,19 +118,16 @@
 **相关**:C4 / C9。
 
 ### B7. 编辑过 / reply 引用的 TG 消息 bot 看不到
-**原因**:TG bridge V0.6.0 只处理 plain text 新消息。
+**原因**:TG bridge 只处理 plain text 新消息(编辑事件不入 inbox)。
 **修复**:编辑后重新 @bot 一次;reply quote 不传入,需在新消息复述要点。
 **相关**:B8。
 
 ### B8. bot 看不到图片 / 文件
-**原因**:V0.6.0 mode 3 只支持 text;富媒体延 V0.7.x。
+**原因**:chat 模式当前只支持 text;富媒体在 backlog。
 **修复**:1) 图片 OCR 后粘贴文字;2) 文件放服务器 + URL 让 bot fetch。
-**相关**:`docs/versions/v0-6-0/prd.md` F109 不在范围。
+**相关**:B7。
 
-### B9. bot 在 DM(私聊)里不回
-**原因**:V0.6.0 mode 3 只支持 group chat,DM 是 V0.6.1。
-**修复**:把 bot 加群后 @ 它;DM 场景等 V0.6.1。
-**相关**:`docs/versions/v0-6-0/prd.md` F109。
+### B9. (reserved)
 
 ### B10. bot 突然回乱码 / 内部错误
 **原因**:模型 API 抽风(rate limit / overload / 内容审核)。
@@ -152,7 +147,7 @@
 ### B13. bot 回复夹了 `<thinking>` / 内部标记
 **原因**:模型未屏蔽 thinking 段,或 system prompt 没拦。
 **修复**:1) 通常 ccteam 自动剥;漏的请报 issue;2) workflow.yaml 加 `strip_thinking: true`。
-**相关**:`docs/versions/v0-6-0/prd.md` F108。
+**相关**:B10。
 
 ### B14. 群里多人同时 @bot,谁先谁后
 **原因**:bot 单 session 串行处理 turn。
@@ -189,7 +184,7 @@
 **相关**:B6 / C8。
 
 ### C5. 想给单个 bot 设硬上限,不动整个 workflow
-**原因**:V0.6.0 cost cap 默认 workflow 级。
+**原因**:cost cap 默认 workflow 级。
 **修复**:1) workflow.yaml `agents.<role>.max_cost_usd_per_day: 5`(per-role);2) 平台层附加 `--max-budget-usd` 硬终止兜底。
 **相关**:C1。
 
@@ -205,7 +200,7 @@
 
 ### C8. Cache 不命中,prompt token 暴涨
 **原因**:system prompt 含动态字段(时间戳 / cwd)每次都变。
-**修复**:V0.6.0 默认带 `--exclude-dynamic-system-prompt-sections`;若仍不命中,workflow.yaml 别在 system prompt 里塞 "今天日期" 这类。
+**修复**:ccteam 默认带 `--exclude-dynamic-system-prompt-sections`;若仍不命中,workflow.yaml 别在 system prompt 里塞 "今天日期" 这类。
 **相关**:C4 / `docs/claude-code-best-practices.md` §6.2。
 
 ### C9. compact 完反而更贵了
@@ -216,7 +211,7 @@
 ### C10. 想完全 dry-run 不花钱
 **原因**:验证 workflow 而不调真实模型。
 **修复**:1) `/ccteam-control dry-run <slug>` — 只校验 yaml + 列将 spawn 的 role,不调 model;2) 单 bot:`CCTEAM_DRY_RUN=1` env。
-**相关**:`docs/versions/v0-6-0/dev-plan.md` validation 节。
+**相关**:C7。
 
 ---
 
@@ -249,7 +244,7 @@
 
 ---
 
-## E. Codex 集成(V0.6.0 引入,5 条)
+## E. Codex 集成(5 条)
 
 ### E1. workflow.yaml 标 `vendor: codex` 但 spawn 报 "codex not found"
 **原因**:Codex CLI 没装在 PATH。
@@ -264,17 +259,53 @@
 ### E3. codex 报 "sandbox denied"
 **原因**:codex 默认 `--sandbox read-only`,不允许写文件。
 **修复**:1) workflow.yaml `agents.<role>.codex_sandbox: workspace-write`;2) 危险场景才用 `danger-full-access`,且仅在容器里。
-**相关**:`docs/versions/v0-6-0/prd.md` Codex sandbox 表。
+**相关**:见 [advanced/multi-llm-codex.md](advanced/multi-llm-codex.md) Codex sandbox 表。
 
 ### E4. codex 比 claude 慢 3-5×
-**原因**:Codex 默认走 OpenAI Responses API,首 token 延迟比 Anthropic 高;且 V0.6.0 还没接 Codex 的 prompt cache。
-**修复**:1) 高频对话场景用 claude;2) batch 任务可接受;3) 等 V0.6.x 优化 codex cache。
+**原因**:Codex 默认走 OpenAI Responses API,首 token 延迟比 Anthropic 高;且 ccteam 还没接 Codex 的 prompt cache。
+**修复**:1) 高频对话场景用 claude;2) batch / advise 一次性场景可接受。
 **相关**:B3。
 
 ### E5. 同 workflow 混 Claude+Codex,cost 报告分裂
-**原因**:两 vendor 计费单位、token 价格不同,V0.6.0 不合算。
+**原因**:两 vendor 计费单位、token 价格不同,目前不合算。
 **修复**:`/ccteam-control show-cost --vendor claude` 和 `--vendor codex` 分别看;workflow 总额按各自 budget 独立 cap。
 **相关**:C6。
+
+---
+
+## F. Daemon / 运维(4 条)
+
+### F1. `ccteam start` 不退 / Ctrl+C 没反应
+**原因**:不应发生。daemon 实现 SIGINT / SIGTERM graceful drain(上限 5 秒);超过 5 秒未退 = bug。
+**修复**:
+1. **优先**:`kill -TERM $(cat ~/.ccteam/ccteam.pid)` 或 Ctrl+C 再等 5 秒
+2. 仍卡 → 收集 `ccteam doctor --full` + 跑 `ps -ef | grep ccteam` 看孤儿进程,贴 GitHub issue
+3. **最后兜底**(会留孤儿 pidfile / 可能伤进行中的 turn 状态):`kill -9 $(cat ~/.ccteam/ccteam.pid) && rm -f ~/.ccteam/ccteam.pid`
+**相关**:F2 / F3。
+
+### F2. 升级 ccteam 后 chat bot 失联 / context 像丢了
+**原因**:不应发生。`ccteam start` 启动时探测每个已注册 bot 的 `ccteam-chat-<slug>-<role>` tmux session,若 session + pane 内 claude 进程都活 → 自动 reattach(bot context 不丢)。
+**修复**:
+1. 终端 `tmux ls | grep ccteam-chat-` 看 session 是否存在
+2. 存在但 ccteam 没 reattach → 看 daemon 日志(`~/.ccteam/logs/ccteam-imd.log`)有无 reattach 行
+3. session 不存在(进程被 OOM-killed / 手动 `tmux kill-server`)→ ccteam 起新 session,context 确实丢;用 `mcp__ccteam__chat_history` 抓上轮 `turns.jsonl` 让 bot 自己重读上下文
+**相关**:F1 / B11。
+
+### F3. `ccteam mcp-serve` 跑起来 stdout 空 / 看不到 prompt
+**原因**:**正常行为**。`mcp-serve` 走 stdio JSON-RPC,**stdout 留给 protocol frame**,所有 tracing / log 走 stderr。
+**修复**:
+- 想看 log:**不要** `2>/dev/null` 屏蔽 stderr。`ccteam mcp-serve 2>&1 | tee debug.log` 才能同时看 RPC + log
+- 想纯 RPC view:`ccteam mcp-serve 2>/dev/null` — stdout 仍能解析(JSON-RPC 不被污染)
+- 想加 verbosity:`RUST_LOG=debug ccteam mcp-serve` 走 stderr
+**相关**:见 [advanced/customize-workflow.md](advanced/customize-workflow.md) MCP 内部章节。
+
+### F4. `chat_reset` 后 bot 还在回老 context
+**原因**:不应发生。`chat_reset` 归档 `turns.jsonl` + 清磁盘 cursor + daemon 内存 cursor 同步重置(三者原子)。
+**修复**:
+1. 看 `<ccteam_root>/imd/registry/<slug>/<role>.json` 里 `cursor` 字段是否 0
+2. 看 `<project>/.ccteam/chat/<bot>/turns.jsonl` 是否空(原内容应在 `archive/turns-<unix-ms>.jsonl`)
+3. tmux session 内 claude 进程仍持着旧 context — `mcp__ccteam__chat_unregister_bot` 再 `chat_register_bot` 一次,强制 spawn 新 claude 进程
+**相关**:B11 / §4.7 (user-manual.md)。
 
 ---
 
@@ -282,4 +313,4 @@
 
 1. 在终端跑 `ccteam doctor --full` 收集所有诊断信息(Claude session 内 `Bash("ccteam doctor --full")` 亦可)
 2. 仍卡:把诊断输出贴 GitHub issue,或 ccteam 用户群 @ 维护者
-3. 进阶 fix:`docs/versions/v0-6-1/prd.md` 找对应 F-finding;`docs/claude-code-tool-surface.md` 看平台原语;`docs/dev-coupling-audit.md` 看历史已修类似问题
+3. 进阶 fix:`docs/claude-code-tool-surface.md` 看平台原语;`docs/dev-coupling-audit.md` 看历史已修类似问题;`docs/tech-design.md` 看架构权威

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -11,20 +11,24 @@
 **先看决策树**,挑一条路再下读对应章节。完整决策树详解见 [task-to-command.md](task-to-command.md)。
 
 ```
-你想做的事                                  → 用这个              → 本手册章节
-─────────────────────────────────────────────────────────────────────────────
-摸底新代码库 / 仓库 audit                    /ccteam-scan          §2.0
-开发 / 修 bug / 重构(全程盯着干)            /ccteam-team          §2.2 Team Sprint
-review PR / 第二意见 / 对答案                /ccteam-advise        §2.6 Advise
-IM 私聊助理(长跑)                          /ccteam-creator       §2.4 Pocket Assistant
-IM 圆桌(多 bot)                            /ccteam-creator       §2.5 IM Squad
-夜里跑长任务(hands-off)                    /ccteam-creator       §2.3 Overnight Builder
-看 / 暂停 / 改 persona / 加工具              /ccteam-control       §4 Admin 操作
-配 / 改 IM token                             /ccteam-im-setup      §2.4 + quickstart
-不确定?用自然语言问                          /ccteam "<NL>"        §3.1
+你想做的事                                  → 用这个                  → 本手册章节
+──────────────────────────────────────────────────────────────────────────────────
+摸底新代码库(60s 零依赖)                    /ccteam-scan --quick      §2.0
+仓库 navigability 体检                        /ccteam-scan              §2.0
+开发 / 修 bug / 重构(全程盯着干)            /ccteam-team              §2.2 Team Sprint
+跨 vendor 第二意见(Claude + Codex)          /ccteam-advise            §2.6 Advise
+IM 私聊助理(长跑)                          /ccteam-creator           §2.4 Pocket Assistant
+IM 圆桌(多 bot)                            /ccteam-creator           §2.5 IM Squad
+夜里跑长任务(hands-off)                    /ccteam-creator           §2.3 Overnight Builder
+程序化起 / 管 chat bot                        mcp__ccteam__chat_*       §4.7
+看 / 暂停 / 改 persona / 加工具              /ccteam-control           §4.1-§4.6
+诊断 / 验 Codex auto-critic                   ccteam doctor             §4.8
+配 / 改 IM token                             /ccteam-im-setup          §2.4 + quickstart
+daemon 优雅停止 / tmux reattach              kill -TERM <pid>          §6
+不确定?用自然语言问                          /ccteam "<NL>"            §3.1
 ```
 
-> §1 介绍 ccteam 是什么 / 三种对话入口;§2 详跑每个场景;§3 是入口手册;§4 是 admin 操作参考;§5 cost。**只想用,跳到 §2 对应小节即可**。
+> §1 介绍 ccteam 是什么 / 三种对话入口;§2 详跑每个场景;§3 是入口手册;§4 是 admin 操作 + MCP 工具参考;§5 cost;§6 daemon 运维。**只想用,跳到 §2 对应小节即可**。
 
 ---
 
@@ -52,9 +56,38 @@ ccteam = "在 Claude session 里召唤一个 AI 团队,长跑 + 跨设备 + 接�
 
 ---
 
-## §2 5 种用法(preset)
+## §2 用法(preset)
 
 每种用法 = "一个 ccteam 团队的预设配方"。你只挑场景,不挑实现细节。
+
+### §2.0 Code-Base Scan — 摸底新代码库
+
+**啥时用**:刚 clone 一个仓库,或者第一次接触 ccteam 想 60 秒看到价值。**零依赖** — 不开 daemon、不需 IM token、不需 Codex,只调一次 Sonnet(失败兜底 Haiku)。
+
+**怎么起**:
+
+```bash
+cd path/to/repo
+claude
+```
+
+session 里:
+
+```
+/ccteam-scan --quick                  # 60 秒快速体检(首选)
+/ccteam-scan                          # 完整 navigability audit(大型 monorepo 用,适合 contributor)
+```
+
+`--quick` 模式三问:
+1. **主语言 / framework / 入口** — 一句话告诉你这仓库是干啥的
+2. **TODO / FIXME 热点** — 哪几个文件 / 模块技术债集中
+3. **`CLAUDE.md` / `README.md` / `AGENTS.md` 状态** — 是否齐全,需不需要 `claude /init` 写初版
+
+报告写到 `<repo>/.ccteam/codebase-scan.md`(带 frontmatter `quick: true`)。24h 内复跑直接显示上次报告 + 建议加 `--force` 强制重扫。
+
+**Cost 估**:每次 ≈ $0.01-0.03(单 Sonnet 调用)。
+
+---
 
 ### §2.1 Solo Sidekick — 写代码时临时召唤一个帮手
 
@@ -220,21 +253,56 @@ writer_bot: 已起草文档,贴 PR 链接 → #1240
 
 ---
 
+### §2.6 Advise — 跨 vendor 第二意见(Claude + Codex)
+
+**啥时用**:你想拿一个**硬问题 / 设计决策 / PR 评审 / 棘手 bug** 去同时问 Claude 和 Codex,看两个 vendor 各给一份答案再自己拍板。**单视角不够**的场景。
+
+**两个 sub-mode**:
+
+| Sub-mode | 行为 | 何时用 |
+|---|---|---|
+| `vote` | 并行调多个 advisor,合成 verdict(majority / unanimous / split)+ 每 vendor 的 raw 答复 | 想看"两边到底同不同意" |
+| `parallel` | 并行调,**不合成**,直接 dump 每 vendor 的 raw 答复 | 想自己读两份对比 |
+
+**怎么起**:
+
+```
+/ccteam-advise vote "<question>"
+/ccteam-advise parallel "<question>"
+```
+
+或显式选 vendor 子集:
+
+```
+/ccteam-advise vote --vendors=claude,codex "<question>"
+```
+
+**前置**:Codex 装好 + `codex login` 跑过(可用 `ccteam doctor --check-codex-auto-critic` 一条命令验)。**没装也能跑** — graceful 降级单 Claude advisor,verdict prose 写 "Codex unavailable: <reason>",**不报错**。
+
+**Budget 守门**:每 vendor 单独 `max_cost_usd_per_24h` cap,记账落 `<ccteam_root>/cost-budget.json`(48h 自动 GC)。某 vendor 撞顶 → 静默跳过该 vendor 跑其余,verdict 标注 `budget_exhausted`。
+
+**底层 MCP 工具**:`mcp__ccteam__advise_vote` / `mcp__ccteam__advise_parallel`(可绕过 skill 直接调,适合 CI / batch)。
+
+**Cost 估**:单次 vote ≈ $0.01-0.05(两 vendor 各跑一次)。
+
+---
+
 ## §3 怎么跟 ccteam 对话(三种入口详解)
 
 ### §3.1 在 Claude session 内
 
 总入口 `/ccteam <NL>` 是万能的 — 发啥都行,它路由到对应 sub-skill。
 
-直接跳过 router 也行,5 个 sub-slash:
+直接跳过 router 也行,7 个 sub-slash:
 
 | Slash | 干啥 |
 |---|---|
+| `/ccteam-scan [--quick]` | 摸底新代码库(`--quick` 60s 零依赖,默认完整 navigability audit)|
 | `/ccteam-team <N> "<task>"` | 起临时 team(Team Sprint)|
 | `/ccteam-creator "<NL>"` | 起新 workflow / 改现有 workflow |
 | `/ccteam-control <subcmd>` | 管已有 workflow(暂停 / 恢复 / 查 cost / 改 persona)|
 | `/ccteam-im-setup` | 一次性绑 IM token(TG / Slack / Discord)|
-| `/ccteam-advise "<hard question>"` | Claude + Codex 并行二答案(仅装了 Codex 才出来)|
+| `/ccteam-advise vote\|parallel "<question>"` | Claude + Codex 并行二答案(没装 Codex 自动降级单 Claude)|
 
 ### §3.2 在 IM 端
 
@@ -262,9 +330,11 @@ Web **只看不操作**。所有控制走 Claude session slash 或 IM。
 
 ---
 
-## §4 Admin 操作参考(`mcp__ccteam__admin_*` + `mcp__ccteam__workflow_*`)
+## §4 Admin / Chat / Doctor MCP 操作参考
 
-> 所有 admin 操作的首选路径是 **MCP 工具**(`mcp__ccteam__*`)。如果 MCP 未注册(尚未跑 `ccteam doctor --install-mcp`),可用对应的 Bash fallback。
+> 所有操作的首选路径是 **MCP 工具**(`mcp__ccteam__*`)。如果 MCP 未注册(尚未跑 `ccteam doctor --install-mcp`),可用对应的 Bash fallback。MCP 工具按 5 个子前缀分组:`workflow_*` / `chat_*` / `advise_*` / `admin_*` / `screenshot_*`。
+>
+> §4.1-§4.6 是 admin 路径(workflow + persona / tool 管理);§4.7 是 chat 生命周期 MCP;§4.8 是 doctor 子命令。
 
 ### §4.1 暂停 / 恢复 workflow
 
@@ -412,6 +482,54 @@ skill 把 NL 翻译成 Claude Code 工具名(如 `WebFetch`、`Bash`)后调:
 
 ---
 
+### §4.7 Chat MCP 工具(程序化起 / 管 / 抓历史 / 重置 bot)
+
+`/ccteam-creator` 是 NL 向导,适合新手 onboarding;**已经懂 ccteam** 后从 Claude session 内直接调 MCP 更快。6 个工具构成完整生命周期:
+
+| 工具 | 用途 | 关键参数 |
+|---|---|---|
+| `mcp__ccteam__chat_register_bot` | 注册一个 chat bot 入 daemon registry | `{ slug, role, vendor, im_chat_id }`(`vendor` 严格小写枚举 `claude` / `codex`)|
+| `mcp__ccteam__chat_list_bots` | 列所有 registered bot + heartbeat 状态 | `{ slug? }`(省 = 全列)|
+| `mcp__ccteam__chat_send_input` | 给某 bot 推一段文本(走 inbox 文件,不直注 tmux pane)| `{ slug, role, text }` |
+| `mcp__ccteam__chat_history` | 抓 bot 对话历史(从 `turns.jsonl` 读)| `{ slug, role, limit? }` |
+| `mcp__ccteam__chat_reset` | 重置 session:归档 `turns.jsonl` + 清 outbound cursor + 清 transcript cursor | `{ slug, role }` |
+| `mcp__ccteam__chat_unregister_bot` | 注销 bot(daemon 自行停 tmux,清 heartbeat sidecar)| `{ slug, role }` |
+
+**Heartbeat 语义**:`chat_list_bots` 返回 `running: true` 当且仅当 `<root>/imd/registry/<slug>/<role>.heartbeat` mtime 在 30 秒内。daemon 重启时,bot tmux session 不丢,**自动 reattach**(详 §6)。
+
+**Reset 行为**:`chat_reset` 把当前 `turns.jsonl` 移到 `archive/turns-<unix-ms>.jsonl`,然后清磁盘 cursor 文件 + 让 daemon 重置内存里的 cursor — 两边同步,**不存在 "磁盘清干净但 daemon 还在读旧位置" 的 race**。
+
+**典型 JSON example**:
+
+```json
+{
+  "name": "chat_register_bot",
+  "args": { "slug": "helper", "role": "main", "vendor": "claude", "im_chat_id": "123456789" }
+}
+```
+
+返回:`{ "ok": true, "slug": "helper", "role": "main", "registered_path": "..." }`
+
+适合场景:CI 编排起多个 bot 做 batch / 给已跑 bot 推一个程序化指令 / 抓 bot 历史做 audit / 自动化测试。
+
+---
+
+### §4.8 Doctor 子命令
+
+`ccteam doctor` 是诊断入口,在任意终端跑(也可 `Bash("ccteam doctor")` 从 Claude session 内调):
+
+| 子命令 / flag | 用途 |
+|---|---|
+| `ccteam doctor` | 全套诊断(claude CLI 版本 / MCP 注册 / tmux / pidfile 路径 / web port)|
+| `ccteam doctor --install-mcp` | 重写 `~/.claude.json` / 项目 `.mcp.json` 里的 `ccteam` MCP server 注册 |
+| `ccteam doctor --check-codex` | 验 codex binary 存在 + auth ok |
+| `ccteam doctor --check-codex-auto-critic` | 验 codex 可用且能跑一次 `codex exec --json` canary(exit 0 = ok / 2 = binary 缺 / 3 = output 格式不对)|
+| `ccteam doctor --full` | 全套 + 详细输出(收集成给 issue)|
+
+`--check-codex-auto-critic` 是 `/ccteam-creator` Phase 3.5 内部调的同一条命令 — 决定 critic 角色是否自动设 `vendor: codex`。手动验等价。
+
+---
+
 ## §5 Cost 透明
 
 ccteam 默认每个 workflow 有 24h cost cap(creator 起项目时问你)。
@@ -437,16 +555,32 @@ qa-loop          $4.12    $5.00     ↘ -3%      ⚠ 82% of cap
 
 ---
 
-## §6 从 V0.5 升级到 V0.6 — 0 用户操作
+## §6 运维:daemon 优雅停止 + tmux reattach
 
-V0.6 升级**完全无感**:
+ccteam 把 orchestrator + IM bridge(`ccteam-imd`) + web 仪表板都装进 `ccteam start` 这一个 tokio runtime,前台跑或加 `&` 后台。
 
-- 你的 V0.5 项目配置继续跑 — 兼容,**0 文件修改**。
-- MCP 工具名字 `mcp__ccteam__*` **全保留** — V0.5 muscle memory 0 破坏。
-- V0.5 的 `/ccteam-team` / `/ccteam-control` / `/ccteam-creator` slash 行为兼容。
-- **新加**:`/ccteam` 总入口、`/ccteam-im-setup`(绑 IM)、`/ccteam-advise`(双 LLM 投票)。
+**优雅停止**:
 
-**唯一新选**:想试 Pocket Assistant / IM Squad?跑一次 `/ccteam-im-setup` 绑 TG token 就行。
+```bash
+kill -TERM $(cat ~/.ccteam/ccteam.pid)   # 或 Ctrl+C 在前台 terminal
+```
+
+行为契约:
+- daemon 收 SIGTERM / SIGINT → 5 秒内进 graceful drain(`TASK_DRAIN_TIMEOUT = 5s` 上限)
+- web port(默认 7331)立即释放
+- pidfile `~/.ccteam/ccteam.pid` 自动 unlink
+- **tmux 长 session 不被 kill**(CLAUDE.md §三 "永不主动 kill 长 session" 红线)— bot 进程留着,等下次 `ccteam start` reattach
+
+**不要用 `kill -9` / `SIGKILL`**。SIGKILL 跳过 graceful drain,会留孤儿 pidfile,可能伤进行中的 turn 状态。只有 graceful 卡死 5 秒以上才考虑 SIGKILL,且属于 bug — 请 issue。
+
+**tmux reattach across daemon restart**:
+
+升级 ccteam 或机器重启后,`ccteam start` 启动时探测每个已注册 bot 的 tmux session(`ccteam-chat-<slug>-<role>`):
+- session 存在 + pane 内 `claude` 进程活 → **reattach**(不 spawn 新 claude,bot context 不丢)
+- session 存在 + pane 死 → `tmux kill-session` 后重起新 session
+- session 不存在 → 起新 session
+
+也就是:**升级 ccteam 不会丢 bot 对话 context**。bot 仍在 IM 端 responsive,不需要人工 `tmux kill-session` 后再 `ccteam-creator` 重起。
 
 ---
 
@@ -459,4 +593,4 @@ V0.6 升级**完全无感**:
 | 改默认 persona / 加 MCP 工具 / 自定义 workflow | [advanced/customize-workflow.md](advanced/customize-workflow.md) |
 | 装 Codex 让两个 LLM 互审 | [advanced/multi-llm-codex.md](advanced/multi-llm-codex.md) |
 | 出错查不到 | [troubleshooting.md](troubleshooting.md) |
-| 看代码 / 改 ccteam | [architecture/](architecture/) |
+| 看代码 / 改 ccteam | [tech-design.md](tech-design.md) + [interfaces.md](interfaces.md) |


### PR DESCRIPTION
## Finding
Ship gate per CLAUDE.md §五 #7 + V0.6.5 README §5 #13 (assigned post-skills-scrub #117).

V0.6.5 capability surface integration into user-facing docs:
- README.md (English decision tree + Run-as-a-daemon + 4-channel MCP mention)
- docs/quickstart.md (decision tree adds scan/advise/chat MCP; new §1.5 scan onramp + §4 advise + §5 chat MCP)
- docs/user-manual.md (§0 quick-jump expanded; new §2.0 Code-Base Scan / §2.6 Advise / §4.7 Chat MCP / §4.8 Doctor / §6 daemon ops)
- docs/recipes.md (3 new recipes: scan --quick, advise vote, programmatic chat MCP)
- docs/troubleshooting.md (scrub version refs; new section F daemon ops × 4)
- docs/advanced/{customize-workflow,multi-llm-codex,presets-reference}.md (version refs + F-tags scrubbed; advise.rs / doctor flag paths updated; Codex matrix refreshed)
- CLAUDE.md §一 baseline 1579/1 → 1583/1 (F163 retro PR #116)

## Verification
- `cargo test --workspace --locked --no-fail-fast`: **1583 / 1** (baseline match; sole failure is known `workflow_summary_reflects_agent_spawn_and_done_events` web flake)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: 0 warnings
- `grep -rnE "V\d+\.\d+|docs/versions" README.md docs/{quickstart,user-manual,recipes,troubleshooting}.md docs/advanced/*.md` → 0 hits
- `grep -rnE "shipped in V|new in V|V0\.6\.5 新增" README.md docs/{quickstart,user-manual,recipes,troubleshooting}.md` → 0 hits
- Decision tree (F158 lead) preserved across README + quickstart §1 + user-manual §0 + task-to-command.md

## Sequencing
After skills-scrub PR #117 (owns CLAUDE.md §三 + README §5). No conflict expected (different sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)