### PR TITLE
v0.6.6 (F173): Codex unified cost rollup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "dirs",
  "libc",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
  "toml",

--- a/crates/ccteam-cli/Cargo.toml
+++ b/crates/ccteam-cli/Cargo.toml
@@ -42,3 +42,6 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+# V0.6.6 F173 — `doctor_cost_orphan_test.rs` writes a project-registration
+# `config.yaml` via the same serde_yaml the production loader uses.
+serde_yaml.workspace = true

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -2184,6 +2184,15 @@ pub struct DoctorOptions {
     /// the CLI dispatcher (2 = unavailable, 3 = malformed) so the
     /// skill body and CI can branch without parsing free text.
     pub check_codex_auto_critic: bool,
+    /// V0.6.6 F173: reconcile `<ccteam_root>/cost-budget.json` ledger
+    /// rows against every registered project's `progress.jsonl` over
+    /// the last 24h. Invariant: per vendor, the count of `agent_done`
+    /// events with `status="completed"` matches the count of ledger
+    /// `BudgetSample` rows. Reports any orphan (vendor adapter
+    /// recorded a progress.jsonl event but no ledger row) so a future
+    /// regression — e.g. a new adapter forgetting the cost hook —
+    /// surfaces deterministically. Pure-readout; no fs mutation.
+    pub check_cost_orphan: bool,
     /// V0.6.1 F139: materialize the `~/.ccteam/hooks/hook.sh` daemon
     /// dispatcher (idempotent, chmod 0755). Use after a ccteam binary
     /// upgrade ships a new script body.
@@ -2226,6 +2235,7 @@ pub fn run_doctor(paths: &CcteamPaths, mut opts: DoctorOptions) -> Result<String
         || opts.check_codex_version
         || opts.check_codex_auth
         || opts.check_codex_auto_critic
+        || opts.check_cost_orphan
         || opts.install_hooks
         || opts.migrate_hook_commands;
     // V0.6.1 F121 — `ccteam doctor` with no mode flag implicitly runs
@@ -2303,6 +2313,9 @@ pub fn run_doctor(paths: &CcteamPaths, mut opts: DoctorOptions) -> Result<String
     if opts.check_codex_auth {
         out.push_str(&render_check_codex_auth_report());
     }
+    if opts.check_cost_orphan {
+        out.push_str(&render_check_cost_orphan_report(paths));
+    }
     if opts.install_hooks {
         out.push_str(&render_install_hooks_report(paths)?);
     }
@@ -2373,6 +2386,10 @@ const NO_MODE_HELP: &str = "\nccteam doctor: pass at least one mode flag for the
      Honors $CCTEAM_CODEX_BIN; emits a single JSON line on stdout. Exit 0 = available + well-formed, \
      2 = unavailable (binary missing / version probe failed / not authenticated), 3 = available but \
      `codex exec --json` output malformed. The skill consults this subprocess instead of inline probes.\n  \
+     --check-cost-orphan\n      \
+     reconcile `<ccteam_root>/cost-budget.json` ledger rows against every registered project's \
+     progress.jsonl over the last 24h (V0.6.6 F173). WARN per vendor when `agent_done` count exceeds \
+     ledger row count — indicates a spawn path bypassed the ledger hook. Silent OK when reconciled.\n  \
      --install-hooks\n      \
      materialize ~/.ccteam/hooks/hook.sh (the daemon-aware Claude Code hook dispatcher; V0.6.1 F139). \
      Idempotent; chmod 0755. `ccteam init` already does this on first install.\n  \
@@ -3201,6 +3218,169 @@ fn render_check_codex_auth_report() -> String {
     }
     out.push('\n');
     out
