### PR TITLE
chore: one-shot cargo fmt --all + CI fmt-check gate + §七 drift-zero policy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,28 @@
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: cargo clippy -D warnings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --workspace --all-targets --locked -- -D warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,11 +147,9 @@ V0.6.0 走通的 4-wave 流程,V0.6.x patch + V0.7 minor 起点直接复用:
 
 ## 七、Rust 代码格式化约定
 
-`rustfmt.toml` pin stable rustfmt(`max_width = 100` / `tab_spaces = 4` / `use_field_init_shorthand`):
+`rustfmt.toml` pin stable rustfmt(`max_width = 100` / `tab_spaces = 4` / `use_field_init_shorthand`)。**Workspace drift 已一次清零**(`cargo fmt --all` chore PR + CI gate 守),drift-zero policy:
 
-- **不用 `cargo fmt`**(含 `cargo fmt -- <files>` 形式)── cargo fmt **silently 忽略文件参数**,会全 workspace 跑,把存量 ~4-5 kLOC fmt drift 拉进你的 PR diff(2026-05-24 V0.6.5 W1-T3 实战踩坑)
-- **新文件 / 大改文件:`rustfmt --edition 2021 <files>` 直调**(commit 前;原地写回)
-- **dry-run probe:**`rustfmt --check --edition 2021 <files>`
-- **小改 drifted 文件:不 fmt-sweep**(让 drift 维持现状,别动)
-- **不上 workspace-wide CI fmt gate**(drift 清零后才指望)
-- **drift 清理走独立 chore PR**,按模块拆,一次一个 crate
+- **commit 前必跑** `cargo fmt --all`(或 `cargo fmt -p <crate>` 局部目标 crate);CI gate (`.github/workflows/check.yml::fmt`) `cargo fmt --all -- --check` 不过 PR 不能 merge
+- **`rustfmt --edition 2021 <files>` 直调仍 OK** ── 单文件场景照样能用,与 `cargo fmt` 等价
+- **0 maintenance overhead** ── 不再有"drift 维持现状"或"小改 drifted 文件不 fmt-sweep"的特例;**一律 fmt 干净**
+- 旧 drift 历史(V0.5 - V0.6.5)git log 可查(任何 commit 之前 fmt drift ~4-5 kLOC,已 chore PR `cargo fmt --all` 清零)

