### PR TITLE
chore(release): drop windows-x64 + fix macOS rolldown native binding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 # GitHub Actions: tag-triggered prebuilt-binary release (F166).
 #
-# Pushing a tag like `v0.6.6` builds the `ccteam` binary on four targets,
+# Pushing a tag like `v0.6.6` builds the `ccteam` binary on three targets,
 # packages each with a per-asset SHA-256 sum, aggregates a single
 # SHA256SUMS file, and uploads everything to the corresponding GitHub
 # Release. `install.sh` (repo root) reads these assets — keep the asset
 # naming `ccteam-<tag>-<suffix>.<ext>` and the suffix vocabulary
-# (linux-x64 / macos-arm64 / macos-x64 / windows-x64) in lockstep with
-# that script.
+# (linux-x64 / macos-arm64 / macos-x64) in lockstep with that script.
+#
+# Windows is intentionally out of scope: ccteam's foundation is tmux +
+# inotify + POSIX signals (`libc::SIGKILL` / `SIGTERM` in
+# `crates/ccteam-core/src/harness.rs`), which are unix-only. Windows
+# users run ccteam under WSL2 with the linux-x64 binary.
 #
 # The repo-guard on every job stops a fork that accidentally inherits
 # this workflow from publishing under the upstream release page.
@@ -41,10 +45,6 @@ jobs:
             target: x86_64-apple-darwin
             suffix: macos-x64
             ext: tar.gz
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            suffix: windows-x64
-            ext: zip
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -63,6 +63,27 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Pre-install the SPA `node_modules/` before `cargo build` so the
+      # `ccteam-web` build.rs (which feature-gates on `web-bundle`,
+      # default-on) finds them and skips its own `npm install`. We split
+      # by runner OS because `package-lock.json` is generated on Linux
+      # and only resolves the linux-x64 rolldown native binding; macOS
+      # `npm ci` would honor that lockfile and skip the darwin
+      # `optionalDependencies`, leaving rolldown unable to load
+      # `.darwin-arm64.node` at build time. Clearing the lockfile on
+      # macOS forces a fresh platform-correct resolution.
+      - name: Pre-install web SPA deps (linux fast path with lockfile)
+        if: runner.os == 'Linux'
+        working-directory: crates/ccteam-web/web
+        run: npm ci --no-audit --no-fund --include=optional
+
+      - name: Pre-install web SPA deps (macOS — drop lockfile for native binding refresh)
+        if: runner.os == 'macOS'
+        working-directory: crates/ccteam-web/web
+        run: |
+          rm -f package-lock.json
+          npm install --no-audit --no-fund --include=optional
 
       - name: Build ccteam binary
         run: cargo build --release --locked --target ${{ matrix.target }} --bin ccteam
@@ -86,21 +107,6 @@ jobs:
             shasum -a 256 "${PKG}.tar.gz" > "${PKG}.tar.gz.sha256"
           fi
 
