### PR TITLE
v0.6.6 (F170): doc-comment scrub 4 sites

### DIFF
--- a/crates/ccteam-core/src/team.rs
+++ b/crates/ccteam-core/src/team.rs
@@ -1499,8 +1499,8 @@ mod tests {
 
     #[test]
     fn f47_sessions_field_parses_codex_harness() {
-        // F47 ship: schema accepts `harness: codex` even though spawn
-        // is still NotImplemented. F49 wires the runtime path.
+        // Schema test: `harness: codex` parsing (F47 schema + F49
+        // runtime path, both shipped V0.4.x).
         let src = concat!(
             "name: my-flex\n",
             "sessions:\n",

--- a/crates/ccteam-core/src/templates/project_mcp_json.rs
+++ b/crates/ccteam-core/src/templates/project_mcp_json.rs
@@ -15,9 +15,8 @@
 //!   `mcpServers.*` entries the user already wired up (Playwright,
 //!   Linear, etc.).
 //!
-//! Wave 1 lands this helper alone; Wave 2 wires it into the
-//! `ccteam-creator` skill execute phase (per `docs/versions/v0-6-0/prd.md` F111
-//! file clean list).
+//! V0.6.5 F148 wires this helper into the `ccteam-creator` skill
+//! execute phase (see `skills/ccteam-creator/SKILL.md` §5.7).
 
 use std::path::Path;
 

--- a/crates/ccteam-cost/src/pricing.rs
+++ b/crates/ccteam-cost/src/pricing.rs
@@ -47,8 +47,8 @@ const ANTHROPIC_TOML: &str = include_str!("../pricing/anthropic.toml");
 const OPENAI_TOML: &str = include_str!("../pricing/openai.toml");
 
 /// Vendor discriminator. Defined here (not in `ccteam-core::harness`)
-/// so this crate has zero `ccteam-core` deps — `ccteam-core` will
-/// re-export `ccteam_cost::Vendor` once Wave 2 lands.
+/// so this crate has zero `ccteam-core` deps; `ccteam-core` re-exports
+/// `ccteam_cost::Vendor` from its `lib.rs` for downstream callers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Vendor {
     Claude,

--- a/crates/ccteam-web/src/routes/dashboard.rs
+++ b/crates/ccteam-web/src/routes/dashboard.rs
@@ -6,8 +6,7 @@
 //!
 //! `templates/base.html` stays in-repo as an askama SSR fallback per
 //! the V0.3.2 PRD §F59 wording. Static htmx / xterm / `style.css`
-//! assets are still served by `routes/assets.rs` for one more release —
-//! see the TODO marker there for V0.3.3 cleanup.
+//! assets are still served by `routes/assets.rs`.
 
 use axum::{
     http::{header, StatusCode},


### PR DESCRIPTION
## Finding
[F170](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-6/prd.md#f170) — stale doc-comment scrub per V0.6.5 post-ship-stub-inventory Cat 7 (4 sites).

## Sites scrubbed
1. `crates/ccteam-web/src/routes/dashboard.rs:10` — dropped stale `V0.3.3 cleanup` TODO marker reference (assets.rs cleanup long-done).
2. `crates/ccteam-core/src/team.rs:1503` — rewrote `F47 ship: ... F49 wires the runtime path` to current-state fact (both F47 + F49 shipped V0.4.x).
3. `crates/ccteam-cost/src/pricing.rs:51` — rewrote `ccteam-core will re-export ... once Wave 2 lands` to current-state fact (verified `ccteam-core::lib.rs:206` already re-exports `Vendor`).
4. `crates/ccteam-core/src/templates/project_mcp_json.rs:18` — rewrote `Wave 1 lands ... Wave 2 wires it` to point at F148 SoT (verified `skills/ccteam-creator/SKILL.md` §5.7 already calls `render_project_mcp_json`).

## Verification
- cargo test --workspace: 1583 / 1 (baseline preserved, no test code touched; second-run reading after one parallel flake)
- cargo clippy --workspace --all-targets -- -D warnings: clean
- diff stat: 4 files / +7 / -9 (pure doc-comment text change, no behavior diff)