### PR TITLE
chore: dual-host plugin (Claude + Codex) via Node.js MCP bridge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ccteam",
       "description": "Multi-vendor (Claude + Codex) AI team orchestration on Claude Code — MCP-driven, file-system-as-control-plane, chat-mode 24/7 IM bots.",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "author": {
         "name": "FirstIntent"
       },
@@ -26,5 +26,5 @@
       ]
     }
   ],
-  "version": "0.6.5"
+  "version": "0.6.6"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccteam",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Multi-vendor AI team orchestration on Claude Code: 7 skills + 27 MCP tools + IM bots + multi-agent voting.",
   "author": {
     "name": "FirstIntent"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "ccteam",
+  "version": "0.6.6",
+  "description": "Multi-vendor (Claude + Codex) AI dev-team orchestration: 7 skills + 27 MCP tools + IM bots + dual-LLM voting.",
+  "author": {
+    "name": "FirstIntent"
+  },
+  "repository": "https://github.com/firstintent/ccteam",
+  "homepage": "https://github.com/firstintent/ccteam",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "claude-code",
+    "plugin",
+    "multi-agent",
+    "orchestration",
+    "mcp",
+    "telegram"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "ccteam",
+    "shortDescription": "Autonomous multi-agent dev team",
+    "longDescription": "An unattended multi-agent orchestration engine that drives software from intent to closed-loop delivery — Claude + Codex dual-vendor, file-system as control plane, 24/7 IM bots, dual-LLM voting.",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "brandColor": "#10A37F",
+    "defaultPrompt": [
+      "Use ccteam to scan this repo and tell me what it does",
+      "Use ccteam to run a long task overnight hands-off",
+      "Use ccteam to get a second opinion (Claude + Codex) on this design"
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "ccteam": {
-      "command": "ccteam",
-      "args": ["mcp-serve"]
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/index.js"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -26,47 +26,48 @@ Not sure? Just describe it in natural language   /ccteam "<what you want>"
 
 ## Get started
 
-```bash
-# 0. Install Claude Code first: https://code.claude.com/docs/install
+### Install (Claude Code or Codex)
 
-# 1. Install the ccteam CLI binary (one line, no Rust toolchain needed):
-curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh
-#    Installs to ~/.local/bin/ccteam. The script prints a PATH-export
-#    hint if that directory isn't on your PATH yet — follow it, then
-#    restart your shell (or `source ~/.bashrc` / `source ~/.zshrc`).
-#    Pin a specific release tag: CCTEAM_VERSION=<tag> curl ... | sh
-#    Install system-wide:        CCTEAM_INSTALL_DIR=/usr/local/bin curl ... | sh
-#    Or download an archive from https://github.com/firstintent/ccteam/releases
-#    Build from source instead (requires Rust 1.85+):
-#      cargo install --git https://github.com/firstintent/ccteam ccteam-cli
-
-# 2. Inside any Claude session, register the marketplace + install the plugin:
-claude
-```
+Inside any Claude Code session:
 
 ```
 /plugin marketplace add https://github.com/firstintent/ccteam
 /plugin install ccteam
 ```
 
+Inside any Codex session:
+
 ```
-# 3. Try the universal entry — describe what you want in any language:
+codex plugin marketplace add firstintent/ccteam
+```
+
+The plugin auto-downloads the Rust engine into its own sandbox on the first MCP invocation — no system-wide binary required, no Rust toolchain, no separate install step. A Node.js bridge (`index.js`) ships in the repo, detects the host (Claude vs Codex), pulls the matching prebuilt tarball from GitHub Releases, and execs `ccteam mcp-serve` under the covers. It also symlinks the binary to `~/.local/bin/ccteam` so the CLI is available from any terminal.
+
+### Use it
+
+```
+# Universal entry — describe what you want in any language:
 /ccteam "scan this repo and tell me what it does"
 /ccteam "fix the TypeScript errors in src/"
 /ccteam "build a Telegram bot that summarizes my GitHub PRs at 7am"
 
-# 4. (Optional) Bootstrap a per-project workflow scaffold from the CLI:
+# (Optional) Bootstrap a per-project workflow scaffold from the CLI:
 ccteam init <project>
 ```
 
-Supported platforms for the prebuilt binary: Linux x86_64, macOS arm64
-(Apple Silicon), macOS x86_64 (Intel). Windows users: install via WSL2
-and use the linux-x64 binary — native Windows isn't supported because
-tmux + inotify + POSIX signals are foundational to ccteam. On macOS,
-if Gatekeeper blocks the binary on first run:
-`xattr -d com.apple.quarantine ~/.local/bin/ccteam`.
+Supported platforms for the prebuilt binary: Linux x86_64, macOS arm64 (Apple Silicon), macOS x86_64 (Intel). Windows users: install via WSL2 and use the linux-x64 binary — native Windows isn't supported because tmux + inotify + POSIX signals are foundational to ccteam. On macOS, if Gatekeeper blocks the binary on first run: `xattr -d com.apple.quarantine ~/.local/bin/ccteam`.
 
-Step 2 registers ccteam as a Claude Code plugin marketplace, then installs the plugin — the seven `/ccteam*` slash commands and `mcp__ccteam__*` MCP tools light up immediately. The 5-minute walkthrough for "private IM assistant" (the flagship use case) lives in [docs/quickstart.md](docs/quickstart.md).
+The plugin install registers the seven `/ccteam*` slash commands and `mcp__ccteam__*` MCP tools — they light up immediately. The 5-minute walkthrough for "private IM assistant" (the flagship use case) lives in [docs/quickstart.md](docs/quickstart.md).
+
+### Advanced: system-wide CLI without the plugin
+
+If you want `ccteam` on `$PATH` for daemon use (`ccteam start`) without going through a Claude or Codex session — for example on a headless server — install the binary directly:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh
+```
+
+Pin a tag: `CCTEAM_VERSION=<tag> curl ... | sh`. System-wide: `CCTEAM_INSTALL_DIR=/usr/local/bin curl ... | sh`. Or build from source: `cargo install --git https://github.com/firstintent/ccteam ccteam-cli` (Rust 1.85+).
 
 ## Three ways to talk to ccteam
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -116,39 +116,9 @@ ccteam probe-project --json    # 看 ccteam 怎么"看"你的仓库
 
 ## Step 1 — 装 ccteam plugin(30 秒)
 
-ccteam 走 Claude Code 官方 plugin marketplace 协议安装 —— **plugin 是首选路径**,CLI binary 作为前置条件先装好(plugin 通过 MCP 调用本机 `ccteam` 命令)。
+ccteam 走 Claude Code(或 Codex)官方 plugin 协议安装 —— **plugin 是首选**且唯一**必需**的入口。plugin 自带 Node.js bridge(`index.js`),首次在 MCP server 启动时探测宿主、按平台从 GitHub Release 拉对应 binary 到 plugin sandbox 内,然后 `exec ccteam mcp-serve`。**不需要预先装 CLI binary**(bridge 会顺手把 binary symlink 到 `~/.local/bin/ccteam`,所以装完 plugin 终端也直接能跑 `ccteam start`)。
 
-### 1.1 装 CLI binary(前置,一次性)
-
-**首选 ── 一行装预编译 binary(不需要 Rust toolchain):**
-
-```bash
-curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh
-ccteam --version    # 应输出当前版本号
-```
-
-默认装到 `~/.local/bin/ccteam`。装完如果该路径不在 `$PATH`,脚本会打印一行 export 指令(贴进 `~/.bashrc` / `~/.zshrc` 再 `source` 即可)。
-
-支持的平台:Linux x86_64、macOS arm64(Apple Silicon)、macOS x86_64(Intel)。Windows 用户走 WSL2 + linux-x64 binary —— native Windows 不支持(tmux + inotify + POSIX signals 是 ccteam 架构根基)。
-
-环境变量:
-- `CCTEAM_INSTALL_DIR=/usr/local/bin sh install.sh` —— 改装目录(系统级安装)
-- `CCTEAM_VERSION=v0.6.6 sh install.sh` —— 装指定 tag(不取 latest)
-
-macOS Gatekeeper 拦截(首次跑报"not verified developer"):
-```bash
-xattr -d com.apple.quarantine ~/.local/bin/ccteam
-```
-
-**回退 ── 从源码 build(需要 Rust 1.85+,5-15 min 编译):**
-
-```bash
-cargo install --git https://github.com/firstintent/ccteam ccteam-cli
-```
-
-新机器没装 Rust 时,先 `curl https://sh.rustup.rs -sSf | sh` 装 rustup,然后再跑上面这条。
-
-### 1.2 在 Claude session 里注册 marketplace + 装 plugin
+### 1.1 在 Claude session 里注册 marketplace + 装 plugin
 
 任意 terminal 起 Claude session:
 
@@ -171,7 +141,42 @@ $ claude
   • mcp__ccteam__* tools available (workflow_* / chat_* / advise_* / admin_* / screenshot_*)
 ```
 
-跑 `ccteam doctor` 验装(claude CLI / MCP / tmux / pidfile 路径都查一遍);加 `--verify-mcp` 自检 MCP 工具表面齐全(应输出 `26 active, 0 stubs`,非零 exit 即 CI gate fail);加 `--check-codex-auto-critic` 验证 Codex 二审是否能开;加 `--check-cost-orphan` 对账 24h 内 ledger 与 progress.jsonl(catch spawn 路径漏写 ledger)。
+首次调用任意 `mcp__ccteam__*` tool 时,`index.js` 会从 GitHub Release 拉对应平台的 tarball(linux-x64 / macos-arm64 / macos-x64),解压到 `${PLUGIN_ROOT}/bin/ccteam`,chmod +x,并 symlink 到 `~/.local/bin/ccteam`。第二次起秒启。
+
+跑 `ccteam doctor` 验装(claude CLI / MCP / tmux / pidfile 路径都查一遍);加 `--verify-mcp` 自检 MCP 工具表面齐全(应输出 `27 active, 0 stubs`,非零 exit 即 CI gate fail);加 `--check-codex-auto-critic` 验证 Codex 二审是否能开;加 `--check-cost-orphan` 对账 24h 内 ledger 与 progress.jsonl(catch spawn 路径漏写 ledger)。
+
+支持的平台:Linux x86_64、macOS arm64(Apple Silicon)、macOS x86_64(Intel)。Windows 用户走 WSL2 + linux-x64 binary —— native Windows 不支持(tmux + inotify + POSIX signals 是 ccteam 架构根基)。
+
+macOS Gatekeeper 拦截(首次跑报"not verified developer"):
+```bash
+xattr -d com.apple.quarantine ~/.local/bin/ccteam
+```
+
+### 1.2 Codex 用户
+
+```
+codex plugin marketplace add firstintent/ccteam
+```
+
+同一仓库同时是 Codex plugin。Bridge 通过 `CODEX_ACTIVE` env 嗅探宿主,自动选择走 Codex 路径。
+
+### 1.3 高级:不走 plugin,直接装 system-wide CLI(可选)
+
+只想在终端 / 服务器跑 `ccteam start` daemon、不打算用 Claude/Codex skill 路径时:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh
+ccteam --version    # 应输出当前版本号
+```
+
+默认装到 `~/.local/bin/ccteam`。装完如果该路径不在 `$PATH`,脚本会打印一行 export 指令。环境变量:
+- `CCTEAM_INSTALL_DIR=/usr/local/bin sh install.sh` —— 改装目录(系统级安装)
+- `CCTEAM_VERSION=v0.6.6 sh install.sh` —— 装指定 tag(不取 latest)
+
+回退 ── 从源码 build(需要 Rust 1.85+,5-15 min 编译):
+```bash
+cargo install --git https://github.com/firstintent/ccteam ccteam-cli
+```
 
 → 卡了?见 [troubleshooting.md](troubleshooting.md) "plugin install 失败"。
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,17 @@
 ### A3. `/plugin install ccteam@claude-plugins-official` 失败
 **原因**:网络 / GitHub rate-limit / 已装同名 plugin 冲突。
 **修复**:1) `/plugin list` 看是否同名 → `/plugin remove ccteam` 重装;2) 走代理 / 国内镜像;3) 仍失败:手动 `git clone` 到 `~/.claude/plugins/marketplaces/`。
