### PR TITLE
v0.6.6: integrate new capabilities into user-facing docs (Wave 4b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A multi-bot IM round-table                       /ccteam-creator "a few bots in 
 Run a long task overnight (hands-off)            /ccteam-creator "<task>, run while I sleep"
 List / pause / resume / check spending           /ccteam-control list | pause | cost
 Wire up an IM token (Telegram / Slack / Discord) /ccteam-im-setup
-Verify your install / check Codex auto-critic    ccteam doctor [--check-codex-auto-critic]
+Verify your install / MCP surface / Codex critic ccteam doctor [--verify-mcp | --check-codex-auto-critic | --check-cost-orphan]
 Not sure? Just describe it in natural language   /ccteam "<what you want>"
 ```
 
@@ -34,10 +34,11 @@ curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh |
 #    Installs to ~/.local/bin/ccteam. The script prints a PATH-export
 #    hint if that directory isn't on your PATH yet — follow it, then
 #    restart your shell (or `source ~/.bashrc` / `source ~/.zshrc`).
+#    Pin a specific release tag: CCTEAM_VERSION=<tag> curl ... | sh
+#    Install system-wide:        CCTEAM_INSTALL_DIR=/usr/local/bin curl ... | sh
+#    Or download an archive from https://github.com/firstintent/ccteam/releases
 #    Build from source instead (requires Rust 1.85+):
 #      cargo install --git https://github.com/firstintent/ccteam ccteam-cli
-#    Pin a specific release tag: CCTEAM_VERSION=<tag> curl ... | sh
-#    Or download an archive from https://github.com/firstintent/ccteam/releases
 
 # 2. Inside any Claude session, register the marketplace + install the plugin:
 claude
@@ -82,7 +83,7 @@ The AI runs on **your computer** — it can read your files, run your commands, 
 kill -TERM $(cat ~/.ccteam/ccteam.pid)   # or just Ctrl+C in the foreground terminal
 ```
 
-It drains within 5 seconds, releases the web port, and unlinks its pidfile automatically. Long-running tmux chat sessions survive a daemon restart and are re-attached on the next `ccteam start` — upgrading ccteam does not lose your bot's context.
+It drains within 5 seconds, releases the web port, and unlinks its pidfile automatically. Long-running tmux chat sessions survive a daemon restart and are re-attached on the next `ccteam start` — upgrading ccteam does not lose your bot's context. If a chat pane was killed (OOM, manual `tmux kill-session`), the next `ccteam start` re-spawns it with `claude --resume <name>` so the model reloads its full API-level context (tool-use history, cache, reasoning) losslessly via the official Anthropic CLI path. If resume isn't possible (no on-disk session, schema drift), ccteam falls back to a fresh session and emits a visible `chat_session_reset` event — you'll see the bot acknowledge the reset rather than silently forget.
 
 ## Docs
 

--- a/docs/advanced/customize-workflow.md
+++ b/docs/advanced/customize-workflow.md
@@ -64,6 +64,42 @@ im_channels:                         # mode: chat 专用;走 openhuman/channels
 
 **不许写** `prompt:` / `system_prompt:` / `messages:` — 红线(`tech-design.md §3.3.3`);agent 行为住 `.claude/agents/<role>.md`。
 
+<a name="sensible-defaults"></a>
+### 二·1 Sensible defaults — `ccteam probe-project` 探测
+
+`/ccteam-creator` 第一次在仓库内跑时,先调 `ccteam probe-project` 探测项目类型 + 主语言,把结果喂给 yaml 生成 ── 用户拿到的初始 `scope:` 已按项目结构 pre-populate。手编 yaml 的高级用户也可单独跑:
+
+```bash
+ccteam probe-project --json
+# {"kind":"Monorepo","languages":["Rust","TypeScript"],
+#  "probable_scope":["crates/api-core/src","crates/api-cli/src","services/web/src"]}
+```
+
+#### 探测启发式(纯文件存在性,不 parse 任何代码)
+
+| 信号 | 推断 |
+|---|---|
+| `Cargo.toml` 内 `workspace.members` | Monorepo (Rust) |
+| `package.json` 内 `workspaces` 或 `pnpm-workspace.yaml` | Monorepo (TS) |
+| `go.work` | Monorepo (Go) |
+| 单 `Cargo.toml` / `package.json` / `pyproject.toml` | SingleRepo |
+| 只有 `*.md` + 无 source dir | DocsOnly |
+| 只有 `*.sh` / `*.py` script | ScriptsOnly |
+
+#### `probable_scope` 截断规则
+
+monorepo 探测出 10+ crate 时,按 LOC 排序取 top-3(fallback alphabetical),避免 scope 默认值过宽。用户对 prompt 内直说"scope 改成 X"即可 override。
+
+#### preset × probe 矩阵(sensible defaults)
+
+| preset | probe = Monorepo | probe = SingleRepo | probe = DocsOnly |
+|---|---|---|---|
+| `bg-overnight` | scope = top-3 workspace members | scope = src/, tests/ | scope = docs/ |
+| `inproc-team` | per-role scope 按 monorepo 子树分发 | per-role 同 scope | scope = docs/ |
+| `chat-pocket` | bot mention scope = repo root | 同 | 同 |
+
+不在范围:跨语言栈完整 template library(只针对当前 5 个 preset 的填充值);LLM-assisted 完整 role auto-gen。漏判时 user prompt override probe 结果。
+
 ## 三、5 preset 的 yaml diff(从 ccteam-creator 默认产物出发)
 
 `ccteam-creator` 模板在 `crates/ccteam-core/src/templates/workflow_templates/{pocket,squad,sprint,builder,solo}.yaml`。
@@ -213,7 +249,7 @@ ccteam start my-bots
 2. **`mode` 是 serde tagged enum** — 改 mode 必须**同时**改 mode-specific 字段。`mode: bg` 留 `bot_name`/`hop_limit` → 静默 ignore;`mode: chat` 漏 `im_channels` → schema error,daemon 不起。
 3. **`vendor` 严格小写枚举** — `vendor: openai` ✗ / `vendor: anthropic` ✗;只 `{ claude | codex }`。
 4. **`vendor` agent.md vs workflow.yaml 不一致** — doctor warn 不 error;运行时**按 workflow.yaml 走**,agent.md 字段静默 ignore。
-5. **`watch:<path>` 是项目相对路径**(F78 修过)— `watch:/abs/path` schema error。
+5. **`watch:<path>` 是项目相对路径** — `watch:/abs/path` schema error。
 6. **`tools:` 列 `mcp__ccteam__*` 无效** — 该工具组给 meta-agent;普通 bot 无 permission。反向 `CCTEAM_DISABLE_TOOLS` env(group enum)才是禁用入口。
 7. **`max_spawn_depth: 0` ≠ 无限,是禁 spawn** — 想"无限"删字段走 default 5,或 `u32::MAX`。
 8. **`compact_every_tokens` 不含 cached input** — cumulative input + output,**不算** cached(implementation detail)。

--- a/docs/advanced/multi-llm-codex.md
+++ b/docs/advanced/multi-llm-codex.md
@@ -19,7 +19,7 @@ ccteam 的"低门槛 / Claude-Code-native UX"原则要求**用户从不直接选
 
 **所有其他场景**(qa-loop / autonomous-orchestrator / chat-bot / 通用 executor / planner / fixer)默认 Claude。Codex 不出场。
 
-**实现路径**:advise 场景由 `crates/ccteam-core/src/advise.rs` 实现 `advise_vote` / `advise_parallel` 两个公开 fn,各自并行 spawn 一个 advisor per vendor(Claude 走 claude-tui adapter / Codex 走 `CodexExecAdapter`),合成器读 `<ccteam_root>/cost-budget.json` 做 per-vendor cap enforcement。auto-critic 场景由 `ccteam-creator` Phase 3.5 调 `ccteam doctor --check-codex-auto-critic` 子进程(exit 0/2/3 三态)决定是否写入 vendor 字段。
+**实现路径**:advise 场景由 `crates/ccteam-core/src/advise.rs` 实现 `advise_vote` / `advise_parallel` 两个公开 fn,各自并行 spawn 一个 advisor per vendor(Claude 走 claude-tui adapter / Codex 走 `CodexExecAdapter`),合成器读 `<ccteam_root>/cost-budget.json` 做 per-vendor cap enforcement。auto-critic 场景由 `ccteam-creator` Phase 3.5 调 `ccteam doctor --check-codex-auto-critic` 子进程(exit 0/2/3 三态)决定是否写入 vendor 字段。**Critic 路径(场景 B/D)** 统一走 daemon-routed `CodexExecAdapter`,`submit_turn` post-turn 自动 append ledger row,与 advise 同账 ── 跨 vendor 调用都在同一账上,旧的 bash 直跑 `codex exec` 路径 deprecated;`ccteam doctor --check-cost-orphan` 守这条 invariant。
 
 ---
 
@@ -72,6 +72,8 @@ ccteam 内部跑 codex 用 `--profile ccteam-default` 引这套;**用户不必�
 ccteam doctor --check-codex                  # binary 存在 + auth ok
 ccteam doctor --check-codex-auto-critic      # 跑一次 codex exec --json canary,验 auto-critic 路径可用
 ccteam doctor --install-codex-profile        # 落 ~/.codex/config.toml [profiles.ccteam-default]
+ccteam doctor --check-cost-orphan            # 对账 24h ledger 与 progress.jsonl(catch 漏 ledger 的 spawn 路径)
+ccteam doctor --verify-mcp                   # 自检 MCP 工具表面 0 STUB(CI gate)
 ```
 
 `--check-codex-auto-critic` 退出码:
@@ -169,9 +171,11 @@ agents:
 | `crates/ccteam-cost/pricing/anthropic.toml` | Claude 各 tier 定价(`opus-4-7` / `sonnet-4-5` / `haiku-4-5`),含 `cache_creation_input_tokens` / `cache_read_input_tokens` 写入价 + 命中价 |
 | `crates/ccteam-cost/pricing/openai.toml` | Codex 各 tier 定价(`gpt-5.2-codex` / `o3` / `o3-mini`),含 `reasoning_output_tokens` 单独计费 |
 | `crates/ccteam-cost/src/budget.rs` | `UnifiedTokenUsage` enum + per-vendor budget cap |
-| `<ccteam_root>/cost-budget.json` | advise.rs 的 per-vendor ledger(48h 自动 GC,atomic-rename 写入)|
+| `<ccteam_root>/cost-budget.json` | per-vendor ledger(48h 自动 GC,atomic-rename 写入)── advise / Codex critic / `CodexExecAdapter::submit_turn` **统一**写入,跨 vendor 同账 |
 
 `UnifiedTokenUsage` 是 superset,容两边字段;`progress.jsonl::agent_done.usage` 序列化此结构。
+
+**Cost-orphan invariant**:`ccteam doctor --check-cost-orphan` 在终端跑(或 CI nightly job),对账 24h 内 `agent_done` event 数与 ledger row 数 ── 不对账即某 spawn 路径绕过 ledger(自加 custom adapter 漏接 hook / 外挂 bash 直跑 codex)。健康输出 `[ok] claude: N agent_done vs N ledger rows` per vendor,WARN 列差额。Codex critic 调用走 daemon-routed `CodexExecAdapter`,与 main spawn 同账,**不再** silent 漏算。
 
 #### Per-vendor budget cap
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@
 程序化起 bot / 看历史 / 重置 session         mcp__ccteam__chat_*      ↓ §5 详跑
 看 / 暂停 / 恢复 / 看花费                    /ccteam-control list / pause / cost
 配 / 改 IM token(TG / Slack / Discord)      /ccteam-im-setup
-验证安装 / 验 Codex auto-critic              ccteam doctor [--check-codex-auto-critic]
+验证安装 / MCP 表面 / Codex critic / cost     ccteam doctor [--verify-mcp | --check-codex-auto-critic | --check-cost-orphan]
 不确定?用自然语言问                          /ccteam "<NL 描述>"
 ```
 
@@ -64,6 +64,42 @@ ccteam-scan (quick) → <repo>/.ccteam/codebase-scan.md
 ```
 
 24h 内复跑会直接显示上次报告(`--force` 强制重扫)。**不**写 git / 不开 daemon / 不动 `~/.ccteam/`。
+
+---
+
+## §1.6 新项目零配置上手:`/ccteam-creator` 自动探测
+
+`/ccteam-creator` 第一次在你仓库内跑时,会先调 `ccteam probe-project` 探测项目类型(monorepo / single repo / docs-only / scripts-only)+ 主语言(Rust / TypeScript / Python / Go ...),然后把探测结果喂给后续 yaml 生成 ── 你拿到的初始 workflow.yaml `scope:` 段已按项目结构填好,role.md 也按主语言挑了合适默认值,**不必手改就能跑**。
+
+```bash
+cd path/to/your/repo
+claude
+```
+
+session 里:
+
+```
+/ccteam-creator "做个 monorepo 后端 reviewer"
+```
+
+ccteam-creator 先报探测结果:
+
+```
+Project probe:
+  kind: Monorepo (cargo workspace)
+  languages: Rust, TypeScript
+  probable scope: crates/api-core/src, crates/api-cli/src, services/web/src
+
+Generating workflow with scope pinned to those subtrees ...
+```
+
+如果探测错(比如混合 monorepo / 你想要别的 scope),后续向导对话里直接 `scope: 改成 X` 覆盖即可。也可单独跑探测:
+
+```bash
+ccteam probe-project --json    # 看 ccteam 怎么"看"你的仓库
+```
+
+输出 `kind` / `languages` / `probable_scope` 三段 JSON。
 
 ---
 
@@ -135,7 +171,7 @@ $ claude
   • mcp__ccteam__* tools available (workflow_* / chat_* / advise_* / admin_* / screenshot_*)
 ```
 
-跑 `ccteam doctor` 验装(claude CLI / MCP / tmux / pidfile 路径都查一遍);加 `--check-codex-auto-critic` 验证 Codex 二审是否能开。
+跑 `ccteam doctor` 验装(claude CLI / MCP / tmux / pidfile 路径都查一遍);加 `--verify-mcp` 自检 MCP 工具表面齐全(应输出 `26 active, 0 stubs`,非零 exit 即 CI gate fail);加 `--check-codex-auto-critic` 验证 Codex 二审是否能开;加 `--check-cost-orphan` 对账 24h 内 ledger 与 progress.jsonl(catch spawn 路径漏写 ledger)。
 
 → 卡了?见 [troubleshooting.md](troubleshooting.md) "plugin install 失败"。
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -635,6 +635,161 @@ MCP 工具本身 0 cost(纯文件操作 + daemon coordination);bot 跑起来后�
 
 ---
 
+## 配方 12 — 新项目零配置上手(ccteam-creator 自动探测)
+
+### 场景
+
+> "我刚 clone 了一个仓库(或者 `cargo new` / `pnpm init` 起的新项目),想直接 `/ccteam-creator` 起一个团队,**不必手改 yaml**就能跑。"
+
+### 适合谁
+
+刚装 ccteam 的新用户;或在不熟悉的项目里临时起 reviewer / squad;或单纯懒得手填 scope。
+
+### 起步
+
+```bash
+cd path/to/your/repo
+claude
+```
+
+session 里直接:
+
+```
+/ccteam-creator "做个后端 reviewer 团队"
+```
+
+ccteam-creator 先调 `ccteam probe-project` 探测:
+
+```
+Project probe:
+  kind: Monorepo (cargo workspace)
+  languages: Rust, TypeScript
+  probable scope: crates/api-core/src, crates/api-cli/src, services/web/src
+
+Generating workflow with scope pinned to those subtrees ...
+```
+
+随后 yaml 生成阶段把 probe 结果喂入 ── `scope:` 段已按项目结构填好,role.md 也按 Rust workspace 默认值(`cargo test --workspace` 风格)预填。
+
+### 用法
+
+probe 结果不满意?向导对话里直接说:
+
+```
+You: scope 改成只 crates/api-core/src,别管 cli 和 web
+Creator: ✓ scope updated → [crates/api-core/src]
+```
+
+或单独跑探测看 ccteam 怎么"看"你的仓库:
+
+```bash
+ccteam probe-project --json
+```
+
+输出 `kind` / `languages` / `probable_scope` 三段 JSON,适合 CI 编排在起 workflow 前先抓项目类型路由到不同 preset。
+
+### 生成什么
+
+- workflow.yaml `scope:` 段非空,按 monorepo 子树或 src/ + tests/ 分发
+- role.md 主语言(Rust → cargo / TS → npm / Python → pytest 风格)默认值
+- DocsOnly 仓库(只 *.md)→ scope = docs/,跳过 build/test 工具
+- ScriptsOnly 仓库(只 *.sh / *.py)→ scope = 顶层脚本目录
+
+### 探测启发式
+
+- `Cargo.toml workspace.members` + `package.json workspaces` + `go.work` → Monorepo
+- 单 `Cargo.toml` / `package.json` / `pyproject.toml` → SingleRepo
+- 只有 `.md` 无 source dir → DocsOnly
+- 只有 `.sh` / `.py` script → ScriptsOnly
+
+漏判时 user prompt override probe 结果,probe 只提供合理初值。
+
+### 预期 cost
+
+probe 本身 0 cost(纯文件扫描)。生成 yaml + 起 team 按对应 preset 计算。
+
+### 想改?
+
+[进阶定制 — preset 默认值 / scope 字段语义](advanced/customize-workflow.md#sensible-defaults)
+
+---
+
+## 配方 13 — 长跑 cost 监控(IM + doctor 对账)
+
+### 场景
+
+> "我有几个长跑 bot,想随时看花了多少钱;每周做一次对账,确认 ledger 没漏(防 spawn 路径绕开计费)。"
+
+### 适合谁
+
+任何长跑超过 1 周的 daemon / overnight builder / 多 bot 团队 owner。
+
+### 起步
+
+实时查 24h cost,IM 端:
+
+```
+@ccteam cost today
+```
+
+bot 回:
+
+```
+ccteam cost today
+  rolling 24h cost: Claude $1.8240 + Codex $0.4120 = total $2.2360
+  cap: $5.00/24h · remaining: $2.7640
+  active bots: 3 (filter: none)
+  full breakdown: `/ccteam-control show-cost`
+```
+
+撞 80% cap 自动加 `⚠️ approaching daily budget cap` 前缀。
+
+Claude session 内同样命令:
+
+```
+/ccteam-control show-cost                       # 全 workflow 24h 汇总
+/ccteam-control show-cost helper-bot --days 7   # 单 workflow 7 天
+```
+
+### 周末对账
+
+每周末终端跑一次:
+
+```bash
+ccteam doctor --check-cost-orphan
+```
+
+健康输出:
+
+```
+[ok] claude: 168 agent_done vs 168 ledger rows
+[ok] codex:  42 agent_done vs 42 ledger rows
+verdict: OK — ledger reconciled with progress.jsonl over 24h.
+```
+
+`WARN per vendor` 不对账 = 某 spawn 路径漏写 ledger ── 通常是新加自定义 adapter 没接 ledger hook,或外挂 codex bash 调用绕过(critic 路径已统一走 ledger,这种 leak 应消失)。
+
+### 配合 `ccteam doctor --verify-mcp` 做 CI gate
+
+CI 跑一次:
+
+```bash
+ccteam doctor --verify-mcp --json | jq .verdict
+# 期望:"PASS"
+```
+
+任何 STUB 注册 → exit 1,fail CI build。
+
+### 预期 cost
+
+监控命令本身 0 cost(纯读 ledger + progress.jsonl)。
+
+### 想改?
+
+[Multi-LLM 进阶](advanced/multi-llm-codex.md):per-vendor budget cap / unified cost rollup 内部架构。
+
+---
+
 ## 看完想自己捣鼓?
 
 每个配方都是 `ccteam-creator` 帮你生成的 `.ccteam/workflow.yaml` + `.claude/agents/*.md`。你 95% 时间不需要看这些文件 — 改东西在 Claude session 里一句话就行:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # ccteam 故障排查手册
 
-> 主入口都在 Claude session 内:`/ccteam`(总入口)、`/ccteam-scan`(摸底)、`/ccteam-team`(临时 team)、`/ccteam-creator`(新建项目)、`/ccteam-control`(运行时)、`/ccteam-im-setup`(TG 配置)、`/ccteam-advise`(双 LLM 投票)。**诊断**走 **CLI**:在任意终端跑 `ccteam doctor`(详细诊断,80% 卡点它自动检出);Claude session 内可以 `Bash("ccteam doctor")` 一键调用。还卡再查本手册。
+> 主入口都在 Claude session 内:`/ccteam`(总入口)、`/ccteam-scan`(摸底)、`/ccteam-team`(临时 team)、`/ccteam-creator`(新建项目)、`/ccteam-control`(运行时)、`/ccteam-im-setup`(TG 配置)、`/ccteam-advise`(双 LLM 投票)。**诊断**走 **CLI**:在任意终端跑 `ccteam doctor`(详细诊断,80% 卡点它自动检出);Claude session 内可以 `Bash("ccteam doctor")` 一键调用。`--verify-mcp` 自检 MCP 表面 27 active / 0 stubs,`--check-cost-orphan` 对账 ledger 与 progress.jsonl,两条都适合放 CI gate。还卡再查本手册。
 >
 > 进阶 fix:`docs/claude-code-tool-surface.md` 看平台原语,`docs/orchestration-patterns.md` 看拓扑选择,`docs/tech-design.md` 看架构权威。
 
@@ -94,8 +94,8 @@
 **相关**:无。
 
 ### A18. `install.sh` 报 "unsupported platform: linux-aarch64"
-**原因**:V0.6.x 还未发布 linux-arm64 prebuilt(只发 x86_64 + macOS arm64/x64)。
-**修复**:走源码 build:`cargo install --git https://github.com/firstintent/ccteam ccteam-cli`(需要 Rust 1.85+);或等 V0.7 把 arm64 加进 release matrix。
+**原因**:当前未发布 linux-arm64 prebuilt(只发 x86_64 + macOS arm64/x64)。
+**修复**:走源码 build:`cargo install --git https://github.com/firstintent/ccteam ccteam-cli`(需要 Rust 1.85+);或等后续 release 把 arm64 加进 matrix。
 **相关**:A16。
 
 ---
@@ -179,7 +179,7 @@
 ## C. 成本 / 配额(10 条)
 
 ### C1. 24h budget 触底,bot 全停
-**原因**:F84 红线 — workflow 24h cost 撞 `max_cost_usd_per_24h`。
+**原因**:cost-cap 红线 — workflow 24h cost 撞 `max_cost_usd_per_24h`。
 **修复**:1) `/ccteam-control show-cost` 看哪个 role 烧得多;2) workflow.yaml 调高 budget 或换便宜模型;3) 等 24h reset 自动恢复。
 **相关**:C5 / C7。
 
