### PR TITLE
v0.6.8: install.sh re-run polish + drop broken SKILL reference (F178/F179)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -162,6 +162,19 @@ main() {
     detect_sha256
     resolve_tag
 
+    # Short-circuit if already at TAG (CCTEAM_FORCE=1 to bypass).
+    # `ccteam --version` may print either `ccteam 0.6.8` or `0.6.8`; the
+    # release TAG may be `v0.6.8` — compare against both forms.
+    if [ -z "${CCTEAM_FORCE:-}" ] && command -v ccteam >/dev/null 2>&1; then
+        _current="$(ccteam --version 2>/dev/null | awk 'NR==1{print $NF}')"
+        _tag_no_v="${TAG#v}"
+        if [ -n "$_current" ] && { [ "$_current" = "$TAG" ] || [ "$_current" = "$_tag_no_v" ]; }; then
+            info "Already at $TAG; nothing to do."
+            info "(Set CCTEAM_FORCE=1 to reinstall anyway.)"
+            exit 0
+        fi
+    fi
+
     _asset="ccteam-${TAG}-${SUFFIX}.${EXT}"
     _base="https://github.com/${REPO}/releases/download/${TAG}"
     _url="${_base}/${_asset}"
@@ -212,6 +225,16 @@ main() {
     fi
 
     mkdir -p "$INSTALL_DIR"
+
+    # Warn if the daemon is currently running — the new binary won't be
+    # picked up until `ccteam stop && ccteam start` cycles the supervisor.
+    # `pgrep -f "ccteam start"` matches the argv (not just the comm name),
+    # so it won't false-positive on the installer's own shell children.
+    if command -v pgrep >/dev/null 2>&1 && pgrep -f "ccteam start" >/dev/null 2>&1; then
+        warn "ccteam daemon is running. Restart after install:"
+        printf '      ccteam stop && ccteam start\n\n'
+    fi
+
     mv "$_extracted" "$INSTALL_DIR/ccteam"
     chmod +x "$INSTALL_DIR/ccteam"
     info "${GREEN}Installed:${RESET} $INSTALL_DIR/ccteam ($TAG)"

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -381,13 +381,7 @@ render_project_mcp_json(current_ccteam_bin()) → project_dir/.mcp.json
 Merges into existing `.mcp.json` if present (does not clobber other
 servers).
 
-## 5.8  Ensure daemon is running
-
-Run `ccteam internal daemon ensure-running` so the workflow is
-picked up. If it was already running, the next reload tick (≤ 5s)
-will roster the new workflow.
-
-## 5.9  User reply
+## 5.8  User reply
 
 ```
 好了 ✓


### PR DESCRIPTION
## Summary

Small QoL PR:

- **F179** `install.sh`:
  - Short-circuits when `ccteam --version` already matches the resolved release tag (saves a multi-MB download on no-op re-runs). `CCTEAM_FORCE=1` bypasses.
  - Warns if `ccteam start` is currently running (the daemon won't pick up a new binary until restarted).
  - Does NOT add an uninstall path — pre-v1.0 wipe stays a documented manual `rm -rf` step.
- **F178**: removes `ccteam internal daemon ensure-running` from `ccteam-creator` SKILL Phase 5.8. That subcommand does not exist in the CLI surface. Section 5.9 (User reply) renumbered to 5.8.

User-facing doc sweep (quickstart / user-manual / recipes / troubleshooting) is deliberately deferred to a follow-up so it can use present-tense statements once the parallel fan-out + chat_handle PRs land.

## Test plan

- [x] `sh -n install.sh` (POSIX syntax check) exits 0
- [x] `dash -n install.sh` (strict POSIX) exits 0
- [ ] Manual: re-run `curl ... | sh` on a host already at the latest tag → short-circuit message + exit 0
- [ ] Manual: re-run with `CCTEAM_FORCE=1 sh install.sh` → proceeds normally
- [ ] Manual: with `ccteam start` running in another shell, run installer → warning shows
- [x] `grep -rn "ensure-running\|ensure_running" skills/` returns nothing
- [x] `cargo build --workspace --locked` still succeeds (no Rust changes — sanity check)

Refs `docs/versions/v0-6-8/README.md` §2.3.