-**相关**:A4 / A5。
+**相关**:A4 / A5 / A3b。
+
+### A3b. plugin 装好了,首次调 `mcp__ccteam__*` 时下载 binary 卡住 / 失败
+**原因**:plugin 的 Node.js bridge(`index.js`)首次 MCP 启动会从 GitHub Release 拉对应平台的 tarball(`ccteam-vX.Y.Z-<linux-x64|macos-arm64|macos-x64>.tar.gz`)到 `${PLUGIN_ROOT}/bin/ccteam`。慢/失败常因:1) GitHub Release 不在 CDN 近端(国内裸连慢);2) plugin sandbox 写权限缺;3) 平台 mismatch(`tar` 不在 PATH / 平台未发布)。
+**修复**:1) bridge 启动日志走 host stderr,Claude session `/mcp` 看 ccteam 启动报错 / Codex 看 server log;2) 走代理:在拉起 Claude/Codex 的 shell 里 `export HTTPS_PROXY=...`;3) 跳过 bridge 下载、走传统 system-wide 安装:`curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh`,然后**临时把 `.mcp.json` 的 command 改回 `ccteam` + args `["mcp-serve"]`** 直至 bridge 路径修复;4) 国内裸连慢首次卡住 → 镜像 GH Release 到内网,把 `index.js` 里的下载 URL 改成镜像。版本严格对齐 `.claude-plugin/plugin.json::version`(SoT);Bridge 通过 `binary --version` 输出与之比对,不匹配会重下。
+**相关**:A3 / A4。
+
+### A3c. plugin 装好但终端 `ccteam --version` 报 command not found
+**原因**:bridge 首次 MCP 调用会把 `${PLUGIN_ROOT}/bin/ccteam` symlink 到 `~/.local/bin/ccteam`,但如果 `~/.local/bin/` 不在 `$PATH`,终端找不到。
+**修复**:1) Claude/Codex 里先调一次 `mcp__ccteam__chat_list_bots` 触发 bridge 下载 + symlink;2) `echo $PATH | grep -q "$HOME/.local/bin" || echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc`(zsh 改 `~/.zshrc`)再 `source` 一次。bridge symlink 失败时会在 stderr 打印 hint,通常因 `~/.local/bin/` 不可写。
+**相关**:A3b。
 
 ### A4. `/mcp` 列表里没 `mcp__ct__*` 工具
 **原因**:MCP 没注册到 `.mcp.json` 或 `~/.claude.json`,或 plugin 装完没 reload。