@@ -299,11 +299,13 @@
 **相关**:F2 / F3。
 
 ### F2. 升级 ccteam 后 chat bot 失联 / context 像丢了
-**原因**:不应发生。`ccteam start` 启动时探测每个已注册 bot 的 `ccteam-chat-<slug>-<role>` tmux session,若 session + pane 内 claude 进程都活 → 自动 reattach(bot context 不丢)。
+**原因**:不应发生。`ccteam start` 启动时探测每个已注册 bot 的 `ccteam-chat-<slug>-<role>` tmux session,若 session + pane 内 claude 进程都活 → 自动 reattach(bot context 不丢);若 session 在但 pane 死 → kill stale + spawn `claude --resume <name>`,Anthropic 官方 CLI 直接 reload full API-level context(模型脑子里还有上次的东西)。
 **修复**:
 1. 终端 `tmux ls | grep ccteam-chat-` 看 session 是否存在
-2. 存在但 ccteam 没 reattach → 看 daemon 日志(`~/.ccteam/logs/ccteam-imd.log`)有无 reattach 行
-3. session 不存在(进程被 OOM-killed / 手动 `tmux kill-server`)→ ccteam 起新 session,context 确实丢;用 `mcp__ccteam__chat_history` 抓上轮 `turns.jsonl` 让 bot 自己重读上下文
+2. 存在但 ccteam 没 reattach → 看 daemon 日志(`~/.ccteam/logs/ccteam-imd.log`)有无 reattach / resume 行
+3. 日志显示 `chat_session_reset` event with `reason="resume_failed_fallback_to_fresh"` → `--resume` 失败(session jsonl 不存在 / 用户清过 `~/.claude/projects/` / Anthropic schema 升级)── bot 已退到 brand-new session,context 真丢;用 `mcp__ccteam__chat_history` 抓上轮 `turns.jsonl` 让 bot 自己重读上下文,或在 IM 端直接 paste 一句 summary
+4. session 不存在 + 无日志(进程被 OOM-killed + `~/.claude/projects/` 也清空)→ ccteam 起新 session,context 确实丢,同上 step 3
+**验证 lossless 恢复**:发条 `刚才那个 X 怎么样?` 风格 follow-up,bot reply 若能直接引用早 turn 内容 = 真 lossless;若 reply 显示"对不起请重述"= fallback 已走。
 **相关**:F1 / B11。
 
 ### F3. `ccteam mcp-serve` 跑起来 stdout 空 / 看不到 prompt
