### PR TITLE
v0.6.6 (F167): /ccteam-creator sensible defaults

### DIFF
--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -4557,6 +4557,51 @@ fn purge_project_managed_paths(
     Ok(())
 }
 
+// V0.6.6 F167 — `ccteam probe-project` CLI subcommand. Thin wrapper
+// over `ccteam_core::probe_project()` that emits a JSON object the
+// `/ccteam-creator` skill can fold into Phase 4's PROJECT PLAN ctx
+// (so the rendered workflow.yaml's `scope:` is pre-populated with
+// sensible defaults instead of the empty stub the skill used to
+// emit). Pure CLI surface — the heuristic lives in the core crate;
+// this just serializes + writes to stdout.
+//
+// Output schema (stable for V0.6.6+):
+//
+// ```json
+// {
+//   "kind": "monorepo" | "single-repo" | "docs-only" | "scripts-only" | "empty",
+//   "languages": ["rust", "typescript", ...],
+//   "has_tests": true | false,
+//   "probable_scope": ["crates/ccteam-core/src", "crates/ccteam-cli/src", ...]
+// }
+// ```
+pub fn run_probe_project(repo_root: &std::path::Path, json: bool) -> Result<String> {
+    let probe = ccteam_core::probe_project(repo_root);
+    if json {
+        // V0.6.6 F167 — the wire shape lives in `ProjectProbe`'s
+        // `serde(rename_all = "kebab-case")` derive, so we just
+        // serialize directly.
+        Ok(serde_json::to_string_pretty(&probe).context("serialize probe-project JSON")?)
+    } else {
+        // Human-readable fallback for `ccteam probe-project` without
+        // `--json` — a 4-line summary the user can eyeball before
+        // they pipe it into the skill.
+        let langs: Vec<&str> = probe.languages.iter().map(|l| l.as_str()).collect();
+        let scope: Vec<String> = probe
+            .probable_scope
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect();
+        Ok(format!(
+            "kind: {}\nlanguages: [{}]\nhas_tests: {}\nprobable_scope: [{}]\n",
+            probe.kind.as_str(),
+            langs.join(", "),
+            probe.has_tests,
+            scope.join(", "),
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Mutex, OnceLock};

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -640,6 +640,27 @@ enum Command {
         #[command(subcommand)]
         action: AdminAction,
     },
+    /// V0.6.6 F167 — probe a repo root and emit the detected
+    /// project kind (monorepo / single-repo / docs-only / scripts-only
+    /// / empty), the top-3 languages, a tests-present flag, and the
+    /// `probable_scope` paths the `/ccteam-creator` skill should
+    /// pre-populate into the rendered `workflow.yaml::agents.<role>.
+    /// scope` field. Pure read-only file-existence sweep — no source
+    /// parsing, no LLM calls.
+    ///
+    /// Skill use: invoked by `/ccteam-creator` Phase 3.6 before the
+    /// PROJECT PLAN render so the user sees sensible scope defaults
+    /// without having to hand-edit yaml after the install.
+    ProbeProject {
+        /// Repo root to probe. Defaults to cwd.
+        #[arg(long, value_name = "PATH")]
+        path: Option<PathBuf>,
+        /// Emit the probe as a JSON object (stable schema — see
+        /// `commands::run_probe_project` docs). Default is a
+        /// 4-line human-readable summary.
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
 }
 
 /// V0.6.1 F128 — `ccteam admin` subcommand surface (chat-mode bot
@@ -1132,6 +1153,18 @@ fn main() -> Result<()> {
                     Ok(())
                 }
             }
+        }
+        Command::ProbeProject { path, json } => {
+            let root = match path {
+                Some(p) => p,
+                None => std::env::current_dir().context("get cwd for probe-project")?,
+            };
+            // JSON branch already produces no trailing newline (consumers
+            // pipe to `jq` — extra newline is noise). Text branch
+            // already includes a trailing `\n`. Both safe with `print!`.
+            let out = commands::run_probe_project(&root, json)?;
+            print!("{out}");
+            Ok(())
         }
     }
 }