--- a/crates/ccteam-cli/tests/doctor_codex_test.rs
+++ b/crates/ccteam-cli/tests/doctor_codex_test.rs
@@ -55,8 +55,7 @@ fn run_doctor_with_path(extra_path: &std::path::Path, args: &[&str]) -> (String,
 #[test]
 fn check_codex_version_reports_ok_for_supported_release() {
     let dir = fake_codex_dir("codex 0.131.0", "Not logged in");
-    let (stdout, _stderr, code) =
-        run_doctor_with_path(dir.path(), &["--check-codex-version"]);
+    let (stdout, _stderr, code) = run_doctor_with_path(dir.path(), &["--check-codex-version"]);
     assert_eq!(code, 0, "stdout: {stdout}");
     assert!(stdout.contains("[OK]"), "stdout: {stdout}");
     assert!(stdout.contains("0.131"), "stdout: {stdout}");
@@ -65,8 +64,7 @@ fn check_codex_version_reports_ok_for_supported_release() {
 #[test]
 fn check_codex_version_warns_on_old_release() {
     let dir = fake_codex_dir("codex 0.120.0", "Not logged in");
-    let (stdout, _stderr, code) =
-        run_doctor_with_path(dir.path(), &["--check-codex-version"]);
+    let (stdout, _stderr, code) = run_doctor_with_path(dir.path(), &["--check-codex-version"]);
     assert_eq!(code, 0);
     assert!(stdout.contains("[WARN]"), "stdout: {stdout}");
 }

--- a/crates/ccteam-cli/tests/start_with_imd_test.rs
+++ b/crates/ccteam-cli/tests/start_with_imd_test.rs
@@ -147,13 +147,7 @@ fn start_spawns_imd_supervisor_unless_no_imd_set() {
     let _ = std::fs::remove_file(&heartbeat);
     let no_imd_started = SystemTime::now();
     let mut child2 = Command::new(ccteam_bin())
-        .args([
-            "start",
-            "--no-web",
-            "--no-imd",
-            "--tick-seconds",
-            "1",
-        ])
+        .args(["start", "--no-web", "--no-imd", "--tick-seconds", "1"])
         .env("HOME", fake_home)
         .env("CCTEAM_HOME", &ccteam_home)
         .env("CCTEAM_PROJECTS_ROOT", fake_home.join("projects"))
@@ -167,10 +161,7 @@ fn start_spawns_imd_supervisor_unless_no_imd_set() {
     // seen the heartbeat if it were going to appear.
     std::thread::sleep(Duration::from_secs(6));
     let stale = match std::fs::metadata(&heartbeat) {
-        Ok(meta) => meta
-            .modified()
-            .map(|m| m < no_imd_started)
-            .unwrap_or(true),
+        Ok(meta) => meta.modified().map(|m| m < no_imd_started).unwrap_or(true),
         Err(_) => true,
     };
 

--- a/crates/ccteam-core/src/agent_naming.rs
+++ b/crates/ccteam-core/src/agent_naming.rs
@@ -133,10 +133,8 @@ pub const SCIENTIST_NAMES: &[&str] = &[
 /// Comparison is case-insensitive but the returned name preserves the
 /// canonical PascalCase form from [`SCIENTIST_NAMES`].
 pub fn pick_unused_bot_name(existing: &[String]) -> String {
-    let taken: std::collections::HashSet<String> = existing
-        .iter()
-        .map(|s| s.to_ascii_lowercase())
-        .collect();
+    let taken: std::collections::HashSet<String> =
+        existing.iter().map(|s| s.to_ascii_lowercase()).collect();
     for &name in SCIENTIST_NAMES {
         if !taken.contains(&name.to_ascii_lowercase()) {
             return name.to_string();

--- a/crates/ccteam-core/src/execution/claude_bg.rs
+++ b/crates/ccteam-core/src/execution/claude_bg.rs
@@ -28,8 +28,8 @@ use futures::stream::{self, BoxStream};
 
 use crate::harness::{
     parse_backgrounded_short_id, parse_pid_from_state, sigterm_pid, state_json_path,
-    AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, SpawnCtx, ThreadEvent,
-    ThreadHandle, TurnId, TurnInput, CLAUDE_BIN_ENV,
+    AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, SpawnCtx,
+    ThreadEvent, ThreadHandle, TurnId, TurnInput, CLAUDE_BIN_ENV,
 };
 use crate::tmux::session_name_for_slug;
 
@@ -189,8 +189,7 @@ impl HarnessAdapter for ClaudeBgAdapter {
             }
         };
 
-        sigterm_pid(pid).map_err(|err| {
-            HarnessError::ShutdownFailed(format!("SIGTERM pid {pid}: {err}"))
-        })
+        sigterm_pid(pid)
+            .map_err(|err| HarnessError::ShutdownFailed(format!("SIGTERM pid {pid}: {err}")))
     }
 }

--- a/crates/ccteam-core/src/execution/codex_jsonrpc.rs
+++ b/crates/ccteam-core/src/execution/codex_jsonrpc.rs
@@ -91,10 +91,7 @@ impl CodexJsonRpcClient {
     /// writer background tasks are spawned immediately.
     pub async fn connect_uds(socket_path: &Path) -> Result<Self> {
         let stream = UnixStream::connect(socket_path).await.with_context(|| {
-            format!(
-                "connect codex app-server UDS at {}",
-                socket_path.display()
-            )
+            format!("connect codex app-server UDS at {}", socket_path.display())
         })?;
         let (read_half, write_half) = stream.into_split();
         Ok(Self::spawn(read_half, write_half))

--- a/crates/ccteam-core/src/execution/transcript_tail.rs
+++ b/crates/ccteam-core/src/execution/transcript_tail.rs
@@ -633,12 +633,20 @@ mod tests {
 
         // Write the main session FIRST (so its mtime is older).
         let main_path = dir.join("main-sid.jsonl");
-        std::fs::write(&main_path, r#"{"type":"last-prompt","sessionId":"main-sid"}"#).unwrap();
+        std::fs::write(
+            &main_path,
+            r#"{"type":"last-prompt","sessionId":"main-sid"}"#,
+        )
+        .unwrap();
 
         // Then write a subagent jsonl — newer mtime.
         std::thread::sleep(std::time::Duration::from_millis(10));
         let sa_path = dir.join("subagent-sid.jsonl");
-        std::fs::write(&sa_path, r#"{"type":"agent-setting","sessionId":"subagent-sid"}"#).unwrap();
+        std::fs::write(
+            &sa_path,
+            r#"{"type":"agent-setting","sessionId":"subagent-sid"}"#,
+        )
+        .unwrap();
 
         let (picked_sid, picked_path) =
             discover_active_session(cwd).expect("should pick the main session, not the subagent");

--- a/crates/ccteam-core/src/handoff.rs
+++ b/crates/ccteam-core/src/handoff.rs
@@ -154,9 +154,7 @@ pub fn list_handoffs(project_dir: &Path, workflow_slug: &str) -> Result<Vec<Path
         return Ok(Vec::new());
     }
     let mut entries: Vec<(u32, String, PathBuf)> = Vec::new();
-    for entry in std::fs::read_dir(&dir)
-        .with_context(|| format!("read_dir {}", dir.display()))?
-    {
+    for entry in std::fs::read_dir(&dir).with_context(|| format!("read_dir {}", dir.display()))? {
         let entry = entry?;
         let path = entry.path();
         if !path.is_file() {
@@ -194,11 +192,7 @@ pub fn list_handoffs(project_dir: &Path, workflow_slug: &str) -> Result<Vec<Path
 /// <!-- ccteam handoff: stage-2-fixer.md -->
 /// ...body...
 /// ```
-pub fn read_concat(
-    project_dir: &Path,
-    workflow_slug: &str,
-    last_n: usize,
-) -> Result<String> {
+pub fn read_concat(project_dir: &Path, workflow_slug: &str, last_n: usize) -> Result<String> {
     if last_n == 0 {
         return Ok(String::new());
     }
@@ -272,8 +266,7 @@ pub fn write_handoff(opts: &WriteHandoffOptions) -> Result<PathBuf> {
         std::process::id()
     );
     tmp.set_file_name(tmp_name);
-    std::fs::write(&tmp, &opts.content)
-        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::write(&tmp, &opts.content).with_context(|| format!("write {}", tmp.display()))?;
     std::fs::rename(&tmp, &final_path)
         .with_context(|| format!("rename {} → {}", tmp.display(), final_path.display()))?;
     Ok(final_path)

--- a/crates/ccteam-core/src/harness.rs
+++ b/crates/ccteam-core/src/harness.rs
@@ -183,13 +183,29 @@ pub enum TurnInput {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ThreadEvent {
-    ThreadStarted { thread_id: String },
-    TurnStarted { turn_id: String },
-    TurnCompleted { turn_id: String, usage: UnifiedTokenUsage },
-    TurnFailed { turn_id: String, err: ThreadErrorEvent },
-    ItemStarted { item: ThreadItem },
-    ItemUpdated { item: ThreadItem },
-    ItemCompleted { item: ThreadItem },
+    ThreadStarted {
+        thread_id: String,
+    },
+    TurnStarted {
+        turn_id: String,
+    },
+    TurnCompleted {
+        turn_id: String,
+        usage: UnifiedTokenUsage,
+    },
+    TurnFailed {
+        turn_id: String,
+        err: ThreadErrorEvent,
+    },
+    ItemStarted {
+        item: ThreadItem,
+    },
+    ItemUpdated {
+        item: ThreadItem,
+    },
+    ItemCompleted {
+        item: ThreadItem,
+    },
     Error(ThreadErrorEvent),
 }
 
@@ -209,10 +225,21 @@ pub struct ThreadItem {
 pub enum ThreadItemDetails {
     AgentMessage(String),
     Reasoning(String),
-    CommandExecution { cmd: String, status: String },
-    FileChange { path: PathBuf, kind: String },
-    ToolCall { name: String, args: serde_json::Value },
-    WebSearch { query: String },
+    CommandExecution {
+        cmd: String,
+        status: String,
+    },
+    FileChange {
+        path: PathBuf,
+        kind: String,
+    },
+    ToolCall {
+        name: String,
+        args: serde_json::Value,
+    },
+    WebSearch {
+        query: String,
+    },
     Error(String),
 }
 
@@ -296,11 +323,8 @@ pub trait HarnessAdapter: Send + Sync {
 
     /// Submit one user-input turn to an existing thread. Bg adapters
     /// (single-turn) return a synthetic turn id from the spawn line.
-    async fn submit_turn(
-        &self,
-        h: &ThreadHandle,
-        input: TurnInput,
-    ) -> Result<TurnId, HarnessError>;
+    async fn submit_turn(&self, h: &ThreadHandle, input: TurnInput)
+        -> Result<TurnId, HarnessError>;
 
     /// Stream of thread events. Adapters that don't yet feed structured
     /// events return an empty stream (the orchestrator's legacy
@@ -313,10 +337,7 @@ pub trait HarnessAdapter: Send + Sync {
     /// session-id, Codex thread id). Bg adapters return
     /// [`HarnessError::NotImplemented`] because every spawn is a fresh
     /// 1M context (red line R3, Claude vendor).
-    async fn resume_thread(
-        &self,
-        persistent_id: &str,
-    ) -> Result<ThreadHandle, HarnessError>;
+    async fn resume_thread(&self, persistent_id: &str) -> Result<ThreadHandle, HarnessError>;
 
     /// Graceful close. Idempotent on missing PID / missing tmux
     /// session (matches V0.5.x `shutdown_session` semantics).
@@ -709,7 +730,11 @@ mod tests {
 
     #[test]
     fn execution_mode_serde_round_trip() {
-        for m in [ExecutionMode::InProc, ExecutionMode::Bg, ExecutionMode::Chat] {
+        for m in [
+            ExecutionMode::InProc,
+            ExecutionMode::Bg,
+            ExecutionMode::Chat,
+        ] {
             let json = serde_json::to_string(&m).unwrap();
             let back: ExecutionMode = serde_json::from_str(&json).unwrap();
             assert_eq!(m, back);

--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -115,8 +115,8 @@ pub use advise::{
     budget_ledger_path as advise_budget_ledger_path, load_budget_ledger as load_advise_budget,
     sum_advise_today, sum_advise_today_by_vendor, AdviseBudgetLedger, AdviseError, Agreement,
     AnswerStatus, BudgetSample, BudgetSnapshot, CodexStatus, ParallelResult, VendorAnswer,
-    VoteResult, APPROX_COST_PER_CALL_USD as APPROX_ADVISE_COST_USD,
-    DEFAULT_ADVISE_BUDGET_USD_24H, DEFAULT_CODEX_TIMEOUT_SECS,
+    VoteResult, APPROX_COST_PER_CALL_USD as APPROX_ADVISE_COST_USD, DEFAULT_ADVISE_BUDGET_USD_24H,
+    DEFAULT_CODEX_TIMEOUT_SECS,
 };
 pub use auto_loop::{AutoLoopDecision, AutoLoopFrontMatter, AutoLoopState};
 pub use claude_job::{

--- a/crates/ccteam-core/src/mode_inferrer.rs
+++ b/crates/ccteam-core/src/mode_inferrer.rs
@@ -184,10 +184,7 @@ pub fn infer_mode(intent: &Intent) -> InferenceResult {
         (Presence::FULL_ATTENDED, Timeline::LONG_RUNNING) => {
             // Long-running + user staying full-attended is unusual —
             // surface ambiguity rather than silently picking one.
-            let mut scores = vec![
-                (CreatorMode::Bg, 0.6),
-                (CreatorMode::InProc, 0.4),
-            ];
+            let mut scores = vec![(CreatorMode::Bg, 0.6), (CreatorMode::InProc, 0.4)];
             if task_type == "qa-loop" {
                 scores[0].1 += 0.1;
             }

--- a/crates/ccteam-core/src/preferences.rs
+++ b/crates/ccteam-core/src/preferences.rs
@@ -127,13 +127,11 @@ pub fn load_or_default(root: &Path) -> Preferences {
 
 /// Atomically write preferences to `<root>/preferences.toml`.
 pub fn save(root: &Path, prefs: &Preferences) -> Result<()> {
-    std::fs::create_dir_all(root)
-        .with_context(|| format!("mkdir {}", root.display()))?;
+    std::fs::create_dir_all(root).with_context(|| format!("mkdir {}", root.display()))?;
     let raw = toml::to_string_pretty(prefs).context("serialize preferences")?;
     let path = preferences_path(root);
     let tmp = path.with_extension("toml.tmp");
-    std::fs::write(&tmp, raw.as_bytes())
-        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::write(&tmp, raw.as_bytes()).with_context(|| format!("write {}", tmp.display()))?;
     std::fs::rename(&tmp, &path)
         .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
     Ok(())

--- a/crates/ccteam-core/src/spawn_brief.rs
+++ b/crates/ccteam-core/src/spawn_brief.rs
@@ -102,10 +102,7 @@ pub fn render_spawn_brief(template: &str, ctx: &SpawnContext) -> Result<String> 
     }
 
     if out.contains("{{stage_num}}") {
-        let val = ctx
-            .stage_num
-            .map(|n| n.to_string())
-            .unwrap_or_default();
+        let val = ctx.stage_num.map(|n| n.to_string()).unwrap_or_default();
         out = out.replace("{{stage_num}}", &val);
     }
 

--- a/crates/ccteam-core/src/templates/project_mcp_json.rs
+++ b/crates/ccteam-core/src/templates/project_mcp_json.rs
@@ -37,10 +37,12 @@ pub const CCTEAM_MCP_SERVER_KEY: &str = "ccteam";
 pub fn render_project_mcp_json(ccteam_bin: &Path) -> Result<String> {
     let mut root = Map::new();
     let mut servers = Map::new();
-    servers.insert(CCTEAM_MCP_SERVER_KEY.into(), ccteam_server_entry(ccteam_bin));
+    servers.insert(
+        CCTEAM_MCP_SERVER_KEY.into(),
+        ccteam_server_entry(ccteam_bin),
+    );
     root.insert("mcpServers".into(), Value::Object(servers));
-    serde_json::to_string_pretty(&Value::Object(root))
-        .context("serialize fresh .mcp.json body")
+    serde_json::to_string_pretty(&Value::Object(root)).context("serialize fresh .mcp.json body")
 }
 
 /// Merge our `mcpServers.ccteam` entry into an existing `.mcp.json`
@@ -59,9 +61,7 @@ pub fn merge_project_mcp_json(existing: &str, ccteam_bin: &Path) -> Result<Strin
             .with_context(|| "parse existing .mcp.json (must be a JSON object)")?
         {
             Value::Object(m) => m,
-            other => anyhow::bail!(
-                "existing .mcp.json root is not a JSON object: {other}"
-            ),
+            other => anyhow::bail!("existing .mcp.json root is not a JSON object: {other}"),
         }
     };
     let servers_entry = root
@@ -76,8 +76,7 @@ pub fn merge_project_mcp_json(existing: &str, ccteam_bin: &Path) -> Result<Strin
         CCTEAM_MCP_SERVER_KEY.into(),
         ccteam_server_entry(ccteam_bin),
     );
-    serde_json::to_string_pretty(&Value::Object(root))
-        .context("serialize merged .mcp.json body")
+    serde_json::to_string_pretty(&Value::Object(root)).context("serialize merged .mcp.json body")
 }
 
 /// The single shared description of the ccteam server entry. Kept
@@ -105,7 +104,10 @@ mod tests {
     fn render_fresh_includes_ccteam_server_entry() {
         let body = render_project_mcp_json(&bin()).unwrap();
         let v: Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/ccteam");
+        assert_eq!(
+            v["mcpServers"]["ccteam"]["command"],
+            "/usr/local/bin/ccteam"
+        );
         assert_eq!(v["mcpServers"]["ccteam"]["args"][0], "mcp-serve");
     }
 
@@ -126,7 +128,10 @@ mod tests {
         let v: Value = serde_json::from_str(&merged).unwrap();
         assert_eq!(v["playwrightConfig"]["headless"], true);
         assert_eq!(v["mcpServers"]["linear"]["command"], "linear-mcp");
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/ccteam");
+        assert_eq!(
+            v["mcpServers"]["ccteam"]["command"],
+            "/usr/local/bin/ccteam"
+        );
     }
 
     #[test]
@@ -140,7 +145,10 @@ mod tests {
         let merged = merge_project_mcp_json(existing, &bin()).unwrap();
         let v: Value = serde_json::from_str(&merged).unwrap();
         // Updated.
-        assert_eq!(v["mcpServers"]["ccteam"]["command"], "/usr/local/bin/ccteam");
+        assert_eq!(
+            v["mcpServers"]["ccteam"]["command"],
+            "/usr/local/bin/ccteam"
+        );
         // Untouched.
         assert_eq!(v["mcpServers"]["playwright"]["command"], "npx");
     }

--- a/crates/ccteam-core/tests/agent_naming_test.rs
+++ b/crates/ccteam-core/tests/agent_naming_test.rs
@@ -5,7 +5,11 @@ use ccteam_core::{pick_unused_bot_name, SCIENTIST_NAMES};
 
 #[test]
 fn pool_is_at_least_fifty_names() {
-    assert!(SCIENTIST_NAMES.len() >= 50, "pool too small: {}", SCIENTIST_NAMES.len());
+    assert!(
+        SCIENTIST_NAMES.len() >= 50,
+        "pool too small: {}",
+        SCIENTIST_NAMES.len()
+    );
 }
 
 #[test]

--- a/crates/ccteam-core/tests/codex_app_server_test.rs
+++ b/crates/ccteam-core/tests/codex_app_server_test.rs
@@ -148,15 +148,13 @@ fn translate_item_completed_extracts_file_change_details() {
     };
     let e = translate_notification(&n, "t-1").unwrap();
     match e {
-        ThreadEvent::ItemCompleted { item } => {
-            match item.details {
-                ccteam_core::harness::ThreadItemDetails::FileChange { path, kind } => {
-                    assert_eq!(path, PathBuf::from("/x.rs"));
-                    assert_eq!(kind, "update");
-                }
-                other => panic!("expected FileChange, got {other:?}"),
+        ThreadEvent::ItemCompleted { item } => match item.details {
+            ccteam_core::harness::ThreadItemDetails::FileChange { path, kind } => {
+                assert_eq!(path, PathBuf::from("/x.rs"));
+                assert_eq!(kind, "update");
             }
-        }
+            other => panic!("expected FileChange, got {other:?}"),
+        },
         _ => panic!("expected ItemCompleted"),
     }
 }
@@ -168,7 +166,9 @@ async fn adapter_returns_spawn_failed_when_socket_missing() {
     std::env::set_var(APP_SERVER_SOCKET_ENV, &bogus);
     let _ = std::fs::remove_file(&bogus);
     let adapter = CodexAppServerAdapter::new();
-    let spec = AgentSpecBrief { role: "demo".into() };
+    let spec = AgentSpecBrief {
+        role: "demo".into(),
+    };
     let ctx = SpawnCtx {
         slug: "test".into(),
         sid: "codex-1".into(),
@@ -200,7 +200,9 @@ async fn adapter_start_thread_against_scripted_peer() {
     tokio::time::sleep(Duration::from_millis(20)).await;
 
     let adapter = CodexAppServerAdapter::new();
-    let spec = AgentSpecBrief { role: "demo".into() };
+    let spec = AgentSpecBrief {
+        role: "demo".into(),
+    };
     let ctx = SpawnCtx {
         slug: "test".into(),
         sid: "codex-1".into(),

--- a/crates/ccteam-core/tests/codex_exec_wave3_test.rs
+++ b/crates/ccteam-core/tests/codex_exec_wave3_test.rs
@@ -80,10 +80,7 @@ async fn submit_turn_rejects_system_directive() {
         .submit_turn(&h, TurnInput::SystemDirective("/compact".into()))
         .await
         .unwrap_err();
-    assert!(
-        matches!(err, HarnessError::SubmitFailed(_)),
-        "got {err:?}"
-    );
+    assert!(matches!(err, HarnessError::SubmitFailed(_)), "got {err:?}");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -106,12 +103,10 @@ async fn events_stream_translates_jsonl_to_thread_events() {
         .await
         .unwrap();
 
-    let collected: Vec<ThreadEvent> = tokio::time::timeout(
-        Duration::from_secs(3),
-        stream.take(4).collect::<Vec<_>>(),
-    )
-    .await
-    .expect("events stream timed out");
+    let collected: Vec<ThreadEvent> =
+        tokio::time::timeout(Duration::from_secs(3), stream.take(4).collect::<Vec<_>>())
+            .await
+            .expect("events stream timed out");
 
     assert!(matches!(collected[0], ThreadEvent::ThreadStarted { .. }));
     assert!(matches!(collected[1], ThreadEvent::TurnStarted { .. }));

--- a/crates/ccteam-core/tests/handoff_test.rs
+++ b/crates/ccteam-core/tests/handoff_test.rs
@@ -8,7 +8,13 @@ use ccteam_core::handoff::{
 };
 use tempfile::TempDir;
 
-fn opts(dir: &std::path::Path, slug: &str, stage: u32, role: &str, body: &str) -> WriteHandoffOptions {
+fn opts(
+    dir: &std::path::Path,
+    slug: &str,
+    stage: u32,
+    role: &str,
+    body: &str,
+) -> WriteHandoffOptions {
     WriteHandoffOptions {
         project_dir: dir.to_path_buf(),
         workflow_slug: slug.into(),
@@ -24,8 +30,7 @@ fn write_handoff_is_atomic_and_overwrites() {
     let body1 = "first version\n";
     let body2 = "second version\n";
 
-    let p1 =
-        write_handoff(&opts(td.path(), "demo", 1, "explorer", body1)).expect("first write");
+    let p1 = write_handoff(&opts(td.path(), "demo", 1, "explorer", body1)).expect("first write");
     assert!(p1.exists(), "file should exist after first write");
     assert_eq!(fs::read_to_string(&p1).unwrap(), body1);
 
@@ -42,8 +47,7 @@ fn write_handoff_is_atomic_and_overwrites() {
         "no .tmp.<pid> leftovers; saw {leftovers:?}"
     );
 
-    let p2 =
-        write_handoff(&opts(td.path(), "demo", 1, "explorer", body2)).expect("overwrite");
+    let p2 = write_handoff(&opts(td.path(), "demo", 1, "explorer", body2)).expect("overwrite");
     assert_eq!(p1, p2, "same (slug, stage, role) → same path");
     assert_eq!(
         fs::read_to_string(&p2).unwrap(),

--- a/crates/ccteam-core/tests/harness_trait_test.rs
+++ b/crates/ccteam-core/tests/harness_trait_test.rs
@@ -293,7 +293,10 @@ async fn codex_exec_submit_turn_returns_synthetic_turn_id_wave3() {
     // success/failure. We point CCTEAM_CODEX_BIN at `/bin/true` so the
     // process exits cleanly and the test doesn't depend on a real
     // codex install.
-    std::env::set_var(ccteam_core::execution::codex_app_server::CODEX_BIN_ENV, "/bin/true");
+    std::env::set_var(
+        ccteam_core::execution::codex_app_server::CODEX_BIN_ENV,
+        "/bin/true",
+    );
     let h = ThreadHandle {
         vendor: AgentVendor::Codex,
         mode: ExecutionMode::Bg,

--- a/crates/ccteam-core/tests/mode_inferrer_test.rs
+++ b/crates/ccteam-core/tests/mode_inferrer_test.rs
@@ -15,7 +15,11 @@ fn intent(task: &str, presence: &str, timeline: &str) -> Intent {
 
 #[test]
 fn inproc_solo_full_attended_one_shot() {
-    let r = infer_mode(&intent("coding", Presence::FULL_ATTENDED, Timeline::ONE_SHOT));
+    let r = infer_mode(&intent(
+        "coding",
+        Presence::FULL_ATTENDED,
+        Timeline::ONE_SHOT,
+    ));
     assert_eq!(r, InferenceResult::Confident(CreatorMode::InProc));
 }
 
@@ -37,7 +41,11 @@ fn bg_overnight_hands_off() {
 
 #[test]
 fn bg_partial_long_running() {
-    let r = infer_mode(&intent("qa-loop", Presence::PARTIAL, Timeline::LONG_RUNNING));
+    let r = infer_mode(&intent(
+        "qa-loop",
+        Presence::PARTIAL,
+        Timeline::LONG_RUNNING,
+    ));
     assert_eq!(r, InferenceResult::Confident(CreatorMode::Bg));
 }
 
@@ -63,7 +71,11 @@ fn chat_group_im_group() {
 
 #[test]
 fn ambiguous_full_attended_long_running() {
-    let r = infer_mode(&intent("coding", Presence::FULL_ATTENDED, Timeline::LONG_RUNNING));
+    let r = infer_mode(&intent(
+        "coding",
+        Presence::FULL_ATTENDED,
+        Timeline::LONG_RUNNING,
+    ));
     match r {
         InferenceResult::Ambiguous(candidates) => {
             assert!(candidates.len() >= 2);

--- a/crates/ccteam-core/tests/per_vendor_budget_test.rs
+++ b/crates/ccteam-core/tests/per_vendor_budget_test.rs
@@ -54,10 +54,7 @@ fn cost_summary_skips_vendor_split_when_field_missing() {
     // Pre-V0.6 events lacked the vendor field. They contribute to the
     // aggregate but the per-vendor map stays empty (per-vendor caps
     // are V0.6-only opt-in).
-    let events = vec![
-        done_event(None, 5.0, "s1"),
-        done_event(None, 1.0, "s2"),
-    ];
+    let events = vec![done_event(None, 5.0, "s1"), done_event(None, 1.0, "s2")];
     let summary = compute_cost_summary(&events, Utc::now(), |_| {
         ccteam_core::claude_job::JobLiveness::Terminal {
             status: "completed",
@@ -82,8 +79,14 @@ fn cost_summary_aggregates_total_per_vendor() {
             cost_usd: 0.0,
         }
     });
-    assert_eq!(summary.cost_total_by_vendor.get("claude").copied(), Some(12.0));
-    assert_eq!(summary.cost_total_by_vendor.get("codex").copied(), Some(4.0));
+    assert_eq!(
+        summary.cost_total_by_vendor.get("claude").copied(),
+        Some(12.0)
+    );
+    assert_eq!(
+        summary.cost_total_by_vendor.get("codex").copied(),
+        Some(4.0)
+    );
     assert!((summary.cost_total_usd - 16.0).abs() < 1e-9);
 }
 

--- a/crates/ccteam-core/tests/persona_test.rs
+++ b/crates/ccteam-core/tests/persona_test.rs
@@ -43,8 +43,7 @@ struct PersonaEntry {
 
 fn read_manifest() -> Manifest {
     let path = personas_dir().join("manifest.toml");
-    let body = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    let body = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
     toml::from_str(&body).unwrap_or_else(|e| panic!("parse {path:?}: {e}"))
 }
 
@@ -101,8 +100,9 @@ fn every_role_md_has_frontmatter() {
 #[test]
 fn manifest_default_modes_are_valid() {
     let m = read_manifest();
-    let valid: std::collections::HashSet<&'static str> =
-        ["in-proc", "bg", "chat-dm", "chat-group"].into_iter().collect();
+    let valid: std::collections::HashSet<&'static str> = ["in-proc", "bg", "chat-dm", "chat-group"]
+        .into_iter()
+        .collect();
     for p in &m.persona {
         assert!(
             valid.contains(p.default_mode.as_str()),

--- a/crates/ccteam-core/tests/workflow_templates_test.rs
+++ b/crates/ccteam-core/tests/workflow_templates_test.rs
@@ -14,7 +14,10 @@ fn inproc_solo_renders() {
     .unwrap();
     assert!(out.contains("mode: agent-team"));
     assert!(out.contains("teammate_mode: in-process"));
-    assert!(!out.contains("{{"), "unsubstituted placeholder leaked:\n{out}");
+    assert!(
+        !out.contains("{{"),
+        "unsubstituted placeholder leaked:\n{out}"
+    );
 }
 
 #[test]
@@ -76,6 +79,10 @@ fn chat_squad_renders() {
 fn all_presets_have_unique_yaml_names() {
     let mut seen = std::collections::HashSet::new();
     for &p in WorkflowPreset::all() {
-        assert!(seen.insert(p.as_str()), "duplicate preset name: {}", p.as_str());
+        assert!(
+            seen.insert(p.as_str()),
+            "duplicate preset name: {}",
+            p.as_str()
+        );
     }
 }

--- a/crates/ccteam-cost/src/budget.rs
+++ b/crates/ccteam-cost/src/budget.rs
@@ -122,7 +122,10 @@ mod tests {
             },
         };
         assert_eq!(b.cap_for(Vendor::Claude).max_cost_usd_per_24h, Some(5.0));
-        assert_eq!(b.cap_for(Vendor::Codex).max_agent_spawns_per_hour, Some(100));
+        assert_eq!(
+            b.cap_for(Vendor::Codex).max_agent_spawns_per_hour,
+            Some(100)
+        );
     }
 
     #[test]

--- a/crates/ccteam-cost/src/pricing.rs
+++ b/crates/ccteam-cost/src/pricing.rs
@@ -277,7 +277,10 @@ mod tests {
         };
         // o3 input = $2 / 1M.
         let cost = estimate_cost(&one_m_input, Vendor::Codex, "o3");
-        assert!((cost - 2.0).abs() < 0.01, "o3 input != $2 / 1M (got {cost})");
+        assert!(
+            (cost - 2.0).abs() < 0.01,
+            "o3 input != $2 / 1M (got {cost})"
+        );
     }
 
     #[test]

--- a/crates/ccteam-hooks/src/lib.rs
+++ b/crates/ccteam-hooks/src/lib.rs
@@ -71,8 +71,8 @@ pub fn dispatch(
         }
         "intercept-ask" => Ok(Some(intercept_ask_decision())),
         "chat-progress" => {
-            let event = action
-                .ok_or_else(|| anyhow!("hook `chat-progress` requires an event argument"))?;
+            let event =
+                action.ok_or_else(|| anyhow!("hook `chat-progress` requires an event argument"))?;
             handle_chat_progress(paths, event, stdin)?;
             Ok(None)
         }

--- a/crates/ccteam-hooks/tests/chat_progress_test.rs
+++ b/crates/ccteam-hooks/tests/chat_progress_test.rs
@@ -8,9 +8,9 @@
 use std::path::Path;
 
 use ccteam_core::{CcteamPaths, ProjectState};
-use serial_test::serial;
 use ccteam_hooks::handle_chat_progress;
 use serde_json::{json, Value};
+use serial_test::serial;
 use tempfile::TempDir;
 
 /// Bootstrap a hermetic `CcteamPaths` rooted at `tmp` + register a

--- a/crates/ccteam-imd/src/credentials.rs
+++ b/crates/ccteam-imd/src/credentials.rs
@@ -110,8 +110,7 @@ pub fn load(path: Option<&Path>) -> Result<Credentials> {
 /// production use is read-only.
 pub fn save(path: &Path, creds: &Credentials) -> Result<()> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("mkdir -p {}", parent.display()))?;
+        fs::create_dir_all(parent).with_context(|| format!("mkdir -p {}", parent.display()))?;
     }
     let body = serde_json::to_string_pretty(creds).context("serialize credentials")?;
     fs::write(path, body).with_context(|| format!("write {}", path.display()))?;

--- a/crates/ccteam-imd/src/three_layer_sec.rs
+++ b/crates/ccteam-imd/src/three_layer_sec.rs
@@ -205,7 +205,9 @@ mod tests {
     #[test]
     fn slack_signature_stub_rejects_old_timestamp() {
         let old = "100"; // epoch=100s — far past window.
-        assert!(!verify_slack_signature_stub("secret", "v0=abc", old, "body"));
+        assert!(!verify_slack_signature_stub(
+            "secret", "v0=abc", old, "body"
+        ));
     }
 
     #[test]

--- a/crates/ccteam-imd/src/transport/providers/discord.rs
+++ b/crates/ccteam-imd/src/transport/providers/discord.rs
@@ -86,10 +86,7 @@ impl Channel for DiscordChannel {
     }
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
-        let url = format!(
-            "{DISCORD_API}/channels/{}/messages",
-            message.recipient
-        );
+        let url = format!("{DISCORD_API}/channels/{}/messages", message.recipient);
         let body = serde_json::json!({ "content": message.content });
         let resp = self
             .http

--- a/crates/ccteam-imd/src/transport/providers/mock.rs
+++ b/crates/ccteam-imd/src/transport/providers/mock.rs
@@ -50,10 +50,7 @@ impl Channel for MockChannel {
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
         self.outbox.lock().await.push(message.clone());
-        Ok(Some(format!(
-            "mock-{}",
-            self.outbox.lock().await.len()
-        )))
+        Ok(Some(format!("mock-{}", self.outbox.lock().await.len())))
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {

--- a/crates/ccteam-imd/src/transport/providers/slack.rs
+++ b/crates/ccteam-imd/src/transport/providers/slack.rs
@@ -139,10 +139,7 @@ impl Channel for SlackChannel {
                     map.get(chan).cloned()
                 };
                 let url = format!("{SLACK_API}/conversations.history");
-                let mut q = vec![
-                    ("channel", chan.clone()),
-                    ("limit", "30".into()),
-                ];
+                let mut q = vec![("channel", chan.clone()), ("limit", "30".into())];
                 if let Some(o) = oldest.clone() {
                     q.push(("oldest", o));
                 }

--- a/crates/ccteam-imd/src/transport/providers/telegram.rs
+++ b/crates/ccteam-imd/src/transport/providers/telegram.rs
@@ -127,12 +127,21 @@ impl Channel for TelegramChannel {
                 content_len = message.content.len(),
                 "latency tg.egress (failed)"
             );
-            anyhow::bail!("telegram sendMessage {} → {}: {}", message.recipient, status, text);
+            anyhow::bail!(
+                "telegram sendMessage {} → {}: {}",
+                message.recipient,
+                status,
+                text
+            );
         }
         // Best-effort: pluck message_id without a full type.
         let id = serde_json::from_str::<serde_json::Value>(&text)
             .ok()
-            .and_then(|v| v.get("result").and_then(|r| r.get("message_id")).and_then(|n| n.as_i64()))
+            .and_then(|v| {
+                v.get("result")
+                    .and_then(|r| r.get("message_id"))
+                    .and_then(|n| n.as_i64())
+            })
             .map(|n| n.to_string());
         tracing::info!(
             event = "latency",

--- a/crates/ccteam-imd/tests/daemon_test.rs
+++ b/crates/ccteam-imd/tests/daemon_test.rs
@@ -46,21 +46,16 @@ async fn daemon_runs_and_writes_heartbeat() {
 fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     use std::sync::{Mutex, OnceLock};
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
 }
 
 #[test]
 fn registration_round_trip() {
     let _g = env_lock();
     let _tmp = isolate_home();
-    let path = register_bot(
-        "dev-foo",
-        "lead",
-        AgentVendor::Claude,
-        "telegram",
-        "12345",
-    )
-    .unwrap();
+    let path = register_bot("dev-foo", "lead", AgentVendor::Claude, "telegram", "12345").unwrap();
     // Recompute path under the *same* HOME (no race because we hold env_lock).
     let expected = registration_path("dev-foo", "lead");
     assert_eq!(path, expected);

--- a/crates/ccteam-imd/tests/e2e_mock_test.rs
+++ b/crates/ccteam-imd/tests/e2e_mock_test.rs
@@ -214,16 +214,9 @@ async fn happy_path_im_to_bot_to_im() {
     let mut handles = HandleMap::new();
     handles.insert("lead", slug, role);
 
-    let res = process_inbound(
-        &im_msg("@lead what's up?"),
-        &sec,
-        &handles,
-        &mailbox,
-        0,
-        1,
-    )
-    .await
-    .unwrap();
+    let res = process_inbound(&im_msg("@lead what's up?"), &sec, &handles, &mailbox, 0, 1)
+        .await
+        .unwrap();
     assert!(matches!(res, InboundOutcome::DroppedToBot { .. }));
 
     // Wire supervisor + adapter; start the thread.
@@ -321,8 +314,16 @@ async fn restart_recovers_from_close_failure() {
     let sup = BotSupervisor::new(reg("dev-foo", "lead"), tmp.path(), adapter.clone());
     sup.ensure_started().await.unwrap();
     sup.restart().await.unwrap();
-    assert_eq!(adapter.starts.load(Ordering::SeqCst), 2, "restart starts again");
-    assert_eq!(adapter.closes.load(Ordering::SeqCst), 1, "close attempted once");
+    assert_eq!(
+        adapter.starts.load(Ordering::SeqCst),
+        2,
+        "restart starts again"
+    );
+    assert_eq!(
+        adapter.closes.load(Ordering::SeqCst),
+        1,
+        "close attempted once"
+    );
     assert!(sup.is_started().await);
 }
 
@@ -384,16 +385,9 @@ async fn multi_bot_parallel() {
     let mut seq = 0_u64;
     for content in ["@lead one", "@lead two", "@ops three"] {
         seq += 1;
-        let outcome = process_inbound(
-            &im_msg(content),
-            &sec,
-            &handles,
-            &mailbox,
-            0,
-            seq,
-        )
-        .await
-        .unwrap();
+        let outcome = process_inbound(&im_msg(content), &sec, &handles, &mailbox, 0, seq)
+            .await
+            .unwrap();
         assert!(matches!(outcome, InboundOutcome::DroppedToBot { .. }));
     }
 
@@ -409,10 +403,8 @@ async fn multi_bot_parallel() {
 
     // Each bot's turns.jsonl has its own assistant rows; outbound
     // forwards to bot-specific MockChannels.
-    let lead_turns = projects_root
-        .join("dev-foo/.ccteam/chat/lead/turns.jsonl");
-    let ops_turns = projects_root
-        .join("dev-bar/.ccteam/chat/ops/turns.jsonl");
+    let lead_turns = projects_root.join("dev-foo/.ccteam/chat/lead/turns.jsonl");
+    let ops_turns = projects_root.join("dev-bar/.ccteam/chat/ops/turns.jsonl");
     let (lead_rows, _) = read_new_rows(&lead_turns, &TailCursor::default()).unwrap();
     let (ops_rows, _) = read_new_rows(&ops_turns, &TailCursor::default()).unwrap();
     assert_eq!(lead_rows.len(), 2);

--- a/crates/ccteam-imd/tests/sanitize_test.rs
+++ b/crates/ccteam-imd/tests/sanitize_test.rs
@@ -2,16 +2,19 @@
 //! basics — this file exercises edge cases that should hold across
 //! the whole crate boundary).
 
-use ccteam_imd::sanitize::{sanitize_for_tmux, sanitize_reply_input, truncate_to_max, MAX_TURN_LEN};
+use ccteam_imd::sanitize::{
+    sanitize_for_tmux, sanitize_reply_input, truncate_to_max, MAX_TURN_LEN,
+};
 
 #[test]
 fn round_trip_with_all_dangerous_chars() {
     let raw = "before\x00 `whoami` $(rm) ${HOME} \u{202e}reverse\u{2069} after";
     let out = sanitize_reply_input(raw);
-    for needle in [
-        "\x00", "\u{202e}", "\u{2069}",
-    ] {
-        assert!(!out.contains(needle), "{needle:?} should have been stripped");
+    for needle in ["\x00", "\u{202e}", "\u{2069}"] {
+        assert!(
+            !out.contains(needle),
+            "{needle:?} should have been stripped"
+        );
     }
     for esc in ["\\`whoami\\`", "\\$(", "\\${"] {
         assert!(out.contains(esc), "missing escape {esc}");

--- a/crates/ccteam-web/src/routes/api_v1.rs
+++ b/crates/ccteam-web/src/routes/api_v1.rs
@@ -269,8 +269,8 @@ async fn handle_project(
     // line read `state.cost_used_usd`, which is now frozen.
     // V0.6.0 Wave 3 F112 — also surface `cost_24h_by_vendor` to drive
     // the SPA's per-vendor split and `/ccteam-advise` UI.
-    let cost = cost_summary(&slug, &app.paths.progress_jsonl(&slug), &app.paths)
-        .unwrap_or_default();
+    let cost =
+        cost_summary(&slug, &app.paths.progress_jsonl(&slug), &app.paths).unwrap_or_default();
     let cost_total = cost.cost_total_usd;
     let cost_24h_by_vendor = cost.cost_24h_by_vendor.clone();
     let summary = ProjectSummary {
@@ -360,10 +360,9 @@ async fn handle_session(
         .as_ref()
         .map(|snap| format!("{:.2}", snap.cost_usd_total))
         .unwrap_or_else(|| {
-            let total =
-                cost_summary(&slug, &app.paths.progress_jsonl(&slug), &app.paths)
-                    .map(|c| c.cost_total_usd)
-                    .unwrap_or(0.0);
+            let total = cost_summary(&slug, &app.paths.progress_jsonl(&slug), &app.paths)
+                .map(|c| c.cost_total_usd)
+                .unwrap_or(0.0);
             format!("{:.2}", total)
         });
 
@@ -494,7 +493,11 @@ fn build_workflow_session_detail(
     // project-wide badge. Fine-grained per-session badging is a flex
     // feature we deliberately don't replicate here.
     let label: &'static str = if live.is_some() { "live" } else { "done" };
-    let cls: &'static str = if live.is_some() { "badge-ok" } else { "badge-neutral" };
+    let cls: &'static str = if live.is_some() {
+        "badge-ok"
+    } else {
+        "badge-neutral"
+    };
 
     let kind = team_kind_label(state.team_kind).to_string();
     let detail = SessionDetail {

--- a/crates/ccteam-web/src/routes/internal_hook.rs
+++ b/crates/ccteam-web/src/routes/internal_hook.rs
@@ -60,12 +60,7 @@ async fn handle_with_action(
 /// Shared invocation path. `None` body is normalized to `Value::Null`
 /// so handlers that don't actually read stdin (today: `intercept-ask`)
 /// still work when the client sent zero bytes.
-fn dispatch(
-    app: &AppState,
-    kind: &str,
-    action: Option<&str>,
-    body: Option<Value>,
-) -> Response {
+fn dispatch(app: &AppState, kind: &str, action: Option<&str>, body: Option<Value>) -> Response {
     let t0 = std::time::Instant::now();
     let stdin = body.unwrap_or(Value::Null);
     // Try to pull session id / role from the Claude Code hook stdin

--- a/crates/ccteam-web/tests/internal_hook_test.rs
+++ b/crates/ccteam-web/tests/internal_hook_test.rs
@@ -18,9 +18,7 @@
 
 use std::net::SocketAddr;
 
-use ccteam_core::{
-    bootstrap_project, disable_tool_surface_bootstrap_for_tests, CcteamPaths,
-};
+use ccteam_core::{bootstrap_project, disable_tool_surface_bootstrap_for_tests, CcteamPaths};
 use ccteam_web::{router_with_state, AppState};
 use serde_json::{json, Value};
 use tempfile::TempDir;
@@ -110,7 +108,10 @@ async fn post_unknown_kind_returns_500_with_error_body() {
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body["ok"], false);
     assert!(
-        body["error"].as_str().unwrap().contains("unknown hook kind"),
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("unknown hook kind"),
         "expected unknown-kind error, got: {body}"
     );
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,9 +2,10 @@
 # whitespace. Stable rustfmt only (no `unstable_features = true`); CI and
 # `cargo fmt --check` must run on stable.
 #
-# **Apply to new / heavily-edited files only.** Pre-existing codebase carries
-# a known fmt drift (~4-5 kLOC); a workspace-wide `cargo fmt --all` sweep
-# explodes diffs and breaks reviewability. See CLAUDE.md §七 for the rule.
+# **Drift-zero policy**: workspace `cargo fmt --all` clean as of the chore
+# fmt-sweep PR. Commit-front `cargo fmt --all` is mandatory; CI gate
+# (`.github/workflows/check.yml::fmt`) enforces `cargo fmt --all -- --check`
+# on push / PR. See CLAUDE.md §七 for the rule.
 
 edition = "2021"
 max_width = 100


### PR DESCRIPTION
## Change
One-shot workspace-wide `cargo fmt --all` (38 .rs files, 242+/207-, pure formatting diff) + new `.github/workflows/check.yml` (fmt + clippy CI gate) + CLAUDE.md §七 policy rewrite from drift-tolerant to drift-zero. `rustfmt.toml` header comment synced.

## Why
V0.6.5 / V0.6.6 cycles saw 5 subagents each manually revert 12-20 unrelated rustfmt drift files after touching a single .rs file — 15-20% time burn / subagent. Root cause = pre-existing drift accumulated pre-§七-rule. Eliminating at source.

## Review
- **All diff is pure formatting** (whitespace, line-wrap per rustfmt.toml pinned style: max_width=100 / tab_spaces=4 / use_field_init_shorthand). Spot-check 1-2 files to verify.
- `cargo test --workspace`: 1614 pass / 26 fail — identical to origin/main pre-fmt run on the same host (failures are WSL2 inotify-host transient, not counted in baseline per CLAUDE.md §一).
- `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean (self-verify)

## Scope
- No code change (semantically identical)
- No version bump (still 0.6.6)
- No baseline change (1639/1 nominal baseline; host-transient delta unchanged)
- CI gate active on next PR

## Follow-up
After merge, memory entries advising "don't run cargo fmt" become obsolete — main session updates them to reflect the new drift-zero policy.