@@ -321,6 +323,22 @@
 2. 看 `<project>/.ccteam/chat/<bot>/turns.jsonl` 是否空(原内容应在 `archive/turns-<unix-ms>.jsonl`)
 3. tmux session 内 claude 进程仍持着旧 context — `mcp__ccteam__chat_unregister_bot` 再 `chat_register_bot` 一次,强制 spawn 新 claude 进程
 **相关**:B11 / §4.7 (user-manual.md)。
+
+### F5. `ccteam doctor --check-cost-orphan` 报 WARN
+**原因**:24h 内某 vendor 的 `agent_done` event 数 ≠ ledger row 数 ── 某 spawn 路径绕过了 `<ccteam_root>/cost-budget.json` ledger 写入。常见原因:(a) 用户自加 custom adapter 没接 ledger hook;(b) 外挂 bash 直跑 `codex exec` / `claude --print` 绕开 `CodexExecAdapter` / `ClaudeTuiAdapter`;(c) ccteam 自身新增 spawn 路径忘接(请提 issue)。
+**修复**:
+1. WARN 提示哪个 vendor 漏算 → 看自己的 workflow.yaml / skill 有没有手写 bash spawn(用 MCP `mcp__ccteam__advise_vote` 替代)
+2. ccteam built-in 路径漏 → 看 `<project>/.ccteam/progress.jsonl` 里漏的 `agent_done.vendor` 字段对应哪个 adapter,提 issue
+3. 长期对账失败 → CI 用 `ccteam doctor --check-cost-orphan` exit code 守 invariant(0 = OK / 1 = orphan,可放 nightly job)
+**相关**:C6 / §4.8(user-manual.md)。
+
+### F6. `ccteam doctor --verify-mcp` 报 STUB found
+**原因**:不应发生(0 STUB 是 ship gate invariant)。当某 MCP tool 注册了但 dispatch fn 返 `NotImplemented` 时触发。
+**修复**:
+1. 看输出 per-group breakdown,找具体哪个 group 有 stub
+2. `cargo clean && cargo build` 排除编译产物错位
+3. 仍报 → 跑 `ccteam doctor --verify-mcp --json | jq .unexpected_stubs` 取 stub 列表 → 提 issue 附完整 doctor 输出
+**相关**:A4 / §4.8。
 
 ---
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -24,7 +24,7 @@ IM 圆桌(多 bot)                            /ccteam-creator           §2.5 IM
 看 / 暂停 / 改 persona / 加工具              /ccteam-control           §4.1-§4.6
 诊断 / 验 Codex auto-critic                   ccteam doctor             §4.8
 配 / 改 IM token                             /ccteam-im-setup          §2.4 + quickstart
