### PR TITLE
v0.6.6 (F169): @ccteam cost today reads real ledger

### DIFF
--- a/crates/ccteam-core/src/advise.rs
+++ b/crates/ccteam-core/src/advise.rs
@@ -836,6 +836,20 @@ pub fn sum_advise_today(ledger: &AdviseBudgetLedger) -> f64 {
         .sum()
 }
 
+/// V0.6.6 F169 — per-vendor 24h spend, surfaced to the IM `@ccteam
+/// cost today` admin path so the user sees `claude: $X / codex: $Y`
+/// rather than the V0.6.1 bot-count placeholder. Same rolling window
+/// the bare [`sum_advise_today`] uses, just filtered by vendor.
+pub fn sum_advise_today_by_vendor(ledger: &AdviseBudgetLedger, vendor: AgentVendor) -> f64 {
+    let cutoff = Utc::now() - chrono::Duration::hours(24);
+    ledger
+        .samples
+        .iter()
+        .filter(|s| s.ts >= cutoff && s.vendor == vendor)
+        .map(|s| s.usd)
+        .sum()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -112,9 +112,9 @@ pub use actions::{
 pub use advise::{
     advise_parallel, advise_vote, append_budget_sample as append_advise_budget_sample,
     budget_ledger_path as advise_budget_ledger_path, load_budget_ledger as load_advise_budget,
-    sum_advise_today, AdviseBudgetLedger, AdviseError, Agreement, AnswerStatus, BudgetSample,
-    BudgetSnapshot, CodexStatus, ParallelResult, VendorAnswer, VoteResult,
-    DEFAULT_ADVISE_BUDGET_USD_24H, DEFAULT_CODEX_TIMEOUT_SECS,
+    sum_advise_today, sum_advise_today_by_vendor, AdviseBudgetLedger, AdviseError, Agreement,
+    AnswerStatus, BudgetSample, BudgetSnapshot, CodexStatus, ParallelResult, VendorAnswer,
+    VoteResult, DEFAULT_ADVISE_BUDGET_USD_24H, DEFAULT_CODEX_TIMEOUT_SECS,
 };
 pub use auto_loop::{AutoLoopDecision, AutoLoopFrontMatter, AutoLoopState};
 pub use claude_job::{

--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -83,6 +83,14 @@ fn default_ccteam_root() -> PathBuf {
         .join(".ccteam")
 }
 
+/// V0.6.6 F169 — pub wrapper around [`default_ccteam_root`] so the
+/// `nl_admin::AdminExecutor` (and other library callers) can resolve
+/// the production ccteam-root without re-implementing the home-derived
+/// path. Tests inject a tempdir via `AdminExecutor::with_ccteam_root`.
+pub fn default_ccteam_root_public() -> PathBuf {
+    default_ccteam_root()
+}
+
 /// `<ccteam_root>/imd/registry/` — base registry dir given an explicit
 /// root (V0.6.5 F146).
 pub fn registry_root_in(ccteam_root: &Path) -> PathBuf {

--- a/crates/ccteam-imd/src/nl_admin.rs
+++ b/crates/ccteam-imd/src/nl_admin.rs
@@ -184,25 +184,40 @@ struct Pending {
 }
 
 /// Admin-command executor. Holds the projects-root config (where bot
-/// signal files live) + the per-target pending-confirm map.
+/// signal files live), the ccteam-root config (where the advise-budget
+/// ledger lives — V0.6.6 F169), + the per-target pending-confirm map.
 ///
 /// One instance per daemon. `Arc<AdminExecutor>` is cheap to clone
 /// into per-message tasks.
 pub struct AdminExecutor {
     projects_root: PathBuf,
+    ccteam_root: PathBuf,
     pending: Mutex<HashMap<String, Pending>>,
     confirm_ttl: Duration,
 }
 
 impl AdminExecutor {
     /// Build an executor rooted at `projects_root`
-    /// (production: `~/projects`; tests: a tempdir).
+    /// (production: `~/projects`; tests: a tempdir). The ccteam-root
+    /// defaults to `~/.ccteam`; use [`Self::with_ccteam_root`] to
+    /// override in tests.
     pub fn new(projects_root: impl Into<PathBuf>) -> Self {
         Self {
             projects_root: projects_root.into(),
+            ccteam_root: crate::default_ccteam_root_public(),
             pending: Mutex::default(),
             confirm_ttl: CONFIRM_TTL,
         }
+    }
+
+    /// V0.6.6 F169 — override the ccteam-root used to read the
+    /// `cost-budget.json` advise ledger. Production daemon stays on
+    /// the home-derived default; tests inject a tempdir so each
+    /// scenario has its own ledger state.
+    #[doc(hidden)]
+    pub fn with_ccteam_root(mut self, ccteam_root: impl Into<PathBuf>) -> Self {
+        self.ccteam_root = ccteam_root.into();
+        self
     }
 
     /// Test helper: override the confirm TTL.
@@ -263,12 +278,27 @@ impl AdminExecutor {
     }
 
     async fn cost_today(&self, slug_filter: Option<&str>) -> AdminReply {
-        // V0.6.1: surface a registry-driven summary. Full per-vendor
-        // 24h cost aggregation across all projects lives behind
-        // `ccteam-control show-cost` (CLI) + the web dashboard — the
-        // IM path returns a deterministic snapshot derived from the
-        // registry so the user can verify the daemon parsed their
-        // request. V0.7 wires the full `ccteam_cost` rollup here.
+        // V0.6.6 F169 — read the real `<ccteam_root>/cost-budget.json`
+        // advise ledger (V0.6.5 F152 schema) so the IM `@ccteam cost
+        // today` path surfaces the same USD numbers the
+        // `/ccteam-control show-cost` CLI prints. The slug filter
+        // stays advisory — the ledger is keyed on vendor + ts only
+        // (per-slug attribution is a V0.7 ledger-schema bump) so we
+        // report it back in the header for transparency.
+        use ccteam_core::advise::{load_budget_ledger, sum_advise_today_by_vendor};
+        use ccteam_core::harness::AgentVendor;
+        use ccteam_core::DEFAULT_ADVISE_BUDGET_USD_24H;
+
+        let ledger = load_budget_ledger(&self.ccteam_root).unwrap_or_default();
+        // `+ 0.0` normalises negative-zero (Rust's `-0.0` formats as
+        // `-0.0000` otherwise, which is ugly in the IM reply).
+        let claude_24h = sum_advise_today_by_vendor(&ledger, AgentVendor::Claude) + 0.0;
+        let codex_24h = sum_advise_today_by_vendor(&ledger, AgentVendor::Codex) + 0.0;
+        let total = claude_24h + codex_24h;
+        let cap = DEFAULT_ADVISE_BUDGET_USD_24H;
+        let remaining = (cap - total).max(0.0);
+        let near_cap = cap > 0.0 && total / cap >= 0.80;
+
         let bots = list_bots().unwrap_or_default();
         let filtered: Vec<&BotRegistration> = match slug_filter {
             Some(s) => bots.iter().filter(|b| b.workflow_slug == s).collect(),
@@ -278,17 +308,22 @@ impl AdminExecutor {
             Some(s) => format!("ccteam cost today — slug `{s}`"),
             None => "ccteam cost today".to_string(),
         };
-        if filtered.is_empty() {
-            return AdminReply {
-                message: format!("{header}: no matching bots."),
-                side_effect: AdminSideEffect::None,
-            };
-        }
+        let warn_prefix = if near_cap {
+            "⚠️ approaching daily budget cap\n"
+        } else {
+            ""
+        };
+        let slug_note = slug_filter.unwrap_or("none");
+        let msg = format!(
+            "{warn_prefix}{header}\n  \
+             rolling 24h cost: Claude ${claude_24h:.4} + Codex ${codex_24h:.4} = total ${total:.4}\n  \
+             cap: ${cap:.2}/24h · remaining: ${remaining:.4}\n  \
+             active bots: {} (filter: {slug_note})\n  \
+             full breakdown: `/ccteam-control show-cost`",
+            filtered.len()
+        );
         AdminReply {
-            message: format!(
-                "{header}\n  bots: {}\n  detailed per-vendor breakdown: `/ccteam-control show-cost`.",
-                filtered.len()
-            ),
+            message: msg,
             side_effect: AdminSideEffect::None,
         }
     }

--- a/crates/ccteam-imd/tests/nl_admin_cost_today_test.rs
+++ b/crates/ccteam-imd/tests/nl_admin_cost_today_test.rs
@@ -1,0 +1,99 @@
+//! V0.6.6 F169 — `@ccteam cost today` now reads the real
+//! `<ccteam_root>/cost-budget.json` advise ledger (V0.6.5 F152 schema)
+//! instead of returning the V0.6.1 bot-count placeholder. These tests
+//! pin the format + numeric correctness across four ledger shapes:
+//!
+//! 1. empty ledger        → header + 0.0000 totals, no warning prefix
+//! 2. single-vendor spend → Claude row only, total = Claude row
+//! 3. dual-vendor spend   → both rows + total = sum
+//! 4. >80% of cap         → ⚠️ approaching daily budget cap prefix
+//!
+//! The executor is constructed with `with_ccteam_root` so each test
+//! owns its ledger file in a `TempDir` — no `HOME` env mutation race
+//! with the other integration tests in this crate.
+
+use ccteam_core::advise::{append_budget_sample, DEFAULT_ADVISE_BUDGET_USD_24H};
+use ccteam_core::harness::AgentVendor;
+use ccteam_imd::nl_admin::{AdminCmd, AdminExecutor, AdminSideEffect};
+use tempfile::TempDir;
+
+/// Build an executor wired to a fresh `(projects_root, ccteam_root)`
+/// pair so each test owns its ledger state.
+fn build_executor() -> (TempDir, TempDir, AdminExecutor) {
+    let projects = TempDir::new().unwrap();
+    let ccteam = TempDir::new().unwrap();
+    let exec = AdminExecutor::new(projects.path()).with_ccteam_root(ccteam.path());
+    (projects, ccteam, exec)
+}
+
+async fn run_cost_today(exec: &AdminExecutor) -> (AdminSideEffect, String) {
+    let reply = exec
+        .execute(AdminCmd::CostToday { slug: None }, "@group-test")
+        .await;
+    (reply.side_effect, reply.message)
+}
+
+#[tokio::test]
+async fn cost_today_empty_ledger_reports_zeros_no_warning() {
+    let (_p, _c, exec) = build_executor();
+    let (side, msg) = run_cost_today(&exec).await;
+    assert_eq!(side, AdminSideEffect::None);
+    assert!(msg.contains("ccteam cost today"), "header missing: {msg}");
+    assert!(msg.contains("Claude $0.0000"), "claude zero missing: {msg}");
+    assert!(msg.contains("Codex $0.0000"), "codex zero missing: {msg}");
+    assert!(msg.contains("total $0.0000"), "total zero missing: {msg}");
+    assert!(
+        msg.contains(&format!("cap: ${DEFAULT_ADVISE_BUDGET_USD_24H:.2}/24h")),
+        "cap line missing: {msg}"
+    );
+    assert!(
+        !msg.contains("approaching daily budget cap"),
+        "warning must NOT trigger on empty ledger: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn cost_today_single_vendor_spend_reports_claude_only() {
+    let (_p, ccteam, exec) = build_executor();
+    // Seed two Claude calls; no Codex rows.
+    append_budget_sample(ccteam.path(), AgentVendor::Claude, 0.0123).unwrap();
+    append_budget_sample(ccteam.path(), AgentVendor::Claude, 0.0077).unwrap();
+    let (_, msg) = run_cost_today(&exec).await;
+    assert!(
+        msg.contains("Claude $0.0200"),
+        "claude sum 0.02 expected: {msg}"
+    );
+    assert!(msg.contains("Codex $0.0000"), "codex zero expected: {msg}");
+    assert!(msg.contains("total $0.0200"), "total 0.02 expected: {msg}");
+    assert!(!msg.contains("approaching daily budget cap"));
+}
+
+#[tokio::test]
+async fn cost_today_dual_vendor_spend_sums_both() {
+    let (_p, ccteam, exec) = build_executor();
+    append_budget_sample(ccteam.path(), AgentVendor::Claude, 0.0500).unwrap();
+    append_budget_sample(ccteam.path(), AgentVendor::Codex, 0.0300).unwrap();
+    let (_, msg) = run_cost_today(&exec).await;
+    assert!(msg.contains("Claude $0.0500"), "{msg}");
+    assert!(msg.contains("Codex $0.0300"), "{msg}");
+    assert!(msg.contains("total $0.0800"), "{msg}");
+    // 0.08 / 0.50 = 16% — well below the 80% warning threshold.
+    assert!(!msg.contains("approaching daily budget cap"));
+}
+
+#[tokio::test]
+async fn cost_today_emits_warning_above_eighty_percent_cap() {
+    let (_p, ccteam, exec) = build_executor();
+    // Seed 0.45 USD = 90% of the 0.50 default cap.
+    for _ in 0..9 {
+        append_budget_sample(ccteam.path(), AgentVendor::Claude, 0.05).unwrap();
+    }
+    let (_, msg) = run_cost_today(&exec).await;
+    assert!(
+        msg.starts_with("⚠️ approaching daily budget cap"),
+        "warning prefix missing: {msg}"
+    );
+    assert!(msg.contains("total $0.4500"), "{msg}");
+    // Remaining shown as cap − total = 0.05.
+    assert!(msg.contains("remaining: $0.0500"), "remaining line: {msg}");
+}


### PR DESCRIPTION
## Finding
[F169](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-6/prd.md#f169)

## Summary
- `AdminExecutor::cost_today` reads `<ccteam_root>/cost-budget.json` (V0.6.5 F152 schema) and reports per-vendor + total 24h USD spend.
- Adds `ccteam_core::advise::sum_advise_today_by_vendor` (per-vendor 24h sum).
- Adds `AdminExecutor::with_ccteam_root` so each integration test owns its ledger state.
- IM reply is prefixed with `⚠️ approaching daily budget cap` when rolling 24h spend ≥80% of the default cap.
- Drops the `V0.7 wires the full ccteam_cost rollup here` TODO (F168 inventory #5).

## Verification
- `cargo test --workspace --locked --no-fail-fast`: 1587 passed / 1 failed (baseline 1583+4 new tests; flake unchanged: `workflow_summary_reflects_agent_spawn_and_done_events`).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: 0 warnings.
- `cargo test -p ccteam-imd --test nl_admin_cost_today_test`: 4/4 (empty / single-vendor / dual-vendor / >80% cap warning).
- `cargo test -p ccteam-imd --test im_nl_admin_test`: 9/9 (existing `cost_today_replies_with_summary` still green).

## Test plan
- [x] Empty ledger → `Claude $0.0000 + Codex $0.0000 = total $0.0000`, no warning prefix.
- [x] Single-vendor (Claude) → `Claude $0.0200 + Codex $0.0000 = total $0.0200`.
- [x] Dual-vendor → both rows + total = sum.
- [x] 0.45 / 0.50 cap (90%) → `⚠️ approaching daily budget cap` prefix + `remaining: $0.0500`.