### PR TITLE
docs(v0.6.6): doc-first PRD + dev-plan (8 findings)

### DIFF
--- a/docs/versions/v0-6-6/README.md
+++ b/docs/versions/v0-6-6/README.md
@@ -1,0 +1,148 @@
+# ccteam V0.6.6 — 低摩擦安装 + V0.6.5 后清扫 + mode-3 上下文恢复 + Codex 成本统一
+
+> **状态:doc-first / Wave 0**(本 PR 范围 = `README.md` + `prd.md` + `dev-plan.md`,代码 PR 走后续 8 个 worktree-per-finding 并行 dispatch)。
+> **主题:** **关 V0.6.5 ship 留的小账 + 把两条原 V0.7 候选拉回 V0.6.6**。V0.6.5 闭了 V0.6 自身的账(chat MCP 桥 / advise / UX cohesion / 运维 robustness),`post-ship-stub-inventory.md` 又给出一张 codebase 干净度地图。本版按那张地图扫尾,加 **F172 mode-3 上下文恢复**(daemon 重启不丢长跑 chat 会话上下文)+ **F173 daemon-routed Codex critic 统一 cost rollup**(V0.6.3 F156 留的 explicit defer 现在补完),同时把 **F166 prebuilt binary + install.sh** 这条「零摩擦安装」做掉 ── 用户不再被 `cargo install --git` 拦在门口。
+> **基线起点:** workspace `0.6.5` / test `1583 / 1`(V0.6.5 ship 数,1 fail 是已知 `workflow_summary_reflects_agent_spawn_and_done_events` flake)/ clippy `-D warnings` clean。
+> **基线目标:** workspace `0.6.6` / test ≥ `1660 / 1`(+~80,见 §0 估算)/ clippy `-D warnings` clean。
+> **痛点对应(13 用户痛点):** 痛点 4(零摩擦上手)/ 痛点 9(团队不依赖人在场,24/7 daemon)/ 痛点 11(Skill / 入口可发现性)/ 痛点 14(长跑可靠性)。
+
+---
+
+## 0. 概览
+
+| Finding | 一句话 | 对应痛点 | 体量 | 估算新测试 |
+|---|---|---|---|---|
+| **F166** | GH Releases 预编译 binary + `install.sh` 一键装 | 4 | M | +12 |
+| **F167** | `/ccteam-creator` 默认 workflow.yaml + role md 按 project 类型出 sensible defaults(**轻量,不是完整 template library**) | 4 / 11 | S-M | +6 |
+| **F168** | active TODO sweep ── codebase 内 9 个分布 site,逐条决断 fix / EOL-delete / V0.7 显式 defer-with-justification | 14 | M | +10 |
+| **F169** | `nl_admin::cost_today` 接真 `ccteam_cost` ledger(替 V0.6.1 占位 registry-count 返值) | 9 / 14 | S | +4 |
+| **F170** | 陈旧 doc-comment scrub(post-ship-stub-inventory Cat 7,实测 4 site) | 14 | XS | 0 |
+| **F171** | `ccteam doctor --verify-mcp` flag 加 stub-counter parity 自检 | 14 | S | +6 |
+| **F172** | tmux mode-3 上下文恢复 ── progress.jsonl 加 `chat_snapshot` event 周期 dump,daemon 重启可重建 | 9 / 14 | L | +30 |
+| **F173** | Codex daemon-routed critic 统一 cost rollup(F156 follow-through;原 V0.7 候选) | 6 / 14 | M | +15 |
+
+**总计** 8 finding · 8 worktree 并行(完全独立)· 估算 +~80 新测试 → baseline 目标 `1660/1`。
+
+---
+
+## 1. 为什么 V0.6.6 而不是 V0.7.0
+
+V0.6.5 ship 时 `post-ship-stub-inventory.md` §"Recommendations" 给了三档候选:V0.6.6 patch(3 项)/ V0.7 minor 主候选(5 项)/ V0.8+ 主线(4 项)。用户决策(本版 scope 拍板)是:
+
+- **3 项 V0.6.6 patch 全收**:F168(TODO sweep,实际范围比 inventory 列的更广,9 site)/ F169(`cost_today` 接真 ledger)/ F170(Cat 7 doc-comment scrub)/ F171(doctor stub-counter parity)。
+- **从「V0.7 minor 主候选」拉两项回 V0.6.6**:**F172 mode-3 上下文恢复** + **F173 Codex critic 统一 cost rollup**。理由:
+  - F172 是「24/7 长跑可靠性」的最后一块拼图 ── V0.6.5 F163 给了 graceful SIGTERM、F164 给了 tmux reattach,但 **daemon 崩 / 重启时 chat bot 已积累的上下文会丢**(F164 reattach 物理 session,F118 `session_recovery` 重建 last-N turns,但「last-N turns 的语义损失」对长跑 bot 来说仍然不可忽略)。F172 让 progress.jsonl 周期 snapshot 关键 context,重启时 chat_handle re-attach 后用 snapshot 续上,把损失从「last-N turns」缩到「最后一次 snapshot 起的增量」。
+  - F173 是 V0.6.3 F156 留的「explicit defer past V0.6.5」 ── V0.6.5 advise/Codex critic 路径全 ship 了,F156 提到的 unified cost rollup 现在前提齐备(`CodexExecAdapter` 已用;`<root>/cost-budget.json` ledger 已在 F152 引入)。本版补完后,Codex critic 调用统计与 main spawn 在同一账上,用户面 `ccteam doctor` + `@ccteam cost today`(F169)出真数,end-to-end 闭环。
+- **加 F166 + F167**:F166 是用户级零摩擦入口(对齐痛点 4 ── 当前 README quickstart 要求 `cargo install --git`,新用户至少装 Rust toolchain 才能开始);F167 是用户首次 `/ccteam-creator` 时落地 yaml 的 sensible defaults,与 F166 一起把「first 5 min user experience」抬一个档。
+
+**F167 明确边界**(防 subagent 滚雪球):F167 = **per-project-type 启发式 + 默认值微调**,不是 LLM-assisted 完整 role auto-gen,也不是 template library 扩张(那是 V0.7 epic,见 §4)。
+
+**与 CLAUDE.md §五 "pre-v1.0 不留技术债" 一致** ── F168 决断里只有「fix / EOL-delete / V0.7 显式 defer-with-justification」三档,**禁止**「TODO ship in V0.6.7」式拖单。本版收账,不开新账。
+
+---
+
+## 2. 痛点映射(13 用户痛点)
+
+| 痛点 | 本版相关 finding | 解释 |
+|---|---|---|
+| 4(零摩擦上手) | F166 / F167 | prebuilt binary + install.sh:`curl ... \| sh` 一行装,不依赖 Rust toolchain;F167:首次 `/ccteam-creator` 生成的 workflow.yaml / role.md 按 project 类型(monorepo / single repo / docs-only / scripts-only)给 sensible defaults,降低用户「拿到模板还得手改」的认知成本 |
+| 9(24/7 daemon) | F169 / F172 | F169:`@ccteam cost today` 出真 ledger 数(对齐 V0.6.5 ship gate item #9);F172:daemon 重启不丢 chat bot 上下文,长跑 7x24 真正能扛重启(不只是 tmux session 物理 reattach,语义层也续上) |
+| 11(Skill / 入口可发现性) | F166 / F167 | install.sh 给非开发者用户(运维 / 业务方)一条「不学 Rust 就能装」的路;F167 让 `/ccteam-creator` 默认输出更接近用户实际意图,减少「装完不知怎么开始」的退出率 |
+| 14(长跑可靠性) | F168 / F170 / F171 / F172 / F173 | F168:9 个 TODO 全部决断,不留「悄悄留 in-code」;F170:doc-comment 不再误导未来 contributor;F171:doctor 自检 MCP stub counter,catch 倒退;F172:上下文恢复 ── 见痛点 9;F173:Codex critic 与 main spawn 同账,长跑成本可观测可控 |
+| 6(跨 vendor 第二意见) | F173 | F156 follow-through:Codex critic 路径走 `CodexExecAdapter`,cost 统一计入 advise budget ledger,用户面看到真实跨-vendor 花销 |
+
+---
+
+## 3. 红线核对(CLAUDE.md §三)
+
+| 红线 | 本版触及? | 守的方式 |
+|---|---|---|
+| 文件系统是控制平面 | F172 写 `chat_snapshot` 到 progress.jsonl | progress.jsonl 是已存在的 SoT,**不**新建第二个文件;snapshot payload 内联(或指向 turns.jsonl 内 byte-offset),不引入新 IPC 通道 |
+| `progress.jsonl` 是唯一 state SoT | F172 **守 + 扩展** | `chat_snapshot` 是 chat-mode event 家族的新成员(继 F108/F118 的 `chat_session_started` / `chat_turn_user_prompt` / `chat_turn_completed` / `chat_session_reset` / `chat_session_reset_with_recovery` / `chat_compact_done` / `chat_hop_escalate` 之后)── **不是新的第 9 类业务 event,而是扩 chat-mode 子家族**(CLAUDE.md §一 的 7 类业务 event + chat 子事件已是同一 SoT);daemon 重启从 progress.jsonl tail 读最近 `chat_snapshot` → 走 F118 既有 `session_recovery::build_recovery_prompt` 路径 |
+| No prompt injection | F172 snapshot 仅作为 recovery context 注入新 tmux pane | recovery 时注入的是 user prompt 形式(对齐 F118 `chat_session_reset_with_recovery` 既有路径),不是 system prompt;`.claude/agents/<role>.md` 仍是 agent 行为唯一 SoT |
+| 每次 spawn = fresh 1M context(bg 模式) | 不触及 | F172 仅作用于 mode-3 chat;chat 复用 context 是 feature(CLAUDE.md §三 原文) |
+| 永不主动 kill 长 session | F172 / F173 守 | F172 snapshot 是**辅助 + 非破坏** ── 周期 dump 到 progress.jsonl,不触 tmux pane,不发 send-keys,不影响 bot 当前活动;只有 daemon 重启时(daemon process 已死) 才走 recovery 路径,不算 kill;F173 critic 通过 daemon route 仍是 fire-and-forget 子进程,与 main spawn 独立 |
+| 不解析 tmux 终端输出 | F172 snapshot 源 = transcript jsonl + turns.jsonl(已存在的 ccteam-owned 路径) | snapshot 内容由 `turns_mirror`(F108 引入)与 progress.jsonl event 拼合而成,**不**调 `tmux capture-pane` |
+| fix-loop 撞 3 次必 escalate | F168 决断须 explicit | F168 任何「continue iterating later」式拖单 → escalate-with-question,不写入 prd 默认 |
+| `ccteam-core` 零 team 名字面量 | 不触及 | 本版 ccteam-core 改动仅在 progress event const(F172)+ chat snapshot helper 函数,**无** team 名 |
+| 跨项目记忆走官方接口 | 不触及 | 本版不改 `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` 处理 |
+| 新建项目走 `<projects_root>/<team>-<slug>/` | 不触及 | F167 改默认值,不动 slug minting |
+| root README.md MUST be English | F166 改 README quickstart 段 | install.sh 一行说明走英文段,中文说明进 `docs/quickstart.md` |
+| README.md 不含版本进展/状态信息 | F166 改 README | install.sh / GH Release 描述是「产品当前能力」展示,**不**含版本号 / shipping 日期 / 验收数字 |
+| HITL approval state SoT(V0.6.1 F124) | 不触及 | 本版无 plan_approval 改 |
+
+**F172 红线设计补充说明**:本版**明确**选「扩 chat-mode 子事件家族」而非「新建第 9 类业务 event」── 决策理由:`chat_snapshot` 与 F118 `chat_session_reset_with_recovery` 是同一抽象层级的孪生事件(一个写、一个读 recovery 路径),把它们划到不同 category 会让 progress.jsonl 消费者(`ccteam-imd::daemon` recovery / `ccteam-web` dashboard / `ccteam-control` admin)的分发逻辑撕成两套,违反 SoT 原则的 spirit。详 prd §F172。
+
+---
+
+## 4. 不在范围(V0.7 候选)
+
+| 项 | 推到 V0.7 的理由 |
+|---|---|
+| `/ccteam-creator` 完整 template library + role auto-gen | F167 只做 sensible defaults 微调(轻量);完整 template library(domain-specific presets)+ LLM-assisted role auto-gen 是 V0.7 主线 epic,体量与 V0.6.6 patch 节奏不匹配 |
+| `ccteam migrate-from-claude`(反向 import 现有 `.claude/` 项目) | researcher R6#4 / codex-expert CX6#5 列入 V0.7+ backlog;依赖 `.claude/agents/*.md` 解析 + workflow.yaml 反推 + 用户交互 disambig,体量同上 |
+| monorepo-aware `.mcp.json` | researcher R6#4;依赖 monorepo workspace 探测 + per-subtree `.mcp.json` 合并语义设计 |
+| 国内 IM 启用(WeChat / 飞书 / DingTalk / QQ) | V0.7 Epic C(已在 V0.6.5 README §4 锁定);依赖各平台 SDK 接入 + Cargo features `lark` / `dingtalk` / `qq` / `wechat` 实装(目前 Cargo.toml 已占名,实现待写) |
+
+---
+
+## 5. Ship gate(V0.6.6 → main)
+
+1. **baseline**:`cargo test --workspace --locked --no-fail-fast` ≥ **1660 / 1**(1583 起点 + ~80 新测试)
+2. **clippy**:`cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
+3. **F166 GH Actions release CI 跑通**:tag `v0.6.6` push → 4-arch matrix(linux-x64 / macOS-arm64 / macOS-x64 / windows-x64)build artifact 上 GH Release,checksum 文件齐
+4. **F166 install.sh 真验**:nas-box005(linux-x64)从 fresh wipe → `curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh` → `ccteam --version` 输出 `0.6.6` + PATH 写入正确;**手动签字** → `docs/versions/v0-6-6/host-probe.md`
+5. **F167 sensible defaults host-probe**:fresh `/ccteam-creator "做个 monorepo 后端 reviewer"` → 生成的 workflow.yaml `scope:` 段非空、role.md 含与 monorepo 相关的 sensible default text;`/ccteam-creator "写个 TG 助理"` → chat-pocket preset + IM bot 段非空
+6. **F168 实数 verify**:`grep -rnE "// TODO|// FIXME|// HACK|TODO\(" crates/*/src/` 输出 ≤ 2 个 site(剩下的必须是 V0.7 显式 defer-with-justification,**禁止**「未决」)
+7. **F169 真 ledger 验**:nas-box005 daemon 跑一次 advise call → `@ccteam cost today` IM 回返值含真 USD 数字 + per-vendor 分项;CLI `ccteam-control show-cost` 输出同样数字
+8. **F170 doc-comment scrub clean**:`grep -rn "V0.3.3 cleanup\|F49 wires\|once Wave 2 lands\|Wave 2 wires it into the" crates/*/src/` 0 命中
+9. **F171 doctor stub-counter**:`cargo run --release -- doctor --verify-mcp` 输出含 `MCP tool surface: 26 active, 0 stubs`(沿用 V0.6.5 ship gate item #9 措辞)+ 失败 exit code = 1;**有自动化 test 覆盖**(`crates/ccteam-cli/tests/doctor_verify_mcp_test.rs`)
+10. **F172 daemon-restart-recovery host-probe**:nas-box005 跑 mode-3 chat bot ≥10 turns → `kill -TERM <daemon pid>` → `ccteam start` 再起 → bot 自动 re-attach + 第 11 turn 输入能用得到前 10 turn 上下文(测试人确认 reply 引用早 turn 内容);progress.jsonl 含 ≥1 `chat_snapshot` event;**手动签字** → host-probe.md
+11. **F173 Codex critic cost rollup 真验**:`mcp__ccteam__advise_vote` 调用 Claude+Codex 各一次 → `<root>/cost-budget.json` `advise_today_usd` 增加;`@ccteam cost today` 显示同样增量;`ccteam doctor` 不报 cost-orphan warning
+12. **CLAUDE.md §一 baseline 表更新到 V0.6.6 数字**(test pass count + version + 当前最新版 + 上一版 + V0.6.x 延期候选)
+13. **dev-coupling-audit.md 加 F166-F173 索引**
+14. **F168 9 site 决断列表** 在 wave-handoff doc 留底(decided / EOL-deleted / V0.7-deferred-with-justification 三档分类)
+15. **tag** `v0.6.6` push + GH Release notes(F166 binary download instructions 嵌入)
+
+---
+
+## 6. Wave 结构(patch 体量,1-2 wave)
+
+详 `dev-plan.md`。概要:
+
+```
+Wave 0  doc-first(本 PR)
+        ├── README.md           ← 本文件
+        ├── prd.md              ← 8 finding 完整需求
+        └── dev-plan.md         ← worktree-per-finding + acceptance gate
+
+Wave 1  8 finding 全并行 worktree(每个独立 Opus subagent)
+        F166 prebuilt binary + install.sh           ── 1.5 d
+        F167 sensible defaults                       ── 1 d
+        F168 active TODO sweep                       ── 1 d
+        F169 cost_today ledger wire-up               ── 0.5 d
+        F170 doc-comment scrub                       ── 0.5 d
+        F171 doctor stub-counter                     ── 0.5 d
+        F172 mode-3 context recovery                 ── 2.5 d
+        F173 Codex critic cost rollup                ── 2 d
+
+Wave 2  doc-syncer + host-probe + ship gate(必要时,可与 Wave 1 末段并行)
+        CLAUDE.md §一 baseline 回填 + dev-coupling-audit.md 索引补
+        nas-box005 真机跑 F166/F167/F169/F170/F171/F172/F173 host-probe,签字落
+        docs/versions/v0-6-6/host-probe.md
+        + workspace 0.6.5 → 0.6.6 + tag v0.6.6
+```
+
+每 Wave PR 必须 baseline ≥ 上 Wave 数字 + clippy 0 警告,否则不发。
+
+**Strict no-wave-leftover**(沿 V0.6.5 加严)**:本版**不允许**把任何 finding 推到 V0.6.7 / V0.7。验收不过的 finding → 主会话 escalate 给用户 → 当场决策(继续做 / 主动 EOL 删除 / V0.7 显式 defer-with-justification),禁止 "TODO ship in V0.6.7"。
+
+---
+
+## 7. Doc-first 完成判据(本 PR 验收)
+
+- [ ] `README.md`(本文件)落
+- [ ] `prd.md` 8 finding 各章节完整(痛点 / 现状缺口 / 设计 / 文件 / 验收 / 风险)
+- [ ] `dev-plan.md` 含 Wave 1 worktree 分配 + acceptance gate + Wave 2 doc-syncer 收尾
+- [ ] CLAUDE.md `§一 当前状态` 表 `当前最新版` 行**暂不动**(代码 ship 后回填)
+- [ ] 用户 review pass → merge → 新会话 8 worktree 并行 dispatch

--- a/docs/versions/v0-6-6/dev-plan.md
+++ b/docs/versions/v0-6-6/dev-plan.md
@@ -1,0 +1,148 @@
+# V0.6.6 — Dev Plan(patch flow,8 worktree 并行,1-2 wave)
+
+> **Plan-first 原则**(CLAUDE.md §五):本文件 + `README.md` + `prd.md` user review pass 后才进 Wave 1。
+> **Pre-v1.0 不留技术债**(CLAUDE.md §五 #3):本版 8 finding 全 ship,不向 V0.6.7 / V0.7 拖单,验收不过 → 主会话 escalate 用户。
+> **多 session 并行**(CLAUDE.md §五 #5):worktree-per-finding,主仓 `main` 不变 dirty;每 finding 一 worktree 一 PR。
+> **执行模型**:主会话 dispatch 8 个独立 Opus subagent 各跑一个 worktree;主会话只做 dispatch + acceptance gate 验,不读各 worktree 实现细节,防 context 膨胀。
+> **Strict no-finding-leftover**:沿 V0.6.5 加严的「strict no-wave-leftover」── 任一 finding 验收不过 → 主会话 escalate → 当场决策(继续做 / 主动 EOL 删 / V0.7 显式 defer-with-justification);**禁止**写 "TODO ship in V0.6.7"。
+
+---
+
+## Wave 0 — doc-first(本 PR,~45 min,本 session 完成)
+
+- `docs/versions/v0-6-6/README.md` ✅
+- `docs/versions/v0-6-6/prd.md` ✅
+- `docs/versions/v0-6-6/dev-plan.md`(本文件)✅
+- user review pass → `go` → Wave 1 kick-off
+
+---
+
+## Wave 1 — 8 finding 全并行 worktree dispatch
+
+**目标:** 8 个独立 Opus subagent 各跑一个 worktree;F166-F173 完全独立(prd 附录 A 依赖图),全并行;主会话依次接收 PR,按 site-overlap 顺序 merge。
+
+### 工作树分配
+
+| Teammate | Branch | Finding | 体量估算 | Briefing 重点 |
+|---|---|---|---|---|
+| W1-T1 `release-binary` | `v066-w1-release-binary` | **F166** | 1.5 d | `.github/workflows/release.yml` 4-matrix CI + `install.sh` POSIX-compliant + checksum 强校验 + README quickstart 改造;windows MSVC build 若 `tokio::signal::unix` fail → `#[cfg(unix)]` gate;macOS-arm64 GH runner 排队等;**关键 invariant**:历史 tag(v0.6.0-v0.6.5)force-push 不触发 release |
+| W1-T2 `sensible-defaults` | `v066-w1-sensible-defaults` | **F167** | 1 d | `project_probe.rs` 启发式探测(Monorepo/SingleRepo/DocsOnly/ScriptsOnly)+ `render_workflow_template` 加 `probe` 参数 + `ccteam probe-project --json` 新 CLI sub-cmd + `ccteam-creator` SKILL.md Phase 3.6;**边界守:不**加新 preset、不 LLM-assisted role auto-gen |
+| W1-T3 `todo-sweep` | `v066-w1-todo-sweep` | **F168** | 1 d | 9 个 site 逐条决断(prd §F168 表)+ V0.7 defer site 改注释为「V0.7 deferred (justification): ...」格式 + `no_silent_todo_test.rs` 回归 grep test;**关键**:实数为准(实际 grep 数 ≠ 9 时,以实际为准 + 全部决断,**禁止悄悄不决断**);F168 site #1/#5/#7 与 F173/F169/F170 PR site-overlap → 同 PR 一并清 |
+| W1-T4 `cost-today-ledger` | `v066-w1-cost-today-ledger` | **F169** | 0.5 d | `nl_admin::cost_today` 重写接 `load_budget_ledger` + `sum_24h(vendor)` helper + budget cap warning + 4 test;ledger schema 与 F152 align(本 finding 第一步 read `<root>/cost-budget.json` 实际 shape) |
+| W1-T5 `doc-scrub` | `v066-w1-doc-scrub` | **F170** | 0.5 d | 4 个 doc-comment site 各 1-line patch(dashboard.rs:10 / team.rs:1503 / pricing.rs:51 / project_mcp_json.rs:18);#3 若发现 `Vendor` 未 re-export → 加 `pub use` 后再改 doc(扩 ~5 LOC);grep verify 0 命中 |
+| W1-T6 `doctor-verify-mcp` | `v066-w1-doctor-verify-mcp` | **F171** | 0.5 d | `--verify-mcp` flag + `run_verify_mcp` + `VerifyMcpReport` struct + static `STUB_TOOLS: &[&str] = &[]` const + 6 test(`doctor_verify_mcp_test.rs`);输出格式对齐 V0.6.5 ship gate item #9 措辞「MCP tool surface: 26 active, 0 stubs」 |
+| W1-T7 `chat-snapshot` | `v066-w1-chat-snapshot` | **F172** | 2.5 d | `chat_snapshot` event const + `build_chat_snapshot_event` helper + `SnapshotPolicy` + `BotSupervisor::maybe_snapshot` 在 `chat_turn_completed` hook 调 + daemon restart recovery flow + idempotent re-attach `recovery_applied_in_restart_cycle` BoolMap;**红线守**:不新建第 9 类业务 event(扩 chat-mode 子家族)/ 不主动 kill / 不 capture-pane(grep verify);29-30 test |
+| W1-T8 `codex-critic-ledger` | `v066-w1-codex-critic-ledger` | **F173** | 2 d | `default_adapter_factory` Codex arm 改用 `CodexExecAdapter` + `orchestrator::adapter_for_chat` 同步 + `CodexExecAdapter::submit_turn` 加 ledger hook + `ccteam doctor` cost-orphan invariant + `skills/ccteam-team/SKILL.md` F156 文案改「shipped V0.6.6 F173」+ `daemon.rs:84` TODO marker 清(F168 #1 决断同 PR);**关键**:`turn.completed` JSONL 实际字段名 verify;`BudgetExceeded` hard-fail(不自动 bypass) |
+
+**并行启动:** T1-T8 day1 同时起,各自独立 worktree,不读其他 worktree 实现。
+
+### Wave 1 PR 合入顺序(由主会话 dispatch agent 控制)
+
+主会话不规定固定顺序,但建议:
+
+1. **T5 F170**(0.5 d,纯 doc)+ **T6 F171**(0.5 d,小独立 CLI)→ 最快可 merge,清场地
+2. **T4 F169**(0.5 d)→ ledger read-only path,无依赖
+3. **T8 F173**(2 d,ledger write path)→ 与 T4 site-overlap(F168 #1)在 T3 之前 merge
+4. **T3 F168**(1 d)→ 等 T4/T8 merge 后再 merge(避免 #1/#5 决断与 T4/T8 重复改)
+5. **T2 F167**(1 d)→ 独立
+6. **T1 F166**(1.5 d)→ 独立但需 tag 测,**最后 merge**(避免误触 release CI on intermediate tags)
+7. **T7 F172**(2.5 d,体量最大)→ 与 T8 时间重叠,但代码路径完全分离,无冲突;最后 merge
+
+**冲突处理:** 任两个 PR rebase 冲突 → 主会话 dispatch 一个 fix-rebase subagent 处理,**不**让 worktree agent 自己解决跨-finding 冲突(防 context 污染)。
+
+### Wave 1 验收(集成 gate)
+
+- `cargo test --workspace --locked --no-fail-fast` ≥ **1660 / 1**(1583 起点 + 各 finding 估算见 README §0)
+- `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
+- 每 finding `prd.md §F1XX` 验收段全过(各 PR 描述链接)
+- F168 决断列表(9 项 + 三档分类)写入 `docs/versions/v0-6-6/wave-1-handoff.md`(Decided / Rejected / Risks / Files / Remaining 五段固定,per V0.6.0 4-wave 范式)
+- 每 PR 描述含 `prd.md` finding 链接 + verification log + `git push -u origin <branch>`(per V0.6 学到的陷阱)
+
+---
+
+## Wave 2 — doc-syncer + host-probe + ship gate(必要时与 Wave 1 末段并行)
+
+**目标:** Tier-1 docs sync + nas-box005 真机验 + version bump + tag。
+
+### 任务分配
+
+| Task | Owner | 内容 | Est. |
+|---|---|---|---|
+| doc-sync | doc-syncer subagent | CLAUDE.md §一 baseline 表更新(test pass count + workspace version + 当前最新版 + 上一版 + V0.6.x 延期候选);`docs/dev-coupling-audit.md` 加 F166-F173 索引段;`docs/versions/v0-6-6/wave-1-handoff.md` 5 段;`docs/versions/v0-6-6/host-probe.md` host-probe 模板 | 0.5 d |
+| host-probe | host-probe subagent on nas-box005 | F166 install.sh(fresh wipe → `curl ... \| sh` → version verify);F167 sensible defaults(`/ccteam-creator` 跑 monorepo + single repo + docs-only 三场景,verify yaml scope 段非空);F169 真 ledger(advise call → IM `cost today` 出真数);F170 grep 0 命中验;F171 `doctor --verify-mcp` PASS;F172 daemon restart recovery(10+ turn → `kill -TERM` → restart → 11th turn 引用早 turn);F173 Codex critic ledger(advise_vote claude+codex → `<root>/cost-budget.json` 含两 row);手动签字 → `host-probe.md` | 1 d |
+| version bump + tag | main session | `workspace.package.version` `0.6.5` → `0.6.6`;commit `v0.6.6: <summary>`;git tag `v0.6.6`;push tag → 触发 F166 release CI;verify GH Release 自动创建 + 4 个 artifact + SHA256SUMS | 0.3 d |
+
+### Wave 2 ship gate(README §5 sync,15 项)
+
+1. ✅ baseline `≥1660/1`
+2. ✅ clippy `-D warnings` clean
+3. ✅ F166 GH Actions release CI(tag push → 4-matrix build → release artifact 全齐)
+4. ✅ F166 install.sh nas-box005 真验
+5. ✅ F167 sensible defaults host-probe(三 project 类型)
+6. ✅ F168 grep 实数验(剩 ≤2 个 site,其余 V0.7 deferred 格式)
+7. ✅ F169 真 ledger 验(IM + CLI 同数字)
+8. ✅ F170 doc-comment scrub clean(`grep -rn "V0.3.3 cleanup\|F49 wires\|once Wave 2 lands\|Wave 2 wires it into the"` 0 命中)
+9. ✅ F171 `doctor --verify-mcp` PASS + 自动化 test 覆盖
+10. ✅ F172 daemon restart recovery host-probe + `grep -rn "tmux capture-pane"` 0 命中(红线守)
+11. ✅ F173 Codex critic ledger 真验 + `doctor` 无 cost-orphan + `skills/ccteam-team/SKILL.md` F156 文案 cleanup
+12. ✅ CLAUDE.md §一 baseline 表 V0.6.6 数字
+13. ✅ dev-coupling-audit.md F166-F173 索引补
+14. ✅ F168 9 site 决断列表 in wave-1-handoff.md
+15. ✅ tag `v0.6.6` push + GH Release notes(F166 install instructions 嵌入)
+
+### Wave 2 验收 → ship
+
+15 项 ship gate 全过 → `v0.6.6` tag + GH Release ship。
+
+---
+
+## 失败处理 / 升级路径(CLAUDE.md §五 #6:测试不过不算完成)
+
+| 场景 | 处理 |
+|---|---|
+| 某 worktree subagent 卡 ≥ 0.5 d 无 progress | 主会话 dispatch 一个 unblock subagent 接手(briefing 含原 PRD section + 已 commit 的 partial work);**不**让原 agent 继续 spin |
+| 某 finding test 通不过 + 估算无法在 +0.5 d 内修 | 主会话 escalate 给用户 → 当场决策三档(EOL 删 / V0.7 显式 defer-with-justification / 加 +0.5 d 继续);**禁止**自动决定推 V0.6.7 |
+| 实际 grep TODO 数(F168)≠ 9 | 实数为准,wave-1-handoff 列实际数 + 全部决断;**禁止**对 spec 数字 freelance(per task block 模式) |
+| F170 实际 site ≠ 4 | 实数为准,标题改 "F170 scrub N sites"(per task block 模式) |
+| F172 设计与红线冲突(如必须新加第 9 类业务 event) | 立即停 + 通报 "v066 SPEC QUESTION: F172 设计 violates <红线>, 主会话需重审"(per task block 模式) |
+| F173 F156 R8 cross-ref(V0.6.5 wave-2-handoff)实际不存在 | 立即停 + 通报(per task block 模式)── doc-first session 已 verify line 36 存在 R8(`docs/versions/v0-6-5/wave-2-handoff.md`),代码 PR 阶段若 wave-2-handoff 内容被改动须重审 |
+| nas-box005 host-probe 失败(网络 / 物理) | 主会话 dispatch retry(最多 2 次)+ 失败留 log;若硬体不可达 → ship gate 走 docker-based fallback verify(F166 install.sh 在 ubuntu:24.04 container 内跑) |
+
+---
+
+## 工时估算汇总
+
+| Wave | Tasks | 估算 | 并行 / 串行 |
+|---|---|---|---|
+| 0 (doc-first) | 本 PR | 0.05 d | 单 session |
+| 1 (8 worktree) | F166-F173 | max(各 finding 估算) ≈ **2.5 d**(F172 体量最大) | 8 worktree 并行 |
+| 2 (doc-sync + host-probe + tag) | 收尾 | 1.5 d | 部分与 Wave 1 末段并行 |
+| **总** | | **~3 d**(并行)/ **~10 d**(串行单线) | |
+
+对比 V0.6.5(19 finding,5 d 并行 / 10-13 d 单线)── V0.6.6 体量 ~50% V0.6.5,patch flow 节奏匹配。
+
+---
+
+## 红线核对(关 CLAUDE.md §三 + README §3)
+
+每 worktree subagent briefing 必含:
+
+- **F166**:install.sh 不破坏用户 PATH;不要求 sudo;不下载未签名 binary 不验 checksum;不静默安装到系统目录
+- **F167**:probe 仅看文件存在性(不 parse 代码);不引入 prompt injection(probe 结果是 yaml ctx,user-visible)
+- **F168**:决断不留 silent TODO;每 V0.7 defer 必带 justification 1-2 sentence
+- **F169**:不破坏 ledger schema(只 read);若需 helper API 加,与 F173 共享
+- **F170**:纯 doc chore,行为零变化;若 #3 需 `pub use` 加,扩 ~5 LOC 不超
+- **F171**:不引入新 MCP tool(F171 是 CLI flag,不动 MCP 总数 26);STUB_TOOLS const 是 invariant 守门员
+- **F172**:**红线最严**:不新建第 9 类业务 event(扩 chat-mode 子家族)/ 不主动 kill / 不 capture-pane / recovery prompt 是 user prompt 形式不是 system prompt
+- **F173**:不动 F124 HumanApprovalAdapter scope(已 V0.7 defer);F156 SKILL.md 文案改「shipped」不留 alias;BudgetExceeded hard-fail 不 bypass
+
+---
+
+## 完成判据(本 dev-plan 验收)
+
+- [ ] Wave 1 8 个 PR 全 merge 到 main(或单一 collation PR)
+- [ ] Wave 2 doc-sync + host-probe + version bump + tag 全完成
+- [ ] 15 项 ship gate 全过
+- [ ] `v0.6.6` GH Release ship 含 4 个 prebuilt binary + SHA256SUMS
+- [ ] CLAUDE.md §一 baseline 表反映 V0.6.6
+- [ ] 无 finding 推 V0.6.7 / V0.7(strict no-leftover 守)

--- a/docs/versions/v0-6-6/prd.md
+++ b/docs/versions/v0-6-6/prd.md
@@ -1,0 +1,823 @@
+# V0.6.6 — PRD(8 finding 完整需求)
+
+> **Status:** doc-first(Wave 0)。每个 finding 6 段固定:**痛点 / 现状缺口 / 设计 / 文件 / 验收 / 风险**。
+> **基线起点:** `1583 / 1`(V0.6.5 ship 数 + 已知 `workflow_summary_reflects_agent_spawn_and_done_events` flake)/ clippy `-D warnings` clean / workspace `0.6.5`。
+> **基线目标:** `1660 / 1`(+~80,各 finding 估算 §README §0)/ clippy `-D warnings` clean / workspace `0.6.6`。
+
+---
+
+## F166 — GH Releases 预编译 binary + `install.sh` 一键装
+
+**痛点:** 用户痛点 4(零摩擦上手)。
+当前 README `quickstart` 要求 `cargo install --git https://github.com/firstintent/ccteam` ── 用户必须先装 Rust toolchain(rustup + 一次 `cargo install` 编译耗 5-15 min,小机器 OOM 风险)。非开发者(运维 / 业务方 / 想试 IM 助理的 PM)被卡在第一步。
+
+**现状缺口:**
+- 仓库无 `.github/workflows/release.yml`。
+- 无 `install.sh`(一键 OS+arch 探测 + 下载 + 校验 + PATH 写入)。
+- README quickstart Step 1 = "`cargo install --git ...`",新用户首次互动门槛过高。
+- GH Releases 页面历史 tag(v0.6.0 - v0.6.5)只有 source tarball,无 prebuilt artifact。
+
+**设计:**
+
+### Sub-1:GH Actions release workflow
+
+新文件 `.github/workflows/release.yml`,trigger = `push: tags: [v*]`。
+
+```yaml
+name: release
+on:
+  push:
+    tags: ['v*']
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-gnu,    suffix: linux-x64    }
+          - { os: macos-14,       target: aarch64-apple-darwin,        suffix: macos-arm64  }
+          - { os: macos-13,       target: x86_64-apple-darwin,         suffix: macos-x64    }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc,      suffix: windows-x64  }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - checkout
+      - cargo build --release --locked --target ${{ matrix.target }} --bin ccteam
+      - 打包 tar.gz(linux/macOS)/ zip(windows)+ sha256 checksum
+      - upload-artifact
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - download-artifact
+      - 汇总所有 *.sha256 到 SHA256SUMS
+      - gh release create $TAG --notes-file <release-notes.md> *.tar.gz *.zip SHA256SUMS
+```
+
+**关键细节:**
+- macOS notarization **不做**(stretch / V0.7)── 用户首次跑会有 Gatekeeper warning;README 给出 `xattr -d com.apple.quarantine` 指引(临时解)。
+- musl static linux build **不做**(只 gnu)── glibc ≥ 2.31(Ubuntu 20.04+ / Debian 11+)覆盖足够;musl 留 V0.7 stretch。
+- windows MSVC build:`ccteam-imd` 当前依赖 `tokio::signal::unix` 路径需 `#[cfg(unix)]` gate(F163 引入)── verify windows build pass,必要时加 `#[cfg(windows)]` stub。
+- release notes 模板:从 `docs/versions/v0-6-6/README.md` §0 概览段抽取 + binary 下载指引 + checksum 验证示例。
+
+### Sub-2:`install.sh`
+
+新文件 `install.sh`(repo root),`curl ... | sh` 一行装。
+
+```sh
+#!/usr/bin/env sh
+set -e
+REPO="firstintent/ccteam"
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$OS-$ARCH" in
+  linux-x86_64)  SUFFIX="linux-x64";   EXT="tar.gz" ;;
+  darwin-arm64)  SUFFIX="macos-arm64"; EXT="tar.gz" ;;
+  darwin-x86_64) SUFFIX="macos-x64";   EXT="tar.gz" ;;
+  *) echo "Unsupported: $OS-$ARCH. Use cargo install --git fallback."; exit 1 ;;
+esac
+LATEST=$(curl -sSL "https://api.github.com/repos/$REPO/releases/latest" | grep tag_name | head -1 | cut -d'"' -f4)
+URL="https://github.com/$REPO/releases/download/$LATEST/ccteam-$LATEST-$SUFFIX.$EXT"
+SUMS_URL="https://github.com/$REPO/releases/download/$LATEST/SHA256SUMS"
+TMP=$(mktemp -d)
+curl -sSL "$URL" -o "$TMP/pkg.$EXT"
+curl -sSL "$SUMS_URL" -o "$TMP/SHA256SUMS"
+# checksum verify
+(cd "$TMP" && grep "$SUFFIX.$EXT" SHA256SUMS | sha256sum -c -) || { echo "checksum mismatch"; exit 1; }
+tar -xzf "$TMP/pkg.$EXT" -C "$TMP"
+INSTALL_DIR="${CCTEAM_INSTALL_DIR:-$HOME/.local/bin}"
+mkdir -p "$INSTALL_DIR"
+mv "$TMP/ccteam" "$INSTALL_DIR/ccteam"
+chmod +x "$INSTALL_DIR/ccteam"
+echo "Installed: $INSTALL_DIR/ccteam"
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *) echo "NOTE: add $INSTALL_DIR to your PATH:"
+     echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc" ;;
+esac
+ccteam --version
+```
+
+**安全细节:**
+- 强 sha256 校验,失败直接 abort(不 silent skip)。
+- 不需要 sudo(默认装 `~/.local/bin`)。
+- `CCTEAM_INSTALL_DIR` env override 给系统级安装的用户。
+- windows 不支持(用户走 GH Release 页手动下载 + 解压 zip)── 文档说明。
+
+### Sub-3:README + quickstart 改造
+
+`README.md` quickstart Step 1 改为:
+
+```markdown
+## Install
+```sh
+curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh
+```
+Or download from [Releases](https://github.com/firstintent/ccteam/releases).
+Building from source (Rust 1.85+ required):
+```sh
+cargo install --git https://github.com/firstintent/ccteam ccteam
+```
+```
+
+`docs/quickstart.md` 中文版同步改;`docs/troubleshooting.md` 加 macOS Gatekeeper 段。
+
+**文件:**
+- 新:`.github/workflows/release.yml`、`install.sh`、`docs/versions/v0-6-6/host-probe.md`(Wave 2)
+- 改:`README.md` quickstart 段、`docs/quickstart.md`、`docs/troubleshooting.md`
+- 测试:`.github/workflows/release.yml` 内 `--dry-run`(可选)+ install.sh 在 nas-box005 真验
+
+**验收:**
+- tag `v0.6.6-rc1` 推 → 4 matrix build 全绿 + GH Release 自动创建 + 含 4 个 tarball/zip + SHA256SUMS
+- nas-box005 fresh wipe 跑 `curl ... | sh` → `ccteam --version` 输出 `0.6.6`
+- checksum 故意改坏 → install.sh abort + exit 1
+- macOS-arm64 host 真验(可借开发者自机)→ `xattr -d com.apple.quarantine` 后 binary 可跑
+- 测试 +~12(GH Actions workflow yml syntax + install.sh dry-run unit)
+
+**风险:**
+- windows MSVC build 可能因 `tokio::signal::unix` cfg 漏洞失败 ── mitigate:本 finding 接到 ⇒ 第一 build attempt 不通过即加 `#[cfg(unix)]` gate 修复(预算 0.3 d)
+- macOS-arm64 GH runner 有时排队长 ── 不 block,异步等
+- release.yml 触发条件 `tags: [v*]` 会让历史 tag(v0.6.0 - v0.6.5)若 force-push 触发重 release ── mitigate:`if: github.repository == 'firstintent/ccteam'` 守 + 文档说明只 `v0.6.6+` 才有 prebuilt(老 tag 不补 release)
+
+---
+
+## F167 — `/ccteam-creator` 默认 sensible defaults(轻量,非完整 template library)
+
+**痛点:** 用户痛点 4 + 11。
+当前 `/ccteam-creator` 落出的默认 workflow.yaml + role md 是「one-size-fits-all」── 用户不论做 monorepo 后端 reviewer / 单 repo bug-hunt squad / TG 聊天助理,拿到的初始模板基本一样,需手改才能用。
+
+**现状缺口:**
+- `crates/ccteam-core/src/templates/workflow_templates/` 有 5 个 preset(bg-overnight / chat-pocket / chat-squad / inproc-solo / inproc-team),但里面变量都是空白默认。
+- `skills/ccteam-creator/SKILL.md` Phase 4(LLM 生成 yaml)对 project 上下文(repo 结构 / 语言栈 / 是否 monorepo)无探测,LLM 完全靠 user prompt 字面意思猜。
+- 用户首次 ship 的 yaml `scope:` 段经常空(V0.6.2 F140 引入,本应是 per-role 重要约束)。
+
+**设计:**
+
+### 边界(防滚雪球)
+
+**F167 = 启发式 + 默认值微调。** **不**做:
+- LLM-assisted 完整 role auto-gen(V0.7 epic)
+- 新增 preset / template 文件(沿用现有 5 个)
+- 跨语言栈适配(只针对当前 5 个 preset 的填充值)
+
+### Sub-1:project-type 探测 helper
+
+新 `crates/ccteam-core/src/templates/project_probe.rs`(~150 LOC):
+
+```rust
+pub struct ProjectProbe {
+    pub kind: ProjectKind,           // Monorepo / SingleRepo / DocsOnly / ScriptsOnly / Empty
+    pub languages: Vec<Language>,    // Rust / TypeScript / Python / Go ...(top 3)
+    pub has_tests: bool,
+    pub probable_scope: Vec<PathBuf>, // 启发式:src/ + crates/<top-level>/src/ + lib/ ...
+}
+
+pub fn probe(repo_root: &Path) -> Result<ProjectProbe>;
+```
+
+探测信号(纯文件存在性,不 parse 任何代码):
+- `Cargo.toml` workspace.members + `package.json` workspaces + `pnpm-workspace.yaml` + `go.work` → Monorepo
+- 单 `Cargo.toml` / 单 `package.json` / `pyproject.toml` → SingleRepo
+- 只有 `*.md` + 无 source dir → DocsOnly
+- 只有 `*.sh` / `*.py` script 文件 → ScriptsOnly
+
+### Sub-2:workflow_templates 默认值 enhancer
+
+`crates/ccteam-core/src/templates/workflow_templates/mod.rs` `render_workflow_template` 加 ctx argument:
+
+```rust
+pub fn render_workflow_template(
+    preset: &str,
+    ctx: &TemplateCtx,
+    probe: Option<&ProjectProbe>,  // new
+) -> Result<String>;
+```
+
+每个 preset 的 sensible default(示例):
+
+| preset | probe = Monorepo | probe = SingleRepo | probe = DocsOnly |
+|---|---|---|---|
+| `bg-overnight` | `scope: [<top-3 workspace member crates>]` | `scope: [src/, tests/]` | `scope: [docs/]` |
+| `inproc-team` | per-role scope 按 monorepo 子树自动分发 | per-role 同 scope | scope = docs/ |
+| `chat-pocket` | bot mention scope = repo root | 同 | 同 |
+
+### Sub-3:`ccteam-creator` SKILL.md Phase 4 集成
+
+Phase 4(yaml 生成)前加 Phase 3.6 "Project probe":
+
+```markdown
+## 3.6  Project probe
+Run `ccteam probe-project --json` to detect:
+- kind (monorepo / single / docs-only)
+- languages (top-3)
+- probable scope paths
+
+Feed into Phase 4 template ctx so the generated yaml's
+`scope:` field is pre-populated with sensible defaults.
+```
+
+新 CLI 子命令 `ccteam probe-project --json`(`crates/ccteam-cli/src/commands.rs`,~50 LOC wrapper)。
+
+**文件:**
+- 新:`crates/ccteam-core/src/templates/project_probe.rs`、`crates/ccteam-cli/tests/probe_project_test.rs`
+- 改:`crates/ccteam-core/src/templates/workflow_templates/mod.rs`、`crates/ccteam-cli/src/commands.rs`(新 sub-cmd)、`crates/ccteam-cli/src/main.rs`(clap 暴露)、`skills/ccteam-creator/SKILL.md`(Phase 3.6 + Phase 4 ctx)
+
+**验收:**
+- 在 ccteam repo 本身跑 `ccteam probe-project --json` → `{"kind": "Monorepo", "languages": ["Rust"], "probable_scope": ["crates/ccteam-core/src", "crates/ccteam-cli/src", ...]}`
+- fresh tmp repo `git init` + `cargo new --bin foo` → probe = SingleRepo + Rust + scope = `["src", "tests"]`
+- `/ccteam-creator "做个 monorepo 后端 reviewer"` 在 monorepo 内跑 → 生成的 workflow.yaml `scope:` 非空
+- 测试 +~6(probe 4 种 project kind + 2 template render 集成)
+
+**风险:**
+- 探测启发式漏判(如 hybrid monorepo)── mitigate:user prompt 仍可 override probe 结果,probe 只提供「合理初值」
+- ccteam 自身 monorepo 探测出 10+ crate,scope 默认值过宽 ── mitigate:probable_scope 截 top-3(按 LOC 排序 / fallback alphabetical)
+
+---
+
+## F168 — active TODO sweep(9 site,逐条决断)
+
+**痛点:** 用户痛点 14。
+codebase 内 TODO/FIXME/HACK/Wave-marker 散布,V0.6.5 post-ship-stub-inventory.md Cat 4 列了 11 production site + Cat 7 列了 4 stale doc-comment site + Cat 6 列了 3 adapter delegation site。本 finding **不只**清 inventory 列的,实际 grep `crates/*/src/` 全 production 路径,逐条决断。
+
+**现状缺口:**
+
+实际 grep 结果(2026-05-24 HEAD = V0.6.5 ship)的 9 site(strict `(// TODO|// FIXME|// HACK|TODO\()` pattern,过滤 template 字符串):
+
+| # | Location | 来源 | 当前归属 |
+|---|---|---|---|
+| 1 | `crates/ccteam-imd/src/daemon.rs:84` | `// TODO(wave-3 codex-exec-impl): swap to CodexAppServerAdapter once it lands` | F173 修(本版,见下) |
+| 2 | `crates/ccteam-imd/src/daemon.rs:409` | `/// 3. (slack / discord — TODO in V0.7: providers exist but the host probe's first round only exercises telegram)` | V0.7 显式 defer-with-justification(Epic C 国内 IM 同 wave) |
+| 3 | `crates/ccteam-imd/src/daemon.rs:458` | `// (single-bot host probe), V0.7 will cache.` | V0.7 显式 defer-with-justification(perf-rework,单 bot 时无影响) |
+| 4 | `crates/ccteam-imd/src/daemon.rs:559-561` | `// V0.7 will land per-bot custom handles. For F132 the typical … collision is theoretical until V0.7.` | V0.7 显式 defer-with-justification(workflow.yaml `chat_handle:` schema 扩展) |
+| 5 | `crates/ccteam-imd/src/nl_admin.rs:271` | `// V0.7 wires the full ccteam_cost rollup here.` | F169 修(本版) |
+| 6 | `crates/ccteam-core/src/orchestrator.rs:684` | `// TODO(F124 full scope, post-F98): introduce a dedicated HumanApprovalAdapter wrapper` | V0.7 显式 defer-with-justification(F124 full scope 在 V0.6.1 已 explicit defer) |
+| 7 | `crates/ccteam-web/src/routes/dashboard.rs:10` | `//! see the TODO marker there for V0.3.3 cleanup.` | F170 修(本版 doc-scrub,marker 早已不存在) |
+| 8 | `crates/ccteam-imd/src/three_layer_sec.rs:111` | `// Slack inbound HTTP receiver is V0.7 scope` | V0.7 显式 defer-with-justification(Slack HMAC 与 Epic C 同 wave) |
+| 9 | `crates/ccteam-imd/src/transport/providers/slack.rs:5` | `// Switch to Socket Mode is a V0.7 decision per docs/versions/v0-6-0/wave-2-decisions.md §5` | V0.7 显式 defer-with-justification(同上) |
+
+**实数验证**:doc-first session 实测 `grep -rnE "(// TODO|// FIXME|// HACK|TODO\()" crates/*/src/` 命中数 = **8**(`crates/ccteam-core/src/handoff.rs` 内 4 处 `- TODO` 是 HANDOFF_TEMPLATE 内文,不算;`crates/ccteam-core/src/team.rs:1431` 内 `"    pattern: TODO\\n"` 是 test fixture 字符串,不算)。**已加** `daemon.rs:458` 与 `daemon.rs:559-561` 是同 inventory Cat 4 列的 V0.7 marker,被 grep pattern 漏(不是 `// TODO` 起头,而是 `// (single-bot host probe), V0.7 will cache.` 类 inline marker)── 本 finding 决断时**一并扫**(扩展 grep 到 `V0\.[7-9]\+?` 在 src 内),最终决断列表 9 项。
+
+### 决断分布
+
+- **本版 fix(2 项)**:#1 → F173 直接覆盖;#5 → F169 直接覆盖;#7 → F170 doc-scrub
+- **EOL 删(0 项)**:本版无「彻底删除决断」
+- **V0.7 显式 defer-with-justification(6 项)**:#2 / #3 / #4 / #6 / #8 / #9
+
+**决断模板**(每条 V0.7 defer 必含):
+```rust
+// V0.7 deferred (justification):
+//   <为什么本版不做的 1-2 sentence 业务 / 架构理由>
+// Tracked in: docs/versions/v0-6-6/prd.md §F168
+// Original marker: <原 TODO 字面意思>
+```
+
+**设计:**
+
+### Sub-1:执行决断
+
+每个 V0.7 defer site 改注释:
+
+例如 `daemon.rs:84` 不被 F173 覆盖的 fallback(if F173 实际只动 Codex chat adapter,bg 路径仍 stub):
+```rust
+// V0.7 deferred (justification):
+//   Codex bg-mode adapter swap is bundled with F156/F173 critic wiring;
+//   bg-mode users still get ClaudeTuiAdapter fallback which works for
+//   non-Codex personas. V0.7 unifies via daemon-routed Codex adoption.
+// Tracked in: docs/versions/v0-6-6/prd.md §F168 + §F173
+// Original marker: TODO(wave-3 codex-exec-impl)
+```
+
+### Sub-2:回归 grep 测试
+
+新 `crates/ccteam-cli/tests/no_silent_todo_test.rs`(~30 LOC):
+```rust
+#[test]
+fn no_silent_todo_in_production_src() {
+    let out = std::process::Command::new("grep")
+        .args(["-rnE", "(// TODO|// FIXME|// HACK)(?!.*V0\\.[7-9])"])
+        .args(["crates/ccteam-core/src", "crates/ccteam-cli/src", ...])
+        .output().unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // 允许 V0.7+ deferred markers(必含 "V0.X" 词)
+    let lines: Vec<_> = stdout.lines()
+        .filter(|l| !l.contains("V0.7") && !l.contains("V0.8"))
+        .collect();
+    assert!(lines.is_empty(), "Silent TODOs found:\n{}", lines.join("\n"));
+}
+```
+
+测试 invariant:**每个剩余 TODO/FIXME/HACK marker 必须在同行或邻行含 `V0.X` deferred-with-justification 标记**,否则失败。
+
+**文件:**
+- 改:`crates/ccteam-imd/src/daemon.rs`(#2/#3/#4)、`crates/ccteam-imd/src/three_layer_sec.rs`(#8)、`crates/ccteam-imd/src/transport/providers/slack.rs`(#9)、`crates/ccteam-core/src/orchestrator.rs`(#6)
+- 新:`crates/ccteam-cli/tests/no_silent_todo_test.rs`
+- 测试 +~10(no_silent_todo + 决断 site grep verify)
+
+**验收:**
+- `grep -rnE "(// TODO|// FIXME|// HACK|TODO\()" crates/*/src/` 输出 ≤ 2 个 site,其余全转 `V0.7 deferred` 格式
+- `cargo test no_silent_todo` 通过
+- F168 决断列表(9 项 + 三档分类)写入 `docs/versions/v0-6-6/wave-1-handoff.md`(Decided / Rejected / Risks / Files / Remaining 五段固定)
+
+**风险:**
+- grep regex 误报(template string 内含 `TODO` 字面)── mitigate:测试用 ripgrep 排除 `\.rs` 内已知 template fixture 行;现 `team.rs:1431` 与 `handoff.rs:49-61` 已知 false positive,whitelist
+- subagent 发现实际不是 9 而是更多 site → 实数为准,在 wave-handoff 列实际数字 + 全部决断;**禁止悄悄不决断**
+
+---
+
+## F169 — `nl_admin::cost_today` 接真 `ccteam_cost` ledger
+
+**痛点:** 用户痛点 9 + 14。
+V0.6.5 ship gate item #9 承诺 `ccteam doctor` 出 "MCP tool surface: 26 active, 0 stubs",但 IM admin `@ccteam cost today` 仍走 V0.6.1 占位 ── 返「bot count」而非真 USD。F169 接真 ledger,end-to-end 闭环。
+
+**现状缺口:**
+- `crates/ccteam-imd/src/nl_admin.rs:265-296` `cost_today()` 返:
+  ```
+  ccteam cost today
+    bots: <count>
+    detailed per-vendor breakdown: `/ccteam-control show-cost`.
+  ```
+- 注释 line 271 explicit 说 "V0.7 wires the full `ccteam_cost` rollup here"。
+- `<ccteam_root>/cost-budget.json` ledger 已在 V0.6.5 F152 引入(advise_today_usd + per-vendor rows);`ccteam-core::advise::load_budget_ledger` API 已 export。
+- 用户 IM 输入 `@ccteam cost today` 得不到真数字 → 痛点 9(团队不依赖人在场)用户面 visibility gap。
+
+**设计:**
+
+### Sub-1:`cost_today` 函数重写
+
+```rust
+async fn cost_today(&self, slug_filter: Option<&str>) -> AdminReply {
+    use ccteam_core::advise::load_budget_ledger;
+    let ccteam_root = ccteam_paths_root();  // 已存在 helper
+    let ledger = load_budget_ledger(&ccteam_root).unwrap_or_default();
+    let bots = list_bots().unwrap_or_default();
+    let filtered: Vec<&BotRegistration> = match slug_filter {
+        Some(s) => bots.iter().filter(|b| b.workflow_slug == s).collect(),
+        None => bots.iter().collect(),
+    };
+    let header = match slug_filter {
+        Some(s) => format!("ccteam cost today — slug `{s}`"),
+        None => "ccteam cost today".to_string(),
+    };
+    let claude_24h = ledger.sum_24h(Vendor::Claude);
+    let codex_24h  = ledger.sum_24h(Vendor::Codex);
+    let total = claude_24h + codex_24h;
+    let cap = ledger.cap_usd;  // 默认 0.50 USD/24h(F152)
+    let msg = format!(
+        "{header}\n\
+        rolling 24h cost: ${total:.4} / ${cap:.2} cap\n\
+        - claude: ${claude_24h:.4}\n\
+        - codex:  ${codex_24h:.4}\n\
+        active bots: {} (filter: {})\n\
+        full breakdown: `/ccteam-control show-cost`",
+        filtered.len(),
+        slug_filter.unwrap_or("none"),
+    );
+    AdminReply { message: msg, side_effect: AdminSideEffect::None }
+}
+```
+
+### Sub-2:`ledger.sum_24h(vendor)` helper
+
+`crates/ccteam-core/src/advise.rs` 加方法:
+```rust
+impl BudgetLedger {
+    pub fn sum_24h(&self, vendor: Vendor) -> f64 {
+        let cutoff = chrono::Utc::now() - chrono::Duration::hours(24);
+        self.rows.iter()
+            .filter(|r| r.ts >= cutoff && r.vendor == vendor)
+            .map(|r| r.cost_usd)
+            .sum()
+    }
+}
+```
+
+(若已存在 `sum_24h` API 则复用;若返 total only,加 per-vendor 版本)
+
+### Sub-3:budget cap 集成
+
+显示 `total / cap`,当 `total > 0.9 * cap` 时 message 加 warning prefix `⚠️ approaching daily budget cap`(对齐 F152 budget enforcement UX)。
+
+**文件:**
+- 改:`crates/ccteam-imd/src/nl_admin.rs`(`cost_today` 函数,~50 LOC)
+- 改:`crates/ccteam-core/src/advise.rs`(`sum_24h` per-vendor helper,可能已有)
+- 新:`crates/ccteam-imd/tests/nl_admin_cost_today_test.rs`(4 test:empty ledger / 单 vendor / dual vendor / cap warning)
+
+**验收:**
+- 测试 +4 全通
+- nas-box005 跑一次 `mcp__ccteam__advise_vote` → `@ccteam cost today` IM 回真 USD(不再是 bot count)
+- 与 `ccteam-control show-cost` 输出数字一致(同源 ledger)
+- 测试 `daemon.rs:271` TODO marker 已删(F168 #5 决断)
+
+**风险:**
+- `BudgetLedger` schema 与 `cost_today` 期望的 row.ts/row.vendor 字段不完全 align ── mitigate:本 finding 第一步 read ledger 实际 struct,必要时加薄 adapter(预算 ~10 LOC)
+- 多 ccteam_root(用户跨 home 跑两份 daemon)── mitigate:nl_admin 在 daemon 内部,daemon 起时已绑定单一 ccteam_root,无歧义
+
+---
+
+## F170 — 陈旧 doc-comment scrub(Cat 7,实测 4 site)
+
+**痛点:** 用户痛点 14。
+post-ship-stub-inventory.md Cat 7 列 4 个 stale doc-comment ── 引用早已 ship/landed 的 work,新 contributor 读 src 时被误导。
+
+**现状缺口:**
+
+实测 4 site(2026-05-24 doc-first session grep 确认):
+
+| # | Location | 字面 | 现状 | 修法 |
+|---|---|---|---|---|
+| 1 | `crates/ccteam-web/src/routes/dashboard.rs:10` | `//! see the TODO marker there for V0.3.3 cleanup.` | `assets.rs` 早已 V0.3.3 cleanup 完毕,无 TODO marker | 删 line 10 整段 reference |
+| 2 | `crates/ccteam-core/src/team.rs:1503` | `// F47 ship: schema accepts harness: codex even though spawn is still NotImplemented. F49 wires the runtime path.` | F49 长期 shipped(V0.4.x) | 改为 `// Schema test: harness: codex parsing (F47 schema + F49 runtime, both shipped)` |
+| 3 | `crates/ccteam-cost/src/pricing.rs:51` | `// ccteam-core will re-export ccteam_cost::Vendor once Wave 2 lands.` | Wave 2 of V0.6.0 long-shipped;verify re-export | 验 `ccteam-core::lib.rs` 已 re-export,改 doc 为「现状 fact」陈述 |
+| 4 | `crates/ccteam-core/src/templates/project_mcp_json.rs:18` | `// Wave 1 lands this helper alone; Wave 2 wires it into the ccteam-creator skill execute phase` | F148(V0.6.5)已 wire,verify | 验 + 改 doc 为「F148 wires it into the ccteam-creator skill Phase 5」(指向当前 SoT) |
+
+**实数 verify**:doc-first session grep 确认 = 4 site(与 post-ship-stub-inventory Cat 7 一致)。
+
+### inventory Cat 7 还提到 `crates/ccteam-imd/src/transport/mod.rs:3` 「V0.6.0 Wave 2 Option-C implementation」── 标 "n/a (keep — historical doc)",本 finding **不动**(尊重 inventory 决断)。
+
+**设计:**
+
+5 site 各自 patch(独立 1-line 改),无新增测试 ── 纯文档 chore,行为零变化。
+
+**文件:**
+- 改:4 个文件各 1 处 doc 注释
+
+**验收:**
+- `grep -rn "V0.3.3 cleanup\|F49 wires\|once Wave 2 lands\|Wave 2 wires it into the" crates/*/src/` 0 命中
+- baseline 不退(无代码改)
+- clippy 0
+
+**风险:**
+- 验 #3 `Vendor` re-export 时发现还没 re-export(就是 Cat 7 「verify」原意)── mitigate:**若**未 re-export,本 finding 范围扩 ~5 LOC `pub use ccteam_cost::Vendor`,然后再改 doc;若 re-export 存在,纯 doc fix
+
+---
+
+## F171 — `ccteam doctor --verify-mcp` flag,stub-counter parity check
+
+**痛点:** 用户痛点 14。
+V0.6.5 ship gate item #9 承诺 `ccteam doctor` 输出 "MCP tool surface: 26 active, 0 stubs",但实际 doctor 没有专门 stub-counter sub-mode ── inventory 显示 V0.6.5 ship 时是 manual 验。F171 加 `--verify-mcp` flag 把这条 invariant 自动化 + 加 0-STUB assertion,catch 未来回归。
+
+**现状缺口:**
+- `ccteam doctor` 现支持多 sub-mode(`--validate-team` / `--check-codex-auto-critic` / `--check-pricing` ...)。
+- 无 `--verify-mcp` flag,无自动 stub counter 输出。
+- 用户 / CI 验「MCP 表面是否仍 0 stub」需手跑 `cargo run -- doctor` + grep 输出 ── 不机械化。
+
+**设计:**
+
+### Sub-1:`--verify-mcp` flag
+
+`crates/ccteam-cli/src/commands.rs` `DoctorOptions` 加 `pub verify_mcp: bool`;`crates/ccteam-cli/src/main.rs` clap 暴露 `--verify-mcp`。
+
+### Sub-2:`run_verify_mcp` 函数
+
+`crates/ccteam-cli/src/commands.rs`(~80 LOC):
+```rust
+pub fn run_verify_mcp() -> Result<VerifyMcpReport> {
+    // 1. List all registered MCP tools via mcp_tool_groups::all_tools()
+    // 2. For each tool, classify:
+    //    - Active: dispatch path returns real result (not Err("not implemented"))
+    //    - Stub: dispatch path is unwired
+    // 3. Count + per-group breakdown
+    // 4. Cross-check against expected count(26 tools per V0.6.1 F128)
+    Ok(VerifyMcpReport {
+        total: 26,
+        active: 26,
+        stubs: 0,
+        per_group: ...,
+        unexpected_stubs: vec![],  // 非空 → exit 1
+    })
+}
+
+pub struct VerifyMcpReport {
+    pub total: usize,
+    pub active: usize,
+    pub stubs: usize,
+    pub per_group: BTreeMap<String, GroupStats>,
+    pub unexpected_stubs: Vec<String>,
+}
+
+impl VerifyMcpReport {
+    pub fn render(&self) -> String { /* human-readable */ }
+    pub fn ok(&self) -> bool { self.unexpected_stubs.is_empty() }
+}
+```
+
+### Sub-3:输出格式
+
+```
+MCP tool surface verification
+===
+total tools:    26 (expected 26)
+active:         26
+stubs:          0
+
+per-group breakdown:
+  workflow_:    7 active / 0 stub
+  chat_:        9 active / 0 stub
+  advise_:      2 active / 0 stub
+  admin_:       7 active / 0 stub  (incl. change_persona, add_tool)
+  screenshot:   1 active / 0 stub
+
+verdict: PASS — all 26 tools live, no production STUBs.
+```
+
+非 0 stub → `verdict: FAIL` + exit code 1。
+
+### Sub-4:dispatch path 自检
+
+「stub」判定:每个 tool name 对应 dispatch fn,fn body 含 `Err(NotImplemented { .. })` 或 `return stub_response()` → 标 stub。
+
+实现:`mcp_tool_groups` 暴露每 tool 的 dispatch fn pointer / async closure;`run_verify_mcp` 用一个 sentinel input 调用 + 检查 result variant。**Notes**:不能真调外部副作用(如 register_bot 写文件),需 design dispatch fn 支持 `dry_run = true` hint,或用 mock fixture(F171 内 ~30 LOC test helper)。
+
+替代实现(更简单):**static lookup table** ── `mcp_tool_groups::STUB_TOOLS: &[&str] = &[]`(V0.6.5 ship 后是空 list)。`run_verify_mcp` 读这个 const + 与 active list 对账。任何 PR 加 stub tool 必同步加 list,grep test 守。
+
+**文件:**
+- 改:`crates/ccteam-cli/src/main.rs`(clap)、`crates/ccteam-cli/src/commands.rs`(`run_verify_mcp` + `VerifyMcpReport`)、`crates/ccteam-cli/src/mcp_tool_groups.rs`(`STUB_TOOLS` const)
+- 新:`crates/ccteam-cli/tests/doctor_verify_mcp_test.rs`(6 test:expected count / 0-stub assertion / per-group breakdown / FAIL exit code / render format / static-table parity)
+
+**验收:**
+- `cargo run --release -- doctor --verify-mcp` 输出含 `MCP tool surface: 26 active, 0 stubs`
+- `mcp_tool_groups::STUB_TOOLS` const = `&[]`
+- 故意临时把一个 dispatch 改成 stub → `doctor --verify-mcp` 输出 FAIL + exit 1
+- 测试 +6 全通
+- V0.6.5 ship gate item #9 提到的措辞通过 grep 验证
+
+**风险:**
+- 「real dispatch 检查」过度复杂 ── mitigate:走 Sub-4 替代实现(static lookup table + grep 守),更轻量
+- 26 tool 总数本版可能因 F167 加 `ccteam probe-project` 而变 27 ── mitigate:`probe-project` 是 CLI sub-cmd,**不**是 MCP tool;MCP 总数仍 26(确认无新 MCP 工具),否则 expected count 同 PR 同步改
+
+---
+
+## F172 — tmux mode-3 上下文恢复(`chat_snapshot` event)
+
+**痛点:** 用户痛点 9 + 14。
+V0.6.5 F163(SIGTERM graceful)+ F164(tmux reattach)解决了「daemon 物理重启不丢 tmux session」,但 **chat bot 已累积的对话上下文若发生 tmux session 死亡(进程崩 / 物理重启 / OOM kill)只能走 F118 `session_recovery::build_recovery_prompt` 回放 last-N turns**。F172 加 proactive snapshotting,让 recovery 不只靠 turns.jsonl 重放,还能续上「最后一次 snapshot 起的增量」── 把长跑 bot 的 context 损失从「last-N turns」收缩到「last snapshot 起的新增 turn 数」。
+
+**现状缺口:**
+- F118 已落 `chat_session_reset_with_recovery` event + `session_recovery::build_recovery_prompt` ── 仅在 session-id invalidated(compaction failure / corruption)时触发,**不是周期性** + recovery prompt 是 last-N turn 回放,不包含 bot 内部 working memory / 已下决断 / 引用的中间 artifact。
+- progress.jsonl 现有 chat-mode 子事件家族(F108 / F118):`chat_session_started` / `chat_turn_user_prompt` / `chat_turn_completed` / `chat_session_reset` / `chat_session_reset_with_recovery` / `chat_compact_done` / `chat_hop_escalate` ── 都是「事件发生时记一笔」,无周期性 snapshot 概念。
+- daemon 重启 → `claude_tui::start_thread` 若 session alive → F164 reattach;若 session dead → F118 recovery 回放 last-N turns。**Loss**:重启窗口内的 in-pane working memory(已用的工具结果 / 已展开的 plan / mid-conversation TODO list)全失。
+
+**设计:**
+
+### 红线核对(详 README §3)
+
+- **不**新建第 9 类业务 event:`chat_snapshot` 加入 chat-mode 子事件家族(与 F108 / F118 同 category),progress.jsonl SoT 红线守。
+- **不**主动 kill long session:snapshot 是非破坏旁路 dump,不触 tmux pane,不发 send-keys,不影响 bot 当前活动。
+- **不**解析 tmux 终端输出:snapshot 源 = `turns.jsonl`(F108 mirror)+ 既有 progress.jsonl event,不调 `tmux capture-pane`。
+- **不**注入 system prompt:recovery 时注入的是 user prompt 形式(对齐 F118 `build_recovery_prompt` 既有路径),`.claude/agents/<role>.md` 仍是 agent 行为唯一 SoT。
+
+### Sub-1:`chat_snapshot` event schema
+
+`crates/ccteam-core/src/progress.rs` 加:
+
+```rust
+/// `chat_snapshot` — V0.6.6 F172: periodic context snapshot dumped by
+/// the BotSupervisor (mode-3 chat). Used by daemon-restart recovery
+/// path to rebuild context beyond the last-N-turns fallback in F118.
+///
+/// Cadence: every N turns OR every M minutes, whichever first
+/// (defaults N=10, M=30). Payload references turns.jsonl byte offset
+/// instead of inlining transcript to keep progress.jsonl scannable.
+pub const CHAT_SNAPSHOT: &str = "chat_snapshot";
+
+pub fn build_chat_snapshot_event(
+    role: &str,
+    turn_id_range: (String, String),  // (first_turn_id, last_turn_id)
+    turns_jsonl_byte_offset: u64,     // resume point in turns.jsonl
+    context_size_tokens: u32,         // approx tokens in window
+    triggers: SnapshotTriggers,       // Periodic { every_n_turns } | TimeElapsed | Manual
+) -> Value {
+    serde_json::json!({
+        "event": CHAT_SNAPSHOT,
+        "role": role,
+        "turn_id_range": [turn_id_range.0, turn_id_range.1],
+        "turns_jsonl_byte_offset": turns_jsonl_byte_offset,
+        "context_size_tokens": context_size_tokens,
+        "triggers": triggers,
+        "ts": Utc::now().to_rfc3339(),
+    })
+}
+```
+
+**关键 schema 设计**:
+- **turns_jsonl_byte_offset**:snapshot 不内联 transcript(避免 progress.jsonl 膨胀),只记 resume point;recovery 时 `seek(offset)` 即可 stream-read 后续 turn。
+- **context_size_tokens**:approx 计数(由 UnifiedTokenUsage 累加),帮 recovery 判断「context 已超模型窗口?要先 compact?」。
+- **triggers**:why-this-snapshot 元数据(便于 dashboard 显示)。
+
+### Sub-2:dump cadence
+
+`crates/ccteam-imd/src/supervisor.rs` `BotSupervisor` 加:
+
+```rust
+pub struct SnapshotPolicy {
+    pub every_n_turns: u32,        // default 10
+    pub max_elapsed: Duration,     // default 30 min
+    pub max_context_tokens: u32,   // emergency snapshot when > 80% window
+}
+
+impl BotSupervisor {
+    async fn maybe_snapshot(&mut self, role: &str) {
+        let since_last = self.turns_since_last_snapshot(role);
+        let elapsed = self.elapsed_since_last_snapshot(role);
+        let tokens = self.approx_context_tokens(role);
+        let trigger = match (since_last, elapsed, tokens) {
+            (n, _, _) if n >= self.policy.every_n_turns => Some(...),
+            (_, e, _) if e >= self.policy.max_elapsed => Some(...),
+            (_, _, t) if t >= self.policy.max_context_tokens => Some(...),
+            _ => None,
+        };
+        if let Some(triggers) = trigger {
+            self.emit_snapshot_event(role, triggers).await;
+        }
+    }
+}
+```
+
+`maybe_snapshot` 在 `chat_turn_completed` handler 末尾调(已是 BotSupervisor 现有 hook 点)。
+
+### Sub-3:daemon restart recovery flow
+
+`crates/ccteam-imd/src/daemon.rs` 起 daemon 时 per-bot 走:
+
+```
+1. tail progress.jsonl(F164 既有)→ 找 latest chat_snapshot event for this role
+2. if found:
+   a. claude_tui::start_thread(role)
+      - F164 path: if tmux session alive → reattach
+      - else: spawn new + run recovery prompt
+   b. read turns.jsonl from snapshot.turns_jsonl_byte_offset onwards
+   c. compose recovery prompt:
+      "[ccteam recovery] Resuming after daemon restart.
+       Last snapshot at turn_id <last_turn_id>, ~<N> turns ago.
+       Recent turns since snapshot: <inline last 5 turns from byte offset>.
+       Please continue from where we left off."
+   d. push as user prompt to tmux pane(对齐 F118 既有路径)
+3. if no snapshot:fallback F118 build_recovery_prompt(last-N turns mode)
+4. emit chat_session_reset_with_recovery event(F118 既有,扩 payload 加 from_snapshot: true 字段)
+```
+
+### Sub-4:idempotent re-attach
+
+`chat_handle` 必须 idempotent:重复调 `start_thread(role)` 时:
+- 若 tmux session alive + snapshot already applied this restart cycle → no-op
+- 否则:走完整 recovery flow
+
+引入 per-role `recovery_applied_in_restart_cycle: BoolMap`(daemon 内存),重启时清空。
+
+### Sub-5:边界(防滚雪球)
+
+**F172 不做**:
+- 主动恢复 in-tmux-pane 用户已输入未发送的 input(不可观测,放弃)
+- 跨机器迁移 chat context(V0.7+ chat memory sync)
+- recovery 时自动 compact(用户决定)── 仅在 `context_size_tokens` 超 90% 阈值时 warn
+
+**文件:**
+- 改:`crates/ccteam-core/src/progress.rs`(`CHAT_SNAPSHOT` const + `build_chat_snapshot_event` + `SnapshotTriggers` enum)、`crates/ccteam-core/src/execution/session_recovery.rs`(`build_recovery_prompt` 加 snapshot-aware overload)、`crates/ccteam-imd/src/supervisor.rs`(`SnapshotPolicy` + `maybe_snapshot`)、`crates/ccteam-imd/src/daemon.rs`(restart recovery flow)、`crates/ccteam-core/src/execution/claude_tui.rs`(idempotent re-attach)
+- 新:`crates/ccteam-imd/tests/chat_snapshot_test.rs`(periodic trigger / time elapsed trigger / token cap trigger)、`crates/ccteam-imd/tests/daemon_restart_recovery_test.rs`(snapshot exists / no snapshot fallback / idempotent re-attach / from_snapshot field set)
+
+**验收:**
+- 测试 +~30 全通(snapshot 8 + recovery 12 + idempotent 4 + progress event helper 6)
+- nas-box005 host-probe:跑 mode-3 chat ≥10 turn → progress.jsonl 有 ≥1 `chat_snapshot` event(periodic trigger);`kill -TERM` daemon → `ccteam start` → 第 11 turn 输入 "continue from where we left off" → bot reply 引用早 turn 内容(测试人确认语义续接);progress.jsonl 含 `chat_session_reset_with_recovery` event with `from_snapshot: true`
+- baseline 不退
+- 红线核对:`grep -rn "tmux capture-pane" crates/ccteam-core/src/execution/session_recovery.rs crates/ccteam-imd/src/supervisor.rs crates/ccteam-imd/src/daemon.rs` 0 命中
+
+**风险:**
+- snapshot 频率过高 → progress.jsonl 膨胀 ── mitigate:默认 every-10-turns OR 30-min,benchmark 实测 < 100 line/day per active bot
+- recovery prompt 过长 → 浪费 context 窗口 ── mitigate:Sub-3 只 inline "since snapshot" 部分(typically 1-9 turns 间隔),完整历史在 turns.jsonl 由 LLM 按需 grep
+- byte_offset 失效(若 turns.jsonl 被外部 truncate)── mitigate:recovery flow 验 offset 在文件长度内,若否 fallback F118 build_recovery_prompt(last-N) + emit warning
+- 与 V0.6.5 F164 `start_thread` reattach 行为耦合 ── mitigate:F172 Sub-4 idempotent guard 独立 BoolMap,不影响 F164 alive-session 探测;严格区分 "session alive but no recovery applied yet"(走 recovery)vs "session alive + recovery already done"(no-op)
+
+---
+
+## F173 — Codex daemon-routed critic 统一 cost rollup(F156 follow-through)
+
+**痛点:** 用户痛点 6 + 14。
+V0.6.3 F156 ship 时说 "Daemon-routed variant (route critic through `CodexExecAdapter` for unified cost accounting) **explicitly deferred past V0.6.5**"(`docs/versions/v0-6-3/README.md` line 16 + V0.6.5 wave-2-handoff R8)。当时理由:advise_* MCP 还没 ship,cost rollup 前提不足。**现在前提齐备**(V0.6.5 F152 引入 `<root>/cost-budget.json` ledger + `CodexExecAdapter` 已用于其他路径),F173 补完 ── critic 调用统一计入同账,end-to-end 闭环。
+
+**现状缺口:**
+- `crates/ccteam-imd/src/daemon.rs:78-89` `default_adapter_factory` Codex arm 仍返 `ClaudeTuiAdapter`(`// TODO(wave-3 codex-exec-impl): swap to CodexAppServerAdapter`)── chat-mode Codex bot **silently** 跑 Claude adapter,critic spawn 不走 Codex 路径。
+- `crates/ccteam-core/src/orchestrator.rs:671-677` `adapter_for_chat` `(Codex, Chat)` arm 同 fallback。
+- `skills/ccteam-team/SKILL.md` §3.5 N≥3 critic 是 bash spawn 直跑 `codex exec --json`,**不走** ledger 账户 ── 这次调用花的 USD 不计入 `<root>/cost-budget.json::advise_today_usd`(对比 F152 `advise_vote` 路径走 ledger)。
+- 用户面影响:`@ccteam cost today`(F169 修后)显示 advise call 真数,但 critic 调用「漏算」── cost visibility 仍有 leak;长跑 Codex 调用累计未被 cap enforce → 痛点 14 长跑可控性 leak。
+
+**设计:**
+
+### Sub-1:critic spawn 路由 `CodexExecAdapter`
+
+`skills/ccteam-team/SKILL.md` §3.5 N≥3 critic 部分:从「bash 直跑 codex exec」改为「调 MCP tool `mcp__ccteam__advise_vote` with vendors=[claude, codex]」,或新 MCP tool `mcp__ccteam__advise_critic`(若 advise_vote 不适用 N≥3 路径)。
+
+**决策**:本版**复用** `advise_vote` ── critic 本质就是「找另一个 vendor 提第二意见」,与 advise_vote 语义重合;无需新 MCP tool。SKILL.md §3.5 文案改为:
+
+```markdown
+For N≥3 review setups, the critic call should go through
+`mcp__ccteam__advise_vote` (which routes through CodexExecAdapter +
+ledger). Bash `codex exec` direct spawn is deprecated as of V0.6.6;
+existing bash path will be removed in V0.7.
+```
+
+### Sub-2:`default_adapter_factory` Codex arm 修
+
+`crates/ccteam-imd/src/daemon.rs:78-89`:
+
+```rust
+fn default_adapter_factory(vendor: AgentVendor) -> Box<dyn HarnessAdapter> {
+    match vendor {
+        AgentVendor::Claude => Box::new(ClaudeTuiAdapter::new()),
+        AgentVendor::Codex => Box::new(CodexExecAdapter::new()),  // was: ClaudeTuiAdapter fallback
+    }
+}
+```
+
+`crates/ccteam-core/src/orchestrator.rs:671-677` 同步:
+```rust
+fn adapter_for_chat(exec: ExecutionMode, vendor: AgentVendor) -> Box<dyn HarnessAdapter> {
+    match (vendor, exec) {
+        (Codex, Chat) => Box::new(CodexExecAdapter::new()),  // was: bg fallback
+        ...
+    }
+}
+```
+
+### Sub-3:ledger 统一接入
+
+`CodexExecAdapter` `submit_turn` 路径加 ledger update hook:
+
+```rust
+async fn submit_turn(&self, h: &ThreadHandle, prompt: &str) -> Result<TurnId> {
+    let ccteam_root = ccteam_paths_root();
+    let pre_spent = load_budget_ledger(&ccteam_root).map(|l| l.advise_today_usd).unwrap_or(0.0);
+    let cap = load_budget_ledger(&ccteam_root).map(|l| l.cap_usd).unwrap_or(DEFAULT_ADVISE_CAP);
+    if pre_spent >= cap {
+        return Err(HarnessError::BudgetExceeded { spent: pre_spent, cap });
+    }
+    // ... existing codex exec spawn ...
+    // post-turn: parse turn.completed JSONL → extract token usage → estimate cost
+    let cost = estimate_cost(usage, AgentVendor::Codex);
+    append_budget_ledger_row(&ccteam_root, AgentVendor::Codex, cost)?;
+    Ok(turn_id)
+}
+```
+
+Helper `append_budget_ledger_row`(`crates/ccteam-core/src/advise.rs` 加):
+```rust
+pub fn append_budget_ledger_row(
+    ccteam_root: &Path,
+    vendor: Vendor,
+    cost_usd: f64,
+) -> Result<()>;
+```
+
+(若 F152 已有等价 API,复用 + 必要时小重构)
+
+### Sub-4:`ccteam doctor` cost-orphan 检查
+
+`crates/ccteam-cli/src/commands.rs::run_doctor` 加 cost-orphan invariant:
+- 扫描 progress.jsonl 内 24h 内 `agent_done` event(含 Codex vendor)→ 对账 ledger row 数
+- 不对账 → warn "cost orphan: N Codex calls in progress.jsonl, M rows in ledger"
+- 完全对账 → silent OK
+
+`ccteam doctor --verify-mcp`(F171)同时调 cost-orphan 检查,double protection。
+
+### Sub-5:F156 explicit defer cleanup
+
+`skills/ccteam-team/SKILL.md` 内「daemon-routed Codex critic with unified cost accounting **explicitly deferred past V0.6.5**」文案删除 → 改为「daemon-routed Codex critic shipped V0.6.6 F173 — see `docs/versions/v0-6-6/prd.md` §F173」。
+
+V0.6.5 wave-2-handoff.md R8 不动(历史文档归档,只在新版本归档反映现状)。
+
+**文件:**
+- 改:`crates/ccteam-imd/src/daemon.rs`(`default_adapter_factory`)、`crates/ccteam-core/src/orchestrator.rs`(`adapter_for_chat`)、`crates/ccteam-core/src/execution/codex_exec.rs`(ledger hook in `submit_turn`)、`crates/ccteam-core/src/advise.rs`(`append_budget_ledger_row` helper if needed)、`crates/ccteam-cli/src/commands.rs`(`run_doctor` cost-orphan)、`skills/ccteam-team/SKILL.md`(F156 文案 cleanup)
+- 新:`crates/ccteam-core/tests/codex_critic_ledger_test.rs`(critic 调用记 ledger 验证,~120 LOC)、`crates/ccteam-cli/tests/doctor_cost_orphan_test.rs`(orphan detect / clean state,~80 LOC)
+- 测试 +~15
+
+**验收:**
+- 测试 +15 全通
+- nas-box005 host-probe:跑 `mcp__ccteam__advise_vote claude+codex same question` → `<root>/cost-budget.json::advise_today_usd` 含 Claude 与 Codex 两 row,数字 = 实际 token 用量 estimate;`@ccteam cost today` 显示同样数字(F169);`ccteam doctor --verify-mcp` 无 cost-orphan warning
+- `daemon.rs:84` TODO marker 已 cleanup(F168 #1 决断)
+- `orchestrator.rs:684` HumanApprovalAdapter TODO **不动**(本 finding 不动 F124 scope,F168 #6 已 V0.7 defer)
+- `skills/ccteam-team/SKILL.md` F156 文案改为「shipped V0.6.6 F173」
+- baseline 不退
+
+**风险:**
+- `CodexExecAdapter` post-turn 解析 `turn.completed` JSONL token usage 字段名 / shape 与 estimate_cost helper 期望不匹配 ── mitigate:本 finding 第一步实测 codex 实际 JSONL output(`crates/ccteam-core/src/execution/codex_exec.rs` 已有解析逻辑可复用)+ 必要时加 `serde(alias)` 兼容
+- `BudgetExceeded` 错误对 critic 调用是 hard fail ── mitigate:N≥3 critic 是 advise call,失败 user-visible OK(用户已知 budget 设定);**不**自动 bypass
+- F156 跨版本 cross-ref:本 finding 必须验 V0.6.5 wave-2-handoff R8 在 codebase 实际存在(doc-first session 已 verify line 36 含 R8)── 若不存在,本 finding 立即停 + escalate(per task spec block 模式)
+
+---
+
+## 附录 A:8 finding 间依赖图
+
+```
+F166 (release CI + install.sh)      ─┐  完全独立(8 worktree 全并行)
+F167 (sensible defaults)             ─┤
+F168 (TODO sweep)                    ─┤  与 F169 + F170 + F173 有 site-overlap
+F169 (cost_today ledger)             ─┤  → F168 #5 决断同 PR
+F170 (doc scrub)                     ─┤  → F168 #7 决断同 PR
+F171 (doctor --verify-mcp)           ─┤
+F172 (chat_snapshot)                 ─┤
+F173 (Codex critic ledger)           ─┘  → F168 #1 决断同 PR + 与 F169 共享 ledger schema(F169 read,F173 write)
+
+site-overlap 处理:每 PR review 时主会话(dispatch agent)负责 cross-check;
+worktree 间不直接 cross-merge,主会话依次 merge 顺序解决冲突。
+```
+
+## 附录 B:Ship gate 复盘(关 §README §5)
+
+15 项 ship gate 中,**本 PRD 验收**对应每 finding 的「验收」段;**集成 ship gate**(baseline / clippy / GH Actions release CI / host-probe / CLAUDE.md baseline 回填 / dev-coupling-audit 索引补 / tag)由 Wave 2 doc-syncer 负责。详 `dev-plan.md`。


### PR DESCRIPTION
## V0.6.6 doc-first
Per CLAUDE.md §五 patch flow.

### Ship findings (8)
- F166 GH Releases prebuilt binary + install.sh
- F167 /ccteam-creator sensible default templates (lightweight; full template library deferred V0.7)
- F168 active TODO sweep (9 sites across codebase, list in prd)
- F169 nl_admin::cost_today wire ccteam_cost ledger
- F170 stale doc-comment scrub (per post-ship-stub-inventory Cat 7)
- F171 ccteam doctor stub-counter parity check
- F172 tmux mode-3 context recovery via progress.jsonl chat_snapshot event
- F173 Codex daemon-routed critic unified cost rollup (F156 follow-through)

### V0.7 explicit defer
- /ccteam-creator full template library + role auto-gen
- ccteam migrate-from-claude
- monorepo-aware .mcp.json
- 国内 IM enable (Epic C)

### Baseline target
1583/1 → ~1660/1 (+~80 tests). workspace 0.6.5 → 0.6.6. clippy 0 warnings.

Awaits user review → then 8 parallel Opus worktree dispatch.