### PR TITLE
docs(v0.6.6): F172 redesign — claude --resume route

### DIFF
--- a/docs/versions/v0-6-6/README.md
+++ b/docs/versions/v0-6-6/README.md
@@ -3,7 +3,7 @@
 > **状态:doc-first / Wave 0**(本 PR 范围 = `README.md` + `prd.md` + `dev-plan.md`,代码 PR 走后续 8 个 worktree-per-finding 并行 dispatch)。
 > **主题:** **关 V0.6.5 ship 留的小账 + 把两条原 V0.7 候选拉回 V0.6.6**。V0.6.5 闭了 V0.6 自身的账(chat MCP 桥 / advise / UX cohesion / 运维 robustness),`post-ship-stub-inventory.md` 又给出一张 codebase 干净度地图。本版按那张地图扫尾,加 **F172 mode-3 上下文恢复**(daemon 重启不丢长跑 chat 会话上下文)+ **F173 daemon-routed Codex critic 统一 cost rollup**(V0.6.3 F156 留的 explicit defer 现在补完),同时把 **F166 prebuilt binary + install.sh** 这条「零摩擦安装」做掉 ── 用户不再被 `cargo install --git` 拦在门口。
 > **基线起点:** workspace `0.6.5` / test `1583 / 1`(V0.6.5 ship 数,1 fail 是已知 `workflow_summary_reflects_agent_spawn_and_done_events` flake)/ clippy `-D warnings` clean。
-> **基线目标:** workspace `0.6.6` / test ≥ `1660 / 1`(+~80,见 §0 估算)/ clippy `-D warnings` clean。
+> **基线目标:** workspace `0.6.6` / test ≥ `1644 / 1`(+~61,见 §0 估算;F172 V2 改 spawn argv 路线 +8 替代原 +30)/ clippy `-D warnings` clean。
 > **痛点对应(13 用户痛点):** 痛点 4(零摩擦上手)/ 痛点 9(团队不依赖人在场,24/7 daemon)/ 痛点 11(Skill / 入口可发现性)/ 痛点 14(长跑可靠性)。
 
 ---
@@ -18,10 +18,10 @@
 | **F169** | `nl_admin::cost_today` 接真 `ccteam_cost` ledger(替 V0.6.1 占位 registry-count 返值) | 9 / 14 | S | +4 |
 | **F170** | 陈旧 doc-comment scrub(post-ship-stub-inventory Cat 7,实测 4 site) | 14 | XS | 0 |
 | **F171** | `ccteam doctor --verify-mcp` flag 加 stub-counter parity 自检 | 14 | S | +6 |
-| **F172** | tmux mode-3 上下文恢复 ── progress.jsonl 加 `chat_snapshot` event 周期 dump,daemon 重启可重建 | 9 / 14 | L | +30 |
+| **F172** | tmux mode-3 上下文恢复 ── 借 Anthropic 官方 `claude --resume <name>` lossless 取回 full API-level context,无需手工 synthesis | 9 / 14 | S-M | +8 |
 | **F173** | Codex daemon-routed critic 统一 cost rollup(F156 follow-through;原 V0.7 候选) | 6 / 14 | M | +15 |
 
-**总计** 8 finding · 8 worktree 并行(完全独立)· 估算 +~80 新测试 → baseline 目标 `1660/1`。
+**总计** 8 finding · 8 worktree 并行(完全独立)· 估算 +~61 新测试 → baseline 目标 `1644/1`。
 
 ---
 
@@ -31,7 +31,7 @@ V0.6.5 ship 时 `post-ship-stub-inventory.md` §"Recommendations" 给了三档�
 
 - **3 项 V0.6.6 patch 全收**:F168(TODO sweep,实际范围比 inventory 列的更广,9 site)/ F169(`cost_today` 接真 ledger)/ F170(Cat 7 doc-comment scrub)/ F171(doctor stub-counter parity)。
 - **从「V0.7 minor 主候选」拉两项回 V0.6.6**:**F172 mode-3 上下文恢复** + **F173 Codex critic 统一 cost rollup**。理由:
-  - F172 是「24/7 长跑可靠性」的最后一块拼图 ── V0.6.5 F163 给了 graceful SIGTERM、F164 给了 tmux reattach,但 **daemon 崩 / 重启时 chat bot 已积累的上下文会丢**(F164 reattach 物理 session,F118 `session_recovery` 重建 last-N turns,但「last-N turns 的语义损失」对长跑 bot 来说仍然不可忽略)。F172 让 progress.jsonl 周期 snapshot 关键 context,重启时 chat_handle re-attach 后用 snapshot 续上,把损失从「last-N turns」缩到「最后一次 snapshot 起的增量」。
+  - F172 是「24/7 长跑可靠性」的最后一块拼图 ── V0.6.5 F163 给了 graceful SIGTERM、F164 给了 tmux reattach(alive)+ recreate(dead pane),但 **F164 dead-pane recreate 路径 spawn 的是 brand-new claude 进程,上一段对话的 full API-level context 全丢**(F118 `session_recovery` 回放 last-N turns 作 user prompt 是 best-effort 字面回放,模型内部 tool-use 中间结果 / 已折叠 plan / cache 状态 / 推理链全失)。F172 V2 转向**直接借 Anthropic 官方 `claude --resume <session-name>` 接口** ── 每个 chat bot spawn 时加 `--name ccteam-chat-<slug>-<role>` deterministic 命名,recreate 路径 spawn `claude --resume <name>` 让 Anthropic 自己 reload session jsonl(`~/.claude/projects/<encoded-cwd>/<sid>.jsonl`)── lossless,无需 ccteam 手工 synthesis;红线 R10(跨项目记忆走官方接口)直接守。
   - F173 是 V0.6.3 F156 留的「explicit defer past V0.6.5」 ── V0.6.5 advise/Codex critic 路径全 ship 了,F156 提到的 unified cost rollup 现在前提齐备(`CodexExecAdapter` 已用;`<root>/cost-budget.json` ledger 已在 F152 引入)。本版补完后,Codex critic 调用统计与 main spawn 在同一账上,用户面 `ccteam doctor` + `@ccteam cost today`(F169)出真数,end-to-end 闭环。
 - **加 F166 + F167**:F166 是用户级零摩擦入口(对齐痛点 4 ── 当前 README quickstart 要求 `cargo install --git`,新用户至少装 Rust toolchain 才能开始);F167 是用户首次 `/ccteam-creator` 时落地 yaml 的 sensible defaults,与 F166 一起把「first 5 min user experience」抬一个档。
 
@@ -57,21 +57,21 @@ V0.6.5 ship 时 `post-ship-stub-inventory.md` §"Recommendations" 给了三档�
 
 | 红线 | 本版触及? | 守的方式 |
 |---|---|---|
