### PR TITLE
chore(plugin): add Claude Code plugin marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "ccteam",
+  "description": "Multi-vendor (Claude + Codex) AI team orchestration on Claude Code — MCP-driven, file-system-as-control-plane, chat-mode 24/7 IM bots.",
+  "owner": {
+    "name": "FirstIntent"
+  },
+  "plugins": [
+    {
+      "name": "ccteam",
+      "description": "Multi-vendor (Claude + Codex) AI team orchestration on Claude Code — MCP-driven, file-system-as-control-plane, chat-mode 24/7 IM bots.",
+      "version": "0.6.5",
+      "author": {
+        "name": "FirstIntent"
+      },
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/firstintent/ccteam",
+      "tags": [
+        "multi-agent",
+        "orchestration",
+        "mcp",
+        "telegram",
+        "codex",
+        "claude-code"
+      ]
+    }
+  ],
+  "version": "0.6.5"
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "ccteam",
+  "version": "0.6.5",
+  "description": "Multi-vendor AI team orchestration on Claude Code: 7 skills + 27 MCP tools + IM bots + multi-agent voting.",
+  "author": {
+    "name": "FirstIntent"
+  },
+  "repository": "https://github.com/firstintent/ccteam",
+  "homepage": "https://github.com/firstintent/ccteam",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "plugin",
+    "multi-agent",
+    "orchestration",
+    "mcp",
+    "telegram",
+    "codex"
+  ],
+  "skills": [
+    "./skills/ccteam/",
+    "./skills/ccteam-creator/",
+    "./skills/ccteam-team/",
+    "./skills/ccteam-control/",
+    "./skills/ccteam-advise/",
+    "./skills/ccteam-scan/",
+    "./skills/ccteam-im-setup/"
+  ],
+  "mcpServers": "./.mcp.json"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ccteam": {
+      "command": "ccteam",
+      "args": ["mcp-serve"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,16 +28,30 @@ Not sure? Just describe it in natural language   /ccteam "<what you want>"
 
 ```bash
 # 0. Install Claude Code first: https://code.claude.com/docs/install
-claude
-/plugin install ccteam
 
-# 1. Try the universal entry — describe what you want in any language:
+# 1. Install the ccteam CLI binary (prerequisite — the plugin shells out to it):
+cargo install ccteam-cli
+
+# 2. Inside any Claude session, register the marketplace + install the plugin:
+claude
+```
+
+```
+/plugin marketplace add https://github.com/firstintent/ccteam
+/plugin install ccteam
+```
+
+```
+# 3. Try the universal entry — describe what you want in any language:
 /ccteam "scan this repo and tell me what it does"
 /ccteam "fix the TypeScript errors in src/"
 /ccteam "build a Telegram bot that summarizes my GitHub PRs at 7am"
+
+# 4. (Optional) Bootstrap a per-project workflow scaffold from the CLI:
+ccteam init <project>
 ```
 
-The 5-minute walkthrough for "private IM assistant" (the flagship use case) lives in [docs/quickstart.md](docs/quickstart.md).
+Step 2 registers ccteam as a Claude Code plugin marketplace, then installs the plugin — the seven `/ccteam*` slash commands and `mcp__ccteam__*` MCP tools light up immediately. The 5-minute walkthrough for "private IM assistant" (the flagship use case) lives in [docs/quickstart.md](docs/quickstart.md).
 
 ## Three ways to talk to ccteam
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -80,15 +80,29 @@ ccteam-scan (quick) → <repo>/.ccteam/codebase-scan.md
 
 ## Step 1 — 装 ccteam plugin(30 秒)
 
+ccteam 走 Claude Code 官方 plugin marketplace 协议安装 —— **plugin 是首选路径**,CLI binary 作为前置条件先装好(plugin 通过 MCP 调用本机 `ccteam` 命令)。
+
+### 1.1 装 CLI binary(前置,一次性)
+
+```bash
+cargo install ccteam-cli
+ccteam --version    # 应输出当前版本号
+```
+
+将来会提供 prebuilt release(brew / GH releases),目前 cargo 是主路径。
+
+### 1.2 在 Claude session 里注册 marketplace + 装 plugin
+
 任意 terminal 起 Claude session:
 
 ```bash
 $ claude
 ```
 
-在 session 里输入:
+在 session 里依次输入:
 
 ```
+/plugin marketplace add https://github.com/firstintent/ccteam
 /plugin install ccteam
 ```
 


### PR DESCRIPTION
## Change
Enables `/plugin marketplace add https://github.com/firstintent/ccteam` + `/plugin install ccteam` path following Anthropic's [plugin marketplace protocol](https://code.claude.com/docs/en/plugin-marketplaces). Models layout after `references/oh-my-claudecode/.claude-plugin/`.

## New files
- `.claude-plugin/marketplace.json` (single-plugin marketplace)
- `.claude-plugin/plugin.json` (declares 7 skills + .mcp.json)
- `.mcp.json` (`ccteam mcp-serve` invocation)

## Updated
- `README.md` (plugin install path lead; binary install Step 1)
- `docs/quickstart.md` (same setup story in Chinese)

## Binary distribution
NOT bundled with the plugin. `ccteam` must be on $PATH first (`cargo install ccteam-cli` or prebuilt release). Plugin only handles skill registration + MCP wiring for zero-friction discovery inside a Claude Code session.

## Scope
- 3 new + 2 doc updates
- No code change
- No baseline impact (1583/1)
- No version bump
- README.md remains English, no version refs