### PR TITLE
chore: restore .codex-plugin/ + Codex install one-liner (post-revert refinement)

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,35 @@
+{
+  "name": "ccteam",
+  "version": "0.6.6",
+  "description": "Multi-vendor (Claude + Codex) AI dev-team orchestration: 7 skills + 27 MCP tools + IM bots + dual-LLM voting.",
+  "author": {
+    "name": "FirstIntent"
+  },
+  "repository": "https://github.com/firstintent/ccteam",
+  "homepage": "https://github.com/firstintent/ccteam",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "claude-code",
+    "plugin",
+    "multi-agent",
+    "orchestration",
+    "mcp",
+    "telegram"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "ccteam",
+    "shortDescription": "Autonomous multi-agent dev team",
+    "longDescription": "An unattended multi-agent orchestration engine that drives software from intent to closed-loop delivery — Claude + Codex dual-vendor, file-system as control plane, 24/7 IM bots, dual-LLM voting.",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "brandColor": "#10A37F",
+    "defaultPrompt": [
+      "Use ccteam to scan this repo and tell me what it does",
+      "Use ccteam to run a long task overnight hands-off",
+      "Use ccteam to get a second opinion (Claude + Codex) on this design"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ claude
 /plugin install ccteam
 ```
 
+Inside any Codex session(same two-step works ── ccteam binary must be on `$PATH` from step 1):
+
+```
+codex plugin marketplace add firstintent/ccteam
+```
+
 ```
 # 3. Try the universal entry — describe what you want in any language:
 /ccteam "scan this repo and tell me what it does"


### PR DESCRIPTION
PR #141 reverted dual-host Node bridge but also dropped Codex manifest. Codex-side manifest is still useful in two-step install: install.sh handles binary, then either /plugin install ccteam (Claude) or codex plugin marketplace add (Codex) wires skills + .mcp.json. Both call ccteam mcp-serve via PATH. No bridge, no Node.js, no version bump.