--- a/index.js
+++ b/index.js
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+// ccteam dual-host MCP bridge.
+//
+// Same repo serves as Claude Code plugin AND Codex plugin. This file is the
+// `command` in `.mcp.json`; when either host spawns it as an MCP server, it:
+//   1. Detects the host (CLAUDE_PLUGIN_ROOT vs CODEX_ACTIVE / PLUGIN_ROOT env).
+//   2. Resolves the cached binary at ${PLUGIN_ROOT}/bin/ccteam.
+//   3. If absent or version-mismatched against plugin.json (SoT), downloads
+//      the per-platform tarball from the matching GitHub Release, extracts
+//      the ccteam binary, chmods it, and symlinks it to ~/.local/bin/ccteam
+//      so the CLI is also usable from a terminal without install.sh.
+//   4. Soft-warns if tmux is missing (chat-mode features need it).
+//   5. Execs `ccteam mcp-serve` with CCTEAM_HOST=claude|codex env injected;
+//      pipes stdio between host <-> Rust process (stderr passes through to
+//      the host for diagnostics).
+//
+// Design notes:
+//   * Zero npm dependencies (require()s only Node.js stdlib).
+//   * Tarball layout mirrors install.sh: ccteam-<TAG>-<suffix>/ccteam.
+//   * Version SoT = .claude-plugin/plugin.json `version` field. The binary
+//     is re-downloaded whenever `ccteam --version` does not contain that
+//     string, so bumping plugin.json + tagging a release on GitHub is the
+//     only release motion required.
+//   * Tarball download follows HTTPS redirect chains (GitHub Releases issue
+//     302 to the CDN); falls back gracefully with a clear stderr message
+//     on any failure.
+
+'use strict';
+
+const { spawn, execSync, spawnSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
+const https = require('https');
+const { URL } = require('url');
+
+const PLUGIN_JSON = path.join(__dirname, '.claude-plugin', 'plugin.json');
+const VERSION = require(PLUGIN_JSON).version;
+const TAG = `v${VERSION}`;
+
+// --- host detection ----------------------------------------------------------
+// Codex sets CODEX_ACTIVE (and possibly PLUGIN_ROOT without CLAUDE_PLUGIN_ROOT);
+// Claude Code sets CLAUDE_PLUGIN_ROOT. We default to Claude when ambiguous.
+const isCodex =
+    !!process.env.CODEX_ACTIVE ||
+    (!!process.env.PLUGIN_ROOT && !process.env.CLAUDE_PLUGIN_ROOT);
+const HOST = isCodex ? 'codex' : 'claude';
+const PLUGIN_ROOT =
+    process.env.CLAUDE_PLUGIN_ROOT || process.env.PLUGIN_ROOT || __dirname;
+const BIN_DIR = path.join(PLUGIN_ROOT, 'bin');
+const BINARY = path.join(BIN_DIR, 'ccteam');
+
+// --- platform target ---------------------------------------------------------
+function targetSuffix() {
+    const p = os.platform();
+    const a = os.arch();
+    if (p === 'darwin' && a === 'arm64') return 'macos-arm64';
+    if (p === 'darwin' && a === 'x64') return 'macos-x64';
+    if (p === 'linux' && a === 'x64') return 'linux-x64';
+    throw new Error(
+        `unsupported platform ${p}-${a}; supported: linux-x64, macos-arm64, macos-x64. ` +
+        `Windows users run ccteam under WSL2 with the linux-x64 binary.`,
+    );
+}
+
+// --- HTTPS download w/ redirect chain ---------------------------------------
+function httpsGet(url, maxRedirects = 5) {
+    return new Promise((resolve, reject) => {
+        const visit = (u, hops) => {
+            if (hops > maxRedirects) {
+                return reject(new Error(`too many redirects fetching ${url}`));
+            }
+            const req = https.get(u, (res) => {
+                const status = res.statusCode || 0;
+                if (status >= 300 && status < 400 && res.headers.location) {
+                    res.resume();
+                    const next = new URL(res.headers.location, u).toString();
+                    return visit(next, hops + 1);
+                }
+                if (status !== 200) {
+                    res.resume();
+                    return reject(
+                        new Error(`HTTP ${status} fetching ${u}`),
+                    );
+                }
+                resolve(res);
+            });
+            req.on('error', reject);
+        };
+        visit(url, 0);
+    });
+}
+
+async function downloadAndExtract(url, destDir) {
+    fs.mkdirSync(destDir, { recursive: true });
+    const res = await httpsGet(url);
+    // Pipe straight into `tar -xz -C destDir --strip-components=1` so the
+    // archive's ccteam-<TAG>-<suffix>/ wrapper dir is unwrapped in place.
+    return new Promise((resolve, reject) => {
+        const tar = spawn(
+            'tar',
+            ['-xz', '-C', destDir, '--strip-components=1'],
+            { stdio: ['pipe', 'inherit', 'inherit'] },
+        );
+        res.pipe(tar.stdin);
+        tar.on('error', reject);
+        tar.on('exit', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`tar exited ${code}`));
+        });
+        res.on('error', reject);
+    });
+}
+
+// --- version alignment -------------------------------------------------------
+function needsDownload() {
+    if (!fs.existsSync(BINARY)) return true;
+    try {
+        const out = execSync(`${JSON.stringify(BINARY)} --version`, {
+            encoding: 'utf8',
+            timeout: 5000,
+        }).trim();
+        // `ccteam --version` prints e.g. "ccteam 0.6.6"; refresh if mismatched.
+        return !out.includes(VERSION);
+    } catch (_) {
+        return true;
+    }
+}
+
+// --- CLI symlink so `ccteam start` works from a terminal --------------------
+function symlinkCli() {
+    const localBin = path.join(os.homedir(), '.local', 'bin');
+    try {
+        fs.mkdirSync(localBin, { recursive: true });
+    } catch (e) {
+        console.error(
+            `[ccteam] CLI symlink skipped (mkdir ${localBin} failed: ${e.message})`,
+        );
+        return;
+    }
+    const link = path.join(localBin, 'ccteam');
+    try {
+        const st = fs.lstatSync(link);
+        if (st.isSymbolicLink() || st.isFile()) fs.unlinkSync(link);
+    } catch (_) {
+        /* link absent — fine */
+    }
+    try {
+        fs.symlinkSync(BINARY, link);
+        console.error(`[ccteam] CLI symlinked: ${link} -> ${BINARY}`);
+    } catch (e) {
+        console.error(
+            `[ccteam] CLI symlink skipped (${e.message}); add ${BIN_DIR} to $PATH manually if you want \`ccteam\` on PATH`,
+        );
+    }
+}
+
+// --- tmux soft-check ---------------------------------------------------------
+function checkTmux() {
+    const r = spawnSync('sh', ['-c', 'command -v tmux'], { stdio: 'ignore' });
+    if (r.status !== 0) {
+        console.error(
+            '[ccteam] warning: tmux not found on PATH — chat-mode features (long-running IM bots, /ccteam-creator) will be unavailable. Install: `brew install tmux` (macOS) or `apt install tmux` (Debian/Ubuntu).',
+        );
+    }
+}
+
+// --- main --------------------------------------------------------------------
+async function main() {
+    console.error(`[ccteam] launching inside host=${HOST}, version=${TAG}`);
+    if (needsDownload()) {
+        const suffix = targetSuffix();
+        const asset = `ccteam-${TAG}-${suffix}.tar.gz`;
+        const url = `https://github.com/firstintent/ccteam/releases/download/${TAG}/${asset}`;
+        console.error(`[ccteam] downloading ${asset} ...`);
+        try {
+            await downloadAndExtract(url, BIN_DIR);
+        } catch (e) {
+            console.error(`[ccteam] download failed: ${e.message}`);
+            console.error(
+                `[ccteam] fallback: install the CLI binary manually with \`curl -sSL https://raw.githubusercontent.com/firstintent/ccteam/main/install.sh | sh\` and re-run.`,
+            );
+            process.exit(1);
+        }
+        if (!fs.existsSync(BINARY)) {
+            console.error(
+                `[ccteam] extraction left no binary at ${BINARY} — archive layout drift?`,
+            );
+            process.exit(1);
+        }
+        fs.chmodSync(BINARY, 0o755);
+        symlinkCli();
+        console.error(`[ccteam] installed binary at ${BINARY}`);
+    }
+    checkTmux();
+    const child = spawn(BINARY, ['mcp-serve'], {
+        env: { ...process.env, CCTEAM_HOST: HOST },
+        stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    process.stdin.pipe(child.stdin);
+    child.stdout.pipe(process.stdout);
+    child.on('exit', (code, signal) => {
+        if (signal) {
+            console.error(`[ccteam] mcp-serve killed by ${signal}`);
+            process.exit(128);
+        }
+        process.exit(code ?? 0);
+    });
+    child.on('error', (err) => {
+        console.error(`[ccteam] failed to spawn ${BINARY}: ${err.message}`);
+        process.exit(1);
+    });
+}
+
+main().catch((err) => {
+    console.error(`[ccteam] fatal: ${err.message}`);
+    process.exit(1);
+});


### PR DESCRIPTION
## What

Same repo now serves as **both** a Claude Code plugin **and** a Codex plugin. A zero-npm-dep Node.js bridge (`index.js`) handles binary lazy download + host detection + stdio proxy to `ccteam mcp-serve`.

## Why

- **Single-command install**: `/plugin install ccteam` (Claude) or `codex plugin marketplace add firstintent/ccteam` (Codex). No `install.sh` required, no `~/.local/bin/` PATH wrangling.
- **Binary in plugin sandbox** = PATH-independent; bridge auto-symlinks to `~/.local/bin/ccteam` so terminal `ccteam start` still works.
- **CCTEAM_HOST env injected** → Rust binary can branch behavior per host (V0.6.7 candidate; this PR does not act on it).
- **install.sh kept** as system-wide CLI fallback for headless / non-Claude/Codex workflows; README + quickstart lead with the plugin path.
- **Version SoT** = `.claude-plugin/plugin.json::version` — index.js reads it at startup and re-downloads the binary whenever `ccteam --version` does not match; no hardcoded version strings inside the bridge.

## Architecture

```
/plugin install ccteam  (Claude)   or   codex plugin marketplace add firstintent/ccteam
   |
   v Anthropic / Codex protocol clones repo + registers .mcp.json
   |
   v user calls any mcp__ccteam__* tool
   |
   v host spawns `node ${PLUGIN_ROOT}/index.js`
       |
       v index.js sniffs host (CLAUDE_PLUGIN_ROOT vs CODEX_ACTIVE/PLUGIN_ROOT env)
       v checks ${PLUGIN_ROOT}/bin/ccteam exists + version matches plugin.json
       v if missing/stale: download ccteam-vX.Y.Z-<platform>.tar.gz from GH Release
                          extract via `tar -xz --strip-components=1` -> ${PLUGIN_ROOT}/bin/
                          chmod +x, symlink ~/.local/bin/ccteam -> ${PLUGIN_ROOT}/bin/ccteam
       v soft-warn if tmux not on PATH (chat-mode features unavailable)
       v exec ccteam mcp-serve with env CCTEAM_HOST=claude|codex
       v pipe stdin/stdout (stderr passes through to host for diagnostics)
```

## Files

- **New**: `index.js` (218 LOC, zero npm deps — stdlib only), `.codex-plugin/plugin.json` (rich Codex UI metadata: interface block, brandColor, defaultPrompt).
- **Modified**: `.mcp.json` (command: `ccteam` -> `node ${CLAUDE_PLUGIN_ROOT}/index.js`), `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` (version drift 0.6.5 -> 0.6.6, matching workspace SoT — **no workspace bump**), `README.md` (lead with plugin install, install.sh demoted to "Advanced"), `docs/quickstart.md` (Step 1 rewritten: no CLI prereq; Codex sub-section added), `docs/troubleshooting.md` (3 new entries A3b/A3c/A3 update: bridge download failures, missing PATH symlink).

## Verify

- `node --check index.js` -> clean
- JSON validity (all 4 manifests: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`, `.mcp.json`) -> clean
- `cargo clippy --workspace --all-targets --locked -- -D warnings` -> 0 warnings (no Rust touched)
- `cargo fmt --all -- --check` -> clean
- `sh -n install.sh && dash -n install.sh` -> clean
- Baseline `cargo test --workspace --locked --no-fail-fast` -> 1545 passed, 95 failed; all 95 failures pre-exist on `origin/main` (ccteam-web SSE / SPA / webhook integration tests, env-dependent — port binding / 502 on this WSL host); zero new failures introduced (no Rust source modified).

## Test plan

- [ ] Tag a `v0.6.6` release once merged so the GH Release tarballs exist (current `firstintent/ccteam` has no release yet; bridge needs assets to download).
- [ ] Verify on Linux x86_64: `/plugin install ccteam` in a fresh Claude session, call any `mcp__ccteam__*` tool, confirm `~/.local/bin/ccteam` appears.
- [ ] Verify on macOS arm64: same as Linux + Gatekeeper bypass.
- [ ] Verify in a Codex session: `codex plugin marketplace add firstintent/ccteam`, confirm bridge picks `CCTEAM_HOST=codex`.
- [ ] Manual fallback: if `${CLAUDE_PLUGIN_ROOT}` env is not substituted by the host, switch `.mcp.json` to absolute path and re-test.