-daemon 优雅停止 / tmux reattach              kill -TERM <pid>          §6
+daemon 优雅停止 / tmux reattach / 崩溃恢复    kill -TERM <pid>          §6
 不确定?用自然语言问                          /ccteam "<NL>"            §3.1
 ```
 
@@ -279,7 +279,7 @@ writer_bot: 已起草文档,贴 PR 链接 → #1240
 
 **前置**:Codex 装好 + `codex login` 跑过(可用 `ccteam doctor --check-codex-auto-critic` 一条命令验)。**没装也能跑** — graceful 降级单 Claude advisor,verdict prose 写 "Codex unavailable: <reason>",**不报错**。
 
-**Budget 守门**:每 vendor 单独 `max_cost_usd_per_24h` cap,记账落 `<ccteam_root>/cost-budget.json`(48h 自动 GC)。某 vendor 撞顶 → 静默跳过该 vendor 跑其余,verdict 标注 `budget_exhausted`。
+**Budget 守门**:每 vendor 单独 `max_cost_usd_per_24h` cap,记账落 `<ccteam_root>/cost-budget.json`(48h 自动 GC)。某 vendor 撞顶 → 静默跳过该 vendor 跑其余,verdict 标注 `budget_exhausted`。**Codex critic 路径** 同样走该 ledger ── 跨 vendor 调用都在同一账上,`@ccteam cost today` 与 `ccteam doctor --check-cost-orphan` 看到的数字是真实跨 vendor 累计(没有 spawn 路径绕开 ledger)。
 
 **底层 MCP 工具**:`mcp__ccteam__advise_vote` / `mcp__ccteam__advise_parallel`(可绕过 skill 直接调,适合 CI / batch)。
 
@@ -299,7 +299,7 @@ writer_bot: 已起草文档,贴 PR 链接 → #1240
 |---|---|
 | `/ccteam-scan [--quick]` | 摸底新代码库(`--quick` 60s 零依赖,默认完整 navigability audit)|
 | `/ccteam-team <N> "<task>"` | 起临时 team(Team Sprint)|
-| `/ccteam-creator "<NL>"` | 起新 workflow / 改现有 workflow |
+| `/ccteam-creator "<NL>"` | 起新 workflow / 改现有 workflow ── 第一次在仓库内跑时先自动调 `ccteam probe-project` 探测 monorepo / 主语言,生成 yaml 的 `scope:` 段直接按结果 pre-populate(不必手改即可跑)|
 | `/ccteam-control <subcmd>` | 管已有 workflow(暂停 / 恢复 / 查 cost / 改 persona)|
 | `/ccteam-im-setup` | 一次性绑 IM token(TG / Slack / Discord)|
 | `/ccteam-advise vote\|parallel "<question>"` | Claude + Codex 并行二答案(没装 Codex 自动降级单 Claude)|
@@ -314,8 +314,19 @@ writer_bot: 已起草文档,贴 PR 链接 → #1240
 @ccteam pause helper-bot           # 暂停某个 bot
 @ccteam resume helper-bot          # 恢复
 @ccteam list bots                  # 列所有跑着的 bot
-@ccteam cost today                 # 今日 cost
+@ccteam cost today                 # 今日 cost(真 USD,跨 vendor)
+@ccteam cost helper-bot            # 单 slug 24h cost
 @ccteam stop everything            # 紧急停所有
+```
+
+`cost today` 返当日 rolling 24h 真 USD(从 `<ccteam_root>/cost-budget.json` ledger 读),分 Claude / Codex 两行 + 总额 + cap + remaining,撞 80% cap 自动加 "⚠️ approaching daily budget cap" 前缀。例:
+
+```
+ccteam cost today
+  rolling 24h cost: Claude $0.1832 + Codex $0.0917 = total $0.2749
+  cap: $0.50/24h · remaining: $0.2251
+  active bots: 2 (filter: none)
+  full breakdown: `/ccteam-control show-cost`
 ```
 
 ### §3.3 Web 仪表板
