### PR TITLE
v0.6.6 (F172 V2): claude --resume by name recovery

### DIFF
--- a/crates/ccteam-core/src/execution/claude_tui.rs
+++ b/crates/ccteam-core/src/execution/claude_tui.rs
@@ -72,6 +72,14 @@ pub fn chat_session_name(slug: &str, role: &str) -> String {
     format!("ccteam-chat-{slug}-{role}")
 }
 
+/// V0.6.6 F172 V2 — compose the deterministic Anthropic `--name` /
+/// `--resume` argument for a chat-mode bot. Same identifier as the tmux
+/// session name; kept as a separate function so the two namespaces can
+/// diverge in the future without grepping callers.
+pub fn chat_session_id_name(slug: &str, role: &str) -> String {
+    chat_session_name(slug, role)
+}
+
 /// V0.6.0 F108 / V0.6.1 F139 — write / merge the chat-progress hooks
 /// into `<project>/.claude/settings.json`. As of F139 the hook command
 /// invokes the per-host `~/.ccteam/hooks/hook.sh` wrapper (HTTP-to-
@@ -234,9 +242,15 @@ impl HarnessAdapter for ClaudeTuiAdapter {
         let session_name = chat_session_name(&ctx.slug, &spec.role);
         let session = TmuxSession::from_name(session_name.clone());
 
+        // V0.6.6 F172 V2 — deterministic Anthropic `--name` / `--resume`
+        // identifier so the dead-pane recreate path can ask Claude itself
+        // to reload the prior session jsonl (lossless context restore
+        // via Anthropic's own CLI surface; R10 守).
+        let session_id_name = chat_session_id_name(&ctx.slug, &spec.role);
         if session.exists() {
             if is_pane_running_claude(&session) {
-                // (a) Alive & healthy — reattach.
+                // (a) Alive & healthy — reattach. F164 path; F172 V2 must
+                // **not** touch this code path (no spawn → no argv change).
                 let pids = session.list_pane_pids();
                 let pane_pid = pids.first().copied();
                 tracing::info!(
@@ -248,7 +262,13 @@ impl HarnessAdapter for ClaudeTuiAdapter {
                     "claude-tui: reattached to existing tmux session (pane claude process alive)"
                 );
             } else {
-                // (b) Dead pane — recreate.
+                // (b) Dead pane — recreate via F172 V2 `--resume <name>`
+                // route. If --resume fails (jsonl absent / corrupt /
+                // user wiped ~/.claude/projects/) we detect a fast pane
+                // death and fall through to a fresh `--name` spawn,
+                // emitting `chat_session_reset` with a reason so the
+                // user-visible bot context loss is explicit (no silent
+                // synthesis — R3 / R10 守).
                 let pids = session.list_pane_pids();
                 let old_pane_pid = pids.first().copied();
                 tracing::info!(
@@ -257,22 +277,83 @@ impl HarnessAdapter for ClaudeTuiAdapter {
                     slug = %ctx.slug,
                     role = %spec.role,
                     old_pane_pid = ?old_pane_pid,
-                    "claude-tui: killing stale tmux session (dead pane), recreating"
+                    "claude-tui: killing stale tmux session (dead pane), recreating via --resume"
                 );
                 session
                     .kill()
                     .map_err(|e| HarnessError::SpawnFailed(format!("tmux kill stale: {e}")))?;
-                // Fall through to new-session below.
                 let bin = claude_bin();
-                let argv: Vec<&str> = vec![&bin, "--dangerously-skip-permissions"];
+                let argv: Vec<&str> = vec![
+                    &bin,
+                    "--dangerously-skip-permissions",
+                    "--resume",
+                    &session_id_name,
+                ];
                 session
                     .start(&ctx.cwd, &argv)
                     .map_err(|e| HarnessError::SpawnFailed(format!("tmux start: {e}")))?;
+
+                // Detect `--resume` failure: claude exits non-zero quickly
+                // if the named session jsonl can't be loaded. Give the
+                // pane a short window to either survive (success) or die
+                // (failure). 400ms is enough for the OS to schedule
+                // claude's startup + first jsonl read + exit on failure,
+                // while staying well under user-perceptible latency.
+                tokio::time::sleep(Duration::from_millis(400)).await;
+                if !is_pane_running_claude(&session) {
+                    tracing::info!(
+                        event = "session_resume_failed_fallback",
+                        session = %session_name,
+                        slug = %ctx.slug,
+                        role = %spec.role,
+                        "claude-tui: `claude --resume <name>` failed; falling back to fresh `--name` spawn"
+                    );
+                    // Kill the dead pane's tmux session shell (still
+                    // exists with remain-on-exit / pane-dead state) and
+                    // re-spawn fresh.
+                    let _ = session.kill();
+                    let fresh_argv: Vec<&str> = vec![
+                        &bin,
+                        "--dangerously-skip-permissions",
+                        "--name",
+                        &session_id_name,
+                    ];
+                    session
+                        .start(&ctx.cwd, &fresh_argv)
+                        .map_err(|e| HarnessError::SpawnFailed(format!("tmux start fresh: {e}")))?;
+                    // Best-effort emit `chat_session_reset` with
+                    // explicit reason so IM / web surfaces show the
+                    // user "context was lost". Path resolution honours
+                    // CCTEAM_HOME so tests land in their tempdir layout.
+                    if let Ok(paths) = crate::CcteamPaths::from_env() {
+                        let progress_path = paths.progress_jsonl(&ctx.slug);
+                        let ev = crate::progress::build_chat_session_reset_event_with_reason(
+                            &spec.role,
+                            "resume_failed_fallback_to_fresh",
+                        );
+                        if let Err(err) = crate::progress::append_event(&progress_path, &ev) {
+                            tracing::warn!(
+                                error = %err,
+                                "claude-tui: failed to append chat_session_reset event"
+                            );
+                        }
+                    }
+                }
             }
         } else {
-            // (c) Absent — normal new session.
+            // (c) Absent — first spawn for this (slug, role). F172 V2:
+            // add `--name <session_id_name>` so Anthropic's session jsonl
+            // is filed under a deterministic name, enabling future
+            // recreate-path `--resume`. F118 brand-new spawn recovery
+            // path is unchanged (operates on turns.jsonl, not Anthropic
+            // session jsonl).
             let bin = claude_bin();
-            let argv: Vec<&str> = vec![&bin, "--dangerously-skip-permissions"];
+            let argv: Vec<&str> = vec![
+                &bin,
+                "--dangerously-skip-permissions",
+                "--name",
+                &session_id_name,
+            ];
             session
                 .start(&ctx.cwd, &argv)
                 .map_err(|e| HarnessError::SpawnFailed(format!("tmux start: {e}")))?;

--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -266,6 +266,19 @@ pub fn build_chat_session_reset_event(role: &str) -> Value {
     })
 }
 
+/// V0.6.6 F172 V2 — build a `chat_session_reset` event with an explicit
+/// `reason` field so user-visible context loss (e.g. failed
+/// `claude --resume <name>` fallback to fresh) carries enough metadata
+/// for IM / web surfaces to distinguish from user-issued `/clear`.
+pub fn build_chat_session_reset_event_with_reason(role: &str, reason: &str) -> Value {
+    serde_json::json!({
+        "event": CHAT_SESSION_RESET,
+        "role": role,
+        "reason": reason,
+        "ts": Utc::now().to_rfc3339(),
+    })
+}
+
 /// Build a `chat_session_reset_with_recovery` event JSON (F118).
 pub fn build_chat_session_reset_with_recovery_event(role: &str, recovered_turns: usize) -> Value {
     serde_json::json!({

--- a/crates/ccteam-core/tests/claude_tui_resume_test.rs
+++ b/crates/ccteam-core/tests/claude_tui_resume_test.rs
@@ -1,0 +1,660 @@
+//! V0.6.6 F172 V2 — tests for `ClaudeTuiAdapter::start_thread` spawn
+//! argv carrying Anthropic `--name` / `--resume <name>` for lossless
+//! context recovery via the official CLI surface.
+//!
+//! ## Coverage matrix
+//!
+//! 1. Fresh path (session absent): spawn argv must contain
+//!    `--name ccteam-chat-<slug>-<role>`.
+//! 2. Recreate path (dead pane): spawn argv must contain
+//!    `--resume ccteam-chat-<slug>-<role>`.
+//! 3. Recreate path with `--resume` failure: fallback to `--name` +
+//!    emit `chat_session_reset` event carrying
+//!    `reason="resume_failed_fallback_to_fresh"`.
+//! 4. Cwd-collision: two bots in the same cwd get distinct
+//!    `--name` values (per-role) so Anthropic's
+//!    `<cwd>:<name>` lookup never crosses streams.
+//! 5. F164 alive-reattach regression guard: when pane is alive we do
+//!    NOT spawn (no argv constructed, pid unchanged). Reuses the
+//!    F164 fake-claude pattern.
+//! 6. F118 brand-new spawn path remains compatible (turns.jsonl dir
+//!    is still created on first spawn — regression guard for
+//!    session_recovery prerequisites).
+//!
+//! ## Test infrastructure
+//!
+//! We use a fake `claude` shell script that records its full argv to a
+//! per-test logfile before sleeping. The `CCTEAM_CLAUDE_BIN` env var
+//! redirects production code to this script — no real claude binary
+//! invocation. Tests are `serial_test::serial` because they share the
+//! tmux server + the `CCTEAM_CLAUDE_BIN` / `CCTEAM_HOME` env vars.
+//!
+//! Red line compliance: this file never invokes `tmux capture-pane`.
+//! Pane liveness is probed via `list_pane_pids` + `ps -o comm=` only.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use ccteam_core::execution::claude_tui::{
+    chat_session_id_name, chat_session_name, ClaudeTuiAdapter,
+};
+use ccteam_core::harness::{AgentSpecBrief, HarnessAdapter, SpawnCtx, CLAUDE_BIN_ENV};
+use ccteam_core::tmux::TmuxSession;
+use serial_test::serial;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn kill_session_quiet(name: &str) {
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", name])
+        .output();
+}
+
+/// A fake "claude" that records its argv to `<tmp>/claude-argv.log`
+/// (one line per invocation, space-separated) then sleeps 999s so the
+/// pane stays alive (process comm = "fake-claude" contains "claude" →
+/// `is_pane_running_claude` returns true).
+fn fake_claude_logging_script(tmp: &tempfile::TempDir) -> PathBuf {
+    let log = tmp.path().join("claude-argv.log");
+    let p = tmp.path().join("fake-claude");
+    let body = format!(
+        "#!/bin/sh\necho \"$@\" >> {}\nsleep 999\n",
+        log.to_str().unwrap()
+    );
+    std::fs::write(&p, body).unwrap();
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+/// A fake "claude" that records argv then **exits with non-zero**
+/// (simulating `--resume <name>` jsonl-not-found failure). Used to
+/// exercise the F172 V2 fallback path.
+fn fake_claude_failing_resume_script(tmp: &tempfile::TempDir) -> PathBuf {
+    let log = tmp.path().join("claude-argv.log");
+    let p = tmp.path().join("fake-claude-failing");
+    // If argv contains `--resume`, exit fast (simulate failure).
+    // Otherwise sleep (the fallback `--name` spawn must stay alive).
+    let body = format!(
+        r#"#!/bin/sh
+echo "$@" >> {log}
+for arg in "$@"; do
+    if [ "$arg" = "--resume" ]; then
+        # Simulate "name not found" — exit fast so tmux pane dies.
+        exit 1
+    fi
+done
+sleep 999
+"#,
+        log = log.to_str().unwrap()
+    );
+    std::fs::write(&p, body).unwrap();
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+fn read_argv_log(tmp: &Path) -> Vec<String> {
+    let log = tmp.join("claude-argv.log");
+    if !log.exists() {
+        return vec![];
+    }
+    std::fs::read_to_string(&log)
+        .unwrap_or_default()
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn make_ctx(slug: &str, tmp: &tempfile::TempDir) -> SpawnCtx {
+    SpawnCtx {
+        slug: slug.to_string(),
+        sid: "chat-f172".into(),
+        cwd: tmp.path().to_path_buf(),
+        project_dir: tmp.path().to_path_buf(),
+        extra_args: vec![],
+        model_id: None,
+    }
+}
+
+/// Create a tmux session whose pane has a **dead** process — used to
+/// force the F164/F172 dead-pane recreate path. Uses
+/// `remain-on-exit on` so tmux keeps the session around after the pane
+/// process exits (default tmux behavior is to destroy the session, which
+/// would land us in the "absent" path instead). The sleep process is
+/// killed and we wait until `ps -p <pid>` returns nothing.
+fn setup_dead_pane_session(session_name: &str, cwd: &Path) {
+    let status = std::process::Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            session_name,
+            "-c",
+            cwd.to_str().unwrap(),
+            "sleep",
+            "100",
+        ])
+        .status()
+        .expect("tmux new-session for dead-pane setup");
+    assert!(status.success(), "pre-create live session failed");
+
+    let _ = std::process::Command::new("tmux")
+        .args(["set-option", "-t", session_name, "remain-on-exit", "on"])
+        .status();
+
+    // Grab the pane pid, kill it, wait for the process to actually die.
+    let session = TmuxSession::from_name(session_name.to_string());
+    let pids = session.list_pane_pids();
+    assert!(!pids.is_empty(), "live session must have pid before kill");
+    let pid = pids[0];
+    let _ = std::process::Command::new("kill")
+        .args(["-9", &pid.to_string()])
+        .status();
+    // Wait up to 3s for the process to vanish from ps.
+    for _ in 0..30 {
+        let alive = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !alive {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    // Session must still exist (remain-on-exit kept it) so start_thread
+    // hits the dead-pane recreate branch, not the absent branch.
+    assert!(
+        session.exists(),
+        "session must still exist after pane death (dead-pane recreate path)"
+    );
+}
+
+/// Wait up to `max_ms` for the argv log to contain at least `n` lines.
+fn wait_for_argv_lines(tmp: &Path, n: usize, max_ms: u64) -> Vec<String> {
+    let start = std::time::Instant::now();
+    loop {
+        let lines = read_argv_log(tmp);
+        if lines.len() >= n {
+            return lines;
+        }
+        if start.elapsed().as_millis() as u64 >= max_ms {
+            return lines;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: chat_session_id_name helper matches expected format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chat_session_id_name_uses_canonical_format() {
+    assert_eq!(
+        chat_session_id_name("dev-foo", "alice"),
+        "ccteam-chat-dev-foo-alice"
+    );
+    // Must agree with tmux session name (same namespace today).
+    assert_eq!(
+        chat_session_id_name("dev-foo", "alice"),
+        chat_session_name("dev-foo", "alice")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Fresh path spawn argv contains `--name <name>`
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn fresh_spawn_argv_contains_name_flag() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_logging_script(&tmp);
+
+    let slug = format!("f172-fresh-{}", std::process::id());
+    let role = "alpha";
+    let session_name = chat_session_name(&slug, role);
+    let expected_id = chat_session_id_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+
+    let handle = ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("start_thread fresh path must succeed");
+    assert_eq!(handle.identity, session_name);
+
+    let lines = wait_for_argv_lines(tmp.path(), 1, 2000);
+    assert_eq!(
+        lines.len(),
+        1,
+        "fresh path spawns exactly one claude invocation"
+    );
+    let argv = &lines[0];
+    assert!(
+        argv.contains("--name"),
+        "fresh argv must contain --name flag; got: {argv}"
+    );
+    assert!(
+        argv.contains(&expected_id),
+        "fresh argv must contain the deterministic session id `{expected_id}`; got: {argv}"
+    );
+    assert!(
+        !argv.contains("--resume"),
+        "fresh argv must NOT contain --resume; got: {argv}"
+    );
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Recreate path spawn argv contains `--resume <name>`
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn recreate_dead_pane_spawn_argv_contains_resume_flag() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_logging_script(&tmp);
+
+    let slug = format!("f172-recreate-{}", std::process::id());
+    let role = "beta";
+    let session_name = chat_session_name(&slug, role);
+    let expected_id = chat_session_id_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    // Pre-create a session with `remain-on-exit on` + a killed pane so
+    // start_thread sees "session exists + pane dead" → recreate path.
+    setup_dead_pane_session(&session_name, tmp.path());
+
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+
+    let handle = ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("start_thread recreate path must succeed");
+    assert_eq!(handle.identity, session_name);
+
+    let lines = wait_for_argv_lines(tmp.path(), 1, 2000);
+    assert!(
+        !lines.is_empty(),
+        "recreate path must spawn at least one claude invocation"
+    );
+    let argv = &lines[0];
+    assert!(
+        argv.contains("--resume"),
+        "recreate argv must contain --resume flag; got: {argv}"
+    );
+    assert!(
+        argv.contains(&expected_id),
+        "recreate argv must contain the deterministic session id `{expected_id}`; got: {argv}"
+    );
+    assert!(
+        !argv.contains("--name"),
+        "recreate argv (first attempt) must NOT contain --name (it's --resume); got: {argv}"
+    );
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: --resume failure → fallback to --name + emit chat_session_reset
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn resume_failure_falls_back_to_fresh_name() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_failing_resume_script(&tmp);
+
+    let slug = format!("f172-fallback-{}", std::process::id());
+    let role = "gamma";
+    let session_name = chat_session_name(&slug, role);
+    let expected_id = chat_session_id_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    // Pre-create dead-pane session to force recreate path.
+    setup_dead_pane_session(&session_name, tmp.path());
+
+    // Redirect CCTEAM_HOME so progress.jsonl lands in tmp.
+    let ccteam_home = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&ccteam_home).unwrap();
+    std::env::set_var("CCTEAM_HOME", ccteam_home.to_str().unwrap());
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+
+    let handle = ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("start_thread fallback path must succeed");
+    assert_eq!(handle.identity, session_name);
+
+    // Wait for both invocations: the failing --resume, then the fresh --name.
+    let lines = wait_for_argv_lines(tmp.path(), 2, 3000);
+    assert!(
+        lines.len() >= 2,
+        "expected 2 invocations (--resume then --name); got: {lines:?}"
+    );
+    let first = &lines[0];
+    let second = &lines[1];
+    assert!(
+        first.contains("--resume") && first.contains(&expected_id),
+        "first invocation must be --resume <name>; got: {first}"
+    );
+    assert!(
+        second.contains("--name") && second.contains(&expected_id),
+        "second invocation must be --name <name> (fallback); got: {second}"
+    );
+    assert!(
+        !second.contains("--resume"),
+        "fallback must NOT include --resume; got: {second}"
+    );
+
+    // Verify `chat_session_reset` event was appended with the right reason.
+    let paths = ccteam_core::CcteamPaths::from_env().expect("CcteamPaths::from_env");
+    let progress_path = paths.progress_jsonl(&slug);
+    assert!(
+        progress_path.exists(),
+        "progress.jsonl must be written; path: {}",
+        progress_path.display()
+    );
+    let body = std::fs::read_to_string(&progress_path).unwrap();
+    let reset_line = body
+        .lines()
+        .find(|line| line.contains("chat_session_reset"))
+        .expect("expected chat_session_reset event line");
+    let ev: serde_json::Value = serde_json::from_str(reset_line).expect("valid JSON");
+    assert_eq!(ev["event"], "chat_session_reset");
+    assert_eq!(ev["role"], role);
+    assert_eq!(ev["reason"], "resume_failed_fallback_to_fresh");
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+    std::env::remove_var("CCTEAM_HOME");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: F164 alive reattach regression guard — no spawn when pane alive
+// ---------------------------------------------------------------------------
+
+/// When a session exists AND its pane is running a claude-like process,
+/// start_thread must reattach without spawning. This guards the F164
+/// alive path against accidental F172 V2 argv churn.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn alive_reattach_does_not_spawn_new_claude() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Non-exec fake-claude (so the wrapper shell stays alive with comm
+    // = "fake-claude" containing "claude").
+    let p = tmp.path().join("fake-claude");
+    std::fs::write(&p, "#!/bin/sh\nsleep 999\n").unwrap();
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let bin = p;
+
+    let slug = format!("f172-alive-{}", std::process::id());
+    let role = "delta";
+    let session_name = chat_session_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    // Pre-create the session running fake-claude — pane will be alive.
+    let status = std::process::Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &session_name,
+            "-c",
+            tmp.path().to_str().unwrap(),
+            bin.to_str().unwrap(),
+        ])
+        .status()
+        .expect("tmux new-session");
+    assert!(status.success());
+
+    let session = TmuxSession::from_name(session_name.clone());
+    let pre_pids = session.list_pane_pids();
+    assert!(!pre_pids.is_empty(), "pre-created session must have pid");
+    let pre_pid = pre_pids[0];
+
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+
+    let _ = ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("start_thread alive reattach must succeed");
+
+    // Pane pid must be unchanged (no new spawn).
+    let post_pids = session.list_pane_pids();
+    assert_eq!(
+        post_pids.first().copied(),
+        Some(pre_pid),
+        "alive reattach must not spawn a new claude process"
+    );
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: cwd-collision — two roles in same cwd get distinct --name args
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn cwd_collision_two_roles_distinct_names() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_logging_script(&tmp);
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+
+    let slug = format!("f172-coll-{}", std::process::id());
+    let role_a = "roleA";
+    let role_b = "roleB";
+    let session_a = chat_session_name(&slug, role_a);
+    let session_b = chat_session_name(&slug, role_b);
+    let id_a = chat_session_id_name(&slug, role_a);
+    let id_b = chat_session_id_name(&slug, role_b);
+    kill_session_quiet(&session_a);
+    kill_session_quiet(&session_b);
+
+    let ctx = make_ctx(&slug, &tmp);
+
+    // Same cwd, two roles.
+    let h_a = ClaudeTuiAdapter::new()
+        .start_thread(
+            &AgentSpecBrief {
+                role: role_a.to_string(),
+            },
+            &ctx,
+        )
+        .await
+        .expect("role A spawn");
+    let h_b = ClaudeTuiAdapter::new()
+        .start_thread(
+            &AgentSpecBrief {
+                role: role_b.to_string(),
+            },
+            &ctx,
+        )
+        .await
+        .expect("role B spawn");
+
+    assert_ne!(h_a.identity, h_b.identity);
+
+    let lines = wait_for_argv_lines(tmp.path(), 2, 2000);
+    assert_eq!(lines.len(), 2, "two spawn calls expected; got: {lines:?}");
+    // Each line carries its own --name <id> — independent namespaces.
+    let combined = lines.join("\n");
+    assert!(
+        combined.contains(&id_a),
+        "argv log must contain role-A id `{id_a}`; got:\n{combined}"
+    );
+    assert!(
+        combined.contains(&id_b),
+        "argv log must contain role-B id `{id_b}`; got:\n{combined}"
+    );
+    assert_ne!(id_a, id_b, "the two role ids must differ");
+
+    kill_session_quiet(&session_a);
+    kill_session_quiet(&session_b);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: F118 brand-new spawn path regression — turns.jsonl dir created
+// ---------------------------------------------------------------------------
+
+/// F172 V2 must not break F118 prerequisites. On a brand-new spawn the
+/// `<project>/.ccteam/chat/<role>/` directory must still be created so
+/// turns_mirror has somewhere to write the per-bot turns.jsonl —
+/// session_recovery::build_recovery_prompt reads from there.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn fresh_spawn_creates_turns_mirror_dir_for_f118() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_logging_script(&tmp);
+
+    let slug = format!("f172-f118-{}", std::process::id());
+    let role = "epsilon";
+    let session_name = chat_session_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+
+    ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("brand-new spawn must succeed");
+
+    // F118 dir contract.
+    let chat_dir = tmp.path().join(".ccteam/chat").join(role);
+    assert!(
+        chat_dir.exists(),
+        "<project>/.ccteam/chat/<role>/ must be created for F118 turns mirror"
+    );
+    // Heartbeat — sanity check the broader spawn path didn't regress.
+    assert!(chat_dir.join("heartbeat").exists());
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: Daemon-restart cycle simulation — bot survives via --resume
+// ---------------------------------------------------------------------------
+
+/// Simulates daemon-restart recovery semantics: a session was previously
+/// running, the pane died (daemon was killed → claude was orphaned →
+/// eventually exited), and on next start_thread call we expect the
+/// `--resume <name>` route to be taken. The fake-claude binary that
+/// records argv lets us verify the argv carries `--resume`.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn daemon_restart_uses_resume_route() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_logging_script(&tmp);
+
+    let slug = format!("f172-restart-{}", std::process::id());
+    let role = "zeta";
+    let session_name = chat_session_name(&slug, role);
+    let expected_id = chat_session_id_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    // Cycle 1: first spawn = fresh --name.
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+    ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("first start_thread (fresh)");
+
+    let lines_after_first = wait_for_argv_lines(tmp.path(), 1, 2000);
+    assert_eq!(lines_after_first.len(), 1);
+    assert!(
+        lines_after_first[0].contains("--name") && lines_after_first[0].contains(&expected_id),
+        "cycle 1 spawn must use --name; got: {}",
+        lines_after_first[0]
+    );
+
+    // Simulate daemon kill: kill the tmux session entirely (orphan
+    // cleanup), then re-setup a dead-pane session so start_thread sees
+    // "session exists + pane dead" → recreate via --resume path.
+    kill_session_quiet(&session_name);
+    setup_dead_pane_session(&session_name, tmp.path());
+
+    // Cycle 2: second spawn = --resume.
+    ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("second start_thread (recreate via --resume)");
+    let lines_after_second = wait_for_argv_lines(tmp.path(), 2, 2000);
+    assert!(
+        lines_after_second.len() >= 2,
+        "cycle 2 spawn must be recorded; got: {lines_after_second:?}"
+    );
+    let second_argv = &lines_after_second[1];
+    assert!(
+        second_argv.contains("--resume") && second_argv.contains(&expected_id),
+        "cycle 2 spawn must use --resume <name>; got: {second_argv}"
+    );
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}


### PR DESCRIPTION
## Finding
[F172](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-6/prd.md#f172) V2 — claude --resume by name route (chat_snapshot ditched per PR #123).

## Design
- spawn gains `--name ccteam-chat-<slug>-<role>` (Fresh + Recreate paths)
- recreate path: `claude --resume <name>`
- failure: detect dead pane after 400ms → fresh session via `--name` (visible degraded, **no** synthesis fallback) + emit `chat_session_reset` with `reason=resume_failed_fallback_to_fresh`
- alive reattach (F164) untouched — verified by regression test
- F118 retained for brand-new spawn (not F172 path)

## Red lines守 (all 6)
- File-system control plane: `--resume` reads Anthropic-owned jsonl, no new ccteam-managed store
- progress.jsonl SoT: no new event const (reuses `chat_session_reset` with a `reason` field)
- No prompt injection: no synthesis text pushed to pane
- Never kill long sessions: only kill in F164 dead-pane case (orphan, not live bot)
- No tmux pane scraping: zero `tmux capture-pane`; only `list-panes` + `ps` (already-allowed metadata)
- R10 跨项目记忆走官方接口: directly satisfied — `--resume` is Anthropic CLI first-class

## Verification
- `cargo test --workspace --locked`: 1591 passed / 1 failed (baseline 1583/1 + 8 new tests, the 1 fail is pre-existing ccteam-web flake)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `grep tmux capture-pane crates/ccteam-core/src/execution/claude_tui.rs`: 0 hits
- `grep CHAT_SNAPSHOT\|chat_snapshot crates/ccteam-core/src/progress.rs`: 0 hits
- New tests cover: argv `--name` on fresh, argv `--resume` on recreate, `--resume` failure fallback + chat_session_reset reason field, alive reattach regression, cwd-collision two roles, F118 turns dir creation, daemon-restart cycle

## Diff stat
3 files changed, 761 insertions(+), 7 deletions(-)