-| 文件系统是控制平面 | F172 写 `chat_snapshot` 到 progress.jsonl | progress.jsonl 是已存在的 SoT,**不**新建第二个文件;snapshot payload 内联(或指向 turns.jsonl 内 byte-offset),不引入新 IPC 通道 |
-| `progress.jsonl` 是唯一 state SoT | F172 **守 + 扩展** | `chat_snapshot` 是 chat-mode event 家族的新成员(继 F108/F118 的 `chat_session_started` / `chat_turn_user_prompt` / `chat_turn_completed` / `chat_session_reset` / `chat_session_reset_with_recovery` / `chat_compact_done` / `chat_hop_escalate` 之后)── **不是新的第 9 类业务 event,而是扩 chat-mode 子家族**(CLAUDE.md §一 的 7 类业务 event + chat 子事件已是同一 SoT);daemon 重启从 progress.jsonl tail 读最近 `chat_snapshot` → 走 F118 既有 `session_recovery::build_recovery_prompt` 路径 |
-| No prompt injection | F172 snapshot 仅作为 recovery context 注入新 tmux pane | recovery 时注入的是 user prompt 形式(对齐 F118 `chat_session_reset_with_recovery` 既有路径),不是 system prompt;`.claude/agents/<role>.md` 仍是 agent 行为唯一 SoT |
-| 每次 spawn = fresh 1M context(bg 模式) | 不触及 | F172 仅作用于 mode-3 chat;chat 复用 context 是 feature(CLAUDE.md §三 原文) |
-| 永不主动 kill 长 session | F172 / F173 守 | F172 snapshot 是**辅助 + 非破坏** ── 周期 dump 到 progress.jsonl,不触 tmux pane,不发 send-keys,不影响 bot 当前活动;只有 daemon 重启时(daemon process 已死) 才走 recovery 路径,不算 kill;F173 critic 通过 daemon route 仍是 fire-and-forget 子进程,与 main spawn 独立 |
-| 不解析 tmux 终端输出 | F172 snapshot 源 = transcript jsonl + turns.jsonl(已存在的 ccteam-owned 路径) | snapshot 内容由 `turns_mirror`(F108 引入)与 progress.jsonl event 拼合而成,**不**调 `tmux capture-pane` |
+| 文件系统是控制平面 | F172 V2 借 Anthropic 官方 session jsonl | `--resume <name>` 读 Anthropic 自己的 `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`(已是控制平面的官方接口),**不**引入新 IPC 通道、**不**新建文件;progress.jsonl 不动 |
+| `progress.jsonl` 是唯一 state SoT | F172 V2 **守(零扩)** | 原 V1 设计的 `chat_snapshot` event **ditch** ── F172 V2 完全 spawn-argv 级改动,SoT 红线零扩;daemon 重启 recovery 走 `claude --resume <name>` 由 Anthropic 自己 reload,不再依赖 ccteam 写 / 读 snapshot 事件 |
+| No prompt injection | F172 V2 守 | Anthropic 自己 reload context,ccteam 不构造 history-synthesis prompt、不向 tmux pane push 任何 text;`.claude/agents/<role>.md` 仍是 agent 行为唯一 SoT |
+| 每次 spawn = fresh 1M context(bg 模式) | 不触及 | F172 V2 仅作用于 mode-3 chat;chat 复用 context 是 feature(CLAUDE.md §三 原文)|
+| 永不主动 kill 长 session | F172 V2 / F173 守 | F172 V2 仅在 F164 探测到 dead pane 时走 recreate(那是 orphan tmux,不是活 bot ── F164 已论证不算红线违反);alive session 完全不动;F173 critic 通过 daemon route 仍是 fire-and-forget 子进程,与 main spawn 独立 |
+| 不解析 tmux 终端输出 | F172 V2 不涉 tmux 任何 pane content | F172 V2 完全 spawn argv 级改动(`--name` / `--resume`),零调 `tmux capture-pane`、零读 pane 内文本 |
 | fix-loop 撞 3 次必 escalate | F168 决断须 explicit | F168 任何「continue iterating later」式拖单 → escalate-with-question,不写入 prd 默认 |
-| `ccteam-core` 零 team 名字面量 | 不触及 | 本版 ccteam-core 改动仅在 progress event const(F172)+ chat snapshot helper 函数,**无** team 名 |
-| 跨项目记忆走官方接口 | 不触及 | 本版不改 `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` 处理 |
+| `ccteam-core` 零 team 名字面量 | 不触及 | 本版 ccteam-core 改动仅在 `claude_tui::start_thread` spawn argv 分支(F172 V2),**无** team 名;原 V1 设计的 progress event const + helper 函数也不再引入 |
+| 跨项目记忆走官方接口(R10) | F172 V2 **直接守** | `--resume <name>` 是 Anthropic CLI 一等公民(等同 `--name` / `-c` 同族),ccteam 借而不替;`~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` 路径完全不动 |
 | 新建项目走 `<projects_root>/<team>-<slug>/` | 不触及 | F167 改默认值,不动 slug minting |
 | root README.md MUST be English | F166 改 README quickstart 段 | install.sh 一行说明走英文段,中文说明进 `docs/quickstart.md` |
 | README.md 不含版本进展/状态信息 | F166 改 README | install.sh / GH Release 描述是「产品当前能力」展示,**不**含版本号 / shipping 日期 / 验收数字 |
 | HITL approval state SoT(V0.6.1 F124) | 不触及 | 本版无 plan_approval 改 |
 
-**F172 红线设计补充说明**:本版**明确**选「扩 chat-mode 子事件家族」而非「新建第 9 类业务 event」── 决策理由:`chat_snapshot` 与 F118 `chat_session_reset_with_recovery` 是同一抽象层级的孪生事件(一个写、一个读 recovery 路径),把它们划到不同 category 会让 progress.jsonl 消费者(`ccteam-imd::daemon` recovery / `ccteam-web` dashboard / `ccteam-control` admin)的分发逻辑撕成两套,违反 SoT 原则的 spirit。详 prd §F172。
+**F172 V2 红线设计补充说明**:本版从原 V1「ccteam 自建 `chat_snapshot` event + synthesis recovery prompt」改为「直接借 Anthropic 官方 `claude --resume <name>` CLI 接口」── 决策理由:Anthropic 自己已把 full API-level context(tool-use 中间结果 / cache 状态 / 推理链)存在 `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`,官方 CLI 提供 lossless `--resume`;ccteam 借而不替,既守 R10(跨项目记忆走官方接口),又零扩 progress.jsonl SoT,还避免了 synthesis 路径的"silent 上下文损失"风险(如果 synthesis 不完整 user 会误以为 resume 成功)。F172 V2 fallback 路径(`--resume` 失败 → fresh session + 显式 `chat_session_reset` event)也是 user-visible degraded,**不**冒充 resume。详 prd §F172。
 
 ---
 
@@ -88,7 +88,7 @@ V0.6.5 ship 时 `post-ship-stub-inventory.md` §"Recommendations" 给了三档�
 
 ## 5. Ship gate(V0.6.6 → main)
 