@@ -409,11 +420,13 @@ Web **只看不操作**。所有控制走 Claude session slash 或 IM。
 **IM 端**:
 
 ```
-@ccteam cost today
+@ccteam cost today           # 全 workflow 24h 汇总
+@ccteam cost <slug>          # 单 workflow 24h
 ```
 
-底层都调 `mcp__ccteam__admin_ls`,从响应里读每个 project 的 `cost_24h_usd`。  
-`cost_24h_usd` = 最近 24h 内的 token 花费;`cost_used_usd` = 项目生命周期累计。
+`/ccteam-control show-cost` 底层调 `mcp__ccteam__admin_ls`,从响应里读每个 project 的 `cost_24h_usd`(= 最近 24h 内的 token 花费;`cost_used_usd` = 项目生命周期累计)。
+
+`@ccteam cost today` 走 IM 路径:从 `<ccteam_root>/cost-budget.json` ledger 聚合 ── 该 ledger 是 advise / Codex critic / 跨 vendor 调用的统一账,**不是** bot 数估算;输出格式见 §3.2。两条路径数字应一致(同源 ledger);若 `ccteam doctor --check-cost-orphan` 报 warn 表示某 spawn 路径绕过了 ledger,见 §4.8。
 
 ---
 
@@ -522,11 +535,44 @@ skill 把 NL 翻译成 Claude Code 工具名(如 `WebFetch`、`Bash`)后调:
 |---|---|
 | `ccteam doctor` | 全套诊断(claude CLI 版本 / MCP 注册 / tmux / pidfile 路径 / web port)|
 | `ccteam doctor --install-mcp` | 重写 `~/.claude.json` / 项目 `.mcp.json` 里的 `ccteam` MCP server 注册 |