--- a/crates/ccteam-cli/tests/probe_project_test.rs
+++ b/crates/ccteam-cli/tests/probe_project_test.rs
@@ -1,0 +1,145 @@
+//! V0.6.6 F167 — integration test for `ccteam probe-project --json`.
+//!
+//! The probe heuristic lives in `ccteam_core::templates::project_probe`
+//! (covered by unit tests in that module). This binary-surface test
+//! pins the CLI wire shape — argv parsing (`--path` / `--json`), exit
+//! code, and the JSON output schema — so the `/ccteam-creator` skill
+//! Phase 3.6 has a stable contract.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+fn ccteam_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_ccteam")
+}
+
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, body).unwrap();
+}
+
+#[test]
+fn probe_project_emits_json_on_fresh_rust_single_repo() {
+    let td = tempdir().unwrap();
+    write(
+        &td.path().join("Cargo.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.1.0\"\n",
+    );
+    write(&td.path().join("src/main.rs"), "fn main() {}\n");
+    fs::create_dir_all(td.path().join("tests")).unwrap();
+
+    let out = Command::new(ccteam_bin())
+        .arg("probe-project")
+        .arg("--path")
+        .arg(td.path())
+        .arg("--json")
+        .output()
+        .expect("spawn ccteam probe-project");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let v: Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout is not JSON: {e}\nstdout:\n{stdout}"));
+    assert_eq!(v["kind"], "single-repo");
+    let langs = v["languages"].as_array().unwrap();
+    assert!(
+        langs.iter().any(|l| l == "rust"),
+        "expected rust in languages, got {langs:?}"
+    );
+    let scope = v["probable_scope"].as_array().unwrap();
+    let scope_strs: Vec<String> = scope
+        .iter()
+        .map(|s| s.as_str().unwrap().to_string())
+        .collect();
+    assert!(scope_strs.contains(&"src".to_string()));
+    assert!(scope_strs.contains(&"tests".to_string()));
+}
+
+#[test]
+fn probe_project_emits_human_readable_text_without_json_flag() {
+    let td = tempdir().unwrap();
+    write(&td.path().join("README.md"), "# hi\n");
+    fs::create_dir_all(td.path().join("docs")).unwrap();
+
+    let out = Command::new(ccteam_bin())
+        .arg("probe-project")
+        .arg("--path")
+        .arg(td.path())
+        .output()
+        .expect("spawn ccteam probe-project");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    assert!(stdout.starts_with("kind: docs-only\n"), "stdout:\n{stdout}");
+    assert!(stdout.contains("probable_scope: [docs]"));
+}
+
+#[test]
+fn probe_project_detects_monorepo_rust_workspace_with_glob() {
+    let td = tempdir().unwrap();
+    write(
+        &td.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/*\"]\n",
+    );
+    for c in ["alpha", "beta"] {
+        write(
+            &td.path().join(format!("crates/{c}/Cargo.toml")),
+            "[package]\nname = \"x\"\nversion = \"0.1\"\n",
+        );
+        let body = match c {
+            "alpha" => "fn x() {}\n".repeat(500),
+            _ => "fn y() {}\n".repeat(100),
+        };
+        write(&td.path().join(format!("crates/{c}/src/lib.rs")), &body);
+    }
+    let out = Command::new(ccteam_bin())
+        .arg("probe-project")
+        .arg("--path")
+        .arg(td.path())
+        .arg("--json")
+        .output()
+        .expect("spawn ccteam probe-project");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["kind"], "monorepo");
+    let scope: Vec<String> = v["probable_scope"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        scope.iter().any(|s| s.starts_with("crates/")),
+        "expected crates/ prefix in scope, got {scope:?}"
+    );
+}
+
+#[test]
+fn probe_project_default_path_uses_cwd() {
+    // No --path arg — `ccteam probe-project --json` should fall back
+    // to `std::env::current_dir()`. We run from a fresh tempdir to
+    // confirm the cwd hand-off works (would Empty-classify a bare
+    // dir).
+    let td = tempdir().unwrap();
+    let out = Command::new(ccteam_bin())
+        .current_dir(td.path())
+        .arg("probe-project")
+        .arg("--json")
+        .output()
+        .expect("spawn ccteam probe-project");
+    assert!(out.status.success());
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["kind"], "empty");
+}

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -255,10 +255,11 @@ pub use team_resolver::{
     TeamSource, TEAM_SOURCES,
 };
 pub use templates::{
-    current_ccteam_bin, default_workflow_ctx, merge_project_mcp_json, render_project_mcp_json,
-    render_project_settings, render_project_settings_agent_team, render_workflow_template,
-    write_global_helper_templates, write_project_settings, write_project_settings_agent_team,
-    EnabledPluginsSetting, SettingsEnv, WorkflowPreset, WorkflowTemplateCtx,
+    apply_probe_defaults_to_workflow_ctx, current_ccteam_bin, default_workflow_ctx,
+    merge_project_mcp_json, probe_project, render_project_mcp_json, render_project_settings,
+    render_project_settings_agent_team, render_workflow_template, write_global_helper_templates,
+    write_project_settings, write_project_settings_agent_team, EnabledPluginsSetting, Language,
+    ProjectKind, ProjectProbe, SettingsEnv, WorkflowPreset, WorkflowTemplateCtx,
     WorkflowTemplateRenderError, CCTEAM_MCP_SERVER_KEY, HELPER_TEMPLATES,
     PROJECT_SETTINGS_AGENT_TEAM_JSON, PROJECT_SETTINGS_JSON,
 };

--- a/crates/ccteam-core/src/templates/mod.rs
+++ b/crates/ccteam-core/src/templates/mod.rs
@@ -33,10 +33,27 @@ pub use project_mcp_json::{
 // `<project>/.ccteam/workflow.yaml`.
 pub mod workflow_templates;
 pub use workflow_templates::{
+    apply_probe_defaults as apply_probe_defaults_to_workflow_ctx,
     default_ctx as default_workflow_ctx, render as render_workflow_template,
     Preset as WorkflowPreset, RenderError as WorkflowTemplateRenderError,
     TemplateCtx as WorkflowTemplateCtx,
 };
+
+// V0.6.6 F167 note: there is no separate `render_workflow_template_with_probe`
+// function. Callers build the ctx, then call
+// `apply_probe_defaults_to_workflow_ctx(&mut ctx, preset, &probe)` to
+// overlay sensible defaults, then call `render_workflow_template` as
+// usual. This keeps the render entry point single + strict, and lets
+// callers stack their own ctx overrides between the probe overlay and
+// the render call.
+
+// V0.6.6 F167 — project-type probe for `/ccteam-creator` sensible
+// defaults. Surfaces ProjectKind / languages / probable_scope from a
+// file-existence sweep so the skill's PROJECT PLAN can pre-populate
+// the rendered workflow.yaml's `scope:` field instead of shipping a
+// generic stub the user has to hand-edit before first run.
+pub mod project_probe;
+pub use project_probe::{probe as probe_project, Language, ProjectKind, ProjectProbe};
 
 /// Per-project `.claude/settings.json` template.
 ///
@@ -60,8 +77,7 @@ pub const PROJECT_SETTINGS_JSON: &str = include_str!("settings.json");
 /// new hook entries: `TeammateIdle`, `TaskCreated`, `TaskCompleted`.
 /// Used only by `ccteam init --mode agent-team` (per PRD F94 红线:
 /// advanced path only).
-pub const PROJECT_SETTINGS_AGENT_TEAM_JSON: &str =
-    include_str!("settings.agent-team.json");
+pub const PROJECT_SETTINGS_AGENT_TEAM_JSON: &str = include_str!("settings.agent-team.json");
 
 /// M2.4: helper templates that user-authored agent / workflow markdown
 /// can `@`-reference. Shipped inside the binary so a fresh install (or
@@ -155,12 +171,9 @@ fn render_settings_template(
     extra_env: &SettingsEnv,
     enabled: &EnabledPluginsSetting,
 ) -> Result<String> {
-    let hook = hook_sh.to_str().ok_or_else(|| {
-        anyhow!(
-            "ccteam hook.sh path not valid UTF-8: {}",
-            hook_sh.display()
-        )
-    })?;
+    let hook = hook_sh
+        .to_str()
+        .ok_or_else(|| anyhow!("ccteam hook.sh path not valid UTF-8: {}", hook_sh.display()))?;
     if hook.contains('"') || hook.contains('\\') {
         return Err(anyhow!(
             "ccteam hook.sh path contains characters that can't be embedded in settings.json: {hook}"

--- a/crates/ccteam-core/src/templates/project_probe.rs
+++ b/crates/ccteam-core/src/templates/project_probe.rs
@@ -1,0 +1,872 @@
+//! V0.6.6 F167 — lightweight project-type probe for `/ccteam-creator`
+//! sensible defaults.
+//!
+//! The probe inspects a repo root via **file-existence checks only**
+//! (no source parsing) and emits:
+//!
+//! - [`ProjectKind`] — Monorepo / SingleRepo / DocsOnly / ScriptsOnly / Empty
+//! - [`Language`] top-3 (Rust / TypeScript / Python / Go / Java / Other)
+//! - [`ProjectProbe::has_tests`] — at least one well-known test dir exists
+//! - [`ProjectProbe::probable_scope`] — top-3 source subtrees the
+//!   `ccteam-creator` skill should pre-populate into the rendered
+//!   `workflow.yaml::agents.<role>.scope` field
+//!
+//! Scope cap is `3` deliberately: the ccteam repo itself probes to
+//! 10+ Rust crates and a naive "all members" answer would blow the
+//! V0.6.2 F140 blast-radius guarantee back open. Top-3 by descending
+//! source line-count, ties broken alphabetically.
+//!
+//! **Non-goals (V0.7 epic):**
+//!
+//! - Cross-language adapter (the probe surfaces languages but does not
+//!   pick per-language templates).
+//! - Per-role auto-generated personas (full template library).
+//! - LLM-assisted role inference.
+//!
+//! The probe is **pure heuristic** — when in doubt it under-reports
+//! (e.g. returns `SingleRepo` rather than `Monorepo` for ambiguous
+//! cases) so the skill's PROJECT PLAN never silently widens the scope
+//! beyond what the user expected.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Coarse project shape, derived from manifest-file presence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProjectKind {
+    /// `Cargo.toml` with `workspace.members`, `package.json` with
+    /// `workspaces`, `pnpm-workspace.yaml`, or `go.work` present.
+    Monorepo,
+    /// Single top-level manifest (`Cargo.toml` without workspace,
+    /// single `package.json`, `pyproject.toml`, `go.mod` alone, etc.)
+    SingleRepo,
+    /// Markdown / docs only — no source dir, no manifest.
+    DocsOnly,
+    /// Scripts (`.sh` / `.py` standalone) with no manifest / no
+    /// proper src tree.
+    ScriptsOnly,
+    /// Empty (or unrecognized) directory.
+    Empty,
+}
+
+impl ProjectKind {
+    /// Wire name matching the JSON `--json` output.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProjectKind::Monorepo => "monorepo",
+            ProjectKind::SingleRepo => "single-repo",
+            ProjectKind::DocsOnly => "docs-only",
+            ProjectKind::ScriptsOnly => "scripts-only",
+            ProjectKind::Empty => "empty",
+        }
+    }
+}
+
+/// Detected language tags — top-3 by source-file count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Language {
+    Rust,
+    TypeScript,
+    JavaScript,
+    Python,
+    Go,
+    Java,
+    Other,
+}
+
+impl Language {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Language::Rust => "rust",
+            Language::TypeScript => "typescript",
+            Language::JavaScript => "javascript",
+            Language::Python => "python",
+            Language::Go => "go",
+            Language::Java => "java",
+            Language::Other => "other",
+        }
+    }
+}
+
+/// The probe result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectProbe {
+    pub kind: ProjectKind,
+    pub languages: Vec<Language>,
+    pub has_tests: bool,
+    /// Suggested `scope:` paths — relative to `repo_root`, top-3 by
+    /// descending source LOC. Always non-empty for `Monorepo` /
+    /// `SingleRepo`; `["docs"]` for `DocsOnly`; empty for `Empty` /
+    /// `ScriptsOnly`.
+    pub probable_scope: Vec<PathBuf>,
+}
+
+/// Probe a repo root. **Infallible by design** — every error path
+/// degrades to a less-specific category (Empty when the dir is
+/// unreadable, SingleRepo when monorepo detection trips midway). The
+/// skill is expected to honor the user's explicit override; this is
+/// only the "sensible default" seed.
+pub fn probe(repo_root: &Path) -> ProjectProbe {
+    // Step 1: detect monorepo first (strongest signal).
+    if let Some(scope) = detect_monorepo(repo_root) {
+        let (langs, has_tests) = detect_languages_and_tests(repo_root);
+        return ProjectProbe {
+            kind: ProjectKind::Monorepo,
+            languages: langs,
+            has_tests,
+            probable_scope: scope,
+        };
+    }
+
+    // Step 2: detect single-repo (any one manifest).
+    if is_single_repo(repo_root) {
+        let (langs, has_tests) = detect_languages_and_tests(repo_root);
+        let scope = single_repo_scope(repo_root);
+        return ProjectProbe {
+            kind: ProjectKind::SingleRepo,
+            languages: langs,
+            has_tests,
+            probable_scope: scope,
+        };
+    }
+
+    // Step 3: docs-only.
+    if is_docs_only(repo_root) {
+        return ProjectProbe {
+            kind: ProjectKind::DocsOnly,
+            languages: Vec::new(),
+            has_tests: false,
+            probable_scope: docs_only_scope(repo_root),
+        };
+    }
+
+    // Step 4: scripts-only.
+    if is_scripts_only(repo_root) {
+        let (langs, _) = detect_languages_and_tests(repo_root);
+        return ProjectProbe {
+            kind: ProjectKind::ScriptsOnly,
+            languages: langs,
+            has_tests: false,
+            probable_scope: Vec::new(),
+        };
+    }
+
+    // Step 5: empty / unrecognized.
+    ProjectProbe {
+        kind: ProjectKind::Empty,
+        languages: Vec::new(),
+        has_tests: false,
+        probable_scope: Vec::new(),
+    }
+}
+
+// -- monorepo detection --------------------------------------------------
+
+/// Returns `Some(scope_paths)` when the root looks like a monorepo,
+/// `None` otherwise. Scope is top-3 first-party member dirs.
+fn detect_monorepo(repo_root: &Path) -> Option<Vec<PathBuf>> {
+    // Cargo workspace.
+    if let Some(scope) = cargo_workspace_members(repo_root) {
+        return Some(scope);
+    }
+    // pnpm workspace.
+    if repo_root.join("pnpm-workspace.yaml").is_file()
+        || repo_root.join("pnpm-workspace.yml").is_file()
+    {
+        let scope = ts_monorepo_members(repo_root);
+        if !scope.is_empty() {
+            return Some(scope);
+        }
+    }
+    // npm/yarn workspaces — coarse: package.json contains `"workspaces"`.
+    let pkg = repo_root.join("package.json");
+    if pkg.is_file() {
+        if let Ok(s) = fs::read_to_string(&pkg) {
+            if s.contains("\"workspaces\"") {
+                let scope = ts_monorepo_members(repo_root);
+                if !scope.is_empty() {
+                    return Some(scope);
+                }
+            }
+        }
+    }
+    // Go workspace.
+    if repo_root.join("go.work").is_file() {
+        let scope = go_workspace_members(repo_root);
+        if !scope.is_empty() {
+            return Some(scope);
+        }
+    }
+    None
+}
+
+/// Parse `Cargo.toml` for `[workspace] members = [...]` and return the
+/// top-3 by descending LOC (under `<member>/src/`). Falls back to
+/// alphabetical when LOC counts tie.
+fn cargo_workspace_members(repo_root: &Path) -> Option<Vec<PathBuf>> {
+    let cargo = repo_root.join("Cargo.toml");
+    if !cargo.is_file() {
+        return None;
+    }
+    let body = fs::read_to_string(&cargo).ok()?;
+    // Coarse parse — we don't need a full TOML reader to detect "this is
+    // a workspace". Look for `[workspace]` section AND members entries.
+    if !body.contains("[workspace]") && !body.contains("[workspace.package]") {
+        return None;
+    }
+    let members = parse_cargo_workspace_members(&body);
+    // If the manifest declares `[workspace]` but glob members didn't
+    // expand to anything (e.g. `members = ["crates/*"]`), fall back to
+    // scanning `crates/` for `Cargo.toml`-bearing subdirs.
+    let mut resolved = resolve_member_paths(repo_root, &members);
+    if resolved.is_empty() {
+        // Standard ccteam layout: `crates/<member>/Cargo.toml`.
+        for sub in ["crates", "packages", "apps", "libs"] {
+            let dir = repo_root.join(sub);
+            if dir.is_dir() {
+                if let Ok(rd) = fs::read_dir(&dir) {
+                    for ent in rd.flatten() {
+                        let p = ent.path();
+                        if p.is_dir() && p.join("Cargo.toml").is_file() {
+                            resolved.push(p);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if resolved.is_empty() {
+        return None;
+    }
+    // Rank by descending source LOC under `<member>/src/`.
+    let mut ranked: Vec<(PathBuf, usize)> = resolved
+        .into_iter()
+        .map(|p| {
+            let loc = scan_loc(&p.join("src"));
+            (p, loc)
+        })
+        .collect();
+    // Secondary key: alphabetical.
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let top: Vec<PathBuf> = ranked
+        .into_iter()
+        .take(3)
+        .map(|(p, _)| relative_to(repo_root, &p))
+        .collect();
+    Some(top)
+}
+
+/// Coarse extract of the `members = [...]` list inside `[workspace]`.
+/// Tolerates inline / multi-line arrays. Returns raw strings (might
+/// include globs like `"crates/*"` which we resolve later).
+fn parse_cargo_workspace_members(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_workspace = false;
+    let mut in_members = false;
+    let mut buf = String::new();
+    for raw in body.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') {
+            in_workspace = line == "[workspace]";
+            in_members = false;
+            buf.clear();
+            continue;
+        }
+        if !in_workspace {
+            continue;
+        }
+        if in_members {
+            buf.push_str(line);
+            if line.contains(']') {
+                in_members = false;
+                extract_quoted(&buf, &mut out);
+                buf.clear();
+            }
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("members") {
+            // `members = [...]` or `members = [` (multi-line).
+            let rest = rest.trim_start().trim_start_matches('=').trim();
+            if rest.contains(']') {
+                extract_quoted(rest, &mut out);
+            } else {
+                in_members = true;
+                buf.push_str(rest);
+            }
+        }
+    }
+    out
+}
+
+fn extract_quoted(s: &str, out: &mut Vec<String>) {
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '"' {
+            let mut word = String::new();
+            for c2 in chars.by_ref() {
+                if c2 == '"' {
+                    break;
+                }
+                word.push(c2);
+            }
+            if !word.is_empty() {
+                out.push(word);
+            }
+        }
+    }
+}
+
+fn resolve_member_paths(repo_root: &Path, patterns: &[String]) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for pat in patterns {
+        if pat.ends_with("/*") {
+            let dir = repo_root.join(pat.trim_end_matches("/*"));
+            if dir.is_dir() {
+                if let Ok(rd) = fs::read_dir(&dir) {
+                    for ent in rd.flatten() {
+                        let p = ent.path();
+                        if p.is_dir() && p.join("Cargo.toml").is_file() {
+                            out.push(p);
+                        }
+                    }
+                }
+            }
+        } else {
+            let p = repo_root.join(pat);
+            if p.is_dir() {
+                out.push(p);
+            }
+        }
+    }
+    out
+}
+
+/// Top-3 first-party packages in a TS monorepo. Scans `packages/` and
+/// `apps/`, ranks by `.ts` / `.tsx` LOC.
+fn ts_monorepo_members(repo_root: &Path) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    for sub in ["packages", "apps", "libs"] {
+        let dir = repo_root.join(sub);
+        if dir.is_dir() {
+            if let Ok(rd) = fs::read_dir(&dir) {
+                for ent in rd.flatten() {
+                    let p = ent.path();
+                    if p.is_dir() && p.join("package.json").is_file() {
+                        candidates.push(p);
+                    }
+                }
+            }
+        }
+    }
+    let mut ranked: Vec<(PathBuf, usize)> = candidates
+        .into_iter()
+        .map(|p| {
+            let loc = scan_loc(&p.join("src"));
+            (p, loc)
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked
+        .into_iter()
+        .take(3)
+        .map(|(p, _)| relative_to(repo_root, &p))
+        .collect()
+}
+
+/// Top-3 Go module dirs in a `go.work` workspace.
+fn go_workspace_members(repo_root: &Path) -> Vec<PathBuf> {
+    let body = match fs::read_to_string(repo_root.join("go.work")) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let mut members: Vec<PathBuf> = Vec::new();
+    let mut in_use = false;
+    for raw in body.lines() {
+        let line = raw.trim();
+        if line.starts_with("use (") {
+            in_use = true;
+            continue;
+        }
+        if in_use {
+            if line == ")" {
+                in_use = false;
+                continue;
+            }
+            if !line.is_empty() && !line.starts_with("//") {
+                members.push(repo_root.join(line));
+            }
+        } else if let Some(rest) = line.strip_prefix("use ") {
+            let rest = rest.trim();
+            if !rest.is_empty() {
+                members.push(repo_root.join(rest));
+            }
+        }
+    }
+    let mut ranked: Vec<(PathBuf, usize)> = members
+        .into_iter()
+        .filter(|p| p.is_dir())
+        .map(|p| {
+            let loc = scan_loc(&p);
+            (p, loc)
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    ranked
+        .into_iter()
+        .take(3)
+        .map(|(p, _)| relative_to(repo_root, &p))
+        .collect()
+}
+
+// -- single-repo detection ----------------------------------------------
+
+fn is_single_repo(repo_root: &Path) -> bool {
+    repo_root.join("Cargo.toml").is_file()
+        || repo_root.join("package.json").is_file()
+        || repo_root.join("pyproject.toml").is_file()
+        || repo_root.join("setup.py").is_file()
+        || repo_root.join("requirements.txt").is_file()
+        || repo_root.join("go.mod").is_file()
+        || repo_root.join("pom.xml").is_file()
+        || repo_root.join("build.gradle").is_file()
+        || repo_root.join("build.gradle.kts").is_file()
+}
+
+/// `["src", "tests"]` style default — only emit subdirs that actually
+/// exist on disk so the skill never writes a `scope:` pointing to a
+/// missing path. Falls back to `["src"]` if `tests/` is absent, or
+/// `[]` if neither exists (rare — most single-repo languages ship a
+/// `src/`).
+fn single_repo_scope(repo_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for cand in ["src", "lib", "tests"] {
+        if repo_root.join(cand).is_dir() {
+            out.push(PathBuf::from(cand));
+        }
+    }
+    out
+}
+
+// -- docs-only / scripts-only -------------------------------------------
+
+fn is_docs_only(repo_root: &Path) -> bool {
+    // Has `.md` files AND no source dir AND no manifest.
+    let mut has_md = false;
+    let mut has_source_signal = false;
+    if let Ok(rd) = fs::read_dir(repo_root) {
+        for ent in rd.flatten() {
+            let name = ent.file_name();
+            let n = name.to_string_lossy().to_string();
+            if n.starts_with('.') {
+                continue;
+            }
+            if n.ends_with(".md") {
+                has_md = true;
+            }
+            if n == "src" || n == "lib" || n == "crates" || n == "packages" {
+                has_source_signal = true;
+            }
+        }
+    }
+    let has_docs_dir = repo_root.join("docs").is_dir();
+    (has_md || has_docs_dir) && !has_source_signal
+}
+
+fn docs_only_scope(repo_root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if repo_root.join("docs").is_dir() {
+        out.push(PathBuf::from("docs"));
+    }
+    out
+}
+
+fn is_scripts_only(repo_root: &Path) -> bool {
+    let mut has_script = false;
+    if let Ok(rd) = fs::read_dir(repo_root) {
+        for ent in rd.flatten() {
+            let name = ent.file_name();
+            let n = name.to_string_lossy().to_string();
+            if n.starts_with('.') {
+                continue;
+            }
+            if n.ends_with(".sh") || (n.ends_with(".py") && n != "setup.py") {
+                has_script = true;
+            }
+        }
+    }
+    has_script
+}
+
+// -- language detection -------------------------------------------------
+
+fn detect_languages_and_tests(repo_root: &Path) -> (Vec<Language>, bool) {
+    // Coarse: peek at first 200 entries to detect predominant extensions.
+    // We do *not* recursively count files — `walkdir` is overkill for a
+    // skill bootstrap hint.
+    let mut count_rs = 0usize;
+    let mut count_ts = 0usize;
+    let mut count_js = 0usize;
+    let mut count_py = 0usize;
+    let mut count_go = 0usize;
+    let mut count_java = 0usize;
+    let mut has_tests = false;
+    let mut roots_to_scan: Vec<PathBuf> = vec![repo_root.to_path_buf()];
+    for sub in [
+        "src", "crates", "packages", "lib", "tests", "test", "app", "apps", "internal", "cmd",
+        "libs",
+    ] {
+        let p = repo_root.join(sub);
+        if p.is_dir() {
+            roots_to_scan.push(p.clone());
+            // For monorepo subdirs (crates/ packages/ apps/ libs/),
+            // also peek into each member's `src/` so the language
+            // tally reflects what lives in the wired-up workspace.
+            if matches!(sub, "crates" | "packages" | "apps" | "libs") {
+                if let Ok(rd) = fs::read_dir(&p) {
+                    for ent in rd.flatten().take(50) {
+                        let member = ent.path();
+                        if member.is_dir() {
+                            roots_to_scan.push(member.clone());
+                            let member_src = member.join("src");
+                            if member_src.is_dir() {
+                                roots_to_scan.push(member_src);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for r in roots_to_scan {
+        if let Ok(rd) = fs::read_dir(&r) {
+            for ent in rd.flatten().take(200) {
+                let name = ent.file_name();
+                let n = name.to_string_lossy().to_string();
+                if n == "tests" || n == "test" || n == "__tests__" {
+                    has_tests = true;
+                }
+                if let Some(ext) = std::path::Path::new(&n).extension() {
+                    match ext.to_string_lossy().as_ref() {
+                        "rs" => count_rs += 1,
+                        "ts" | "tsx" => count_ts += 1,
+                        "js" | "mjs" | "cjs" => count_js += 1,
+                        "py" => count_py += 1,
+                        "go" => count_go += 1,
+                        "java" | "kt" => count_java += 1,
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    // Manifest-implied language signals — covers projects whose top-
+    // level dir has manifest-only and source under nested folders.
+    if repo_root.join("Cargo.toml").is_file() {
+        count_rs += 1;
+    }
+    if repo_root.join("go.mod").is_file() || repo_root.join("go.work").is_file() {
+        count_go += 1;
+    }
+    if repo_root.join("tsconfig.json").is_file() {
+        count_ts += 1;
+    }
+    if repo_root.join("pyproject.toml").is_file() || repo_root.join("setup.py").is_file() {
+        count_py += 1;
+    }
+    if repo_root.join("pom.xml").is_file()
+        || repo_root.join("build.gradle").is_file()
+        || repo_root.join("build.gradle.kts").is_file()
+    {
+        count_java += 1;
+    }
+
+    let mut ranked: Vec<(Language, usize)> = vec![
+        (Language::Rust, count_rs),
+        (Language::TypeScript, count_ts),
+        (Language::JavaScript, count_js),
+        (Language::Python, count_py),
+        (Language::Go, count_go),
+        (Language::Java, count_java),
+    ];
+    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    let langs: Vec<Language> = ranked
+        .into_iter()
+        .filter(|(_, n)| *n > 0)
+        .map(|(l, _)| l)
+        .take(3)
+        .collect();
+    (langs, has_tests)
+}
+
+// -- LOC scanner (shallow, capped) --------------------------------------
+
+/// Tally bytes (rounded to a coarse "lines" proxy) under `dir`, capped
+/// at the first 500 entries per directory and 2 levels deep. Cheap
+/// enough for an interactive `ccteam probe-project --json` even on
+/// 10k-file monorepos.
+fn scan_loc(dir: &Path) -> usize {
+    fn walk(dir: &Path, depth: usize, acc: &mut usize) {
+        if depth > 2 || *acc > 1_000_000 {
+            return;
+        }
+        let rd = match fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(_) => return,
+        };
+        for ent in rd.flatten().take(500) {
+            let p = ent.path();
+            if let Ok(md) = ent.metadata() {
+                if md.is_file() {
+                    let ext = p
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .unwrap_or("")
+                        .to_ascii_lowercase();
+                    if matches!(
+                        ext.as_str(),
+                        "rs" | "ts" | "tsx" | "js" | "mjs" | "cjs" | "py" | "go" | "java" | "kt"
+                    ) {
+                        *acc = acc.saturating_add(md.len() as usize / 40);
+                    }
+                } else if md.is_dir() {
+                    let name = ent.file_name();
+                    let n = name.to_string_lossy().to_string();
+                    if n == "target" || n == "node_modules" || n == ".git" || n.starts_with('.') {
+                        continue;
+                    }
+                    walk(&p, depth + 1, acc);
+                }
+            }
+        }
+    }
+    let mut acc = 0usize;
+    walk(dir, 0, &mut acc);
+    acc
+}
+
+fn relative_to(root: &Path, p: &Path) -> PathBuf {
+    p.strip_prefix(root)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| p.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, b"").unwrap();
+    }
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn empty_dir_probes_to_empty() {
+        let td = tempdir().unwrap();
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::Empty);
+        assert!(p.languages.is_empty());
+        assert!(p.probable_scope.is_empty());
+    }
+
+    #[test]
+    fn docs_only_dir() {
+        let td = tempdir().unwrap();
+        touch(&td.path().join("README.md"));
+        touch(&td.path().join("CONTRIBUTING.md"));
+        fs::create_dir_all(td.path().join("docs")).unwrap();
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::DocsOnly);
+        assert_eq!(p.probable_scope, vec![PathBuf::from("docs")]);
+    }
+
+    #[test]
+    fn scripts_only_dir() {
+        let td = tempdir().unwrap();
+        touch(&td.path().join("deploy.sh"));
+        touch(&td.path().join("cleanup.py"));
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::ScriptsOnly);
+        assert!(p.probable_scope.is_empty());
+    }
+
+    #[test]
+    fn single_repo_rust() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("Cargo.toml"),
+            "[package]\nname = \"foo\"\nversion = \"0.1.0\"\n",
+        );
+        fs::create_dir_all(td.path().join("src")).unwrap();
+        touch(&td.path().join("src/main.rs"));
+        fs::create_dir_all(td.path().join("tests")).unwrap();
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::SingleRepo);
+        assert!(p.languages.contains(&Language::Rust));
+        assert_eq!(
+            p.probable_scope,
+            vec![PathBuf::from("src"), PathBuf::from("tests")]
+        );
+        assert!(p.has_tests);
+    }
+
+    #[test]
+    fn single_repo_python() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("pyproject.toml"),
+            "[project]\nname = \"foo\"\n",
+        );
+        fs::create_dir_all(td.path().join("src")).unwrap();
+        touch(&td.path().join("src/foo.py"));
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::SingleRepo);
+        assert!(p.languages.contains(&Language::Python));
+        assert_eq!(p.probable_scope, vec![PathBuf::from("src")]);
+    }
+
+    #[test]
+    fn monorepo_rust_workspace_glob() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]\n",
+        );
+        for c in ["alpha", "beta", "gamma"] {
+            write(
+                &td.path().join(format!("crates/{c}/Cargo.toml")),
+                "[package]\nname = \"x\"\nversion = \"0.1\"\n",
+            );
+            // Synthesize LOC: alpha=largest, beta=mid, gamma=smallest.
+            let body = match c {
+                "alpha" => "a".repeat(8000),
+                "beta" => "a".repeat(4000),
+                _ => "a".repeat(1000),
+            };
+            write(&td.path().join(format!("crates/{c}/src/lib.rs")), &body);
+        }
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::Monorepo);
+        assert!(p.languages.contains(&Language::Rust));
+        // Top-3 by LOC, alpha first.
+        assert_eq!(p.probable_scope.len(), 3);
+        assert_eq!(p.probable_scope[0], PathBuf::from("crates/alpha"));
+    }
+
+    #[test]
+    fn monorepo_rust_workspace_explicit_members() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"foo\", \"bar\"]\n",
+        );
+        for c in ["foo", "bar"] {
+            write(
+                &td.path().join(format!("{c}/Cargo.toml")),
+                "[package]\nname = \"x\"\nversion = \"0.1\"\n",
+            );
+            write(
+                &td.path().join(format!("{c}/src/lib.rs")),
+                &"a".repeat(2000),
+            );
+        }
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::Monorepo);
+        assert!(p.probable_scope.iter().any(|p| p == &PathBuf::from("foo")));
+        assert!(p.probable_scope.iter().any(|p| p == &PathBuf::from("bar")));
+    }
+
+    #[test]
+    fn monorepo_caps_at_three_members() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]\n",
+        );
+        for c in ["c1", "c2", "c3", "c4", "c5"] {
+            write(
+                &td.path().join(format!("crates/{c}/Cargo.toml")),
+                "[package]\nname = \"x\"\nversion = \"0.1\"\n",
+            );
+            write(
+                &td.path().join(format!("crates/{c}/src/lib.rs")),
+                "fn x(){}",
+            );
+        }
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::Monorepo);
+        assert_eq!(p.probable_scope.len(), 3, "scope must cap at top-3");
+    }
+
+    #[test]
+    fn monorepo_pnpm_workspace() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - 'packages/*'\n",
+        );
+        for c in ["web", "api"] {
+            write(
+                &td.path().join(format!("packages/{c}/package.json")),
+                "{\"name\":\"x\"}",
+            );
+            write(
+                &td.path().join(format!("packages/{c}/src/index.ts")),
+                "export {}",
+            );
+        }
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::Monorepo);
+        assert!(p.languages.contains(&Language::TypeScript));
+        assert!(p.probable_scope.iter().any(|p| p.starts_with("packages/")));
+    }
+
+    #[test]
+    fn monorepo_go_workspace() {
+        let td = tempdir().unwrap();
+        write(
+            &td.path().join("go.work"),
+            "go 1.21\n\nuse (\n  ./svc-a\n  ./svc-b\n)\n",
+        );
+        for c in ["svc-a", "svc-b"] {
+            write(
+                &td.path().join(format!("{c}/go.mod")),
+                &format!("module example.com/{c}\n"),
+            );
+            write(&td.path().join(format!("{c}/main.go")), "package main");
+        }
+        let p = probe(td.path());
+        assert_eq!(p.kind, ProjectKind::Monorepo);
+        assert!(p.languages.contains(&Language::Go));
+    }
+
+    #[test]
+    fn probe_kind_as_str_matches_wire() {
+        assert_eq!(ProjectKind::Monorepo.as_str(), "monorepo");
+        assert_eq!(ProjectKind::SingleRepo.as_str(), "single-repo");
+        assert_eq!(ProjectKind::DocsOnly.as_str(), "docs-only");
+        assert_eq!(ProjectKind::ScriptsOnly.as_str(), "scripts-only");
+        assert_eq!(ProjectKind::Empty.as_str(), "empty");
+    }
+
+    #[test]
+    fn language_as_str_matches_wire() {
+        assert_eq!(Language::Rust.as_str(), "rust");
+        assert_eq!(Language::TypeScript.as_str(), "typescript");
+        assert_eq!(Language::Go.as_str(), "go");
+    }
+}

--- a/crates/ccteam-core/src/templates/workflow_templates/bg-overnight.yaml
+++ b/crates/ccteam-core/src/templates/workflow_templates/bg-overnight.yaml
@@ -21,11 +21,12 @@ agents:
   planner:
     trigger: manual
     max_parallel: 1
-
+{{scope_yaml}}
   executor:
     trigger: watch:.ccteam/inbox/executor
     max_parallel: 1
-
+{{scope_yaml}}
   critic:
     trigger: watch:.ccteam/inbox/critic
     max_parallel: 1
+{{scope_yaml}}

--- a/crates/ccteam-core/src/templates/workflow_templates/mod.rs
+++ b/crates/ccteam-core/src/templates/workflow_templates/mod.rs
@@ -163,6 +163,55 @@ pub fn render(preset: Preset, ctx: &TemplateCtx) -> Result<String, RenderError> 
     Ok(out)
 }
 
+/// V0.6.6 F167 — overlay `ProjectProbe`-derived sensible defaults onto a
+/// `TemplateCtx`. Today it sets `scope_yaml` (a small YAML fragment the
+/// preset templates embed under `agents.<role>` when present) based on
+/// `probe.probable_scope`. Existing `scope_yaml` overrides from the
+/// caller win — this is a *default seed*, never a clobber.
+///
+/// Templates that do not reference `scope_yaml` (chat-pocket /
+/// chat-squad — chat bots scope is naturally the project root) leave
+/// the key unused; render() is strict, so we only inject keys the
+/// templates actually consume.
+pub fn apply_probe_defaults(
+    ctx: &mut TemplateCtx,
+    preset: Preset,
+    probe: &super::project_probe::ProjectProbe,
+) {
+    // Build a YAML fragment for the `agents.<role>.scope:` slot. We
+    // emit a *single* scope for the role-bearing preset slots — for
+    // monorepos with multiple member crates, we pick the first
+    // probable_scope (top-LOC), matching the V0.6.2 F140 "one scope
+    // per role" semantics. The skill / user can hand-edit later if
+    // they want per-role splits.
+    let scope_yaml = probe
+        .probable_scope
+        .first()
+        .map(|p| format!("    scope: {}\n", p.display()))
+        .unwrap_or_default();
+
+    match preset {
+        Preset::BgOvernight => {
+            // Clobber only if the current value is the empty-default
+            // sentinel — preserves any explicit user-supplied scope.
+            let current = ctx.vars.get("scope_yaml").cloned().unwrap_or_default();
+            if current.trim().is_empty() {
+                ctx.vars.insert("scope_yaml".into(), scope_yaml.clone());
+            }
+        }
+        Preset::InprocTeam | Preset::InprocSolo => {
+            // agent-team mode renders agents: {} — scope lives on the
+            // per-role suggested_teammates instead. Future: extend.
+            // For now, leave a hint comment in the persona section
+            // via persona_label_hint (skill can format).
+            let _ = scope_yaml;
+        }
+        Preset::ChatPocket | Preset::ChatSquad => {
+            // chat bots run at project root by design — no scope.
+        }
+    }
+}
+
 /// Convenience: build a [`TemplateCtx`] populated with the minimal
 /// required keys for each preset, then let the caller layer extra
 /// overrides on top via [`TemplateCtx::with`]. Useful for the skill +
@@ -181,7 +230,12 @@ pub fn default_ctx(preset: Preset) -> TemplateCtx {
         Preset::InprocTeam => {
             ctx = ctx.with("worker_count", "3");
         }
-        Preset::BgOvernight => {}
+        Preset::BgOvernight => {
+            // V0.6.6 F167 — `scope_yaml` is an empty placeholder by
+            // default; `apply_probe_defaults` overlays a real
+            // `scope: <path>` line when a project probe is available.
+            ctx = ctx.with("scope_yaml", "");
+        }
         Preset::ChatPocket => {
             ctx = ctx
                 .with("primary_role", "tech-helper")
@@ -232,6 +286,55 @@ mod tests {
         assert!(out.contains("watch:.ccteam/inbox/executor"));
         assert!(out.contains("max_cost_usd_per_24h"));
         assert!(!out.contains("{{"));
+        // V0.6.6 F167: default scope_yaml is empty (no probe overlaid).
+        assert!(
+            !out.contains("scope:"),
+            "default render must not embed a scope until probe overlay applies"
+        );
+    }
+
+    #[test]
+    fn bg_overnight_applies_probe_scope_overlay() {
+        use super::super::project_probe::{Language, ProjectKind, ProjectProbe};
+        use std::path::PathBuf;
+
+        let mut ctx = default_ctx(Preset::BgOvernight);
+        let probe = ProjectProbe {
+            kind: ProjectKind::SingleRepo,
+            languages: vec![Language::Rust],
+            has_tests: true,
+            probable_scope: vec![PathBuf::from("src"), PathBuf::from("tests")],
+        };
+        apply_probe_defaults(&mut ctx, Preset::BgOvernight, &probe);
+        let out = render(Preset::BgOvernight, &ctx).unwrap();
+        assert!(
+            out.contains("    scope: src"),
+            "expected `scope: src` after probe overlay, got:\n{out}"
+        );
+        assert!(!out.contains("{{"));
+    }
+
+    #[test]
+    fn apply_probe_defaults_is_idempotent_and_does_not_clobber() {
+        use super::super::project_probe::{Language, ProjectKind, ProjectProbe};
+        use std::path::PathBuf;
+
+        let mut ctx =
+            default_ctx(Preset::BgOvernight).with("scope_yaml", "    scope: custom-dir\n");
+        let probe = ProjectProbe {
+            kind: ProjectKind::SingleRepo,
+            languages: vec![Language::Rust],
+            has_tests: false,
+            probable_scope: vec![PathBuf::from("src")],
+        };
+        apply_probe_defaults(&mut ctx, Preset::BgOvernight, &probe);
+        let out = render(Preset::BgOvernight, &ctx).unwrap();
+        // User-provided scope_yaml wins (entry().or_insert_with semantics).
+        assert!(
+            out.contains("scope: custom-dir"),
+            "explicit ctx override must win over probe defaults:\n{out}"
+        );
+        assert!(!out.contains("scope: src"));
     }
 
     #[test]

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -169,6 +169,58 @@ The persona `.md` body copied in Phase 5.4 is unchanged — vendor
 selection is purely a `workflow.yaml::agents.<role>.executor: codex`
 injection. The user does not edit YAML at any point.
 
+## Phase 3.6 — Project probe (sensible scope defaults)
+
+Before rendering the PROJECT PLAN, probe the target project root so
+the rendered `workflow.yaml` ships with a `scope:` field already
+pointing at the right subtree. Without this, every freshly-created
+workflow has an empty `scope:` and the user has to hand-edit before
+the first spawn picks the right cwd — defeating the per-role scope
+blast-radius guarantee that keeps large-codebase agents focused.
+
+```bash
+ccteam probe-project --path <project_dir> --json
+```
+
+Returns:
+
+```json
+{
+  "kind": "monorepo" | "single-repo" | "docs-only" | "scripts-only" | "empty",
+  "languages": ["rust", "typescript", ...],
+  "has_tests": true | false,
+  "probable_scope": ["crates/foo/src", "crates/bar/src", ...]
+}
+```
+
+Use the result as input to Phase 5.3's template ctx:
+
+- For `bg-overnight`, set `scope_yaml` to `"    scope: <probable_scope[0]>\n"`
+  so each `agents.<role>` block embeds the scope (or call
+  `ccteam_core::apply_probe_defaults_to_workflow_ctx(&mut ctx, preset,
+  &probe)` if you're rendering in-process).
+- For `inproc-solo` / `inproc-team`, surface `probable_scope[0]` in the
+  PROJECT PLAN "Files I'll write" section as a comment hint — the
+  agent-team preset renders `agents: {}` so per-role scope is set by
+  the lead at Task-spawn time, not by the bootstrap.
+- For `chat-pocket` / `chat-squad`, chat bots run at project root by
+  design — no scope override needed.
+
+Detection is pure file-existence sweep (no source parsing, no LLM
+call) so the probe is fast (~10 ms even on the ccteam repo) and
+deterministic.
+
+**Edge cases:**
+
+- `kind == "empty"` → the user likely pointed at a fresh dir; PROJECT
+  PLAN shows `scope: (none — fresh repo)`.
+- `kind == "monorepo"` with > 3 first-party crates → probe caps at
+  top-3 by descending LOC, ties broken alphabetically. The skill
+  surfaces "(top 3 of N detected)" in PROJECT PLAN so the user knows
+  to widen if needed.
+- `kind == "docs-only"` + `bg-overnight` is unusual but valid — the
+  probe returns `scope: ["docs"]` and the user can override.
+
 ---
 
 # Phase 4 — Output PROJECT PLAN (plan-first)
@@ -241,6 +293,13 @@ ctx = WorkflowTemplateCtx::new()
     .with("bot_handle", "@" + bot_name)          # chat-only
     .with("im_platform", "telegram")              # chat-only
     .with("owner_chat_id", creds.owner_chat_id)   # chat-only
+
+# Overlay sensible scope defaults from the project probe (Phase 3.6)
+# so the rendered yaml's `scope:` is non-empty out of the box. Skill
+# callers without in-process access can `ccteam probe-project --json`
+# and set `scope_yaml` manually.
+apply_probe_defaults_to_workflow_ctx(&mut ctx, preset, &probe)
+
 yaml = render_workflow_template(preset, &ctx)
 write_to(project_dir + "/.ccteam/workflow.yaml", yaml)
 ```


### PR DESCRIPTION
## Finding
[F167](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-6/prd.md#f167) — lightweight defaults; full template library deferred V0.7.

## Summary
- New `crates/ccteam-core/src/templates/project_probe.rs` — file-existence probe emitting `ProjectKind` (monorepo / single-repo / docs-only / scripts-only / empty), top-3 `Language` tags, `has_tests` flag, and `probable_scope` (top-3 by descending source LOC, ties alphabetical, capped at 3 so ccteam's own 10+ crate workspace doesn't blow the V0.6.2 F140 blast-radius guarantee).
- New `ccteam probe-project [--path <dir>] [--json]` CLI subcommand wrapping the probe. Stable JSON schema matches the `ProjectProbe` serde derive.
- `bg-overnight.yaml` template gains a `{{scope_yaml}}` slot under each `agents.<role>` block; the `apply_probe_defaults` helper overlays a real `scope: <probable_scope[0]>` line when a probe is available. `inproc-*` and `chat-*` presets unchanged (chat bots are root-scoped by design; agent-team mode emits `agents: {}` and per-role scope is decided at Task-spawn time).
- `skills/ccteam-creator/SKILL.md` gains a Phase 3.6 section describing the probe + how to feed it into Phase 5.3 ctx so freshly-rendered workflow.yaml ships with non-empty `scope:`.

## Scope respected (no V0.7 creep)
- No new presets added (sticks to the existing 5).
- No LLM-assisted role auto-gen (V0.7 epic).
- No cross-language template adapter (probe reports languages but doesn't fork templates).

## Verification
- `cargo test --workspace --locked --no-fail-fast`: 1613 passed / 1 failed (known V0.6.5 baseline flake `workflow_summary_reflects_agent_spawn_and_done_events`). +13 new tests (10 probe unit + 4 CLI integration — one bg-overnight render integration already existed).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.
- `ccteam probe-project --json` on this repo emits `{"kind": "monorepo", "languages": ["rust"], "has_tests": true, "probable_scope": ["crates/ccteam-core", "crates/ccteam-cli", "crates/ccteam-web"]}` — F167 acceptance #1 met.
- Fresh `cargo new --bin foo` tempdir → `{"kind": "single-repo", "languages": ["rust"], ..., "probable_scope": ["src", "tests"]}` — F167 acceptance #2 met.
- Probe detection types covered in tests: Empty, DocsOnly, ScriptsOnly, SingleRepo (Rust + Python), Monorepo (Cargo workspace glob + explicit members, pnpm workspace, go.work).

## Files
- new `crates/ccteam-core/src/templates/project_probe.rs` (~870 LOC inc. tests)
- new `crates/ccteam-cli/tests/probe_project_test.rs`
- mod `crates/ccteam-core/src/templates/{mod.rs, workflow_templates/mod.rs, workflow_templates/bg-overnight.yaml}`
- mod `crates/ccteam-core/src/lib.rs` (re-exports)
- mod `crates/ccteam-cli/src/{main.rs, commands.rs}` (new CLI subcommand)
- mod `skills/ccteam-creator/SKILL.md` (Phase 3.6 + Phase 5.3 ctx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)