-1. **baseline**:`cargo test --workspace --locked --no-fail-fast` ≥ **1660 / 1**(1583 起点 + ~80 新测试)
+1. **baseline**:`cargo test --workspace --locked --no-fail-fast` ≥ **1644 / 1**(1583 起点 + ~61 新测试;F172 V2 spawn argv 路线 +8 替代原 +30 chat_snapshot 设计)
 2. **clippy**:`cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
 3. **F166 GH Actions release CI 跑通**:tag `v0.6.6` push → 4-arch matrix(linux-x64 / macOS-arm64 / macOS-x64 / windows-x64)build artifact 上 GH Release,checksum 文件齐
 4. **F166 install.sh 真验**:nas-box005(linux-x64)从 fresh wipe → `curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh` → `ccteam --version` 输出 `0.6.6` + PATH 写入正确;**手动签字** → `docs/versions/v0-6-6/host-probe.md`
@@ -97,7 +97,7 @@ V0.6.5 ship 时 `post-ship-stub-inventory.md` §"Recommendations" 给了三档�
 7. **F169 真 ledger 验**:nas-box005 daemon 跑一次 advise call → `@ccteam cost today` IM 回返值含真 USD 数字 + per-vendor 分项;CLI `ccteam-control show-cost` 输出同样数字
 8. **F170 doc-comment scrub clean**:`grep -rn "V0.3.3 cleanup\|F49 wires\|once Wave 2 lands\|Wave 2 wires it into the" crates/*/src/` 0 命中
 9. **F171 doctor stub-counter**:`cargo run --release -- doctor --verify-mcp` 输出含 `MCP tool surface: 26 active, 0 stubs`(沿用 V0.6.5 ship gate item #9 措辞)+ 失败 exit code = 1;**有自动化 test 覆盖**(`crates/ccteam-cli/tests/doctor_verify_mcp_test.rs`)
-10. **F172 daemon-restart-recovery host-probe**:nas-box005 跑 mode-3 chat bot ≥10 turns → `kill -TERM <daemon pid>` → `ccteam start` 再起 → bot 自动 re-attach + 第 11 turn 输入能用得到前 10 turn 上下文(测试人确认 reply 引用早 turn 内容);progress.jsonl 含 ≥1 `chat_snapshot` event;**手动签字** → host-probe.md
+10. **F172 V2 daemon-restart-recovery host-probe**:nas-box005 跑 mode-3 chat bot ≥10 turns → `tmux kill-session -t <ccteam-chat-name>` 模拟 dead pane → daemon 探测 dead → `start_thread` 走 Recreate 路径 spawn `claude --resume ccteam-chat-<slug>-<role>` → 第 11 turn 输入「刚才那个 X 怎么样」→ bot reply 直接引用早 turn 内容(模型内部 cache 续接,**不是** F118 last-N 字面回放);`grep -rn "tmux capture-pane\|CHAT_SNAPSHOT\|chat_snapshot" crates/ccteam-core/src/execution/claude_tui.rs crates/ccteam-core/src/progress.rs` 0 命中(红线守);**手动签字** → host-probe.md
 11. **F173 Codex critic cost rollup 真验**:`mcp__ccteam__advise_vote` 调用 Claude+Codex 各一次 → `<root>/cost-budget.json` `advise_today_usd` 增加;`@ccteam cost today` 显示同样增量;`ccteam doctor` 不报 cost-orphan warning
 12. **CLAUDE.md §一 baseline 表更新到 V0.6.6 数字**(test pass count + version + 当前最新版 + 上一版 + V0.6.x 延期候选)
 13. **dev-coupling-audit.md 加 F166-F173 索引**
@@ -123,7 +123,7 @@ Wave 1  8 finding 全并行 worktree(每个独立 Opus subagent)
         F169 cost_today ledger wire-up               ── 0.5 d
         F170 doc-comment scrub                       ── 0.5 d
         F171 doctor stub-counter                     ── 0.5 d
-        F172 mode-3 context recovery                 ── 2.5 d
+        F172 V2 mode-3 context recovery via claude --resume by name ── 0.5-1 d
         F173 Codex critic cost rollup                ── 2 d
 
 Wave 2  doc-syncer + host-probe + ship gate(必要时,可与 Wave 1 末段并行)

--- a/docs/versions/v0-6-6/dev-plan.md
+++ b/docs/versions/v0-6-6/dev-plan.md
@@ -31,7 +31,7 @@
 | W1-T4 `cost-today-ledger` | `v066-w1-cost-today-ledger` | **F169** | 0.5 d | `nl_admin::cost_today` 重写接 `load_budget_ledger` + `sum_24h(vendor)` helper + budget cap warning + 4 test;ledger schema 与 F152 align(本 finding 第一步 read `<root>/cost-budget.json` 实际 shape) |
 | W1-T5 `doc-scrub` | `v066-w1-doc-scrub` | **F170** | 0.5 d | 4 个 doc-comment site 各 1-line patch(dashboard.rs:10 / team.rs:1503 / pricing.rs:51 / project_mcp_json.rs:18);#3 若发现 `Vendor` 未 re-export → 加 `pub use` 后再改 doc(扩 ~5 LOC);grep verify 0 命中 |
 | W1-T6 `doctor-verify-mcp` | `v066-w1-doctor-verify-mcp` | **F171** | 0.5 d | `--verify-mcp` flag + `run_verify_mcp` + `VerifyMcpReport` struct + static `STUB_TOOLS: &[&str] = &[]` const + 6 test(`doctor_verify_mcp_test.rs`);输出格式对齐 V0.6.5 ship gate item #9 措辞「MCP tool surface: 26 active, 0 stubs」 |
-| W1-T7 `chat-snapshot` | `v066-w1-chat-snapshot` | **F172** | 2.5 d | `chat_snapshot` event const + `build_chat_snapshot_event` helper + `SnapshotPolicy` + `BotSupervisor::maybe_snapshot` 在 `chat_turn_completed` hook 调 + daemon restart recovery flow + idempotent re-attach `recovery_applied_in_restart_cycle` BoolMap;**红线守**:不新建第 9 类业务 event(扩 chat-mode 子家族)/ 不主动 kill / 不 capture-pane(grep verify);29-30 test |
+| W1-T7 `claude-resume-by-name` | `v066-w1-claude-resume-by-name` | **F172 V2** | 0.5-1 d | `claude_tui::start_thread` spawn argv 加 `--name ccteam-chat-<slug>-<role>` deterministic 命名(Fresh path)+ F164 dead-pane recreate 路径 spawn `claude --resume <name>` lossless lookup(Recreate path)+ `--resume` 失败 fallback 走 Fresh + emit `chat_session_reset` event with reason 字段;**第一步必须** `claude --help` verify `--name` / `--resume` flag 存在 + 行为对齐(若漂移 → block + escalate 主会话);**红线守**:不加 progress.jsonl event(原 V1 `chat_snapshot` ditch)/ 不动 alive reattach (a) 路径 / 不 capture-pane / 不 synthesis prompt;`grep -rn "CHAT_SNAPSHOT\|chat_snapshot" crates/ccteam-core/src/progress.rs` 0 命中验;~8 test;**不动** F118 `session_recovery::build_recovery_prompt`(brand-new spawn 路径保留) |
 | W1-T8 `codex-critic-ledger` | `v066-w1-codex-critic-ledger` | **F173** | 2 d | `default_adapter_factory` Codex arm 改用 `CodexExecAdapter` + `orchestrator::adapter_for_chat` 同步 + `CodexExecAdapter::submit_turn` 加 ledger hook + `ccteam doctor` cost-orphan invariant + `skills/ccteam-team/SKILL.md` F156 文案改「shipped V0.6.6 F173」+ `daemon.rs:84` TODO marker 清(F168 #1 决断同 PR);**关键**:`turn.completed` JSONL 实际字段名 verify;`BudgetExceeded` hard-fail(不自动 bypass) |
 
 **并行启动:** T1-T8 day1 同时起,各自独立 worktree,不读其他 worktree 实现。
@@ -46,13 +46,13 @@
 4. **T3 F168**(1 d)→ 等 T4/T8 merge 后再 merge(避免 #1/#5 决断与 T4/T8 重复改)
 5. **T2 F167**(1 d)→ 独立
 6. **T1 F166**(1.5 d)→ 独立但需 tag 测,**最后 merge**(避免误触 release CI on intermediate tags)
-7. **T7 F172**(2.5 d,体量最大)→ 与 T8 时间重叠,但代码路径完全分离,无冲突;最后 merge
+7. **T7 F172 V2**(0.5-1 d,spawn argv 级改动)→ 仅动 `claude_tui::start_thread`,与其他 finding 代码路径完全分离;可任意时点 merge
 
 **冲突处理:** 任两个 PR rebase 冲突 → 主会话 dispatch 一个 fix-rebase subagent 处理,**不**让 worktree agent 自己解决跨-finding 冲突(防 context 污染)。
 
 ### Wave 1 验收(集成 gate)
 
-- `cargo test --workspace --locked --no-fail-fast` ≥ **1660 / 1**(1583 起点 + 各 finding 估算见 README §0)
+- `cargo test --workspace --locked --no-fail-fast` ≥ **1644 / 1**(1583 起点 + 各 finding 估算见 README §0;F172 V2 +8 替代原 +30)
 - `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 命中
 - 每 finding `prd.md §F1XX` 验收段全过(各 PR 描述链接)
 - F168 决断列表(9 项 + 三档分类)写入 `docs/versions/v0-6-6/wave-1-handoff.md`(Decided / Rejected / Risks / Files / Remaining 五段固定,per V0.6.0 4-wave 范式)
@@ -69,12 +69,12 @@
 | Task | Owner | 内容 | Est. |
 |---|---|---|---|
 | doc-sync | doc-syncer subagent | CLAUDE.md §一 baseline 表更新(test pass count + workspace version + 当前最新版 + 上一版 + V0.6.x 延期候选);`docs/dev-coupling-audit.md` 加 F166-F173 索引段;`docs/versions/v0-6-6/wave-1-handoff.md` 5 段;`docs/versions/v0-6-6/host-probe.md` host-probe 模板 | 0.5 d |
-| host-probe | host-probe subagent on nas-box005 | F166 install.sh(fresh wipe → `curl ... \| sh` → version verify);F167 sensible defaults(`/ccteam-creator` 跑 monorepo + single repo + docs-only 三场景,verify yaml scope 段非空);F169 真 ledger(advise call → IM `cost today` 出真数);F170 grep 0 命中验;F171 `doctor --verify-mcp` PASS;F172 daemon restart recovery(10+ turn → `kill -TERM` → restart → 11th turn 引用早 turn);F173 Codex critic ledger(advise_vote claude+codex → `<root>/cost-budget.json` 含两 row);手动签字 → `host-probe.md` | 1 d |
+| host-probe | host-probe subagent on nas-box005 | F166 install.sh(fresh wipe → `curl ... \| sh` → version verify);F167 sensible defaults(`/ccteam-creator` 跑 monorepo + single repo + docs-only 三场景,verify yaml scope 段非空);F169 真 ledger(advise call → IM `cost today` 出真数);F170 grep 0 命中验;F171 `doctor --verify-mcp` PASS;F172 V2 daemon restart recovery(10+ turn → `tmux kill-session -t <ccteam-chat-name>` 模拟 dead pane → daemon Recreate 路径 spawn `claude --resume <name>` → 11th turn "刚才那个 X" 引用早 turn,模型 cache 续接);F173 Codex critic ledger(advise_vote claude+codex → `<root>/cost-budget.json` 含两 row);手动签字 → `host-probe.md` | 1 d |
 | version bump + tag | main session | `workspace.package.version` `0.6.5` → `0.6.6`;commit `v0.6.6: <summary>`;git tag `v0.6.6`;push tag → 触发 F166 release CI;verify GH Release 自动创建 + 4 个 artifact + SHA256SUMS | 0.3 d |
 
 ### Wave 2 ship gate(README §5 sync,15 项)
 
-1. ✅ baseline `≥1660/1`
+1. ✅ baseline `≥1644/1`
 2. ✅ clippy `-D warnings` clean
 3. ✅ F166 GH Actions release CI(tag push → 4-matrix build → release artifact 全齐)
 4. ✅ F166 install.sh nas-box005 真验
@@ -83,7 +83,7 @@
 7. ✅ F169 真 ledger 验(IM + CLI 同数字)
 8. ✅ F170 doc-comment scrub clean(`grep -rn "V0.3.3 cleanup\|F49 wires\|once Wave 2 lands\|Wave 2 wires it into the"` 0 命中)
 9. ✅ F171 `doctor --verify-mcp` PASS + 自动化 test 覆盖
-10. ✅ F172 daemon restart recovery host-probe + `grep -rn "tmux capture-pane"` 0 命中(红线守)
+10. ✅ F172 V2 daemon restart recovery host-probe(dead-pane recreate → `--resume <name>` lossless 续接)+ `grep -rn "tmux capture-pane\|CHAT_SNAPSHOT\|chat_snapshot" crates/ccteam-core/src/execution/claude_tui.rs crates/ccteam-core/src/progress.rs` 0 命中(红线守 + V1 chat_snapshot 设计未污染)
 11. ✅ F173 Codex critic ledger 真验 + `doctor` 无 cost-orphan + `skills/ccteam-team/SKILL.md` F156 文案 cleanup
 12. ✅ CLAUDE.md §一 baseline 表 V0.6.6 数字
 13. ✅ dev-coupling-audit.md F166-F173 索引补
@@ -104,7 +104,7 @@
 | 某 finding test 通不过 + 估算无法在 +0.5 d 内修 | 主会话 escalate 给用户 → 当场决策三档(EOL 删 / V0.7 显式 defer-with-justification / 加 +0.5 d 继续);**禁止**自动决定推 V0.6.7 |
 | 实际 grep TODO 数(F168)≠ 9 | 实数为准,wave-1-handoff 列实际数 + 全部决断;**禁止**对 spec 数字 freelance(per task block 模式) |
 | F170 实际 site ≠ 4 | 实数为准,标题改 "F170 scrub N sites"(per task block 模式) |
-| F172 设计与红线冲突(如必须新加第 9 类业务 event) | 立即停 + 通报 "v066 SPEC QUESTION: F172 设计 violates <红线>, 主会话需重审"(per task block 模式) |
+| F172 V2 `claude --help` 验 `--name` / `--resume` flag 不存在 / 漂移 / 行为不对齐 | 立即停 + 通报 "v066 SPEC QUESTION: F172 V2 Anthropic CLI `--name`/`--resume` <flag-status>, 主会话需重审"(per task block 模式)── 不假装 flag 存在跑下去 |
 | F173 F156 R8 cross-ref(V0.6.5 wave-2-handoff)实际不存在 | 立即停 + 通报(per task block 模式)── doc-first session 已 verify line 36 存在 R8(`docs/versions/v0-6-5/wave-2-handoff.md`),代码 PR 阶段若 wave-2-handoff 内容被改动须重审 |
 | nas-box005 host-probe 失败(网络 / 物理) | 主会话 dispatch retry(最多 2 次)+ 失败留 log;若硬体不可达 → ship gate 走 docker-based fallback verify(F166 install.sh 在 ubuntu:24.04 container 内跑) |
 
@@ -115,7 +115,7 @@
 | Wave | Tasks | 估算 | 并行 / 串行 |
 |---|---|---|---|
 | 0 (doc-first) | 本 PR | 0.05 d | 单 session |
-| 1 (8 worktree) | F166-F173 | max(各 finding 估算) ≈ **2.5 d**(F172 体量最大) | 8 worktree 并行 |
+| 1 (8 worktree) | F166-F173 | max(各 finding 估算) ≈ **2 d**(F173 体量最大;F172 V2 转 spawn argv 路线后 0.5-1 d) | 8 worktree 并行 |
 | 2 (doc-sync + host-probe + tag) | 收尾 | 1.5 d | 部分与 Wave 1 末段并行 |
 | **总** | | **~3 d**(并行)/ **~10 d**(串行单线) | |
 
@@ -133,7 +133,7 @@
 - **F169**:不破坏 ledger schema(只 read);若需 helper API 加,与 F173 共享
 - **F170**:纯 doc chore,行为零变化;若 #3 需 `pub use` 加,扩 ~5 LOC 不超
 - **F171**:不引入新 MCP tool(F171 是 CLI flag,不动 MCP 总数 26);STUB_TOOLS const 是 invariant 守门员
-- **F172**:**红线最严**:不新建第 9 类业务 event(扩 chat-mode 子家族)/ 不主动 kill / 不 capture-pane / recovery prompt 是 user prompt 形式不是 system prompt
+- **F172 V2**:借 Anthropic 官方 `claude --resume <name>` 接口(R10 直接守);**不**加 progress.jsonl event(原 V1 `chat_snapshot` 设计 ditch)/ **不**动 F164 alive reattach (a) 路径 / **不**主动 kill alive session / **不** capture-pane / **不**构造 history-synthesis prompt(Anthropic 自己 reload);F118 `build_recovery_prompt` 保留作 brand-new spawn 路径用,**不删不重构**;`--resume` 失败 user-visible fallback(emit `chat_session_reset` event with reason 字段),禁止 silent context 损失冒充 resume
 - **F173**:不动 F124 HumanApprovalAdapter scope(已 V0.7 defer);F156 SKILL.md 文案改「shipped」不留 alias;BudgetExceeded hard-fail 不 bypass
 
 ---

--- a/docs/versions/v0-6-6/prd.md
+++ b/docs/versions/v0-6-6/prd.md
@@ -545,145 +545,118 @@ verdict: PASS — all 26 tools live, no production STUBs.
 
 ---
 
-## F172 — tmux mode-3 上下文恢复(`chat_snapshot` event)
+## F172 — tmux mode-3 上下文恢复(借 Anthropic 官方 `claude --resume <name>` 路径)
 
 **痛点:** 用户痛点 9 + 14。
-V0.6.5 F163(SIGTERM graceful)+ F164(tmux reattach)解决了「daemon 物理重启不丢 tmux session」,但 **chat bot 已累积的对话上下文若发生 tmux session 死亡(进程崩 / 物理重启 / OOM kill)只能走 F118 `session_recovery::build_recovery_prompt` 回放 last-N turns**。F172 加 proactive snapshotting,让 recovery 不只靠 turns.jsonl 重放,还能续上「最后一次 snapshot 起的增量」── 把长跑 bot 的 context 损失从「last-N turns」收缩到「last snapshot 起的新增 turn 数」。
+V0.6.5 F163(SIGTERM graceful)+ F164(tmux reattach 含 dead-pane recreate)解决了 daemon 物理重启:**alive session** 走 F164 (a) reattach,**dead pane** 走 F164 (b) recreate(kill stale tmux + spawn 新 claude)。但 **dead-pane recreate 路径目前 spawn 的是 brand-new `claude` 进程,上一段对话的 full API-level context 全丢** ── F118 `session_recovery::build_recovery_prompt` 是 brand-new spawn 路径的最佳努力(回放 last-N turns 作 user prompt),只能给 bot 看到「最近几轮 user/assistant 字面 text」,**模型内部的 tool-use 中间结果、已折叠的 plan、cache 状态、推理链全失**。
+
+F172 V2 的设计转向:**直接借 Anthropic 官方 `claude --resume <session-name>` 接口** ── Anthropic 自己把每个 session 的 full API-level context 存在 `~/.claude/projects/<encoded-cwd>/<sid>.jsonl`,官方 CLI 提供 `--name <name>` 显式命名 + `--resume <name>` lossless 取回;ccteam 给每个 chat bot 起 deterministic name `ccteam-chat-<slug>-<role>`,recreate 路径用 `--resume <name>` spawn 即可 ── 无需 ccteam 手工 synthesis,context 由 Anthropic 自己 reload。
 
 **现状缺口:**
-- F118 已落 `chat_session_reset_with_recovery` event + `session_recovery::build_recovery_prompt` ── 仅在 session-id invalidated(compaction failure / corruption)时触发,**不是周期性** + recovery prompt 是 last-N turn 回放,不包含 bot 内部 working memory / 已下决断 / 引用的中间 artifact。
-- progress.jsonl 现有 chat-mode 子事件家族(F108 / F118):`chat_session_started` / `chat_turn_user_prompt` / `chat_turn_completed` / `chat_session_reset` / `chat_session_reset_with_recovery` / `chat_compact_done` / `chat_hop_escalate` ── 都是「事件发生时记一笔」,无周期性 snapshot 概念。
-- daemon 重启 → `claude_tui::start_thread` 若 session alive → F164 reattach;若 session dead → F118 recovery 回放 last-N turns。**Loss**:重启窗口内的 in-pane working memory(已用的工具结果 / 已展开的 plan / mid-conversation TODO list)全失。
+- `crates/ccteam-core/src/execution/claude_tui.rs::start_thread` 现 spawn argv 是 `[<claude>, --dangerously-skip-permissions]`(line 267 / 275)── 无 `--name`,无 deterministic identity,Anthropic 内部按 fresh session 处理;recreate 后无法用任何官方接口 reload 上一段。
+- F164 dead-pane recreate 路径 (b) 直接 spawn 新 claude,F118 `build_recovery_prompt` 路径(brand-new spawn 用)是已有的"最佳努力",但**远不如 `--resume` 完整**。
+- daemon 重启 / OOM kill / 物理重启的灾害恢复语义:F164 解决了 tmux session 物理回到桌面,F172 V2 解决「再次开口时模型脑子里还有上次的东西」。
 
 **设计:**
 
 ### 红线核对(详 README §3)
 
-- **不**新建第 9 类业务 event:`chat_snapshot` 加入 chat-mode 子事件家族(与 F108 / F118 同 category),progress.jsonl SoT 红线守。
-- **不**主动 kill long session:snapshot 是非破坏旁路 dump,不触 tmux pane,不发 send-keys,不影响 bot 当前活动。
-- **不**解析 tmux 终端输出:snapshot 源 = `turns.jsonl`(F108 mirror)+ 既有 progress.jsonl event,不调 `tmux capture-pane`。
-- **不**注入 system prompt:recovery 时注入的是 user prompt 形式(对齐 F118 `build_recovery_prompt` 既有路径),`.claude/agents/<role>.md` 仍是 agent 行为唯一 SoT。
+- **不**新建任何 progress.jsonl event(原 V1 设计的 `chat_snapshot` event ditch)── SoT 红线零扩,F172 V2 完全 spawn-argv 级改动。
+- **不**主动 kill long session:recreate 路径只在 F164 探测到 dead pane 时触发(那是 orphan tmux,不是活 bot ── F164 已论证不算红线违反),alive session 完全不动。
+- **不**解析 tmux 终端输出:零涉 pane content;`--resume <name>` 读 Anthropic 自己的 session jsonl,不调 `tmux capture-pane`。
+- **不**注入 system prompt:Anthropic 自己 reload context,ccteam 不构造 history-synthesis prompt 也不向 pane push 任何 text;`.claude/agents/<role>.md` 仍是 agent 行为唯一 SoT。
+- **跨项目记忆走官方接口(R10 直接守)**:`--resume <name>` 是 Anthropic CLI 一等公民,等同 `--name` / `-c` 同族;ccteam 借而不替,不引入第二个 context store。
 
-### Sub-1:`chat_snapshot` event schema
+### Sub-1:spawn argv 加 deterministic `--name`
 
-`crates/ccteam-core/src/progress.rs` 加:
-
-```rust
-/// `chat_snapshot` — V0.6.6 F172: periodic context snapshot dumped by
-/// the BotSupervisor (mode-3 chat). Used by daemon-restart recovery
-/// path to rebuild context beyond the last-N-turns fallback in F118.
-///
-/// Cadence: every N turns OR every M minutes, whichever first
-/// (defaults N=10, M=30). Payload references turns.jsonl byte offset
-/// instead of inlining transcript to keep progress.jsonl scannable.
-pub const CHAT_SNAPSHOT: &str = "chat_snapshot";
-
-pub fn build_chat_snapshot_event(
-    role: &str,
-    turn_id_range: (String, String),  // (first_turn_id, last_turn_id)
-    turns_jsonl_byte_offset: u64,     // resume point in turns.jsonl
-    context_size_tokens: u32,         // approx tokens in window
-    triggers: SnapshotTriggers,       // Periodic { every_n_turns } | TimeElapsed | Manual
-) -> Value {
-    serde_json::json!({
-        "event": CHAT_SNAPSHOT,
-        "role": role,
-        "turn_id_range": [turn_id_range.0, turn_id_range.1],
-        "turns_jsonl_byte_offset": turns_jsonl_byte_offset,
-        "context_size_tokens": context_size_tokens,
-        "triggers": triggers,
-        "ts": Utc::now().to_rfc3339(),
-    })
-}
-```
-
-**关键 schema 设计**:
-- **turns_jsonl_byte_offset**:snapshot 不内联 transcript(避免 progress.jsonl 膨胀),只记 resume point;recovery 时 `seek(offset)` 即可 stream-read 后续 turn。
-- **context_size_tokens**:approx 计数(由 UnifiedTokenUsage 累加),帮 recovery 判断「context 已超模型窗口?要先 compact?」。
-- **triggers**:why-this-snapshot 元数据(便于 dashboard 显示)。
-
-### Sub-2:dump cadence
-
-`crates/ccteam-imd/src/supervisor.rs` `BotSupervisor` 加:
+`crates/ccteam-core/src/execution/claude_tui.rs::start_thread` (c) absent + (b) dead-pane recreate 后的 new-session spawn argv 改:
 
 ```rust
-pub struct SnapshotPolicy {
-    pub every_n_turns: u32,        // default 10
-    pub max_elapsed: Duration,     // default 30 min
-    pub max_context_tokens: u32,   // emergency snapshot when > 80% window
-}
+// Before:
+let argv: Vec<&str> = vec![&bin, "--dangerously-skip-permissions"];
 
-impl BotSupervisor {
-    async fn maybe_snapshot(&mut self, role: &str) {
-        let since_last = self.turns_since_last_snapshot(role);
-        let elapsed = self.elapsed_since_last_snapshot(role);
-        let tokens = self.approx_context_tokens(role);
-        let trigger = match (since_last, elapsed, tokens) {
-            (n, _, _) if n >= self.policy.every_n_turns => Some(...),
-            (_, e, _) if e >= self.policy.max_elapsed => Some(...),
-            (_, _, t) if t >= self.policy.max_context_tokens => Some(...),
-            _ => None,
-        };
-        if let Some(triggers) = trigger {
-            self.emit_snapshot_event(role, triggers).await;
-        }
-    }
-}
+// After (Sub-1 + Sub-2):
+let session_id_name = format!("ccteam-chat-{}-{}", ctx.slug, spec.role);
+let argv: Vec<&str> = match recreate_kind {
+    NewSession::Fresh => vec![
+        &bin, "--dangerously-skip-permissions",
+        "--name", &session_id_name,
+    ],
+    NewSession::Recreate => vec![
+        &bin, "--dangerously-skip-permissions",
+        "--resume", &session_id_name,
+    ],
+};
 ```
 
-`maybe_snapshot` 在 `chat_turn_completed` handler 末尾调(已是 BotSupervisor 现有 hook 点)。
+`NewSession` enum 区分两条 new-session 路径:
+- **Fresh**(F164 (c) absent + Sub-1):首次为 (slug, role) 启 bot,加 `--name` 让 Anthropic 把 session jsonl 落到 deterministic 名字下,以备未来 `--resume`。
+- **Recreate**(F164 (b) dead-pane + Sub-2):tmux session 已存在但 pane 死掉,先 kill stale tmux(F164 既有),再 spawn `claude --resume <name>` 让 Anthropic 自己 reload 上次 session jsonl。
 
-### Sub-3:daemon restart recovery flow
+### Sub-2:`--resume` 失败 fallback(信任 Anthropic + degraded fresh)
 
-`crates/ccteam-imd/src/daemon.rs` 起 daemon 时 per-bot 走:
+`--resume <name>` 若失败(name 对应 session jsonl 不存在 / corrupt / 用户 `~/.claude/projects/` 被清理 / Anthropic schema 变更),官方 CLI 行为是非零 exit。ccteam 探测后 fallback:
 
-```
-1. tail progress.jsonl(F164 既有)→ 找 latest chat_snapshot event for this role
-2. if found:
-   a. claude_tui::start_thread(role)
-      - F164 path: if tmux session alive → reattach
-      - else: spawn new + run recovery prompt
-   b. read turns.jsonl from snapshot.turns_jsonl_byte_offset onwards
-   c. compose recovery prompt:
-      "[ccteam recovery] Resuming after daemon restart.
-       Last snapshot at turn_id <last_turn_id>, ~<N> turns ago.
-       Recent turns since snapshot: <inline last 5 turns from byte offset>.
-       Please continue from where we left off."
-   d. push as user prompt to tmux pane(对齐 F118 既有路径)
-3. if no snapshot:fallback F118 build_recovery_prompt(last-N turns mode)
-4. emit chat_session_reset_with_recovery event(F118 既有,扩 payload 加 from_snapshot: true 字段)
-```
+- **不**走 F118 synthesis"假装 resume" ── 与"silent 上下文损失"等价,user-visible 行为是"bot 突然忘了前面",但 user 误以为 `--resume` 成功。F172 V2 红线:**fallback 必须 user-visible**。
+- **走 brand-new session**(同 Sub-1 Fresh 路径):新 spawn `claude --dangerously-skip-permissions --name <name>`(覆盖旧 name);progress.jsonl emit 既有 `chat_session_reset` event(F108)即可 ── user 在 IM / web 看到 reset 提示,知道 context 丢了,自己决定怎么续。
 
-### Sub-4:idempotent re-attach
+实现要点:`claude_tui::start_thread` 的 recreate 路径 spawn `claude --resume <name>` 失败 → fall through Fresh 路径 spawn `claude --name <name>` + emit `chat_session_reset` event(reason = `"resume_failed_fallback_to_fresh"`)。
 
-`chat_handle` 必须 idempotent:重复调 `start_thread(role)` 时:
-- 若 tmux session alive + snapshot already applied this restart cycle → no-op
-- 否则:走完整 recovery flow
+### Sub-3:F164 alive reattach 路径不动
 
-引入 per-role `recovery_applied_in_restart_cycle: BoolMap`(daemon 内存),重启时清空。
+F164 (a) alive reattach 走 `is_pane_running_claude(&session)` 探测 + 复用 tmux 同 pane 同进程 ── **不**涉 claude session jsonl,**不**涉 `--resume`,F172 V2 完全不动。
 
-### Sub-5:边界(防滚雪球)
+F172 V2 只动 (b) recreate + (c) absent 两条 new-session 路径。regression test 必须验 F164 alive 路径行为零变化。
 
-**F172 不做**:
-- 主动恢复 in-tmux-pane 用户已输入未发送的 input(不可观测,放弃)
-- 跨机器迁移 chat context(V0.7+ chat memory sync)
-- recovery 时自动 compact(用户决定)── 仅在 `context_size_tokens` 超 90% 阈值时 warn
+### Sub-4:F118 路径保留(brand-new spawn 用)
+
+`crates/ccteam-core/src/execution/session_recovery.rs::build_recovery_prompt` **不删** ── 现仍是合法路径:用户首次为 bot 启动时(无 `~/.claude/projects/` 历史 + 无 turns.jsonl 之前 record)虽然走 Sub-1 Fresh,但若用户操作如「ccteam wipe / 项目搬迁后再起」无法 resume,turns.jsonl 仍可作 last-N turn 回放(F118 既有)。
+
+F172 V2 与 F118 关系:
+- F118 = brand-new spawn 时的"基于 turns.jsonl 的 best-effort context seed"(已有,保留)
+- F172 V2 = recreate 时的"基于 Anthropic 官方 session jsonl 的 lossless restore"(新主路)
+
+两者**不冲突**:不同触发场景。
+
+### Sub-5:cwd 隔离与多 bot 共存
+
+`--name` 的 namespace 是 per-CWD(Anthropic `~/.claude/projects/<encoded-cwd>/` 已按 cwd 分目录)。ccteam 每个 chat bot spawn 时 `ctx.cwd` 已是 `<project>/.ccteam/chat/<bot>/` 类 per-bot subtree(详 V0.6 F108 决策),天然不冲突。
+
+但如果两个 bot 同 cwd(罕见但可能 ── 例如 `scope: ""` 配合 multi-role workflow),`ccteam-chat-<slug>-<role>` deterministic name 仍按 role 区分;Anthropic 内部按 `<cwd>:<name>` lookup,不会串。验收时需 cwd-collision integration test 守这一点。
+
+### Sub-6:边界(防滚雪球)
+
+**F172 V2 不做**:
+- 不加 progress.jsonl event(原 `chat_snapshot` 设计 ditch);若用户需 "context % 观测 / dashboard 续点显示" → V0.7 单独 finding,本版不在 F172 scope。
+- 不主动恢复 in-tmux-pane 用户已输入未发送的 input(不可观测,放弃)。
+- 不跨机器迁移 chat context(V0.7+ chat memory sync epic)。
+- 不动 F118 `build_recovery_prompt` 实现 ── F172 V2 是平行路径,不重构既有。
 
 **文件:**
-- 改:`crates/ccteam-core/src/progress.rs`(`CHAT_SNAPSHOT` const + `build_chat_snapshot_event` + `SnapshotTriggers` enum)、`crates/ccteam-core/src/execution/session_recovery.rs`(`build_recovery_prompt` 加 snapshot-aware overload)、`crates/ccteam-imd/src/supervisor.rs`(`SnapshotPolicy` + `maybe_snapshot`)、`crates/ccteam-imd/src/daemon.rs`(restart recovery flow)、`crates/ccteam-core/src/execution/claude_tui.rs`(idempotent re-attach)
-- 新:`crates/ccteam-imd/tests/chat_snapshot_test.rs`(periodic trigger / time elapsed trigger / token cap trigger)、`crates/ccteam-imd/tests/daemon_restart_recovery_test.rs`(snapshot exists / no snapshot fallback / idempotent re-attach / from_snapshot field set)
+- 改:`crates/ccteam-core/src/execution/claude_tui.rs::start_thread`(spawn argv `--name` / `--resume` 分支)
+- 改(若必要):`crates/ccteam-core/src/execution/claude_tui.rs` 引入 `chat_session_name_canonical` helper 与既有 `chat_session_name` 协调(后者是 tmux session 名,前者是 Anthropic `--name`)── 若 tmux 名已合法可复用,**不**额外引 helper(本 finding 决断:复用,以最小 diff 为准)
+- 新:`crates/ccteam-core/tests/claude_tui_resume_test.rs`(spawn argv `--name` / `--resume` 分支 unit,`--resume` 失败 fallback unit,F164 alive reattach regression guard 引用 / cwd-collision integration)
+- **不动**:`crates/ccteam-core/src/progress.rs`(无新 const)、`crates/ccteam-imd/src/supervisor.rs`(无 SnapshotPolicy)、`crates/ccteam-imd/src/daemon.rs`(无 restart recovery flow)、`crates/ccteam-core/src/execution/session_recovery.rs`(F118 路径保留不重构)
 
 **验收:**
-- 测试 +~30 全通(snapshot 8 + recovery 12 + idempotent 4 + progress event helper 6)
-- nas-box005 host-probe:跑 mode-3 chat ≥10 turn → progress.jsonl 有 ≥1 `chat_snapshot` event(periodic trigger);`kill -TERM` daemon → `ccteam start` → 第 11 turn 输入 "continue from where we left off" → bot reply 引用早 turn 内容(测试人确认语义续接);progress.jsonl 含 `chat_session_reset_with_recovery` event with `from_snapshot: true`
+- 测试 +~8 全通,分项:
+  - `start_thread` Fresh path spawn argv 含 `--name ccteam-chat-<slug>-<role>` (unit, ~1 test)
+  - `start_thread` Recreate path spawn argv 含 `--resume ccteam-chat-<slug>-<role>` (unit, ~1 test)
+  - `--resume` 失败 → fallback to Fresh + emit `chat_session_reset` event with `reason="resume_failed_fallback_to_fresh"` (unit, ~2 test)
+  - F164 alive reattach 路径不受影响(regression guard, reuse F164 既有 test 形态, ~1 test)
+  - cwd-collision:同 cwd 两 bot 各自 `--name` 独立 resume 不串扰 (integration, ~1 test, 可 stub `CCTEAM_CLAUDE_BIN` 验 argv)
+  - daemon restart cycle 后 bot 仍能 "刚才那个 X 怎么样" 风格 message(integration, stub claude bin echoing argv to log, ~1 test)
+  - F118 `build_recovery_prompt` 仍存(brand-new spawn 路径未破)── regression guard (1 test 可复用既有 F118 test)
+- nas-box005 host-probe:跑 mode-3 chat bot ≥10 turn → `tmux kill-session -t <ccteam-chat-name>`(模拟 dead pane)→ daemon 探测 dead → `start_thread` 走 Recreate 路径 spawn `claude --resume <name>` → 第 11 turn 输入「刚才那个 X 怎么样」→ bot reply 直接引用早 turn 内容(测试人确认 semantic 续接,**不是** F118 last-N 字面回放,而是模型脑子里真有 cache);**手动签字** → `docs/versions/v0-6-6/host-probe.md`
 - baseline 不退
-- 红线核对:`grep -rn "tmux capture-pane" crates/ccteam-core/src/execution/session_recovery.rs crates/ccteam-imd/src/supervisor.rs crates/ccteam-imd/src/daemon.rs` 0 命中
+- 红线核对:`grep -rn "tmux capture-pane" crates/ccteam-core/src/execution/claude_tui.rs` 0 命中;`grep -rn "CHAT_SNAPSHOT\|chat_snapshot" crates/ccteam-core/src/progress.rs` 0 命中(原 V1 设计未污染 progress event 表)
 
 **风险:**
-- snapshot 频率过高 → progress.jsonl 膨胀 ── mitigate:默认 every-10-turns OR 30-min,benchmark 实测 < 100 line/day per active bot
-- recovery prompt 过长 → 浪费 context 窗口 ── mitigate:Sub-3 只 inline "since snapshot" 部分(typically 1-9 turns 间隔),完整历史在 turns.jsonl 由 LLM 按需 grep
-- byte_offset 失效(若 turns.jsonl 被外部 truncate)── mitigate:recovery flow 验 offset 在文件长度内,若否 fallback F118 build_recovery_prompt(last-N) + emit warning
-- 与 V0.6.5 F164 `start_thread` reattach 行为耦合 ── mitigate:F172 Sub-4 idempotent guard 独立 BoolMap,不影响 F164 alive-session 探测;严格区分 "session alive but no recovery applied yet"(走 recovery)vs "session alive + recovery already done"(no-op)
+- Anthropic `--name` / `--resume` CLI flag 漂移(未来 minor 改名 / 改语义)── mitigate:本 finding W1 第一步 verify `claude --help | grep -E 'name|resume'` 实测;若 flag 缺失 / 不同 → block subagent + escalate 主会话(per task block 模式);若 flag 存在 + 行为对齐 → 走;由 `CCTEAM_CLAUDE_BIN` env override 让测试不依赖真实 claude
+- `~/.claude/projects/<encoded-cwd>/<sid>.jsonl` 路径或编码方式变(我方对此存储无 schema 责任,但 `--resume` 是接口契约)── mitigate:ccteam 完全不读 / 不写 / 不假设这个文件路径,只走 `--resume <name>` CLI 接口;Anthropic 内部存储改了 CLI 行为不变即可
+- `--resume` 在 daemon 重启窗口期 spawn 可能比 fresh 多 ~3-5s(读 jsonl + 重建 cache 状态)── mitigate:user 已知"重启恢复"语义,慢一点合理;dashboard 可 V0.7 加 "resuming..." 提示但本版不做
+- cwd-collision 罕见场景未充分覆盖 ── mitigate:integration test 显式守;后续 V0.7 若大型 monorepo 共 cwd 模式普及再扩
+- F164 alive reattach regression 风险(spawn argv 修改如果污染 alive 路径)── mitigate:严格隔离 ── 改动仅在 (b) 与 (c) 两个 spawn 点,(a) reattach 完全不进 argv 构造代码;regression test 守
 
 ---
 
@@ -811,7 +784,7 @@ F168 (TODO sweep)                    ─┤  与 F169 + F170 + F173 有 site-ove
 F169 (cost_today ledger)             ─┤  → F168 #5 决断同 PR
 F170 (doc scrub)                     ─┤  → F168 #7 决断同 PR
 F171 (doctor --verify-mcp)           ─┤
-F172 (chat_snapshot)                 ─┤
+F172 (claude --resume by name)       ─┤
 F173 (Codex critic ledger)           ─┘  → F168 #1 决断同 PR + 与 F169 共享 ledger schema(F169 read,F173 write)
 
 site-overlap 处理:每 PR review 时主会话(dispatch agent)负责 cross-check;


### PR DESCRIPTION
## Change
F172 PRD design replaced. Use Anthropic CLI `--resume <name>` for lossless recovery; drop synthesis + `chat_snapshot` event.

## Rationale
Anthropic stores full API-level context in session jsonl (`~/.claude/projects/<encoded-cwd>/<sid>.jsonl`). Official `--resume <name>` is lossless + simpler than custom synthesis. Red line R10 (cross-project memory via official interface) directly satisfied.

## Design summary
- `claude_tui::start_thread` Fresh path: spawn argv adds `--name ccteam-chat-<slug>-<role>` (deterministic name).
- F164 dead-pane recreate path: spawn `claude --resume <name>` → Anthropic reloads session jsonl losslessly.
- F164 alive reattach path: untouched.
- `--resume` failure fallback: spawn fresh + emit `chat_session_reset` event with explicit reason (user-visible degraded — no silent context loss masquerading as resume).
- F118 `build_recovery_prompt` retained for brand-new spawn path; not deleted, not refactored.
- No new `progress.jsonl` event (V1 design's `chat_snapshot` ditched — SoT zero expansion).

## Baseline
1660/1 → **1644/1** (F172 V2 +8 tests replaces V1 +30; per-finding sum F166+12 / F167+6 / F168+10 / F169+4 / F170 0 / F171+6 / F172+8 / F173+15 = +61).

## Files
- `docs/versions/v0-6-6/prd.md` §F172 rewrite (~130 lines diff)
- `docs/versions/v0-6-6/README.md` — overview table / red-line table / ship gate item #10 / wave timing
- `docs/versions/v0-6-6/dev-plan.md` — W1-T7 briefing / baseline / host-probe / red-line / failure-handling rows

## Verification
- `cargo test --workspace --locked --no-fail-fast`: 1583 / 1 (matches V0.6.6 starting baseline; doc-only PR, Rust untouched)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)