+| `ccteam doctor --verify-mcp [--json]` | 自检 MCP 工具表面齐全,输出 `total / active / stubs` 与 per-group 分项,任何 STUB 注册 → exit 1(CI gate)|
 | `ccteam doctor --check-codex` | 验 codex binary 存在 + auth ok |
 | `ccteam doctor --check-codex-auto-critic` | 验 codex 可用且能跑一次 `codex exec --json` canary(exit 0 = ok / 2 = binary 缺 / 3 = output 格式不对)|
+| `ccteam doctor --check-cost-orphan` | 对账 24h 内 `<ccteam_root>/cost-budget.json` ledger 行数与每项目 progress.jsonl 的 `agent_done` event 数 ── 不对账 = 某 spawn 路径绕过 ledger,WARN per vendor,catch cost visibility leak |
 | `ccteam doctor --full` | 全套 + 详细输出(收集成给 issue)|
 
-`--check-codex-auto-critic` 是 `/ccteam-creator` Phase 3.5 内部调的同一条命令 — 决定 critic 角色是否自动设 `vendor: codex`。手动验等价。
+`--check-codex-auto-critic` 是 `/ccteam-creator` Phase 3.5 内部调的同一条命令 ── 决定 critic 角色是否自动设 `vendor: codex`。手动验等价。
+
+`--verify-mcp` 的预期输出:
+
+```
+MCP tool surface verification
+total tools:    27 (expected 27)
+active:         27
+stubs:          0
+
+per-group breakdown:
+  workflow_:    7 active / 0 stub
+  chat_:        9 active / 0 stub
+  advise_:      2 active / 0 stub
+  admin_:       8 active / 0 stub
+  screenshot:   1 active / 0 stub
+
+verdict: PASS — all 27 tools live, no production STUBs.
+```
+
+非 0 stub 或 unexpected stub 注册 → verdict 转 `FAIL` + exit code 1,适合放 CI。
+
+`--check-cost-orphan` 的预期输出(健康):
+
+```
+ccteam doctor --check-cost-orphan
+[ok] claude: 12 agent_done vs 12 ledger rows
+[ok] codex:  3 agent_done vs 3 ledger rows
+verdict: OK — ledger reconciled with progress.jsonl over 24h.
+```
+
+不对账时 WARN 列出 vendor + 差额,提示哪条 spawn 路径漏写 ledger(典型是新加的自定义 adapter 没接 ledger hook)。
 
 ---
 