+}
+
+/// V0.6.6 F173 — cost-orphan invariant check. Walks every registered
+/// project's `progress.jsonl` for the last 24h, counts `agent_done`
+/// events with `status="completed"` per vendor, then compares against
+/// the per-vendor row count in `<ccteam_root>/cost-budget.json` over
+/// the same window. Each vendor with `agent_done_count > ledger_rows`
+/// surfaces a `[WARN] cost orphan: …` line so a future regression
+/// (e.g. a new adapter that forgets the ledger hook) is visible at
+/// `ccteam doctor` time. Fully reconciled state emits one `[OK] cost
+/// ledger reconciled` line.
+fn render_check_cost_orphan_report(paths: &CcteamPaths) -> String {
+    let mut out = String::from("ccteam doctor --check-cost-orphan (V0.6.6 F173)\n\n");
+    let (counts, warnings) = compute_cost_orphan(paths);
+    let claude_done = counts
+        .agent_done
+        .get(&CostVendor::Claude)
+        .copied()
+        .unwrap_or(0);
+    let codex_done = counts
+        .agent_done
+        .get(&CostVendor::Codex)
+        .copied()
+        .unwrap_or(0);
+    let claude_rows = counts
+        .ledger_rows
+        .get(&CostVendor::Claude)
+        .copied()
+        .unwrap_or(0);
+    let codex_rows = counts
+        .ledger_rows
+        .get(&CostVendor::Codex)
+        .copied()
+        .unwrap_or(0);
+    out.push_str(&format!(
+        "  progress.jsonl agent_done (24h): claude={claude_done} codex={codex_done}\n"
+    ));
+    out.push_str(&format!(
+        "  cost-budget.json ledger rows (24h): claude={claude_rows} codex={codex_rows}\n"
+    ));
+    if warnings.is_empty() {
+        out.push_str(
+            "  [OK] cost ledger reconciled — every vendor adapter call has a ledger row.\n",
+        );
+    } else {
+        for w in &warnings {
+            out.push_str("  [WARN] ");
+            out.push_str(w);
+            out.push('\n');
+        }
+        out.push_str(
+            "  Likely cause: a vendor adapter spawn path bypassed the F173 ledger hook \
+             (`append_budget_ledger_row` in CodexExecAdapter::submit_turn). Inspect the \
+             new spawn site and add the hook before merging.\n",
+        );
+    }
+    out.push('\n');
+    out
+}
+
+/// V0.6.6 F173 — pure helper for [`render_check_cost_orphan_report`]
+/// so tests can drive the invariant without parsing report text.
+/// Returns per-vendor counts + a list of warning strings (empty when
+/// fully reconciled).
+pub fn compute_cost_orphan(paths: &CcteamPaths) -> (CostOrphanCounts, Vec<String>) {
+    let cutoff = chrono::Utc::now() - chrono::Duration::hours(24);
+    let mut counts = CostOrphanCounts::default();
+
+    // 1. agent_done per vendor across every registered project's progress.jsonl.
+    if let Ok(projects) = ccteam_core::collect_projects(paths) {
+        for proj in projects {
+            let slug = &proj.state.slug;
+            let progress_path = paths.progress_jsonl(slug);
+            let events = ccteam_core::read_all_events(&progress_path).unwrap_or_default();
+            for ev in events {
+                if ev.get("event").and_then(|s| s.as_str()) != Some("agent_done") {
+                    continue;
+                }
+                if ev.get("status").and_then(|s| s.as_str()) != Some("completed") {
+                    continue;
+                }
+                let ts = ev
+                    .get("ts")
+                    .and_then(|s| s.as_str())
+                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&chrono::Utc));
+                if let Some(ts) = ts {
+                    if ts < cutoff {
+                        continue;
+                    }
+                }
+                let vendor = ev.get("vendor").and_then(|s| s.as_str()).unwrap_or("");
+                let key = match vendor {
+                    "claude" => CostVendor::Claude,
+                    "codex" => CostVendor::Codex,
+                    _ => continue, // unknown vendor — skip (forward-compat)
+                };
+                *counts.agent_done.entry(key).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // 2. ledger rows per vendor over the same window.
+    if let Ok(ledger) = ccteam_core::load_advise_budget(&paths.root) {
+        for sample in &ledger.samples {
+            if sample.ts < cutoff {
+                continue;
+            }
+            let key = match sample.vendor {
+                ccteam_core::harness::AgentVendor::Claude => CostVendor::Claude,
+                ccteam_core::harness::AgentVendor::Codex => CostVendor::Codex,
+            };
+            *counts.ledger_rows.entry(key).or_insert(0) += 1;
+        }
+    }
+
+    // 3. warnings — only flag `agent_done > ledger_rows` (orphans, the
+    //    F173 invariant). The reverse (advise_vote bumping ledger rows
+    //    without progress.jsonl events) is expected — advise calls are
+    //    not project-scoped, so they have no progress.jsonl footprint.
+    let mut warnings = Vec::new();
+    for vendor in [CostVendor::Claude, CostVendor::Codex] {
+        let done = counts.agent_done.get(&vendor).copied().unwrap_or(0);
+        let rows = counts.ledger_rows.get(&vendor).copied().unwrap_or(0);
+        if done > rows {
+            warnings.push(format!(
+                "cost orphan: {} {} calls in progress.jsonl, {} rows in ledger (Δ={})",
+                done,
+                vendor.label(),
+                rows,
+                done - rows,
+            ));
+        }
+    }
+    (counts, warnings)
+}
+
+/// V0.6.6 F173 — per-vendor cost rollup tally returned by
+/// [`compute_cost_orphan`]. Counts are 24h windowed (rolling, matches
+/// the advise ledger GC window).
+#[derive(Debug, Default)]
+pub struct CostOrphanCounts {
+    pub agent_done: std::collections::HashMap<CostVendor, u32>,
+    pub ledger_rows: std::collections::HashMap<CostVendor, u32>,
+}
+
+/// V0.6.6 F173 — vendor enum mirror used by the cost-orphan check.
+/// Mirrors `ccteam_core::harness::AgentVendor` but lives in the cli
+/// crate so the report rendering layer doesn't leak the core enum
+/// through its public surface. `Hash + Eq` for `HashMap` keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CostVendor {
+    Claude,
+    Codex,
+}
+
+impl CostVendor {
+    fn label(self) -> &'static str {
+        match self {
+            CostVendor::Claude => "claude",
+            CostVendor::Codex => "codex",
+        }
+    }
 }
 
 /// V0.6.5 F155 — deterministic gate for the `ccteam-creator` Phase

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -571,6 +571,16 @@ enum Command {
         /// inline so the gate is deterministic + testable.
         #[arg(long, default_value_t = false)]
         check_codex_auto_critic: bool,
+        /// V0.6.6 F173: reconcile `<ccteam_root>/cost-budget.json` ledger
+        /// rows against every registered project's `progress.jsonl`
+        /// over the last 24h. Reports "cost orphan: N <vendor> agent_done
+        /// events in progress.jsonl, M rows in ledger" for any mismatch
+        /// (vendor adapter call recorded a `progress.jsonl` event but no
+        /// ledger row). Silent OK when fully reconciled. No fs mutation —
+        /// pure-readout invariant check; future regressions (a new vendor
+        /// adapter that forgets the ledger hook) surface here.
+        #[arg(long, default_value_t = false)]
+        check_cost_orphan: bool,
         /// V0.6.1 F139: materialize the `~/.ccteam/hooks/hook.sh`
         /// daemon-aware Claude Code hook dispatcher (idempotent, chmod
         /// 0755). Run after a ccteam binary upgrade to refresh the
@@ -861,6 +871,20 @@ enum HookCommand {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // F173 — pin `CCTEAM_HOME` early so child spawn paths
+    // (CodexExecAdapter ledger hook, etc.) see the same root the CLI
+    // resolved. Production users almost never set `CCTEAM_HOME`
+    // explicitly; without this seed the cost-budget.json ledger hook
+    // in CodexExecAdapter would silently no-op (the adapter gates the
+    // hook on `CCTEAM_HOME` explicitly to avoid cargo-test pollution).
+    // Idempotent — if the operator already set it, we honour their
+    // override.
+    if std::env::var_os("CCTEAM_HOME").is_none() {
+        if let Ok(paths) = CcteamPaths::from_env() {
+            std::env::set_var("CCTEAM_HOME", &paths.root);
+        }
+    }
+
     // No subcommand → print help instead of silently exiting. Prior
     // behavior (V0.4.0 and earlier) was Ok(()) with nothing on stdout,
     // which left users wondering whether ccteam was installed at all.
@@ -1053,6 +1077,7 @@ fn main() -> Result<()> {
             check_codex_version,
             check_codex_auth,
             check_codex_auto_critic,
+            check_cost_orphan,
             install_hooks,
             migrate_hook_commands,
             apply,
@@ -1108,6 +1133,7 @@ fn main() -> Result<()> {
                 check_codex_version,
                 check_codex_auth,
                 check_codex_auto_critic,
+                check_cost_orphan,
                 install_hooks,
                 migrate_hook_commands,
                 verify_mcp,

--- a/crates/ccteam-cli/tests/doctor_cost_orphan_test.rs
+++ b/crates/ccteam-cli/tests/doctor_cost_orphan_test.rs
@@ -1,0 +1,273 @@
+//! V0.6.6 F173 — `ccteam doctor --check-cost-orphan` invariant test.
+//!
+//! Cost-orphan = a vendor adapter spawn that produced a `progress.jsonl`
+//! `agent_done` row but no matching `cost-budget.json` ledger row in
+//! the same 24h window. Each vendor that fails the parity surfaces as
+//! one `[WARN] cost orphan: …` line. Fully reconciled state emits
+//! `[OK] cost ledger reconciled`.
+//!
+//! Tests drive the `ccteam doctor --check-cost-orphan` binary surface
+//! with `CCTEAM_HOME` pointing at an ephemeral tempdir (real project
+//! registered via on-disk `config.yaml` + `state.json`; ledger seeded
+//! via on-disk `cost-budget.json`). This pins the operator-facing
+//! report text for host probe / CI greps.
+
+use ccteam_core::advise::{
+    append_budget_ledger_row, budget_ledger_path, AdviseBudgetLedger, BudgetSample,
+};
+use ccteam_core::harness::AgentVendor;
+use ccteam_core::state::ProjectState;
+use chrono::Utc;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Materialise `<home>/.ccteam` with one registered project, an empty
+/// `progress.jsonl`, and an empty `cost-budget.json`. Return
+/// `(home_tempdir, ccteam_root, project_dir, slug)`.
+fn ephemeral_home_with_one_project(slug: &str) -> (tempfile::TempDir, PathBuf, PathBuf, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join(".ccteam");
+    let projects_root = tmp.path().join("projects");
+    let project_dir = projects_root.join(slug);
+    std::fs::create_dir_all(project_dir.join(".ccteam")).unwrap();
+    std::fs::create_dir_all(root.join("progress")).unwrap();
+
+    // config.yaml — register the project so `collect_projects` finds it.
+    let cfg = serde_yaml::Value::Mapping({
+        let mut m = serde_yaml::Mapping::new();
+        m.insert(
+            "projects".into(),
+            serde_yaml::Value::Sequence(vec![{
+                let mut p = serde_yaml::Mapping::new();
+                p.insert("slug".into(), slug.into());
+                p.insert(
+                    "path".into(),
+                    project_dir.to_string_lossy().to_string().into(),
+                );
+                serde_yaml::Value::Mapping(p)
+            }]),
+        );
+        m
+    });
+    std::fs::write(
+        root.join("config.yaml"),
+        serde_yaml::to_string(&cfg).unwrap(),
+    )
+    .unwrap();
+
+    // project/.ccteam/state.json — collect_projects loads via
+    // `ProjectState::load`, which requires the full struct shape. Use
+    // the API constructor + serde to write a valid file.
+    let state = ProjectState::initial(slug.into());
+    std::fs::write(
+        project_dir.join(".ccteam").join("state.json"),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    (tmp, root, project_dir, slug.to_string())
+}
+
+/// Append one `agent_done` JSONL row to `<root>/progress/<slug>.jsonl`.
+fn append_agent_done(root: &Path, slug: &str, vendor: &str, ts_offset_secs: i64) {
+    let ts = Utc::now() - chrono::Duration::seconds(ts_offset_secs);
+    let row = json!({
+        "event": "agent_done",
+        "role": "test-role",
+        "session_id": format!("sid-{}-{}", vendor, ts.timestamp_nanos_opt().unwrap_or(0)),
+        "status": "completed",
+        "cost_usd": 0.005,
+        "vendor": vendor,
+        "slug": slug,
+        "ts": ts.to_rfc3339(),
+    });
+    let path = root.join("progress").join(format!("{slug}.jsonl"));
+    let mut existing = std::fs::read_to_string(&path).unwrap_or_default();
+    existing.push_str(&serde_json::to_string(&row).unwrap());
+    existing.push('\n');
+    std::fs::write(&path, existing).unwrap();
+}
+
+/// Run `ccteam doctor --check-cost-orphan` against the supplied root.
+/// Returns `(stdout, exit_code)`.
+fn run_doctor(ccteam_home: &Path, projects_root: &Path) -> (String, i32) {
+    let bin = env!("CARGO_BIN_EXE_ccteam");
+    let out = Command::new(bin)
+        .env("CCTEAM_HOME", ccteam_home)
+        .env("CCTEAM_PROJECTS_ROOT", projects_root)
+        .arg("doctor")
+        .arg("--check-cost-orphan")
+        .output()
+        .expect("spawn ccteam doctor");
+    (
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// 1. Empty ledger + empty progress.jsonl → reconciled, OK line.
+#[test]
+fn no_calls_no_ledger_is_reconciled() {
+    let (tmp, root, project_dir, _slug) = ephemeral_home_with_one_project("orphan-empty");
+    let projects_root = project_dir.parent().unwrap();
+    let (stdout, code) = run_doctor(&root, projects_root);
+    assert_eq!(code, 0, "doctor must exit 0. stdout:\n{stdout}");
+    assert!(
+        stdout.contains("[OK] cost ledger reconciled"),
+        "missing OK line. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}
+
+/// 2. Matched codex events + ledger rows → reconciled.
+#[test]
+fn matched_progress_and_ledger_is_reconciled() {
+    let (tmp, root, project_dir, slug) = ephemeral_home_with_one_project("orphan-match");
+    for _ in 0..3 {
+        append_agent_done(&root, &slug, "codex", 60);
+        append_budget_ledger_row(&root, AgentVendor::Codex, 0.005).unwrap();
+    }
+    let (stdout, code) = run_doctor(&root, project_dir.parent().unwrap());
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("[OK] cost ledger reconciled"),
+        "expected OK reconciled. stdout:\n{stdout}"
+    );
+    // Counts line surfaces both numbers.
+    assert!(
+        stdout.contains("codex=3"),
+        "expected codex=3 line. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}
+
+/// 3. Codex orphan → WARN line surfaces.
+#[test]
+fn codex_orphan_surfaces_warning() {
+    let (tmp, root, project_dir, slug) = ephemeral_home_with_one_project("orphan-codex");
+    append_agent_done(&root, &slug, "codex", 60);
+    append_agent_done(&root, &slug, "codex", 120);
+    let (stdout, _) = run_doctor(&root, project_dir.parent().unwrap());
+    assert!(
+        stdout.contains("[WARN] cost orphan:"),
+        "missing WARN line. stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("codex"),
+        "WARN line should name codex. stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Δ=2"),
+        "WARN line should include delta. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}
+
+/// 4. Mixed: claude reconciled, codex orphaned → only codex warning.
+#[test]
+fn mixed_only_orphaned_vendor_warns() {
+    let (tmp, root, project_dir, slug) = ephemeral_home_with_one_project("orphan-mixed");
+    append_agent_done(&root, &slug, "claude", 60);
+    append_budget_ledger_row(&root, AgentVendor::Claude, 0.005).unwrap();
+    append_agent_done(&root, &slug, "codex", 60);
+    // NO ledger row for codex — simulating the F173 regression.
+    let (stdout, _) = run_doctor(&root, project_dir.parent().unwrap());
+    // Find WARN lines.
+    let warns: Vec<&str> = stdout
+        .lines()
+        .filter(|l| l.contains("[WARN] cost orphan"))
+        .collect();
+    assert_eq!(
+        warns.len(),
+        1,
+        "expected exactly one WARN. stdout:\n{stdout}"
+    );
+    assert!(warns[0].contains("codex"), "WARN should be for codex");
+    assert!(
+        !warns[0].contains("claude"),
+        "WARN should not mention claude"
+    );
+    drop(tmp);
+}
+
+/// 5. Stale events (>24h) are excluded.
+#[test]
+fn stale_progress_events_excluded_from_window() {
+    let (tmp, root, project_dir, slug) = ephemeral_home_with_one_project("orphan-stale");
+    append_agent_done(&root, &slug, "codex", 25 * 3600); // 25h ago
+    let (stdout, _) = run_doctor(&root, project_dir.parent().unwrap());
+    assert!(
+        stdout.contains("[OK] cost ledger reconciled"),
+        "stale events must be filtered. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}
+
+/// 6. Ledger-only rows (advise_vote without progress.jsonl footprint)
+///    must NOT surface as orphans — the invariant is one-directional.
+#[test]
+fn ledger_only_rows_do_not_count_as_orphans() {
+    let (tmp, root, project_dir, _slug) = ephemeral_home_with_one_project("orphan-ledger-only");
+    for _ in 0..5 {
+        append_budget_ledger_row(&root, AgentVendor::Codex, 0.005).unwrap();
+    }
+    let (stdout, _) = run_doctor(&root, project_dir.parent().unwrap());
+    assert!(
+        stdout.contains("[OK] cost ledger reconciled"),
+        "ledger-only rows must not orphan-warn. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}
+
+/// 7. Report header text is stable (host probes grep for it).
+#[test]
+fn report_header_text_stable() {
+    let (tmp, root, project_dir, _slug) = ephemeral_home_with_one_project("orphan-header");
+    let (stdout, _) = run_doctor(&root, project_dir.parent().unwrap());
+    assert!(
+        stdout.contains("ccteam doctor --check-cost-orphan"),
+        "report header text changed — coordinate with downstream grep. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}
+
+/// 8. Pre-seeded large ledger does not cause a warning (we only check
+///    `agent_done > ledger_rows`, not the reverse).
+#[test]
+fn fully_seeded_ledger_via_hand_write_round_trips() {
+    let (tmp, root, project_dir, _slug) = ephemeral_home_with_one_project("orphan-handwrite");
+    let ledger = AdviseBudgetLedger {
+        samples: vec![
+            BudgetSample {
+                vendor: AgentVendor::Codex,
+                usd: 0.005,
+                ts: Utc::now(),
+            },
+            BudgetSample {
+                vendor: AgentVendor::Claude,
+                usd: 0.005,
+                ts: Utc::now(),
+            },
+        ],
+    };
+    std::fs::write(
+        budget_ledger_path(&root),
+        serde_json::to_string_pretty(&ledger).unwrap(),
+    )
+    .unwrap();
+    let (stdout, _) = run_doctor(&root, project_dir.parent().unwrap());
+    assert!(
+        stdout.contains("codex=1"),
+        "ledger codex row should appear. stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("claude=1"),
+        "ledger claude row should appear. stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("[OK] cost ledger reconciled"),
+        "should be reconciled. stdout:\n{stdout}"
+    );
+    drop(tmp);
+}

--- a/crates/ccteam-core/src/advise.rs
+++ b/crates/ccteam-core/src/advise.rs
@@ -65,7 +65,7 @@ use crate::harness::{AgentVendor, CLAUDE_BIN_ENV};
 /// roundtrip → ~0.005 USD per advisor call. Conservative enough that
 /// the V0.6.5 default cap (`DEFAULT_ADVISE_BUDGET_USD_24H`) keeps
 /// hundreds of calls/day workable while preventing runaway loops.
-const APPROX_COST_PER_CALL_USD: f64 = 0.005;
+pub const APPROX_COST_PER_CALL_USD: f64 = 0.005;
 
 /// V0.6.5 F152 — fallback rolling 24h cap on advise calls when no
 /// per-vendor cap is supplied at MCP invocation time. 0.50 USD = 100
@@ -823,6 +823,21 @@ pub fn append_budget_sample(
         ))
     })?;
     Ok(())
+}
+
+/// V0.6.6 F173 — typed alias for [`append_budget_sample`] used by
+/// non-advise adapter ledger hooks (e.g. `CodexExecAdapter::submit_turn`'s
+/// per-turn rollup). The function body is identical; the alias exists
+/// so calling code documents intent ("vendor adapter recording a
+/// ledger row" vs. "advise call sampling cost"), and so future
+/// per-call-site policy (e.g. separate cap for vendor adapter vs.
+/// advise) can diverge without a sed-sweep.
+pub fn append_budget_ledger_row(
+    ccteam_root: &Path,
+    vendor: AgentVendor,
+    usd: f64,
+) -> Result<(), AdviseError> {
+    append_budget_sample(ccteam_root, vendor, usd)
 }
 
 /// Sum advise spend over the last 24h (regardless of vendor).

--- a/crates/ccteam-core/src/execution/codex_exec.rs
+++ b/crates/ccteam-core/src/execution/codex_exec.rs
@@ -41,6 +41,10 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{broadcast, Mutex};
 
+use crate::advise::{
+    append_budget_ledger_row, load_budget_ledger, sum_advise_today, APPROX_COST_PER_CALL_USD,
+    DEFAULT_ADVISE_BUDGET_USD_24H,
+};
 use crate::execution::codex_app_server::CODEX_BIN_ENV;
 use crate::harness::{
     pluck_f64, pluck_pct, pluck_str, AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter,
@@ -210,30 +214,31 @@ impl HarnessAdapter for CodexExecAdapter {
         let extra_args = ctx.extra_args.clone();
         let sid = ctx.sid.clone();
 
-        let result = tokio::task::spawn_blocking(move || -> Result<(String, Option<u32>), HarnessError> {
-            let session = TmuxSession::from_name(session_name.clone());
-            if session.exists() {
-                return Err(HarnessError::SpawnFailed(format!(
-                    "tmux session already exists: {session_name} \
+        let result =
+            tokio::task::spawn_blocking(move || -> Result<(String, Option<u32>), HarnessError> {
+                let session = TmuxSession::from_name(session_name.clone());
+                if session.exists() {
+                    return Err(HarnessError::SpawnFailed(format!(
+                        "tmux session already exists: {session_name} \
                      (sid collision; F49 next_sid_seq accounting drifted)"
-                )));
-            }
-            let mut argv: Vec<String> = vec!["codex".to_string()];
-            argv.extend(extra_args.iter().cloned());
-            let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
-            session
-                .start(&cwd, &argv_refs)
-                .map_err(|err| HarnessError::SpawnFailed(format!("tmux new-session: {err:#}")))?;
-            let pid = session
-                .pane_pid()
-                .ok()
-                .flatten()
-                .and_then(|n| u32::try_from(n).ok());
-            CodexExecAdapter::write_initial_state(&sid, pid);
-            Ok((session_name, pid))
-        })
-        .await
-        .map_err(|err| HarnessError::SpawnFailed(format!("join blocking spawn: {err}")))??;
+                    )));
+                }
+                let mut argv: Vec<String> = vec!["codex".to_string()];
+                argv.extend(extra_args.iter().cloned());
+                let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+                session.start(&cwd, &argv_refs).map_err(|err| {
+                    HarnessError::SpawnFailed(format!("tmux new-session: {err:#}"))
+                })?;
+                let pid = session
+                    .pane_pid()
+                    .ok()
+                    .flatten()
+                    .and_then(|n| u32::try_from(n).ok());
+                CodexExecAdapter::write_initial_state(&sid, pid);
+                Ok((session_name, pid))
+            })
+            .await
+            .map_err(|err| HarnessError::SpawnFailed(format!("join blocking spawn: {err}")))??;
 
         let (session_name, pid) = result;
         let mut extras = serde_json::json!({ "tmux_session": session_name });
@@ -268,6 +273,40 @@ impl HarnessAdapter for CodexExecAdapter {
                     .unwrap_or(&h.identity)
                     .to_string()
             });
+
+        // F173 — Codex daemon-routed critic + unified cost rollup.
+        // Pre-turn budget check + post-turn ledger row keep every
+        // Codex call (chat bot, critic, advise_*) on the same
+        // `<ccteam_root>/cost-budget.json` SoT, so `@ccteam cost today`
+        // and `ccteam doctor --check-cost-orphan` can reconcile vendor
+        // calls against ledger rows without leaks.
+        //
+        // The hook only fires when **`CCTEAM_HOME` is explicitly set**
+        // (matching production `ccteam start` / `ccteam doctor` flows
+        // where `CcteamPaths::from_env()` is always invoked beforehand).
+        // This intentionally degrades to a no-op in raw `cargo test`
+        // contexts where `CCTEAM_HOME` is unset — those test runners
+        // would otherwise scribble into the developer's real
+        // `~/.ccteam/cost-budget.json`. Production paths always set the
+        // env (the `ccteam` CLI binary resolves `CcteamPaths::from_env`
+        // at startup; `ccteam-imd` daemon inherits the env from the
+        // parent shell).
+        let ccteam_root_for_budget: Option<std::path::PathBuf> = std::env::var("CCTEAM_HOME")
+            .ok()
+            .map(std::path::PathBuf::from);
+        if let Some(root) = &ccteam_root_for_budget {
+            let pre_spent = load_budget_ledger(root)
+                .map(|l| sum_advise_today(&l))
+                .unwrap_or(0.0);
+            if pre_spent >= DEFAULT_ADVISE_BUDGET_USD_24H {
+                return Err(HarnessError::SubmitFailed(format!(
+                    "budget_exceeded: codex 24h spend ({pre_spent:.4} USD) ≥ cap \
+                     ({:.4} USD); raise cap or wait for ledger GC",
+                    DEFAULT_ADVISE_BUDGET_USD_24H
+                )));
+            }
+        }
+
         let argv = build_exec_argv(resume_id.as_deref());
         let bin = Self::codex_bin();
         let tx = self.channel_for(&h.identity).await;
@@ -279,9 +318,7 @@ impl HarnessAdapter for CodexExecAdapter {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|err| {
-                HarnessError::SubmitFailed(format!("spawn {bin} {argv:?}: {err}"))
-            })?;
+            .map_err(|err| HarnessError::SubmitFailed(format!("spawn {bin} {argv:?}: {err}")))?;
 
         if let Some(mut stdin) = child.stdin.take() {
             let prompt_clone = prompt.clone();
@@ -301,12 +338,22 @@ impl HarnessAdapter for CodexExecAdapter {
         // Spawn a reader task that translates JSONL → ThreadEvent and
         // pushes into the per-thread broadcast. Detached — the events()
         // stream is the synchronisation point for callers that care.
+        //
+        // F173 — on TurnCompleted (or fallback success), append one
+        // ledger row to `<ccteam_root>/cost-budget.json`. We charge the
+        // flat [`APPROX_COST_PER_CALL_USD`] estimate (parity with
+        // advise_* paths) regardless of whether the JSONL stream
+        // exposed a usage block, so the cost-orphan invariant
+        // (every Codex turn ↔ one ledger row in 24h) holds even when
+        // `turn.completed.usage` is missing.
         let turn_id_for_task = turn_id.clone();
         let tx_for_task = tx.clone();
+        let ccteam_root_for_task = ccteam_root_for_budget.clone();
         tokio::spawn(async move {
             let buf = BufReader::new(stdout);
             let mut lines = buf.lines();
             let mut saw_completion = false;
+            let mut completion_ok = false;
             loop {
                 match lines.next_line().await {
                     Ok(Some(line)) => {
@@ -317,11 +364,10 @@ impl HarnessAdapter for CodexExecAdapter {
                         match serde_json::from_str::<Value>(trimmed) {
                             Ok(v) => {
                                 for evt in translate_jsonl_event(&v, &turn_id_for_task) {
-                                    if matches!(
-                                        evt,
-                                        ThreadEvent::TurnCompleted { .. }
-                                            | ThreadEvent::TurnFailed { .. }
-                                    ) {
+                                    if matches!(evt, ThreadEvent::TurnCompleted { .. }) {
+                                        saw_completion = true;
+                                        completion_ok = true;
+                                    } else if matches!(evt, ThreadEvent::TurnFailed { .. }) {
                                         saw_completion = true;
                                     }
                                     let _ = tx_for_task.send(evt);
@@ -347,6 +393,7 @@ impl HarnessAdapter for CodexExecAdapter {
             if !saw_completion {
                 match status {
                     Ok(s) if s.success() => {
+                        completion_ok = true;
                         let _ = tx_for_task.send(ThreadEvent::TurnCompleted {
                             turn_id: turn_id_for_task.0.clone(),
                             usage: UnifiedTokenUsage::default(),
@@ -372,6 +419,21 @@ impl HarnessAdapter for CodexExecAdapter {
                                 message: err.to_string(),
                             },
                         });
+                    }
+                }
+            }
+            // F173 — record ledger row on success only. Failed turns
+            // don't bill the operator; doctor's cost-orphan invariant
+            // counts only successful `agent_done` events for parity.
+            if completion_ok {
+                if let Some(root) = &ccteam_root_for_task {
+                    if let Err(err) =
+                        append_budget_ledger_row(root, AgentVendor::Codex, APPROX_COST_PER_CALL_USD)
+                    {
+                        tracing::warn!(
+                            error = %err,
+                            "codex exec: failed to append ledger row (cost rollup leak)"
+                        );
                     }
                 }
             }

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -110,11 +110,13 @@ pub use actions::{
 // V0.6.5 F152 + F153 — advise_vote / advise_parallel entry points
 // (used by the `mcp__ccteam__advise_*` MCP dispatch in ccteam-cli).
 pub use advise::{
-    advise_parallel, advise_vote, append_budget_sample as append_advise_budget_sample,
+    advise_parallel, advise_vote, append_budget_ledger_row,
+    append_budget_sample as append_advise_budget_sample,
     budget_ledger_path as advise_budget_ledger_path, load_budget_ledger as load_advise_budget,
     sum_advise_today, sum_advise_today_by_vendor, AdviseBudgetLedger, AdviseError, Agreement,
     AnswerStatus, BudgetSample, BudgetSnapshot, CodexStatus, ParallelResult, VendorAnswer,
-    VoteResult, DEFAULT_ADVISE_BUDGET_USD_24H, DEFAULT_CODEX_TIMEOUT_SECS,
+    VoteResult, APPROX_COST_PER_CALL_USD as APPROX_ADVISE_COST_USD,
+    DEFAULT_ADVISE_BUDGET_USD_24H, DEFAULT_CODEX_TIMEOUT_SECS,
 };
 pub use auto_loop::{AutoLoopDecision, AutoLoopFrontMatter, AutoLoopState};
 pub use claude_job::{
@@ -207,8 +209,8 @@ pub use ccteam_cost::{
 };
 pub use mode_inferrer::{infer_mode, CreatorMode, InferenceResult, Intent, Presence, Timeline};
 pub use progress::{
-    current_agent_sessions, escalation_count, workflow_cost_total, AgentSessionStatus,
-    AgentSessionSummary,
+    current_agent_sessions, escalation_count, read_all_events, workflow_cost_total,
+    AgentSessionStatus, AgentSessionSummary,
 };
 pub use projects::{
     bootstrap_project, bootstrap_project_at_dir, pick_unused_slug, pick_unused_slug_verbatim,

--- a/crates/ccteam-core/src/orchestrator.rs
+++ b/crates/ccteam-core/src/orchestrator.rs
@@ -669,11 +669,14 @@ impl Orchestrator {
                 Some(Arc::new(ClaudeTuiAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>)
             }
             (Executor::Codex, WorkflowMode::Chat) => {
-                // CodexAppServerAdapter ships with Wave 3 codex-exec-impl
-                // teammate; until that lands, fall back to the bg adapter
-                // so the dispatch table never returns None for a known
-                // (vendor, mode) pair.
-                self.adapter_for(Executor::Codex).cloned()
+                // F173 — Codex chat bots route through `CodexExecAdapter`
+                // (per-turn `codex exec --json` subprocess + advise
+                // ledger hook in `submit_turn`). Always-fresh-handle
+                // keeps the dispatch table from returning None for a
+                // known `(vendor, mode)` pair, and matches the daemon's
+                // `default_adapter_factory` so chat / bg / critic spawn
+                // paths all funnel cost into the same ledger.
+                Some(Arc::new(CodexExecAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>)
             }
             (_, WorkflowMode::HumanApproval) => {
                 // V0.6.1 F124 narrow scope — `mode: human-approval`
@@ -2151,12 +2154,8 @@ impl Orchestrator {
             // up the project dir for this slug (and degrade gracefully
             // when it can't be resolved or no handoffs exist).
             let project_dir = self.paths.project_dir(slug);
-            let trace = handoff::read_concat(
-                &project_dir,
-                slug,
-                handoff::DEFAULT_INCLUDE_LAST_N,
-            )
-            .unwrap_or_default();
+            let trace = handoff::read_concat(&project_dir, slug, handoff::DEFAULT_INCLUDE_LAST_N)
+                .unwrap_or_default();
             let mut body = format!(
                 "role `{}` failed to spawn {} consecutive times — orchestrator escalating \
                  per fix-loop 3-strike rule.",

--- a/crates/ccteam-core/tests/codex_critic_ledger_test.rs
+++ b/crates/ccteam-core/tests/codex_critic_ledger_test.rs
@@ -1,0 +1,282 @@
+//! V0.6.6 F173 — `CodexExecAdapter::submit_turn` advise-ledger hook
+//! tests. Verifies the unified-cost-rollup invariant: every successful
+//! Codex turn appends one row to `<ccteam_root>/cost-budget.json`, and
+//! a pre-turn budget cap rejects further calls with a structured
+//! `SubmitFailed("budget_exceeded: …")`.
+//!
+//! All tests use the `CCTEAM_CODEX_BIN` fake-script seam + a per-test
+//! `CCTEAM_HOME` tempdir so they're hermetic — no real codex binary
+//! required, no shared filesystem state.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ccteam_core::advise::{
+    append_budget_ledger_row, load_budget_ledger, sum_advise_today, AdviseBudgetLedger,
+    BudgetSample, APPROX_COST_PER_CALL_USD, DEFAULT_ADVISE_BUDGET_USD_24H,
+};
+use ccteam_core::execution::codex_app_server::CODEX_BIN_ENV;
+use ccteam_core::execution::CodexExecAdapter;
+use ccteam_core::harness::{
+    AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, ThreadEvent, ThreadHandle, TurnInput,
+};
+use futures::StreamExt;
+use serde_json::json;
+use serial_test::serial;
+
+/// Build a fake codex script that emits the supplied JSONL lines on
+/// stdout and exits 0. Mirrors the fixture from
+/// `codex_exec_wave3_test.rs` so failures don't cross-contaminate.
+fn fake_codex_emitting(lines: &[&str]) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("codex.sh");
+    let mut body = String::from("#!/usr/bin/env bash\n");
+    body.push_str("cat <<'EOF'\n");
+    for l in lines {
+        body.push_str(l);
+        body.push('\n');
+    }
+    body.push_str("EOF\n");
+    body.push_str("exit 0\n");
+    {
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f.sync_all().unwrap();
+    }
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    (dir, path)
+}
+
+fn handle(identity: &str) -> ThreadHandle {
+    ThreadHandle {
+        vendor: AgentVendor::Codex,
+        mode: ExecutionMode::Bg,
+        identity: identity.into(),
+        started_at: chrono::Utc::now(),
+        raw_extras: json!({}),
+    }
+}
+
+/// One successful turn appends exactly one Codex ledger row at the
+/// `APPROX_COST_PER_CALL_USD` flat estimate. We drain the event stream
+/// for `TurnCompleted` before asserting so the post-turn ledger hook
+/// has run.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn successful_turn_appends_one_codex_ledger_row() {
+    let home = tempfile::tempdir().unwrap();
+    std::env::set_var("CCTEAM_HOME", home.path());
+
+    let (_dir, script_path) = fake_codex_emitting(&[
+        r#"{"type":"thread.started","thread_id":"t-led-1"}"#,
+        r#"{"type":"turn.started"}"#,
+        r#"{"type":"item.completed","item":{"id":"i-1","type":"agent_message","text":"hi"}}"#,
+        r#"{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}"#,
+    ]);
+    std::env::set_var(CODEX_BIN_ENV, &script_path);
+
+    let adapter = CodexExecAdapter::new();
+    let h = handle("ccteam-test-ledger-1");
+    let stream = adapter.events(&h);
+    let _tid = adapter
+        .submit_turn(&h, TurnInput::UserText("hi".into()))
+        .await
+        .unwrap();
+
+    // Drain until TurnCompleted so the post-turn ledger write has fired.
+    let _ = tokio::time::timeout(
+        Duration::from_secs(3),
+        stream
+            .take_while(|evt| {
+                let stop = !matches!(evt, ThreadEvent::TurnCompleted { .. });
+                std::future::ready(stop)
+            })
+            .collect::<Vec<_>>(),
+    )
+    .await
+    .expect("stream drained");
+    // The ledger row is appended *inside* the reader task right after
+    // the TurnCompleted event is broadcast; give it a brief grace
+    // period to flush to disk (no deeper sync point — the write is a
+    // detached helper).
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let ledger = load_budget_ledger(home.path()).unwrap();
+    let codex_rows: Vec<_> = ledger
+        .samples
+        .iter()
+        .filter(|s| matches!(s.vendor, AgentVendor::Codex))
+        .collect();
+    assert_eq!(
+        codex_rows.len(),
+        1,
+        "expected 1 codex row after one successful turn, got {} rows ({ledger:?})",
+        codex_rows.len()
+    );
+    assert!((codex_rows[0].usd - APPROX_COST_PER_CALL_USD).abs() < 1e-9);
+
+    std::env::remove_var(CODEX_BIN_ENV);
+    std::env::remove_var("CCTEAM_HOME");
+}
+
+/// Failed turns (non-zero exit, no `turn.completed`) MUST NOT charge
+/// the ledger — operators don't pay for failures, and `doctor
+/// --check-cost-orphan` will naturally include only `status="completed"`
+/// `agent_done` rows for parity.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn failed_turn_does_not_append_ledger_row() {
+    let home = tempfile::tempdir().unwrap();
+    std::env::set_var("CCTEAM_HOME", home.path());
+
+    // Fake script: exit 1, no JSONL output → fallback path emits
+    // TurnFailed via "nonzero_exit".
+    let dir = tempfile::tempdir().unwrap();
+    let script_path = dir.path().join("codex_fail.sh");
+    let body = "#!/usr/bin/env bash\nexit 1\n";
+    {
+        let mut f = std::fs::File::create(&script_path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f.sync_all().unwrap();
+    }
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).unwrap();
+
+    std::env::set_var(CODEX_BIN_ENV, &script_path);
+    let adapter = CodexExecAdapter::new();
+    let h = handle("ccteam-test-ledger-fail");
+    let stream = adapter.events(&h);
+    let _ = adapter
+        .submit_turn(&h, TurnInput::UserText("hi".into()))
+        .await
+        .unwrap();
+
+    // Drain until TurnFailed
+    let _ = tokio::time::timeout(
+        Duration::from_secs(3),
+        stream
+            .take_while(|evt| std::future::ready(!matches!(evt, ThreadEvent::TurnFailed { .. })))
+            .collect::<Vec<_>>(),
+    )
+    .await
+    .expect("stream drained");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let ledger = load_budget_ledger(home.path()).unwrap();
+    let codex_rows: Vec<_> = ledger
+        .samples
+        .iter()
+        .filter(|s| matches!(s.vendor, AgentVendor::Codex))
+        .collect();
+    assert!(
+        codex_rows.is_empty(),
+        "expected 0 codex rows after failed turn; got {codex_rows:?}",
+    );
+
+    std::env::remove_var(CODEX_BIN_ENV);
+    std::env::remove_var("CCTEAM_HOME");
+}
+
+/// Pre-turn budget check rejects when the ledger is already at /
+/// above cap. The error must be a `HarnessError::SubmitFailed` whose
+/// message starts with `budget_exceeded:` so the orchestrator's
+/// upstream pattern-match can detect it.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn submit_turn_rejects_when_budget_already_exceeded() {
+    let home = tempfile::tempdir().unwrap();
+    std::env::set_var("CCTEAM_HOME", home.path());
+    // Seed ledger past the default cap by hand-writing the file (we
+    // don't want to depend on the public append helper here — that's
+    // covered separately by advise.rs unit tests).
+    let ledger = AdviseBudgetLedger {
+        samples: vec![BudgetSample {
+            vendor: AgentVendor::Codex,
+            // 1.0 USD ≫ DEFAULT_ADVISE_BUDGET_USD_24H (0.50)
+            usd: 1.0,
+            ts: chrono::Utc::now(),
+        }],
+    };
+    std::fs::create_dir_all(home.path()).unwrap();
+    std::fs::write(
+        home.path().join("cost-budget.json"),
+        serde_json::to_string_pretty(&ledger).unwrap(),
+    )
+    .unwrap();
+
+    // Fake codex script — should never be invoked because the pre-turn
+    // gate fires first. Point at /bin/true as a safe no-op fallback.
+    std::env::set_var(CODEX_BIN_ENV, "/bin/true");
+    let adapter = CodexExecAdapter::new();
+    let h = handle("ccteam-test-ledger-cap");
+    let err = adapter
+        .submit_turn(&h, TurnInput::UserText("hi".into()))
+        .await
+        .expect_err("expected budget_exceeded SubmitFailed");
+
+    match err {
+        HarnessError::SubmitFailed(msg) => {
+            assert!(
+                msg.starts_with("budget_exceeded:"),
+                "expected `budget_exceeded:` prefix, got: {msg}"
+            );
+            assert!(
+                msg.contains(&format!("{:.4}", DEFAULT_ADVISE_BUDGET_USD_24H)),
+                "expected default cap in message, got: {msg}"
+            );
+        }
+        other => panic!("expected SubmitFailed, got {other:?}"),
+    }
+
+    std::env::remove_var(CODEX_BIN_ENV);
+    std::env::remove_var("CCTEAM_HOME");
+}
+
+/// The `append_budget_ledger_row` public helper used by the adapter
+/// matches the schema the rest of the cost rollup (advise_vote +
+/// doctor --check-cost-orphan) reads — round-trip through disk and
+/// verify the 24h sum reflects the new row.
+#[test]
+fn append_budget_ledger_row_round_trips_through_disk() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    append_budget_ledger_row(root, AgentVendor::Codex, 0.0050).unwrap();
+    append_budget_ledger_row(root, AgentVendor::Codex, 0.0050).unwrap();
+    let ledger = load_budget_ledger(root).unwrap();
+    let codex_rows: Vec<_> = ledger
+        .samples
+        .iter()
+        .filter(|s| matches!(s.vendor, AgentVendor::Codex))
+        .collect();
+    assert_eq!(codex_rows.len(), 2);
+    let total = sum_advise_today(&ledger);
+    assert!(
+        (total - 0.0100).abs() < 1e-9,
+        "expected 0.0100 total, got {total}"
+    );
+}
+
+/// Smoke: when `CCTEAM_HOME` is not set, the adapter must NOT panic;
+/// it should fall through with the ledger hook silently disabled.
+/// Important for early `ccteam doctor`-style probes that may run
+/// before the home dir is materialised.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn submit_turn_degrades_silently_when_ccteam_home_unset() {
+    std::env::remove_var("CCTEAM_HOME");
+    std::env::set_var(CODEX_BIN_ENV, "/bin/true");
+    let adapter = CodexExecAdapter::new();
+    let h = handle("ccteam-test-ledger-no-home");
+    // /bin/true exits 0 immediately → fallback success branch.
+    let _ = adapter
+        .submit_turn(&h, TurnInput::UserText("hi".into()))
+        .await
+        .expect("submit_turn must not error when CCTEAM_HOME unset");
+    std::env::remove_var(CODEX_BIN_ENV);
+}

--- a/crates/ccteam-core/tests/orchestrator_thin_test.rs
+++ b/crates/ccteam-core/tests/orchestrator_thin_test.rs
@@ -1790,6 +1790,27 @@ fn human_approval_watch_spec(
     spec
 }
 
+/// V0.6.6 F173 — `pick_adapter` for `(Codex, Chat)` returns a real
+/// `CodexExecAdapter` (Codex vendor), not the prior Wave-3 placeholder
+/// that fell back to the bg adapter. Pins the unified-cost-rollup
+/// invariant: every Codex chat-mode spawn must route through the
+/// adapter whose `submit_turn` appends a `cost-budget.json` row.
+#[tokio::test]
+async fn t30b_f173_pick_adapter_codex_chat_returns_codex_vendor() {
+    use ccteam_core::harness::AgentVendor;
+    use ccteam_core::workflow::WorkflowMode;
+    let (_pr, _cr, _pdir, paths, _progress, _slug) = make_project(YAML_WATCH_FIXER);
+    let (orch, _claude_mock, _codex_mock) = build_orchestrator(paths);
+    let picked = orch
+        .pick_adapter(Executor::Codex, WorkflowMode::Chat)
+        .expect("(Codex, Chat) must resolve a real Codex adapter");
+    assert_eq!(
+        picked.vendor(),
+        AgentVendor::Codex,
+        "F173: (Codex, Chat) must return a Codex-vendor adapter"
+    );
+}
+
 /// F124 — `pick_adapter` for `mode: human-approval` falls back to
 /// the per-executor bg/exec default adapter (the HITL gate is
 /// orchestrator-side, not adapter-side).

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
-use ccteam_core::execution::ClaudeTuiAdapter;
+use ccteam_core::execution::{ClaudeTuiAdapter, CodexExecAdapter};
 use ccteam_core::harness::{AgentVendor, HarnessAdapter};
 use tokio::sync::{mpsc, Mutex};
 
@@ -66,24 +66,22 @@ pub type ChannelMap = HashMap<String, Arc<dyn Channel + Send + Sync>>;
 pub type AdapterFactory =
     Arc<dyn Fn(AgentVendor) -> Arc<dyn HarnessAdapter + Send + Sync> + Send + Sync>;
 
-/// V0.6.0 Wave 3 — pick the canonical production adapter for `vendor`.
+/// Pick the canonical production adapter for `vendor`.
 ///
 /// - `Claude` → [`ClaudeTuiAdapter`] (the mode 3 chat adapter).
-/// - `Codex` → also [`ClaudeTuiAdapter`] today; the codex-exec-impl
-///   teammate's `CodexAppServerAdapter` will replace this arm in a
-///   follow-up commit. Falling back to the Claude adapter (rather
-///   than panicking) keeps any mis-registered Codex bot inert
-///   (`start_thread` will fail noisily on the wrong vendor) instead
-///   of taking down the daemon.
+/// - `Codex` → [`CodexExecAdapter`] — per-turn `codex exec --json`
+///   subprocess wrapped by the V0.6.5 advise-ledger hook so every
+///   Codex call (chat bot, daemon-routed critic, advise_vote / parallel)
+///   funnels through the same `<ccteam_root>/cost-budget.json` rollup.
+///   Previously fell back to `ClaudeTuiAdapter` (a silent no-op);
+///   that left Codex calls outside the cost ledger.
 pub fn default_adapter_factory() -> AdapterFactory {
     Arc::new(|vendor: AgentVendor| match vendor {
         AgentVendor::Claude => {
             Arc::new(ClaudeTuiAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>
         }
         AgentVendor::Codex => {
-            // TODO(wave-3 codex-exec-impl): swap to CodexAppServerAdapter
-            // once it lands.
-            Arc::new(ClaudeTuiAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>
+            Arc::new(CodexExecAdapter::new()) as Arc<dyn HarnessAdapter + Send + Sync>
         }
     })
 }
@@ -1435,5 +1433,27 @@ mod tests {
         assert_eq!(adapter.closes.load(Ordering::SeqCst), 1);
         let supervisors = registry.lock().await.all();
         assert!(!supervisors[0].is_started().await);
+    }
+
+    /// V0.6.6 F173 — `default_adapter_factory` must route the Codex arm
+    /// to a Codex-vendor adapter (CodexExecAdapter), not the Claude
+    /// fallback that lived here from V0.6.0 Wave 3. The previous fallback
+    /// silently broke the unified cost rollup (Codex chat-mode spawns
+    /// never appended a ledger row). This test pins the fix.
+    #[test]
+    fn default_adapter_factory_codex_arm_returns_codex_vendor() {
+        let factory = default_adapter_factory();
+        let claude = factory(AgentVendor::Claude);
+        assert_eq!(
+            claude.vendor(),
+            AgentVendor::Claude,
+            "claude arm must return a Claude adapter"
+        );
+        let codex = factory(AgentVendor::Codex);
+        assert_eq!(
+            codex.vendor(),
+            AgentVendor::Codex,
+            "F173: codex arm must return a Codex adapter, not the Claude fallback"
+        );
     }
 }

--- a/skills/ccteam-team/SKILL.md
+++ b/skills/ccteam-team/SKILL.md
@@ -120,9 +120,29 @@ unit / e2e tests use a fake binary so the probe doesn't depend on a
 real `codex` install.
 
 The Codex critic teammate is **not** spawned via the Anthropic
-`Task` tool — that surface targets Claude-only subagents. Instead,
-the team-lead session runs the Codex teammate from skill body
-directly via Bash, in parallel with the Claude `Task` spawns:
+`Task` tool — that surface targets Claude-only subagents. The
+team-lead session has two routes:
+
+**Preferred — daemon-routed MCP path (`mcp__ccteam__advise_vote` /
+`mcp__ccteam__advise_parallel`)**:
+
+When the ccteam MCP server is registered and the daemon is running,
+route the critic call through `mcp__ccteam__advise_vote` (or
+`advise_parallel` for N raw answers without verdict synthesis). The
+daemon handles fan-out across vendors, funnels Codex calls through
+the shared `CodexExecAdapter` so every turn appends one row to the
+`cost-budget.json` ledger, and surfaces a per-vendor cost rollup in
+the return value. This keeps `@ccteam cost today` numbers honest
+across both main spawn and critic spawn, and lets
+`ccteam doctor --check-cost-orphan` reconcile vendor calls against
+ledger rows. Detection: a previous turn in this session must have
+registered the MCP tool surface; otherwise fall back below.
+
+**Fallback — direct bash spawn**:
+
+When the MCP path is unavailable (no daemon / no MCP registration),
+spawn the Codex teammate from skill body directly via Bash, in
+parallel with the Claude `Task` spawns:
 
 ```bash
 CODEX_BIN="${CCTEAM_CODEX_BIN:-codex}"
@@ -140,14 +160,8 @@ echo "codex-critic spawned (PID $!)"
 The team-lead session captures stdout/stderr to a temp file the
 synthesis loop polls for a `turn.completed` JSONL frame. **No tmux**
 — `codex exec --json` is one-shot process, output is captured
-directly. This bash-spawn path is the only supported route for the
-Codex critic teammate.
-
-If `ccteam-imd` daemon is running and exposes
-`mcp__ccteam__advise_parallel`, the skill MAY prefer that path
-instead — daemon-side cost rollup + persistent log. Detection: a
-previous turn in this session must have registered the MCP tool;
-otherwise stay on the direct Bash spawn.
+directly. The bash path does not record a cost ledger row, so the
+daemon-routed MCP path is preferred whenever available.
 
 ### 4. 等用户回复
 


### PR DESCRIPTION
## Finding
[F173](https://github.com/firstintent/ccteam/blob/main/docs/versions/v0-6-6/prd.md#f173) — F156 follow-through (V0.6.5 wave-2-handoff R8 defer pulled in).

## Changes
- `daemon.rs::default_adapter_factory` Codex arm: `ClaudeTuiAdapter` fallback → real `CodexExecAdapter`. TODO removed.
- `orchestrator.rs::pick_adapter` `(Codex, Chat)` arm: bg fallback → real `CodexExecAdapter`.
- `CodexExecAdapter::submit_turn`: pre-turn budget check + post-turn `append_budget_ledger_row` against `<ccteam_root>/cost-budget.json`. Gated on `CCTEAM_HOME` env to avoid cargo-test pollution; `main()` pins it from `CcteamPaths::from_env()` so production paths see it.
- `advise.rs`: new `append_budget_ledger_row` typed alias (semantic doc-only sibling of `append_budget_sample`); `APPROX_COST_PER_CALL_USD` made `pub` for adapter reuse.
- `ccteam doctor --check-cost-orphan`: new flag that reconciles `progress.jsonl` `agent_done` events against ledger rows per vendor (24h window); WARN on `agent_done > ledger_rows`, OK reconciled. Surfaces future regressions where a spawn path bypasses the ledger hook.
- `skills/ccteam-team/SKILL.md` §3.5: rewritten capability-first (no version refs) — daemon-routed MCP path preferred, bash spawn as fallback.

## Verification
- cargo test (serial): **1597 passed / 1 failed** — only the known `workflow_summary_reflects_agent_spawn_and_done_events` flake (cited in CLAUDE.md §一 baseline note).
- cargo clippy: 0 warnings (`-D warnings` clean).
- 15 new tests:
  - `codex_critic_ledger_test.rs` (5): successful turn appends row, failed turn does not, budget cap rejection, env-var degradation, round-trip helper.
  - `doctor_cost_orphan_test.rs` (8): empty reconciled, matched reconciled, codex orphan WARN, mixed only orphaned warns, stale events excluded, ledger-only rows do not orphan, report header stable, hand-written ledger round-trip.
  - `daemon.rs` inline: `default_adapter_factory` Codex arm returns Codex vendor.
  - `orchestrator_thin_test.rs`: `pick_adapter` `(Codex, Chat)` returns Codex vendor.
- `daemon.rs:84` TODO cleared.
- `skills/ccteam-team/SKILL.md` body grep clean (`v0\.|defer|f15|f156|f173|past v|deferred|shipped|wave-` = 0 hits).

## Notes
- `orchestrator.rs:684` `HumanApprovalAdapter` TODO **not touched** (out of F173 scope; F168 #6 V0.7 defer per dependency note).