-      - name: Package (windows)
-        if: matrix.ext == 'zip'
-        shell: pwsh
-        run: |
-          $tag = $env:GITHUB_REF_NAME
-          $pkg = "ccteam-$tag-${{ matrix.suffix }}"
-          $stage = Join-Path ([System.IO.Path]::GetTempPath()) $pkg
-          New-Item -ItemType Directory -Force -Path $stage | Out-Null
-          Copy-Item "target/${{ matrix.target }}/release/ccteam.exe" "$stage/ccteam.exe"
-          Copy-Item "README.md" "$stage/README.md"
-          Copy-Item "LICENSE" "$stage/LICENSE"
-          Compress-Archive -Path $stage -DestinationPath "$pkg.zip" -Force
-          $hash = (Get-FileHash "$pkg.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $pkg.zip" | Out-File -FilePath "$pkg.zip.sha256" -Encoding ascii
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -108,8 +114,6 @@ jobs:
           path: |
             ccteam-*-${{ matrix.suffix }}.tar.gz
             ccteam-*-${{ matrix.suffix }}.tar.gz.sha256
-            ccteam-*-${{ matrix.suffix }}.zip
-            ccteam-*-${{ matrix.suffix }}.zip.sha256
           if-no-files-found: error
           retention-days: 7
 
@@ -150,7 +154,10 @@ jobs:
           cat > release-notes.md <<EOF
           # ccteam ${TAG}
 
-          Prebuilt binaries for Linux, macOS (Intel + Apple Silicon), and Windows.
+          Prebuilt binaries for Linux x86_64 and macOS (Intel + Apple Silicon).
+          Windows users: run ccteam under WSL2 with the linux-x64 binary
+          (ccteam's foundation is tmux + inotify + POSIX signals, which
+          are unix-only).
 
           ## Install (zero-Rust)
 
@@ -196,4 +203,4 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --title "ccteam ${TAG}" \
             --notes-file ../release-notes.md \
-            ccteam-*.tar.gz ccteam-*.zip SHA256SUMS
+            ccteam-*.tar.gz SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ ccteam init <project>
 ```
 
 Supported platforms for the prebuilt binary: Linux x86_64, macOS arm64
-(Apple Silicon), macOS x86_64 (Intel), Windows x86_64 (download the zip
-from the releases page — the install script is POSIX-only). On macOS,
+(Apple Silicon), macOS x86_64 (Intel). Windows users: install via WSL2
+and use the linux-x64 binary — native Windows isn't supported because
+tmux + inotify + POSIX signals are foundational to ccteam. On macOS,
 if Gatekeeper blocks the binary on first run:
 `xattr -d com.apple.quarantine ~/.local/bin/ccteam`.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -129,7 +129,7 @@ ccteam --version    # 应输出当前版本号
 
 默认装到 `~/.local/bin/ccteam`。装完如果该路径不在 `$PATH`,脚本会打印一行 export 指令(贴进 `~/.bashrc` / `~/.zshrc` 再 `source` 即可)。
 
-支持的平台:Linux x86_64、macOS arm64(Apple Silicon)、macOS x86_64(Intel)。Windows 用户直接到 [Releases 页面](https://github.com/firstintent/ccteam/releases)下载 `windows-x64.zip` 解压(`install.sh` 是 POSIX 脚本,不跑 Windows)。
+支持的平台:Linux x86_64、macOS arm64(Apple Silicon)、macOS x86_64(Intel)。Windows 用户走 WSL2 + linux-x64 binary —— native Windows 不支持(tmux + inotify + POSIX signals 是 ccteam 架构根基)。
 
 环境变量:
 - `CCTEAM_INSTALL_DIR=/usr/local/bin sh install.sh` —— 改装目录(系统级安装)

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,8 @@
 #   * No sudo. Writes to $HOME/.local/bin by default.
 #   * Override target dir: CCTEAM_INSTALL_DIR=/usr/local/bin sh install.sh
 #   * Override tag (CI / pin): CCTEAM_VERSION=v0.6.6 sh install.sh
-#   * Windows is not supported — use the GitHub Releases page (zip).
+#   * Windows is not supported — run ccteam under WSL2 and use the
+#     linux-x64 binary (tmux + inotify + POSIX signals are foundational).
 #
 # Usage:
 #   curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh


### PR DESCRIPTION
## Change
- release.yml matrix: drop windows-x64 (libc::SIGKILL POSIX-only; ccteam is tmux/inotify-based unix product)
- release.yml: split SPA pre-install step by runner.os — linux `npm ci --include=optional`, macOS `rm -f package-lock.json && npm install --include=optional` to force darwin native binding fetch
- release.yml: drop `Package (windows)` pwsh step + .zip from upload-artifact glob + .zip from `gh release create` asset list
- release notes template: drop "Windows" from prebuilt-binary list + add WSL2 note
- README + docs/quickstart.md + install.sh comment: "Windows users → WSL2 + linux-x64 binary" (no version number, per README §三 红线)

## Diagnosis
v0.6.6 release run #26355340751 failed 3/4 platforms:
- **Windows**: rustc cannot resolve `libc::SIGKILL` on `x86_64-pc-windows-msvc` target (`crates/ccteam-core/src/harness.rs:574/589` POSIX-only)
- **macOS arm64 + x64**: rolldown native binding (`@rolldown/binding-darwin-*`) missing because `package-lock.json` only resolves `@rolldown/binding-linux-x64-gnu` (generated on linux dev machine); macOS `npm install` honors the lockfile and skips darwin `optionalDependencies`

## Local verification
- `cargo fmt --all -- --check` clean
- `cargo build --release --bin ccteam` succeeds
- `cd crates/ccteam-web/web && rm -f package-lock.json && npm install --include=optional && npm run build` succeeds (simulates macOS path on linux; can't directly verify darwin binding fetch, but proves the lockfile-clear + install flow works)
- `cargo test --workspace --locked --no-fail-fast` → 1639/1 baseline (only flake = `workflow_summary_reflects_agent_spawn_and_done_events`, per CLAUDE.md §一)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` clean

## Re-tag (post-merge)
Per pre-v1.0 + CLAUDE.md §五 #3 (no historical migration), maintainer will:
1. `git push origin :refs/tags/v0.6.6` (delete remote tag)
2. `git tag -d v0.6.6` (delete local tag)
3. `git tag -a v0.6.6 <fixed-HEAD>` + push
4. release.yml retriggers → 3/3 platform PASS → GH Release published → install.sh works

## Scope
- No code change to ccteam-core (Windows gate not needed since Windows is dropped from matrix)
- No version bump (0.6.6 stays)
- No baseline change (1639/1)

## Diff stat
4 files changed, 39 insertions(+), 30 deletions(-)