@@ -573,14 +619,17 @@ kill -TERM $(cat ~/.ccteam/ccteam.pid)   # 或 Ctrl+C 在前台 terminal
 
 **不要用 `kill -9` / `SIGKILL`**。SIGKILL 跳过 graceful drain,会留孤儿 pidfile,可能伤进行中的 turn 状态。只有 graceful 卡死 5 秒以上才考虑 SIGKILL,且属于 bug — 请 issue。
 
-**tmux reattach across daemon restart**:
+**崩溃恢复(tmux reattach + lossless context resume)**:
 
 升级 ccteam 或机器重启后,`ccteam start` 启动时探测每个已注册 bot 的 tmux session(`ccteam-chat-<slug>-<role>`):
 - session 存在 + pane 内 `claude` 进程活 → **reattach**(不 spawn 新 claude,bot context 不丢)
-- session 存在 + pane 死 → `tmux kill-session` 后重起新 session
-- session 不存在 → 起新 session
+- session 存在 + pane 死(被 OOM-killed / 用户手动 `tmux kill-pane`)→ kill stale tmux + spawn `claude --resume <name>`,**Anthropic 官方 CLI 直接 reload 上次 session 的 full API-level context**(tool-use 中间结果、推理链、cache 状态全在)── 模型脑子里还有上次的东西,不只是 last-N turns 字面回放
+- session 不存在(首次启 bot)→ 起新 session,带 deterministic `--name`,以备未来 `--resume`
+- `--resume` 失败(session jsonl 不存在 / corrupt / 用户清过 `~/.claude/projects/`)→ 退到 brand-new session + 显式 emit `chat_session_reset` event,bot 在 IM 端会"告诉你它忘了"(visible degraded,不冒充 resume)
 
-也就是:**升级 ccteam 不会丢 bot 对话 context**。bot 仍在 IM 端 responsive,不需要人工 `tmux kill-session` 后再 `ccteam-creator` 重起。
+也就是:**升级 ccteam 不会丢 bot 对话 context;dead pane recreate 也尽力 lossless 还原**。bot 仍在 IM 端 responsive,不需要人工 `tmux kill-session` 后再 `ccteam-creator` 重起。
+
+实际验证:发 `刚才那个 X 怎么样?` 风格 follow-up,bot reply 若能直接引用早 turn 内容(不是 "对不起,能否再讲一下 X")= 真 lossless;若 reply 显示 `chat_session_reset` 提示 = fallback 走了,context 已重置。
 
 ---
 


### PR DESCRIPTION
## V0.6.6 user-facing docs integration

Ship gate per CLAUDE.md §五 #7. V0.6.6 capabilities integrated into:
- README (binary install lead refined, daemon lossless recovery, doctor flag set)
- quickstart §1.1 (install.sh nuances) + new §1.6 (probe-project zero-config)
- user-manual (cost real-ledger output, doctor --verify-mcp / --check-cost-orphan, daemon lossless recovery, advise unified cost note)
- recipes (new #12 zero-config new project, new #13 cost monitoring + orphan reconcile)
- troubleshooting (F2 daemon recovery rewritten for resume path, new F5 cost-orphan, new F6 verify-mcp stub)
- advanced/customize-workflow (new §二·1 sensible-defaults anchor for probe-project)
- advanced/multi-llm-codex (doctor cost-orphan + verify-mcp, unified critic ledger note)

Pre-existing version refs (V0.6.x / V0.7 in A18, F78 / F84 markers) scrubbed to comply with §三 README/user-docs red line (no version refs, no F-tag, no Wave markers).

Grep verified:
- `V\d+\.\d+|docs/versions` in user-facing docs → 0 hits
- `shipped in V|new in V|V0.6.6 新增` → 0 hits
- `F[0-9]{2,3}|Wave [0-9]` → 0 hits

Diff stat: 7 files, +327 / -28.

## Test plan
- [x] grep gates 0 hit (3 patterns above)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean
- [x] doc-only changes (no .rs / Cargo.toml touched)
- [x] no CLAUDE.md / tier-1 internal docs / skills/* touched (4a owns those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)