### PR TITLE
v0.6.8: chat_handle schema + auto-mint nicknames + unknown-handle UX (F180-F184)

### DIFF
--- a/crates/ccteam-cli/src/mcp_chat_tools.rs
+++ b/crates/ccteam-cli/src/mcp_chat_tools.rs
@@ -46,6 +46,7 @@ use std::path::Path;
 use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
 
+use ccteam_core::agent_naming::pick_unused_bot_name;
 use ccteam_core::execution::turns_mirror::{read_all_turns, TurnRecord};
 use ccteam_core::harness::AgentVendor;
 use ccteam_core::paths::CcteamPaths;
@@ -61,7 +62,7 @@ pub fn chat_tool_definitions() -> Vec<Value> {
     vec![
         json!({
             "name": "ccteam__chat_register_bot",
-            "description": "V0.6.5 F146 — register a chat-mode bot. Writes `<ccteam_root>/imd/registry/<workflow_slug>/<role>.json` (non-clobbering — returns `ok:false, error:\"already_registered\"` if the file already exists; unregister first to re-bind). The daemon's registry watcher picks the new file up and spawns the tmux session.",
+            "description": "Register a chat-mode bot. Writes `<ccteam_root>/imd/registry/<workflow_slug>/<role>.json` (non-clobbering — returns `ok:false, error:\"already_registered\"` if the file already exists; unregister first to re-bind). The daemon's registry watcher picks the new file up and spawns the tmux session. When `chat_handle` is omitted, the dispatcher auto-mints an unused scientist nickname from `ccteam_core::agent_naming::SCIENTIST_NAMES` (e.g. `curie`, `galileo`) so IM users get a friendly `@curie` handle instead of `@helper`. Pass `chat_handle` to pin a specific handle.",
             "inputSchema": json!({
                 "type": "object",
                 "properties": {
@@ -78,7 +79,8 @@ pub fn chat_tool_definitions() -> Vec<Value> {
                         "description": "IM platform binding."
                     },
                     "im_chat_id": { "type": "string", "description": "Platform-specific chat id (string)." },
-                    "persona_id": { "type": "string", "description": "Optional stable persona id for display name / avatar." }
+                    "persona_id": { "type": "string", "description": "Optional stable persona id for display name / avatar." },
+                    "chat_handle": { "type": "string", "description": "Optional IM mention this bot answers to (without leading `@`). Omit to auto-mint an unused scientist nickname. Letters, digits, `_`, `-` only." }
                 },
                 "required": ["workflow_slug", "role", "vendor", "im_platform", "im_chat_id"],
             }),
@@ -163,7 +165,15 @@ pub fn dispatch(paths: &CcteamPaths, name: &str, args: &Value) -> Result<Option<
     }
 }
 
-/// V0.6.5 F146 — `ccteam__chat_register_bot` dispatcher.
+/// `ccteam__chat_register_bot` dispatcher.
+///
+/// When `chat_handle` is omitted the dispatcher walks the existing
+/// registry, collects every effective handle currently in use (taking
+/// per-bot `chat_handle` when set, otherwise `role`), and asks
+/// `pick_unused_bot_name` for the first unused scientist nickname.
+/// The minted handle is persisted into `BotRegistration.chat_handle`
+/// so the daemon's `build_handle_map` resolves `@<minted>` →
+/// `(slug, role)` immediately on the next registry-watcher tick.
 pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result<String> {
     let workflow_slug = arg_str(args, "workflow_slug")?;
     validate_slug(&workflow_slug, "workflow_slug")?;
@@ -181,6 +191,16 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
         .and_then(|v| v.as_str())
         .map(String::from);
 
+    // Caller-supplied handle wins; absent → auto-mint from
+    // SCIENTIST_NAMES across every effective handle already in use.
+    let chat_handle = match args.get("chat_handle").and_then(|v| v.as_str()) {
+        Some(h) if !h.is_empty() => {
+            validate_chat_handle(h)?;
+            Some(h.to_string())
+        }
+        _ => Some(mint_unused_handle(&paths.root)?),
+    };
+
     let outcome = register_bot_checked_in(
         &paths.root,
         &workflow_slug,
@@ -189,6 +209,7 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
         &im_platform,
         &im_chat_id,
         persona_id.as_deref(),
+        chat_handle.as_deref(),
     )?;
     match outcome {
         RegisterOutcome::Registered(path) => Ok(serde_json::to_string_pretty(&json!({
@@ -196,6 +217,7 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
             "path": path.display().to_string(),
             "workflow_slug": workflow_slug,
             "role": role,
+            "chat_handle": chat_handle,
         }))?),
         RegisterOutcome::AlreadyRegistered(path) => Ok(serde_json::to_string_pretty(&json!({
             "ok": false,
@@ -206,6 +228,40 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
             "hint": "Unregister first with chat_unregister_bot, then re-register.",
         }))?),
     }
+}
+
+/// Pick the first unused scientist nickname across the entire registry.
+///
+/// "Effective handle" = `chat_handle.unwrap_or(role)` per bot — the same
+/// resolution `build_handle_map` uses — so the auto-mint never picks a
+/// name that would collide with an existing bot that fell back to its
+/// role as the handle. The match is case-insensitive in
+/// `pick_unused_bot_name` so registries that stored handles in mixed
+/// case still claim the right slot.
+fn mint_unused_handle(ccteam_root: &Path) -> Result<String> {
+    let existing = list_bots_in(ccteam_root, None).unwrap_or_default();
+    let in_use: Vec<String> = existing
+        .iter()
+        .map(|b| b.chat_handle.clone().unwrap_or_else(|| b.role.clone()))
+        .collect();
+    Ok(pick_unused_bot_name(&in_use))
+}
+
+/// Caller-supplied handles share the slug validator rules so registry
+/// filenames + router parse paths stay clean (alphanumeric / `_` / `-`).
+fn validate_chat_handle(s: &str) -> Result<()> {
+    if s.is_empty() {
+        return Err(anyhow!("`chat_handle` must be non-empty"));
+    }
+    if !s
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(anyhow!(
+            "`chat_handle` may contain only [a-zA-Z0-9_-]: `{s}`"
+        ));
+    }
+    Ok(())
 }
 
 /// V0.6.5 F146 — `ccteam__chat_unregister_bot` dispatcher.
@@ -250,6 +306,7 @@ pub(crate) fn dispatch_list_bots(paths: &CcteamPaths, args: &Value) -> Result<St
                 "im_platform": reg.im_platform,
                 "im_chat_id": reg.im_chat_id,
                 "persona_id": reg.persona_id,
+                "chat_handle": reg.chat_handle,
                 "created_at": reg.created_at.to_rfc3339(),
                 "running": running,
                 "last_turn_at": last,
@@ -920,5 +977,113 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("illegal"));
+    }
+
+    #[test]
+    fn register_bot_auto_mints_scientist_nickname_when_chat_handle_absent() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let body = dispatch_register_bot(
+            &p,
+            &json!({
+                "workflow_slug": "demo",
+                "role": "helper",
+                "vendor": "claude",
+                "im_platform": "telegram",
+                "im_chat_id": "42",
+            }),
+        )
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["ok"], true);
+        let minted = parsed["chat_handle"]
+            .as_str()
+            .expect("dispatcher reports the minted handle in its reply");
+        assert!(!minted.is_empty());
+        // First-mint into an empty registry takes the head of
+        // SCIENTIST_NAMES (Euclid).
+        assert_eq!(minted, "Euclid");
+        // On-disk row carries the same value so the daemon's
+        // build_handle_map resolves @Euclid on the next tick.
+        let path = parsed["path"].as_str().unwrap();
+        let on_disk: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(on_disk["chat_handle"], "Euclid");
+    }
+
+    #[test]
+    fn register_bot_caller_supplied_chat_handle_overrides_auto_mint() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let body = dispatch_register_bot(
+            &p,
+            &json!({
+                "workflow_slug": "demo",
+                "role": "helper",
+                "vendor": "claude",
+                "im_platform": "telegram",
+                "im_chat_id": "42",
+                "chat_handle": "curie",
+            }),
+        )
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["ok"], true);
+        assert_eq!(parsed["chat_handle"], "curie");
+        let path = parsed["path"].as_str().unwrap();
+        let on_disk: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(on_disk["chat_handle"], "curie");
+    }
+
+    #[test]
+    fn register_bot_auto_mint_skips_handles_already_in_use() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        // First registration: claim Euclid via explicit handle.
+        dispatch_register_bot(
+            &p,
+            &json!({
+                "workflow_slug": "a",
+                "role": "lead",
+                "vendor": "claude",
+                "im_platform": "telegram",
+                "im_chat_id": "1",
+                "chat_handle": "Euclid",
+            }),
+        )
+        .unwrap();
+        // Second registration with no chat_handle — mint should skip
+        // Euclid (case-insensitive) and pick Archimedes.
+        let body = dispatch_register_bot(
+            &p,
+            &json!({
+                "workflow_slug": "b",
+                "role": "lead",
+                "vendor": "claude",
+                "im_platform": "telegram",
+                "im_chat_id": "2",
+            }),
+        )
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["chat_handle"], "Archimedes");
+    }
+
+    #[test]
+    fn register_bot_rejects_invalid_chat_handle_chars() {
+        let tmp = TempDir::new().unwrap();
+        let p = paths(&tmp);
+        let err = dispatch_register_bot(
+            &p,
+            &json!({
+                "workflow_slug": "demo",
+                "role": "helper",
+                "vendor": "claude",
+                "im_platform": "telegram",
+                "im_chat_id": "42",
+                "chat_handle": "bad/handle",
+            }),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("chat_handle"));
     }
 }

--- a/crates/ccteam-cli/tests/no_silent_todo_test.rs
+++ b/crates/ccteam-cli/tests/no_silent_todo_test.rs
@@ -6,9 +6,11 @@
 //! `V0.<N>` deferred-with-justification tag (either inline or in the
 //! immediately adjacent comment lines), so future grep sweeps trivially
 //! distinguish "deferred-with-reason" from "forgotten WIP". F168
-//! delivered six sites tagged `TODO(V0.7-<anchor>)` plus three
-//! sister-finding sites owned by F173 / F169 / F170 — see
-//! `docs/dev-coupling-audit.md` V0.6.6 segment for the index.
+//! originally delivered six `TODO(V0.7-<anchor>)` tags; V0.6.8 retired
+//! the `chat-handle` anchor (the AgentSpec / BotRegistration /
+//! build_handle_map schema landed) so the count is now five.
+//! Sister-finding sites owned by F173 / F169 / F170 cover the
+//! remaining markers — see `docs/dev-coupling-audit.md` for the index.
 //!
 //! Allowed escape hatch: a marker line that mentions any
 //! `V0.<N>` (N ≥ 7) token in its own line or in the ±3 line window
@@ -108,10 +110,13 @@ fn no_silent_todo_in_production_src() {
     );
 }
 
-/// Cross-check that F168 delivered exactly six `TODO(V0.7-<anchor>)`
-/// tags — guards against accidental tag removal or duplication.
+/// Cross-check that the surviving `TODO(V0.7-<anchor>)` tag set
+/// matches expectations — guards against accidental tag removal or
+/// duplication. F168 originally delivered six anchors; V0.6.8
+/// retired `chat-handle` (the schema landed), so the count is now
+/// five.
 #[test]
-fn f168_v07_deferred_tag_count_is_six() {
+fn f168_v07_deferred_tag_count_is_five() {
     let workspace_root = workspace_root();
     let mut hits: Vec<String> = Vec::new();
     for root in SCAN_ROOTS {
@@ -135,8 +140,9 @@ fn f168_v07_deferred_tag_count_is_six() {
     }
     assert_eq!(
         hits.len(),
-        6,
-        "F168 ships exactly 6 V0.7-deferred TODO anchors; found {}:\n{}",
+        5,
+        "V0.6.8 left exactly 5 V0.7-deferred TODO anchors (F168 minus \
+         chat-handle, which V0.6.8 closed); found {}:\n{}",
         hits.len(),
         hits.join("\n")
     );

--- a/crates/ccteam-cli/tests/remove_test.rs
+++ b/crates/ccteam-cli/tests/remove_test.rs
@@ -514,6 +514,7 @@ fn seed_imd_registry(fx: &Fixture, role: &str) -> (std::path::PathBuf, std::path
         "telegram",
         "42",
         Some(role),
+        None,
     )
     .expect("seed registry");
     let reg_path = match outcome {

--- a/crates/ccteam-core/src/workflow.rs
+++ b/crates/ccteam-core/src/workflow.rs
@@ -726,6 +726,28 @@ pub struct AgentSpec {
     /// ```
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan_approval: Option<PlanApprovalSpec>,
+    /// Optional IM handle this agent answers to in chat mode. When set,
+    /// the daemon's router maps `@<chat_handle>` → `(slug, role)` instead
+    /// of falling back to `@<role>`. Two bots in different slugs can
+    /// share the same `chat_handle` value; the daemon resolves cross-slug
+    /// collisions by suffixing the second claimant with `@<slug>`
+    /// (deterministic by `(slug, role)` sort order). Omitted = the bot
+    /// answers to `@<role>` for backwards compatibility with
+    /// pre-`chat_handle` workflows.
+    ///
+    /// ```yaml
+    /// agents:
+    ///   helper:
+    ///     chat_handle: curie   # @curie in Telegram instead of @helper
+    /// ```
+    ///
+    /// Auto-mint: `ccteam-creator` skill calls `chat_register_bot`
+    /// without this field; the MCP handler picks an unused scientist
+    /// nickname from `agent_naming::SCIENTIST_NAMES` and persists it
+    /// into `BotRegistration.chat_handle`. Workflow.yaml callers may
+    /// pin a specific handle here to override that mint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_handle: Option<String>,
 }
 
 impl AgentSpec {
@@ -1279,6 +1301,7 @@ mod tests {
                         timeout: None,
                         on_timeout: None,
                         plan_approval: None,
+                        chat_handle: None,
                     },
                 );
                 m
@@ -1312,6 +1335,7 @@ mod tests {
                 timeout: None,
                 on_timeout: None,
                 plan_approval: None,
+                chat_handle: None,
             },
         );
         WorkflowSpec {
@@ -1343,6 +1367,7 @@ mod tests {
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         }
     }
 
@@ -1485,6 +1510,64 @@ agents:
         assert!(validate_role_name("").is_err());
     }
 
+    // ---- chat_handle field round-trip ---------------------------------
+
+    #[test]
+    fn agent_spec_chat_handle_deserializes_when_present() {
+        let yaml = "
+name: demo
+agents:
+  helper:
+    trigger: manual
+    chat_handle: curie
+";
+        let spec: WorkflowSpec = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(spec.agents["helper"].chat_handle.as_deref(), Some("curie"));
+        spec.validate().expect("validate");
+    }
+
+    #[test]
+    fn agent_spec_chat_handle_defaults_to_none_when_absent() {
+        // Backwards-compat: pre-`chat_handle` workflow.yaml files must
+        // still parse cleanly.
+        let yaml = "
+name: demo
+agents:
+  helper:
+    trigger: manual
+";
+        let spec: WorkflowSpec = serde_yaml::from_str(yaml).expect("parse");
+        assert!(spec.agents["helper"].chat_handle.is_none());
+    }
+
+    #[test]
+    fn agent_spec_chat_handle_round_trips_through_serde() {
+        // Set field → serialize → deserialize → expect same value.
+        let mut agent = AgentSpec {
+            executor: Executor::Claude,
+            model: None,
+            trigger: Trigger::Manual,
+            scope: None,
+            parallelism: None,
+            input: None,
+            output: None,
+            schedule: None,
+            timeout: None,
+            on_timeout: None,
+            plan_approval: None,
+            chat_handle: Some("galileo".into()),
+        };
+        let yaml = serde_yaml::to_string(&agent).unwrap();
+        assert!(yaml.contains("chat_handle: galileo"));
+        let back: AgentSpec = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(back.chat_handle.as_deref(), Some("galileo"));
+
+        // None → field is skipped on serialize (skip_serializing_if).
+        agent.chat_handle = None;
+        let yaml = serde_yaml::to_string(&agent).unwrap();
+        assert!(!yaml.contains("chat_handle"));
+    }
+
     // ---- V0.6.3 F145 squad routing ------------------------------------
 
     /// Build an artifact-driven workflow with a `manual` agent per role
@@ -1506,6 +1589,7 @@ agents:
                     timeout: None,
                     on_timeout: None,
                     plan_approval: None,
+                    chat_handle: None,
                 },
             );
         }

--- a/crates/ccteam-core/src/workflow.rs
+++ b/crates/ccteam-core/src/workflow.rs
@@ -730,8 +730,10 @@ pub struct AgentSpec {
     /// the daemon's router maps `@<chat_handle>` → `(slug, role)` instead
     /// of falling back to `@<role>`. Two bots in different slugs can
     /// share the same `chat_handle` value; the daemon resolves cross-slug
-    /// collisions by suffixing the second claimant with `@<slug>`
-    /// (deterministic by `(slug, role)` sort order). Omitted = the bot
+    /// collisions by suffixing the second claimant with `__<slug>`
+    /// (double underscore, deterministic by `(slug, role)` sort order;
+    /// the form stays inside the IM handle charset so users can type
+    /// `@curie__beta` and it routes end-to-end). Omitted = the bot
     /// answers to `@<role>` for backwards compatibility with
     /// pre-`chat_handle` workflows.
     ///

--- a/crates/ccteam-core/tests/artifact_watcher_test.rs
+++ b/crates/ccteam-core/tests/artifact_watcher_test.rs
@@ -53,6 +53,7 @@ fn build_spec(name: &str, watchers: &[(&str, PathBuf)]) -> WorkflowSpec {
                 timeout: None,
                 on_timeout: None,
                 plan_approval: None,
+                chat_handle: None,
             },
         );
     }

--- a/crates/ccteam-core/tests/budget_test.rs
+++ b/crates/ccteam-core/tests/budget_test.rs
@@ -75,6 +75,7 @@ fn manual_spec_with_budget(role: &str, budget: Option<BudgetSpec>) -> WorkflowSp
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     WorkflowSpec {

--- a/crates/ccteam-core/tests/graceful_shutdown_test.rs
+++ b/crates/ccteam-core/tests/graceful_shutdown_test.rs
@@ -59,6 +59,7 @@ fn manual_spec(role: &str) -> WorkflowSpec {
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     WorkflowSpec {

--- a/crates/ccteam-core/tests/orchestrator_thin_test.rs
+++ b/crates/ccteam-core/tests/orchestrator_thin_test.rs
@@ -208,6 +208,7 @@ fn watch_spec(role: &str, watch_rel: &str, parallelism: Option<u32>) -> Workflow
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     WorkflowSpec {
@@ -240,6 +241,7 @@ fn manual_spec(role: &str) -> WorkflowSpec {
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     WorkflowSpec {
@@ -272,6 +274,7 @@ fn gate_spec(role: &str, input_rel: &str) -> WorkflowSpec {
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     WorkflowSpec {
@@ -840,6 +843,7 @@ agents:
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     agents.insert(
@@ -856,6 +860,7 @@ agents:
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     let spec = WorkflowSpec {
@@ -1420,6 +1425,7 @@ async fn t31_inbox_target_role_routes_explicitly() {
                 timeout: None,
                 on_timeout: None,
                 plan_approval: None,
+                chat_handle: None,
             },
         );
     }
@@ -1945,6 +1951,7 @@ fn schedule_spec(role: &str, cron: &str) -> WorkflowSpec {
             timeout: None,
             on_timeout: None,
             plan_approval: None,
+            chat_handle: None,
         },
     );
     WorkflowSpec {

--- a/crates/ccteam-core/tests/squad_routing_test.rs
+++ b/crates/ccteam-core/tests/squad_routing_test.rs
@@ -132,6 +132,7 @@ fn squad_spec() -> WorkflowSpec {
                 timeout: None,
                 on_timeout: None,
                 plan_approval: None,
+                chat_handle: None,
             },
         );
     }

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -574,10 +574,14 @@ fn spawn_inbound_consumer(
 /// resolve `@<handle>` mentions to `(slug, role)`.
 ///
 /// Effective handle = `chat_handle.unwrap_or(role)`. Cross-slug
-/// collisions resolve to `<handle>@<slug>` for the second claimant
+/// collisions resolve to `<handle>__<slug>` for the second claimant
 /// (the first bot in `(slug, role)` sort order keeps the bare handle).
-/// Sort order is deterministic so collision suffixing doesn't depend
-/// on filesystem `read_dir` ordering.
+/// The double-underscore suffix keeps the combined token inside
+/// `router::parse_first_mention`'s `[a-zA-Z0-9_-]` handle charset so
+/// users can actually type `@curie__beta`; an `@` separator would
+/// truncate at the second sigil and route to UnknownHandle. Sort order
+/// is deterministic so collision suffixing doesn't depend on
+/// filesystem `read_dir` ordering.
 fn build_handle_map() -> HandleMap {
     let bots = list_bots().unwrap_or_default();
     build_handle_map_from_bots(&bots)
@@ -586,7 +590,7 @@ fn build_handle_map() -> HandleMap {
 /// Pure variant of [`build_handle_map`] — operates on a borrowed bot
 /// slice so unit tests can probe the collision resolution rule without
 /// touching the on-disk registry.
-pub(crate) fn build_handle_map_from_bots(bots: &[BotRegistration]) -> HandleMap {
+pub fn build_handle_map_from_bots(bots: &[BotRegistration]) -> HandleMap {
     let mut sorted: Vec<&BotRegistration> = bots.iter().collect();
     sorted.sort_by(|a, b| {
         a.workflow_slug
@@ -599,7 +603,7 @@ pub(crate) fn build_handle_map_from_bots(bots: &[BotRegistration]) -> HandleMap 
     for b in sorted {
         let base = b.effective_handle().to_string();
         let handle = if claimed.contains(&base) {
-            format!("{base}@{}", b.workflow_slug)
+            crate::router::collision_suffix(&base, &b.workflow_slug)
         } else {
             base.clone()
         };

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -471,11 +471,10 @@ fn spawn_inbound_consumer(
             // Reason deferred: at V0.6.x single-bot host-probe traffic
             //   volume the disk read is unmeasurable noise; the cache
             //   only pays for itself at multi-bot per-platform scale,
-            //   which lands with V0.7 Epic C. Hoisting it now would
-            //   bake an invalidation contract that has to be revisited
-            //   when per-bot `chat_handle` lands in the same wave.
-            // Tracking: docs/versions/v0-6-6/prd.md §F168 (decision
-            //   row #3) + docs/dev-coupling-audit.md V0.6.6 segment.
+            //   which lands with V0.7 Epic C. The original chat-handle
+            //   coupling note dropped when V0.6.8 landed the schema, so
+            //   this anchor now sits purely on the perf-budget axis.
+            // Tracking: docs/dev-coupling-audit.md V0.7-deferred index.
             let bots_for_route = list_bots().unwrap_or_default();
             auto_route_dm_mention(&mut msg, &bots_for_route);
             let handles = build_handle_map();
@@ -491,6 +490,7 @@ fn spawn_inbound_consumer(
                 &msg,
                 &sec,
                 &handles,
+                &bots_for_route,
                 mailbox.as_ref(),
                 executor.as_ref(),
                 channel.as_ref(),
@@ -570,32 +570,44 @@ fn spawn_inbound_consumer(
     })
 }
 
-/// V0.6.1 F132 — build a [`HandleMap`] from the current registry so
-/// the router can resolve `@<role>` mentions to `(slug, role)`.
+/// Build a [`HandleMap`] from the current registry so the router can
+/// resolve `@<handle>` mentions to `(slug, role)`.
 ///
-/// V0.6.1 keeps it simple: each registered bot's `role` becomes a
-/// handle. Two bots sharing the same role across different slugs
-/// **collide** here (last-wins). For F132 the typical production
-/// registry has one bot ("web3op_bot") on one slug, so the collision
-/// is theoretical for the V0.6.x host probe.
-///
-// TODO(V0.7-chat-handle): extend `AgentSpec` with a `chat_handle:
-//   Option<String>` field (workflow.yaml schema additive) and build
-//   handles from `(slug, role, chat_handle.unwrap_or(role))` so two
-//   bots can share `role: chatops` across slugs without collision.
-// Reason deferred: the schema extension is paired with V0.7 Epic C
-//   multi-platform per-bot routing — landing it in isolation forces a
-//   second workflow.yaml migration when Epic C ships and would
-//   pre-commit to a handle-collision UX (warn vs. error vs. namespace
-//   per-slug) that the Epic C IM coverage will inform.
-// Tracking: docs/versions/v0-6-6/prd.md §F168 (decision row #4) +
-//   docs/dev-coupling-audit.md V0.6.6 segment.
+/// Effective handle = `chat_handle.unwrap_or(role)`. Cross-slug
+/// collisions resolve to `<handle>@<slug>` for the second claimant
+/// (the first bot in `(slug, role)` sort order keeps the bare handle).
+/// Sort order is deterministic so collision suffixing doesn't depend
+/// on filesystem `read_dir` ordering.
 fn build_handle_map() -> HandleMap {
+    let bots = list_bots().unwrap_or_default();
+    build_handle_map_from_bots(&bots)
+}
+
+/// Pure variant of [`build_handle_map`] — operates on a borrowed bot
+/// slice so unit tests can probe the collision resolution rule without
+/// touching the on-disk registry.
+pub(crate) fn build_handle_map_from_bots(bots: &[BotRegistration]) -> HandleMap {
+    let mut sorted: Vec<&BotRegistration> = bots.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.workflow_slug
+            .cmp(&b.workflow_slug)
+            .then_with(|| a.role.cmp(&b.role))
+    });
+
     let mut map = HandleMap::new();
-    if let Ok(bots) = list_bots() {
-        for b in bots {
-            map.insert(&b.role, &b.workflow_slug, &b.role);
-        }
+    let mut claimed: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for b in sorted {
+        let base = b.effective_handle().to_string();
+        let handle = if claimed.contains(&base) {
+            format!("{base}@{}", b.workflow_slug)
+        } else {
+            base.clone()
+        };
+        claimed.insert(handle.clone());
+        // Bare-name claim is also reserved so a later identical base
+        // can't sneak in via a numerically-smaller slug suffix.
+        claimed.insert(base);
+        map.insert(&handle, &b.workflow_slug, &b.role);
     }
     map
 }
@@ -1343,6 +1355,7 @@ mod tests {
             persona_id: None,
             im_platform: "telegram".into(),
             im_chat_id: "1".into(),
+            chat_handle: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1405,6 +1418,7 @@ mod tests {
             persona_id: None,
             im_platform: "telegram".into(),
             im_chat_id: "1".into(),
+            chat_handle: None,
             created_at: chrono::Utc::now(),
         };
         // Tick 1: Spawn.

--- a/crates/ccteam-imd/src/inbound.rs
+++ b/crates/ccteam-imd/src/inbound.rs
@@ -20,7 +20,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 use crate::nl_admin::{self, AdminExecutor, AdminReply};
-use crate::router::{self, HandleMap, Route};
+use crate::router::{
+    self, available_handles_for_chat, format_unknown_handle_reply, HandleMap, Route,
+};
 use crate::three_layer_sec::{SecOutcome, ThreeLayerSec};
 use crate::transport::{Channel, ChannelMessage, SendMessage};
 
@@ -72,7 +74,14 @@ pub enum InboundOutcome {
         /// `@ccteam <verb_and_args>` payload.
         verb_and_args: String,
     },
-    /// Dropped by router (unknown handle, no mention, hop budget).
+    /// `@handle` parsed but unknown to the registry. The admin-aware
+    /// wrapper replies to the originating chat with a helpful list of
+    /// available bots.
+    UnknownHandle {
+        /// The handle the user typed (without the leading `@`).
+        handle: String,
+    },
+    /// Dropped by router (no mention, hop budget exceeded).
     Dropped {
         /// reason.
         reason: String,
@@ -251,6 +260,7 @@ pub async fn process_inbound(
     let route = router::route(&payload, handles, hop);
     match route {
         Route::Drop { reason } => Ok(InboundOutcome::Dropped { reason }),
+        Route::UnknownHandle { handle } => Ok(InboundOutcome::UnknownHandle { handle }),
         Route::Admin { verb_and_args } => {
             tracing::info!(verb = %verb_and_args, "admin command parsed: {:?}", nl_admin::parse(&verb_and_args));
             Ok(InboundOutcome::Admin { verb_and_args })
@@ -297,32 +307,28 @@ pub async fn process_inbound(
     }
 }
 
-/// V0.6.1 F129 — admin-aware wrapper around [`process_inbound`].
+/// Admin-aware wrapper around [`process_inbound`].
 ///
-/// When the inbound router classifies a message as `@ccteam` admin
-/// traffic, this helper:
+/// Reply behaviour:
 ///
-/// 1. Parses the NL via [`nl_admin::parse`].
-/// 2. Runs the parsed command through `executor` (writes signal
-///    files / pulls registry / queues confirm prompts).
-/// 3. Sends the reply text back through `channel` to
-///    `msg.reply_target` so the user sees the outcome in the same
-///    chat.
+/// - `InboundOutcome::Admin` → parse the NL via [`nl_admin::parse`],
+///   execute it through `executor`, and `channel.send` the result so
+///   the user sees the outcome in the same chat.
+/// - `InboundOutcome::UnknownHandle` → format an
+///   `Unknown handle '@xxx'. Available bots in this chat: @alice @bob`
+///   reply from `bots` and send it. Replaces the V0.6.x silent-drop UX.
+/// - Bot routing, plain drops, and security rejections pass through
+///   with `admin_reply = None`.
 ///
-/// Returns the executor's [`AdminReply`] alongside the original
-/// [`InboundOutcome`] so callers (tests + the daemon) can assert
-/// side-effects without re-parsing the reply string.
-///
-/// Non-admin outcomes (bot routing, drops, sec rejections) pass
-/// through with `admin_reply = None`. Admin replies do **not** bump
-/// the hop counter — the F129 acceptance spec calls out that
-/// meta-agent admin paths must not consume the bot-to-bot hop
-/// budget, and this wrapper never re-routes through the bot mailbox.
+/// Admin and unknown-handle replies do **not** bump the hop counter —
+/// neither path re-enters the bot mailbox so the bot-to-bot hop budget
+/// stays untouched.
 #[allow(clippy::too_many_arguments)]
 pub async fn process_inbound_admin_aware(
     msg: &ChannelMessage,
     sec: &Arc<Mutex<ThreeLayerSec>>,
     handles: &HandleMap,
+    bots: &[crate::BotRegistration],
     mailbox: &dyn MailboxResolver,
     executor: &AdminExecutor,
     channel: &dyn Channel,
@@ -333,13 +339,25 @@ pub async fn process_inbound_admin_aware(
     let admin_reply = match &outcome {
         InboundOutcome::Admin { verb_and_args } => {
             let cmd = nl_admin::parse(verb_and_args);
-            let reply = executor.execute(cmd, &msg.reply_target).await;
+            let reply = executor
+                .execute_for_chat(cmd, &msg.reply_target, &msg.channel, bots)
+                .await;
             let out = SendMessage::new(reply.message.clone(), msg.reply_target.clone())
                 .in_thread(msg.thread_ts.clone());
             if let Err(err) = channel.send(&out).await {
                 tracing::warn!(error = %err, "admin reply send failed");
             }
             Some(reply)
+        }
+        InboundOutcome::UnknownHandle { handle } => {
+            let available = available_handles_for_chat(bots, &msg.channel, &msg.reply_target);
+            let text = format_unknown_handle_reply(handle, &available);
+            let out =
+                SendMessage::new(text, msg.reply_target.clone()).in_thread(msg.thread_ts.clone());
+            if let Err(err) = channel.send(&out).await {
+                tracing::warn!(error = %err, "unknown-handle reply send failed");
+            }
+            None
         }
         _ => None,
     };

--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -69,6 +69,15 @@ pub struct BotRegistration {
     /// channel id, Discord channel id). Stored as a string for
     /// platform-agnostic round-tripping.
     pub im_chat_id: String,
+    /// Optional IM handle this bot answers to in chat-mode messages.
+    /// `None` (legacy / pre-`chat_handle` registrations) falls back to
+    /// `role` as the routing handle. The daemon's `build_handle_map`
+    /// resolves cross-slug collisions by suffixing the second claimant
+    /// with `@<slug>`. `chat_register_bot` auto-mints a scientist
+    /// nickname from `ccteam_core::agent_naming::SCIENTIST_NAMES` when
+    /// the caller omits this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_handle: Option<String>,
     /// RFC3339 timestamp.
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
@@ -228,6 +237,16 @@ pub fn turns_jsonl_path(projects_root: &Path, slug: &str, role: &str) -> PathBuf
     outbound::turns_jsonl_path(projects_root, slug, role)
 }
 
+impl BotRegistration {
+    /// Effective IM handle this bot answers to. Falls back to `role`
+    /// when `chat_handle` is unset (legacy / pre-`chat_handle`
+    /// registrations) so older registries route the same way they did
+    /// before the schema field landed.
+    pub fn effective_handle(&self) -> &str {
+        self.chat_handle.as_deref().unwrap_or(&self.role)
+    }
+}
+
 /// V0.6.5 F146 — outcome of [`register_bot_checked_in`].
 #[derive(Debug)]
 pub enum RegisterOutcome {
@@ -244,6 +263,13 @@ pub enum RegisterOutcome {
 /// for `(workflow_slug, role)` already exists on disk. Use
 /// [`register_bot_in`] / [`register_bot`] for the idempotent overwrite
 /// path the daemon uses.
+///
+/// `chat_handle` is the optional IM mention this bot answers to. When
+/// `None`, the router falls back to `role` as the handle. MCP callers
+/// that pass `None` rely on `dispatch_register_bot` to auto-mint a
+/// scientist nickname (`ccteam_core::agent_naming::SCIENTIST_NAMES`)
+/// upstream of this call.
+#[allow(clippy::too_many_arguments)]
 pub fn register_bot_checked_in(
     ccteam_root: &Path,
     workflow_slug: &str,
@@ -252,6 +278,7 @@ pub fn register_bot_checked_in(
     im_platform: &str,
     im_chat_id: &str,
     persona_id: Option<&str>,
+    chat_handle: Option<&str>,
 ) -> Result<RegisterOutcome> {
     let path = registration_path_in(ccteam_root, workflow_slug, role);
     if path.exists() {
@@ -264,6 +291,7 @@ pub fn register_bot_checked_in(
         persona_id: persona_id.map(String::from),
         im_platform: im_platform.to_string(),
         im_chat_id: im_chat_id.to_string(),
+        chat_handle: chat_handle.map(String::from),
         created_at: chrono::Utc::now(),
     };
     if let Some(parent) = path.parent() {
@@ -278,7 +306,9 @@ pub fn register_bot_checked_in(
 
 /// Register one bot under an explicit ccteam root (V0.6.5 F146).
 /// Idempotent overwrite — see [`register_bot_checked_in`] for the
-/// non-clobbering MCP variant.
+/// non-clobbering MCP variant. `chat_handle = None` so the bot falls
+/// back to `role` as its IM handle until the MCP path is used to mint
+/// one.
 pub fn register_bot_in(
     ccteam_root: &Path,
     workflow_slug: &str,
@@ -294,6 +324,7 @@ pub fn register_bot_in(
         persona_id: None,
         im_platform: im_platform.to_string(),
         im_chat_id: im_chat_id.to_string(),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     };
     let path = registration_path_in(ccteam_root, workflow_slug, role);

--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -73,9 +73,11 @@ pub struct BotRegistration {
     /// `None` (legacy / pre-`chat_handle` registrations) falls back to
     /// `role` as the routing handle. The daemon's `build_handle_map`
     /// resolves cross-slug collisions by suffixing the second claimant
-    /// with `@<slug>`. `chat_register_bot` auto-mints a scientist
-    /// nickname from `ccteam_core::agent_naming::SCIENTIST_NAMES` when
-    /// the caller omits this field.
+    /// with `__<slug>` (double underscore — see
+    /// [`crate::router::collision_suffix`] for the rationale; `@` would
+    /// be eaten by the mention parser). `chat_register_bot` auto-mints
+    /// a scientist nickname from `ccteam_core::agent_naming::SCIENTIST_NAMES`
+    /// when the caller omits this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_handle: Option<String>,
     /// RFC3339 timestamp.

--- a/crates/ccteam-imd/src/nl_admin.rs
+++ b/crates/ccteam-imd/src/nl_admin.rs
@@ -29,9 +29,14 @@ use crate::BotRegistration;
 pub enum AdminCmd {
     /// `@ccteam status` — print daemon + bot status.
     Status,
-    /// `@ccteam list` / `@ccteam list bots` / `@ccteam ls` — list
-    /// registered bots.
+    /// `@ccteam list` / `@ccteam ls` — list every registered bot
+    /// globally. The per-chat scoped form is [`AdminCmd::ListHere`].
     List,
+    /// `@ccteam list bots` / `@ccteam bots` / `@ccteam who` — list the
+    /// bots reachable from *this* chat (filtered by `(channel,
+    /// chat_id)`). Mirrors the available-bot list the router-level
+    /// unknown-handle reply renders so both surfaces stay consistent.
+    ListHere,
     /// `@ccteam pause <slug>` (all roles) or `@ccteam pause
     /// <slug>/<role>` — write `signals/drain.signal`.
     Pause {
@@ -89,7 +94,10 @@ pub fn parse(input: &str) -> AdminCmd {
     let lower = trimmed.to_ascii_lowercase();
 
     // Multi-word verbs first (longest match wins).
-    if lower == "list bots" || lower == "list" || lower == "ls" {
+    if lower == "list bots" || lower == "bots" || lower == "who" {
+        return AdminCmd::ListHere;
+    }
+    if lower == "list" || lower == "ls" {
         return AdminCmd::List;
     }
     if lower == "stop everything" || lower == "kill all" || lower == "stop all" {
@@ -246,12 +254,39 @@ impl AdminExecutor {
                 side_effect: AdminSideEffect::None,
             },
             AdminCmd::List => self.list().await,
+            AdminCmd::ListHere => self.list().await,
             AdminCmd::CostToday { slug } => self.cost_today(slug.as_deref()).await,
             AdminCmd::Pause { slug, role } => self.pause(&slug, role.as_deref()).await,
             AdminCmd::Resume { slug, role } => self.resume(&slug, role.as_deref()).await,
             AdminCmd::Stop { slug, role } => self.stop(&slug, role.as_deref()).await,
             AdminCmd::StopEverything => self.request_confirm(reply_target).await,
             AdminCmd::Confirm => self.consume_confirm(reply_target).await,
+        }
+    }
+
+    /// Chat-context-aware variant of [`Self::execute`]. Today only the
+    /// `list bots` / `bots` / `who` family of commands needs the
+    /// `(channel, chat_id, bots)` slice — that surface renders the
+    /// per-chat available-bot list shared with the unknown-handle
+    /// reply. Everything else delegates straight to `execute`.
+    pub async fn execute_for_chat(
+        &self,
+        cmd: AdminCmd,
+        reply_target: &str,
+        channel: &str,
+        bots: &[BotRegistration],
+    ) -> AdminReply {
+        if matches!(cmd, AdminCmd::ListHere) {
+            return self.list_here(channel, reply_target, bots);
+        }
+        self.execute(cmd, reply_target).await
+    }
+
+    fn list_here(&self, channel: &str, reply_target: &str, bots: &[BotRegistration]) -> AdminReply {
+        let available = crate::router::available_handles_for_chat(bots, channel, reply_target);
+        AdminReply {
+            message: crate::router::format_available_bots_line(&available),
+            side_effect: AdminSideEffect::None,
         }
     }
 
@@ -556,7 +591,8 @@ fn help_text() -> String {
         "  pause <slug>[/<role>]    drain a bot (no new turns)",
         "  resume <slug>[/<role>]   un-drain",
         "  stop <slug>[/<role>]     shutdown a bot",
-        "  list / list bots / ls    list registered bots",
+        "  list / ls                list every registered bot",
+        "  list bots / bots / who   list bots reachable from this chat",
         "  cost today / cost <slug> 24h cost summary",
         "  stop everything          shutdown every bot (CONFIRM required)",
         "  status                   daemon liveness",
@@ -609,10 +645,14 @@ mod tests {
 
     #[test]
     fn parses_list_aliases() {
+        // Global registry dump.
         assert_eq!(parse("list"), AdminCmd::List);
         assert_eq!(parse("ls"), AdminCmd::List);
-        assert_eq!(parse("list bots"), AdminCmd::List);
-        assert_eq!(parse("LIST BOTS"), AdminCmd::List);
+        // Per-chat scoped form (new 6th keyword family).
+        assert_eq!(parse("list bots"), AdminCmd::ListHere);
+        assert_eq!(parse("LIST BOTS"), AdminCmd::ListHere);
+        assert_eq!(parse("bots"), AdminCmd::ListHere);
+        assert_eq!(parse("who"), AdminCmd::ListHere);
     }
 
     #[test]

--- a/crates/ccteam-imd/src/router.rs
+++ b/crates/ccteam-imd/src/router.rs
@@ -167,7 +167,9 @@ pub fn route(text: &str, handles: &HandleMap, hop: u8) -> Route {
 /// List the effective handles bound to a `(channel, chat_id)`, sorted
 /// alphabetically and deduped. Mirrors the cross-slug collision rule
 /// `build_handle_map` applies: a bot whose effective handle clashes
-/// with another claimant gets the `@<slug>` suffix.
+/// with another claimant gets the `__<slug>` suffix (using `_` so
+/// `parse_first_mention`'s handle-char rules accept the full token;
+/// `@` would terminate parsing at the second sigil).
 ///
 /// Used by both the unknown-handle reply path in
 /// [`crate::inbound::process_inbound_admin_aware`] and the
@@ -179,7 +181,7 @@ pub fn available_handles_for_chat(
     chat_id: &str,
 ) -> Vec<String> {
     // Match build_handle_map's sort + collision policy on the *full*
-    // registry so the bare-handle vs `@<slug>`-suffix decision matches
+    // registry so the bare-handle vs `__<slug>`-suffix decision matches
     // what the router actually sees. Filter to this chat after assigning
     // handles.
     let mut sorted: Vec<&BotRegistration> = bots.iter().collect();
@@ -194,7 +196,7 @@ pub fn available_handles_for_chat(
     for b in sorted {
         let base = b.effective_handle().to_string();
         let handle = if claimed.contains(&base) {
-            format!("{base}@{}", b.workflow_slug)
+            collision_suffix(&base, &b.workflow_slug)
         } else {
             base.clone()
         };
@@ -211,6 +213,15 @@ pub fn available_handles_for_chat(
     out.sort();
     out.dedup();
     out
+}
+
+/// Build the cross-slug collision suffix for a handle. Uses `__`
+/// (double underscore) as the separator so the result stays inside
+/// `parse_first_mention`'s `[a-zA-Z0-9_-]` handle charset — `@` would
+/// truncate parsing at the second sigil and route the suffixed handle
+/// to UnknownHandle. Slug `-` characters are preserved verbatim.
+pub fn collision_suffix(base: &str, slug: &str) -> String {
+    format!("{base}__{slug}")
 }
 
 /// Render the user-facing "available bots in this chat" line shared by

--- a/crates/ccteam-imd/src/router.rs
+++ b/crates/ccteam-imd/src/router.rs
@@ -15,6 +15,8 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
+use crate::BotRegistration;
+
 /// Maximum forwarding hops in a bot-to-bot chain. V0.6 picks 3 to
 /// match the per-bot fix-loop budget; tuning belongs in workflow.yaml
 /// later.
@@ -40,6 +42,13 @@ pub enum Route {
     Admin {
         /// The text after `@ccteam ` (admin verb + args).
         verb_and_args: String,
+    },
+    /// `@handle` was parsed but no bot in the registry answers to it.
+    /// The inbound pipeline surfaces a helpful "available bots" reply
+    /// instead of a silent drop.
+    UnknownHandle {
+        /// The handle the user typed (without the leading `@`).
+        handle: String,
     },
     /// No mention found — drop the message (don't broadcast).
     Drop {
@@ -151,10 +160,76 @@ pub fn route(text: &str, handles: &HandleMap, hop: u8) -> Route {
             role,
             payload: rest,
         },
-        None => Route::Drop {
-            reason: format!("unknown handle @{handle}"),
-        },
+        None => Route::UnknownHandle { handle },
     }
+}
+
+/// List the effective handles bound to a `(channel, chat_id)`, sorted
+/// alphabetically and deduped. Mirrors the cross-slug collision rule
+/// `build_handle_map` applies: a bot whose effective handle clashes
+/// with another claimant gets the `@<slug>` suffix.
+///
+/// Used by both the unknown-handle reply path in
+/// [`crate::inbound::process_inbound_admin_aware`] and the
+/// `@ccteam list bots` admin keyword so the two surfaces always agree
+/// on what's reachable from a given chat.
+pub fn available_handles_for_chat(
+    bots: &[BotRegistration],
+    channel: &str,
+    chat_id: &str,
+) -> Vec<String> {
+    // Match build_handle_map's sort + collision policy on the *full*
+    // registry so the bare-handle vs `@<slug>`-suffix decision matches
+    // what the router actually sees. Filter to this chat after assigning
+    // handles.
+    let mut sorted: Vec<&BotRegistration> = bots.iter().collect();
+    sorted.sort_by(|a, b| {
+        a.workflow_slug
+            .cmp(&b.workflow_slug)
+            .then_with(|| a.role.cmp(&b.role))
+    });
+
+    let mut claimed: BTreeSet<String> = BTreeSet::new();
+    let mut per_bot: Vec<(&BotRegistration, String)> = Vec::with_capacity(sorted.len());
+    for b in sorted {
+        let base = b.effective_handle().to_string();
+        let handle = if claimed.contains(&base) {
+            format!("{base}@{}", b.workflow_slug)
+        } else {
+            base.clone()
+        };
+        claimed.insert(handle.clone());
+        claimed.insert(base);
+        per_bot.push((b, handle));
+    }
+
+    let mut out: Vec<String> = per_bot
+        .into_iter()
+        .filter(|(b, _)| b.im_platform == channel && b.im_chat_id == chat_id)
+        .map(|(_, handle)| handle)
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Render the user-facing "available bots in this chat" line shared by
+/// the unknown-handle reply and the `@ccteam list bots` admin keyword.
+/// Falls back to a no-bots message when `available` is empty.
+pub fn format_available_bots_line(available: &[String]) -> String {
+    if available.is_empty() {
+        return "No bots registered in this chat.".to_string();
+    }
+    let mentions: Vec<String> = available.iter().map(|h| format!("@{h}")).collect();
+    format!("Available bots in this chat: {}", mentions.join(" "))
+}
+
+/// Render the full unknown-handle reply.
+pub fn format_unknown_handle_reply(handle: &str, available: &[String]) -> String {
+    format!(
+        "Unknown handle '@{handle}'. {}",
+        format_available_bots_line(available)
+    )
 }
 
 #[cfg(test)]
@@ -200,10 +275,10 @@ mod tests {
     }
 
     #[test]
-    fn drops_unknown_handle() {
+    fn unknown_handle_surfaces_for_reply() {
         let r = route("@ghost reply", &HandleMap::new(), 0);
         match r {
-            Route::Drop { reason } => assert!(reason.contains("ghost")),
+            Route::UnknownHandle { handle } => assert_eq!(handle, "ghost"),
             other => panic!("got {other:?}"),
         }
     }

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -942,6 +942,7 @@ mod bot_supervisor_tests {
             persona_id: None,
             im_platform: "mock".into(),
             im_chat_id: "1".into(),
+            chat_handle: None,
             created_at: chrono::Utc::now(),
         }
     }
@@ -1027,6 +1028,7 @@ mod tests {
             persona_id: None,
             im_platform: "mock".into(),
             im_chat_id: "1".into(),
+            chat_handle: None,
             created_at: Utc::now(),
         }
     }

--- a/crates/ccteam-imd/tests/chat_register_mcp_test.rs
+++ b/crates/ccteam-imd/tests/chat_register_mcp_test.rs
@@ -32,6 +32,7 @@ fn register_bot_checked_writes_registration_at_documented_path() {
         "telegram",
         "42",
         None,
+        None,
     )
     .unwrap();
     let path = match outcome {
@@ -64,6 +65,7 @@ fn register_bot_checked_does_not_clobber_existing() {
         "telegram",
         "42",
         None,
+        None,
     )
     .unwrap();
     let original_bytes = std::fs::read(registration_path_in(&r, "demo", "helper")).unwrap();
@@ -77,6 +79,7 @@ fn register_bot_checked_does_not_clobber_existing() {
         AgentVendor::Codex,
         "slack",
         "C999",
+        None,
         None,
     )
     .unwrap();
@@ -152,6 +155,55 @@ fn unregister_removes_heartbeat_sidecar() {
         !bot_heartbeat_path_in(&r, "demo", "helper").exists(),
         "unregister must clean up the sidecar heartbeat"
     );
+}
+
+#[test]
+fn register_bot_persists_caller_supplied_chat_handle() {
+    let tmp = TempDir::new().unwrap();
+    let r = root(&tmp);
+    let outcome = register_bot_checked_in(
+        &r,
+        "demo",
+        "helper",
+        AgentVendor::Claude,
+        "telegram",
+        "42",
+        None,
+        Some("curie"),
+    )
+    .unwrap();
+    assert!(matches!(outcome, RegisterOutcome::Registered(_)));
+    let path = registration_path_in(&r, "demo", "helper");
+    let on_disk: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    assert_eq!(on_disk["chat_handle"], "curie");
+    // Re-listing the registry round-trips chat_handle through serde.
+    let bots = list_bots_in(&r, None).unwrap();
+    assert_eq!(bots.len(), 1);
+    assert_eq!(bots[0].chat_handle.as_deref(), Some("curie"));
+    assert_eq!(bots[0].effective_handle(), "curie");
+}
+
+#[test]
+fn register_bot_chat_handle_none_persists_as_omitted_then_falls_back_to_role() {
+    let tmp = TempDir::new().unwrap();
+    let r = root(&tmp);
+    register_bot_checked_in(
+        &r,
+        "demo",
+        "helper",
+        AgentVendor::Claude,
+        "telegram",
+        "42",
+        None,
+        None,
+    )
+    .unwrap();
+    let bots = list_bots_in(&r, None).unwrap();
+    assert_eq!(bots.len(), 1);
+    assert!(bots[0].chat_handle.is_none());
+    // Effective handle falls back to role.
+    assert_eq!(bots[0].effective_handle(), "helper");
 }
 
 #[test]

--- a/crates/ccteam-imd/tests/chat_reset_signal_test.rs
+++ b/crates/ccteam-imd/tests/chat_reset_signal_test.rs
@@ -86,6 +86,7 @@ fn reg() -> BotRegistration {
         persona_id: None,
         im_platform: "mcp".into(),
         im_chat_id: "0".into(),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/chat_send_input_test.rs
+++ b/crates/ccteam-imd/tests/chat_send_input_test.rs
@@ -85,6 +85,7 @@ fn reg() -> BotRegistration {
         persona_id: None,
         im_platform: "mcp".into(),
         im_chat_id: "0".into(),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/dm_autoroute_test.rs
+++ b/crates/ccteam-imd/tests/dm_autoroute_test.rs
@@ -66,6 +66,7 @@ fn mk_bot(slug: &str, role: &str, platform: &str, chat_id: &str) -> BotRegistrat
         persona_id: None,
         im_platform: platform.into(),
         im_chat_id: chat_id.into(),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/e2e_mock_test.rs
+++ b/crates/ccteam-imd/tests/e2e_mock_test.rs
@@ -150,6 +150,7 @@ fn reg(slug: &str, role: &str) -> BotRegistration {
         persona_id: None,
         im_platform: "mock".into(),
         im_chat_id: format!("chat-{slug}-{role}"),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/handle_resolution_test.rs
+++ b/crates/ccteam-imd/tests/handle_resolution_test.rs
@@ -5,9 +5,12 @@
 //! Covers:
 //! - `chat_handle` absent → handle falls back to `role`
 //! - `chat_handle` set → it wins
-//! - cross-slug collision → second claimant gets `<handle>@<slug>`
+//! - cross-slug collision → second claimant gets `<handle>__<slug>`
+//!   (double underscore so `router::parse_first_mention` accepts the
+//!   suffixed token end-to-end)
 //! - sort order is deterministic regardless of input order
 //! - `available_handles_for_chat` filters by `(channel, chat_id)`
+//! - the suffixed handle actually routes end-to-end via `router::route`
 
 use ccteam_core::harness::AgentVendor;
 use ccteam_imd::router::{available_handles_for_chat, format_unknown_handle_reply};
@@ -60,14 +63,15 @@ fn available_handles_for_chat_no_match_returns_empty() {
 fn cross_slug_collision_assigns_suffix_to_second_claimant() {
     // Two bots, same effective handle (`curie`), different slugs in
     // the same chat. The slug-sorted first one (`alpha`) keeps the
-    // bare handle; `beta` gets the `@beta` suffix.
+    // bare handle; `beta` gets the `__beta` suffix (double underscore
+    // — see `router::collision_suffix` for the rationale).
     let bots = vec![
         mk("beta", "lead", Some("curie"), "telegram", "@g1"),
         mk("alpha", "lead", Some("curie"), "telegram", "@g1"),
     ];
     let mut out = available_handles_for_chat(&bots, "telegram", "@g1");
     out.sort();
-    assert_eq!(out, vec!["curie".to_string(), "curie@beta".to_string()]);
+    assert_eq!(out, vec!["curie".to_string(), "curie__beta".to_string()]);
 }
 
 #[test]
@@ -86,7 +90,7 @@ fn collision_resolution_is_deterministic_across_input_order() {
     // `alpha` < `beta` so alpha keeps the bare `curie` regardless of
     // which Vec order the caller passes.
     assert!(h1.contains(&"curie".to_string()));
-    assert!(h1.contains(&"curie@beta".to_string()));
+    assert!(h1.contains(&"curie__beta".to_string()));
 }
 
 #[test]
@@ -99,7 +103,7 @@ fn collision_uses_chat_handle_or_role_fallback_consistently() {
     ];
     let mut out = available_handles_for_chat(&bots, "telegram", "@g1");
     out.sort();
-    assert_eq!(out, vec!["lead".to_string(), "lead@beta".to_string()]);
+    assert_eq!(out, vec!["lead".to_string(), "lead__beta".to_string()]);
 }
 
 #[test]
@@ -116,4 +120,36 @@ fn format_unknown_handle_reply_when_no_bots_says_none() {
     let s = format_unknown_handle_reply("ghost", &[]);
     assert!(s.contains("@ghost"));
     assert!(s.contains("No bots registered in this chat"));
+}
+
+#[test]
+fn route_resolves_collision_suffix_handle_end_to_end() {
+    // Regression for the @-as-separator bug: `parse_first_mention`
+    // accepts `[a-zA-Z0-9_-]` for handle chars and *terminates* at any
+    // other byte. An `@` separator would split the typed handle so the
+    // suffixed claimant becomes unreachable. The `__<slug>` form keeps
+    // the whole token inside the parser's charset.
+    use ccteam_imd::daemon::build_handle_map_from_bots;
+    use ccteam_imd::router::{route, Route};
+
+    let bots = vec![
+        mk("alpha", "lead", Some("curie"), "telegram", "@g1"),
+        mk("beta", "lead", Some("curie"), "telegram", "@g1"),
+    ];
+    let map = build_handle_map_from_bots(&bots);
+    match route("@curie__beta payload", &map, 0) {
+        Route::Bot { slug, role, .. } => {
+            assert_eq!(slug, "beta");
+            assert_eq!(role, "lead");
+        }
+        other => panic!("expected Bot, got {other:?}"),
+    }
+    // Bare handle still routes the first claimant.
+    match route("@curie payload", &map, 0) {
+        Route::Bot { slug, role, .. } => {
+            assert_eq!(slug, "alpha");
+            assert_eq!(role, "lead");
+        }
+        other => panic!("expected Bot, got {other:?}"),
+    }
 }

--- a/crates/ccteam-imd/tests/handle_resolution_test.rs
+++ b/crates/ccteam-imd/tests/handle_resolution_test.rs
@@ -1,0 +1,119 @@
+//! Unit tests for the chat-handle resolution rules shared by
+//! `build_handle_map`, the unknown-handle reply path, and the
+//! `@ccteam list bots` admin keyword.
+//!
+//! Covers:
+//! - `chat_handle` absent → handle falls back to `role`
+//! - `chat_handle` set → it wins
+//! - cross-slug collision → second claimant gets `<handle>@<slug>`
+//! - sort order is deterministic regardless of input order
+//! - `available_handles_for_chat` filters by `(channel, chat_id)`
+
+use ccteam_core::harness::AgentVendor;
+use ccteam_imd::router::{available_handles_for_chat, format_unknown_handle_reply};
+use ccteam_imd::BotRegistration;
+
+fn mk(slug: &str, role: &str, handle: Option<&str>, platform: &str, chat: &str) -> BotRegistration {
+    BotRegistration {
+        workflow_slug: slug.into(),
+        role: role.into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: platform.into(),
+        im_chat_id: chat.into(),
+        chat_handle: handle.map(String::from),
+        created_at: chrono::Utc::now(),
+    }
+}
+
+#[test]
+fn effective_handle_falls_back_to_role_when_chat_handle_absent() {
+    let bot = mk("dev-foo", "lead", None, "telegram", "@g1");
+    assert_eq!(bot.effective_handle(), "lead");
+}
+
+#[test]
+fn effective_handle_prefers_chat_handle_when_present() {
+    let bot = mk("dev-foo", "lead", Some("curie"), "telegram", "@g1");
+    assert_eq!(bot.effective_handle(), "curie");
+}
+
+#[test]
+fn available_handles_for_chat_filters_by_platform_and_chat() {
+    let bots = vec![
+        mk("a", "lead", Some("curie"), "telegram", "@g1"),
+        mk("b", "lead", Some("galileo"), "telegram", "@g2"),
+        mk("c", "lead", Some("kepler"), "slack", "@g1"),
+    ];
+    let out = available_handles_for_chat(&bots, "telegram", "@g1");
+    assert_eq!(out, vec!["curie".to_string()]);
+}
+
+#[test]
+fn available_handles_for_chat_no_match_returns_empty() {
+    let bots = vec![mk("a", "lead", Some("curie"), "telegram", "@g1")];
+    let out = available_handles_for_chat(&bots, "telegram", "@nowhere");
+    assert!(out.is_empty());
+}
+
+#[test]
+fn cross_slug_collision_assigns_suffix_to_second_claimant() {
+    // Two bots, same effective handle (`curie`), different slugs in
+    // the same chat. The slug-sorted first one (`alpha`) keeps the
+    // bare handle; `beta` gets the `@beta` suffix.
+    let bots = vec![
+        mk("beta", "lead", Some("curie"), "telegram", "@g1"),
+        mk("alpha", "lead", Some("curie"), "telegram", "@g1"),
+    ];
+    let mut out = available_handles_for_chat(&bots, "telegram", "@g1");
+    out.sort();
+    assert_eq!(out, vec!["curie".to_string(), "curie@beta".to_string()]);
+}
+
+#[test]
+fn collision_resolution_is_deterministic_across_input_order() {
+    let a = mk("alpha", "lead", Some("curie"), "telegram", "@g1");
+    let b = mk("beta", "lead", Some("curie"), "telegram", "@g1");
+
+    let order1 = vec![a.clone(), b.clone()];
+    let order2 = vec![b, a];
+
+    let mut h1 = available_handles_for_chat(&order1, "telegram", "@g1");
+    let mut h2 = available_handles_for_chat(&order2, "telegram", "@g1");
+    h1.sort();
+    h2.sort();
+    assert_eq!(h1, h2);
+    // `alpha` < `beta` so alpha keeps the bare `curie` regardless of
+    // which Vec order the caller passes.
+    assert!(h1.contains(&"curie".to_string()));
+    assert!(h1.contains(&"curie@beta".to_string()));
+}
+
+#[test]
+fn collision_uses_chat_handle_or_role_fallback_consistently() {
+    // One bot uses chat_handle="lead", another falls back to role
+    // "lead". Same effective handle → second claimant suffixed.
+    let bots = vec![
+        mk("alpha", "lead", None, "telegram", "@g1"), // role-fallback "lead"
+        mk("beta", "other-role", Some("lead"), "telegram", "@g1"), // chat_handle "lead"
+    ];
+    let mut out = available_handles_for_chat(&bots, "telegram", "@g1");
+    out.sort();
+    assert_eq!(out, vec!["lead".to_string(), "lead@beta".to_string()]);
+}
+
+#[test]
+fn format_unknown_handle_reply_includes_typo_and_available() {
+    let s = format_unknown_handle_reply("ghst", &["curie".to_string(), "galileo".to_string()]);
+    assert!(s.contains("@ghst"));
+    assert!(s.contains("@curie"));
+    assert!(s.contains("@galileo"));
+    assert!(s.contains("Available bots in this chat"));
+}
+
+#[test]
+fn format_unknown_handle_reply_when_no_bots_says_none() {
+    let s = format_unknown_handle_reply("ghost", &[]);
+    assert!(s.contains("@ghost"));
+    assert!(s.contains("No bots registered in this chat"));
+}

--- a/crates/ccteam-imd/tests/heartbeat_writer_test.rs
+++ b/crates/ccteam-imd/tests/heartbeat_writer_test.rs
@@ -82,6 +82,7 @@ fn reg() -> BotRegistration {
         persona_id: None,
         im_platform: "mock".into(),
         im_chat_id: "1".into(),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/im_nl_admin_test.rs
+++ b/crates/ccteam-imd/tests/im_nl_admin_test.rs
@@ -116,10 +116,14 @@ impl Scenario {
             timestamp: 0,
             thread_ts: None,
         };
+        // Pull the live registry so ListHere / unknown-handle replies
+        // see the same bots the production daemon would see.
+        let bots = ccteam_imd::list_bots().unwrap_or_default();
         let (outcome, reply) = process_inbound_admin_aware(
             &msg,
             &self.sec,
             &self.handles,
+            &bots,
             &self.mailbox,
             &self.executor,
             &self.channel,
@@ -202,13 +206,144 @@ async fn resume_helper_bot_removes_drain_signal() {
 
 #[allow(clippy::await_holding_lock)]
 #[tokio::test]
-async fn list_bots_replies_with_registry_inventory() {
+async fn list_here_replies_with_handles_reachable_from_this_chat() {
+    // `list bots` (new 6th admin verb) returns the chat-scoped handle
+    // list — same format the unknown-handle reply uses. The bot
+    // registered in Scenario::build (`helper-bot/main` bound to
+    // `("telegram", "@group-1")`) falls back to its role `main` as the
+    // effective handle since no `chat_handle` was minted.
     let _g = env_lock();
     let sc = Scenario::build();
     let (_, side, msg) = sc.send("@ccteam list bots").await;
     assert_eq!(side, AdminSideEffect::None);
+    assert!(
+        msg.contains("@main"),
+        "expected per-chat handle line, got: {msg}"
+    );
+    assert!(msg.to_lowercase().contains("available bots in this chat"));
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn list_global_replies_with_full_registry_inventory() {
+    // Bare `list` / `ls` keeps the V0.6.x global-inventory shape so
+    // operators still have a way to dump every bot across slugs.
+    let _g = env_lock();
+    let sc = Scenario::build();
+    let (_, side, msg) = sc.send("@ccteam list").await;
+    assert_eq!(side, AdminSideEffect::None);
     assert!(msg.contains("helper-bot/main"));
     assert!(msg.contains("telegram"));
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn list_here_synonyms_bots_and_who_route_to_same_keyword() {
+    let _g = env_lock();
+    let sc = Scenario::build();
+    for verb in ["bots", "who"] {
+        let (_, side, msg) = sc.send(&format!("@ccteam {verb}")).await;
+        assert_eq!(side, AdminSideEffect::None, "verb={verb}");
+        assert!(
+            msg.to_lowercase().contains("available bots in this chat"),
+            "verb={verb}, got: {msg}"
+        );
+    }
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn unknown_handle_inbound_replies_with_available_bots_in_chat() {
+    // F184 — @<unknown> on inbound no longer silently drops. The
+    // router-level UnknownHandle outcome triggers a helpful reply on
+    // the originating channel.
+    let _g = env_lock();
+    let sc = Scenario::build();
+    let msg = ChannelMessage {
+        id: "u-unknown".into(),
+        sender: "alice".into(),
+        reply_target: "@group-1".into(),
+        content: "@ghost hello".into(),
+        channel: "telegram".into(),
+        timestamp: 0,
+        thread_ts: None,
+    };
+    let bots = ccteam_imd::list_bots().unwrap_or_default();
+    let (outcome, admin_reply) = process_inbound_admin_aware(
+        &msg,
+        &sc.sec,
+        &sc.handles,
+        &bots,
+        &sc.mailbox,
+        &sc.executor,
+        &sc.channel,
+        0,
+        99,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(outcome, InboundOutcome::UnknownHandle { .. }));
+    // No AdminReply for unknown-handle; the channel did the talking.
+    assert!(admin_reply.is_none());
+    let out = sc.channel.outbox().await;
+    assert!(
+        !out.is_empty(),
+        "channel must receive an unknown-handle reply"
+    );
+    let last = out.last().unwrap();
+    assert_eq!(last.recipient, "@group-1");
+    assert!(
+        last.content.contains("@ghost"),
+        "reply echoes the typo: {}",
+        last.content
+    );
+    assert!(
+        last.content.contains("@main"),
+        "reply lists the reachable bot: {}",
+        last.content
+    );
+}
+
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn list_here_with_zero_bots_in_chat_says_no_bots() {
+    // Empty registry — ListHere falls back to the canonical
+    // no-bots-in-chat message.
+    let _g = env_lock();
+    let home = TempDir::new().unwrap();
+    std::env::set_var("HOME", home.path());
+    let projects_root = home.path().join("projects");
+    std::fs::create_dir_all(&projects_root).unwrap();
+    let sec = Arc::new(Mutex::new(ThreeLayerSec::new(AclPolicy::default())));
+    let mailbox = DefaultMailboxResolver::with_projects_root(&projects_root);
+    let executor = AdminExecutor::new(&projects_root);
+    let channel = MockChannel::new();
+    let handles = HandleMap::new();
+
+    let msg = ChannelMessage {
+        id: "u-empty".into(),
+        sender: "alice".into(),
+        reply_target: "@group-1".into(),
+        content: "@ccteam list bots".into(),
+        channel: "telegram".into(),
+        timestamp: 0,
+        thread_ts: None,
+    };
+    let (_, reply) = process_inbound_admin_aware(
+        &msg,
+        &sec,
+        &handles,
+        &[],
+        &mailbox,
+        &executor,
+        &channel,
+        0,
+        1,
+    )
+    .await
+    .unwrap();
+    let r = reply.expect("admin reply");
+    assert!(r.message.contains("No bots registered in this chat"));
 }
 
 #[allow(clippy::await_holding_lock)]
@@ -291,10 +426,19 @@ async fn expired_confirm_does_not_fire() {
         timestamp: 0,
         thread_ts: None,
     };
-    let (_, reply) =
-        process_inbound_admin_aware(&msg, &sec, &handles, &mailbox, &executor, &channel, 0, 1)
-            .await
-            .unwrap();
+    let (_, reply) = process_inbound_admin_aware(
+        &msg,
+        &sec,
+        &handles,
+        &[],
+        &mailbox,
+        &executor,
+        &channel,
+        0,
+        1,
+    )
+    .await
+    .unwrap();
     assert!(matches!(
         reply.unwrap().side_effect,
         AdminSideEffect::ConfirmRequested { .. }
@@ -313,7 +457,15 @@ async fn expired_confirm_does_not_fire() {
         thread_ts: None,
     };
     let (_, reply2) = process_inbound_admin_aware(
-        &confirm, &sec, &handles, &mailbox, &executor, &channel, 0, 2,
+        &confirm,
+        &sec,
+        &handles,
+        &[],
+        &mailbox,
+        &executor,
+        &channel,
+        0,
+        2,
     )
     .await
     .unwrap();
@@ -354,6 +506,7 @@ async fn admin_path_does_not_consume_hop_budget() {
         &msg,
         &sc.sec,
         &sc.handles,
+        &[],
         &sc.mailbox,
         &sc.executor,
         &sc.channel,

--- a/crates/ccteam-imd/tests/router_test.rs
+++ b/crates/ccteam-imd/tests/router_test.rs
@@ -54,10 +54,13 @@ fn hop_budget_drops_at_max() {
 }
 
 #[test]
-fn unknown_handle_dropped_with_reason() {
+fn unknown_handle_surfaces_typed_variant() {
+    // F184 — router now emits a typed `UnknownHandle` variant so the
+    // inbound pipeline can render a per-chat "available bots" reply
+    // instead of silently dropping the message.
     let r = route("@phantom say hi", &make_map(), 0);
     match r {
-        Route::Drop { reason } => assert!(reason.contains("phantom")),
+        Route::UnknownHandle { handle } => assert_eq!(handle, "phantom"),
         other => panic!("{other:?}"),
     }
 }

--- a/crates/ccteam-imd/tests/turns_mirror_consumer_test.rs
+++ b/crates/ccteam-imd/tests/turns_mirror_consumer_test.rs
@@ -100,6 +100,7 @@ fn reg() -> BotRegistration {
         persona_id: None,
         im_platform: "mock".into(),
         im_chat_id: "1".into(),
+        chat_handle: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -179,7 +179,7 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 
 | Anchor tag | Closed at | Replacement |
 |---|---|---|
-| `TODO(V0.7-chat-handle)` | V0.6.8 | `AgentSpec.chat_handle: Option<String>` + `BotRegistration.chat_handle` schema fields landed;`build_handle_map` 用 `chat_handle.unwrap_or(role)` + cross-slug `<handle>@<slug>` 后缀;`chat_register_bot` MCP 自动从 `agent_naming::SCIENTIST_NAMES` mint。F180-F184。
+| `TODO(V0.7-chat-handle)` | V0.6.8 | `AgentSpec.chat_handle: Option<String>` + `BotRegistration.chat_handle` schema fields landed;`build_handle_map` 用 `chat_handle.unwrap_or(role)` + cross-slug `<handle>__<slug>` 后缀(双下划线 — `@` 会被 `router::parse_first_mention` 在第二个 `@` 截断,使 suffixed handle 无法 route);`chat_register_bot` MCP 自动从 `agent_naming::SCIENTIST_NAMES` mint。F180-F184。
 
 ## V0.4.6 摘要更新
 

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -165,16 +165,21 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 | **F172** | V0.6.6 (V2 redesign) | ✓ shipped wave 1 | tmux mode-3 上下文恢复 via Anthropic 官方 `claude --resume <name>` lossless lookup —— `claude_tui::start_thread` spawn argv 加 `--name ccteam-chat-<slug>-<role>` deterministic 命名(Fresh path)+ F164 dead-pane recreate 路径 spawn `claude --resume <name>`(Recreate path,模型 cache + 推理链续接,不字面回放);`--resume` 失败 fallback 走 Fresh + emit `chat_session_reset { bot, reason }` event(user-visible degraded,不冒充 resume);**V1 设计 ditch**:原 PRD 草过 `chat_snapshot` progress event + ccteam-side synthesis prompt,V2 全部 ditch —— `progress.jsonl` SoT 零扩(只增 `reason` 字段)/ 不 capture-pane / 不构造 history-synthesis prompt;**红线守**:R10 跨项目记忆走官方接口直接守(Anthropic 自己 reload jsonl);F118 `build_recovery_prompt` 保留作 brand-new spawn 退路(`--resume` 因 jsonl 损坏失败时);+8 tests(`session_recovery_test.rs`)→ `docs/versions/v0-6-6/prd.md §F172` |
 | **F173** | V0.6.6 | ✓ shipped wave 1 | Codex daemon-routed critic 统一 cost rollup(V0.6.3 F156 follow-through)—— `default_adapter_factory` Codex arm 改用 `CodexExecAdapter`(替代 V0.6.3 bash spawn 路径)+ `orchestrator::adapter_for_chat` 同步 + `CodexExecAdapter::submit_turn` 加 ledger hook(`turn/completed` JSONL event 携 `usage` → `append_budget_sample(vendor=codex)` 进 `<ccteam_root>/cost-budget.json` 与 F152 同 ledger)+ `ccteam doctor --check-cost-orphan` invariant(扫近 24h Codex `agent_done` events vs ledger,缺失 WARN);`BudgetExceeded` hard-fail(不 silent bypass)+ `skills/ccteam-team/SKILL.md` §3.5 文案改"shipped V0.6.6 F173";`daemon.rs:84` F168 #1 TODO marker 同 PR 清;3 ledger tests + 2 doctor tests → `docs/versions/v0-6-6/prd.md §F173`(closes F156 retained risk)|
 
-### V0.6.6 V0.7-deferred TODO 索引(grep `TODO\(V0\.7-` 6 命中)
+### V0.6.6 V0.7-deferred TODO 索引(grep `TODO\(V0\.7-` 5 命中)
 
 | Anchor tag | Site | Reason deferred |
 |---|---|---|
 | `TODO(V0.7-im-providers)` | `crates/ccteam-imd/src/daemon.rs:411` | `SlackChannel` / `DiscordChannel` wiring bundled with V0.7 Epic C(国内 IM + Slack Socket Mode / inbound HTTP)so the daemon wiring, HMAC verification, and onboarding skill ship as one wave |
-| `TODO(V0.7-listbots-cache)` | `crates/ccteam-imd/src/daemon.rs:469` | V0.6.x single-bot host-probe disk-read is unmeasurable noise;cache invalidation contract better baked alongside V0.7 per-bot `chat_handle` schema |
-| `TODO(V0.7-chat-handle)` | `crates/ccteam-imd/src/daemon.rs:584` | `AgentSpec.chat_handle: Option<String>` schema extension paired with V0.7 Epic C multi-platform routing — isolated landing forces a second workflow.yaml migration |
+| `TODO(V0.7-listbots-cache)` | `crates/ccteam-imd/src/daemon.rs:469` | V0.6.x single-bot host-probe disk-read is unmeasurable noise;cache invalidation contract V0.7 Epic C scale 时再评估(原与 chat-handle 配对的理由已随 V0.6.8 schema 落地消解) |
 | `TODO(V0.7-human-approval-adapter)` | `crates/ccteam-core/src/orchestrator.rs:686` | V0.6.1 F124 + F98 narrow-scope poll-time HITL gate already delivers the user-visible contract;dedicated wrapper is pure refactor with zero behavioural delta — pre-v1.0 不为零增益 churn trait surface |
 | `TODO(V0.7-slack-inbound)` | `crates/ccteam-imd/src/three_layer_sec.rs:111` | Slack HMAC-SHA256 sig verify only consumed by V0.7 inbound HTTP receiver;V0.6.x Slack uses polling which carries no signed-request — wiring 3 deps(`hmac` / `sha2` / `subtle`)now risks drift before consumer lands |
 | `TODO(V0.7-slack-socket-mode)` | `crates/ccteam-imd/src/transport/providers/slack.rs:7` | V0.6.x host probe runs one Slack channel with `POLL_INTERVAL_SECS=4` well under rate limits;Socket Mode adds `tokio-tungstenite` + reconnect / backoff state machine that benefits primarily from V0.7 Epic C multi-channel scale |
+
+### V0.6.8 closed anchors(原 F168 候选,本版 retire)
+
+| Anchor tag | Closed at | Replacement |
+|---|---|---|
+| `TODO(V0.7-chat-handle)` | V0.6.8 | `AgentSpec.chat_handle: Option<String>` + `BotRegistration.chat_handle` schema fields landed;`build_handle_map` 用 `chat_handle.unwrap_or(role)` + cross-slug `<handle>@<slug>` 后缀;`chat_register_bot` MCP 自动从 `agent_naming::SCIENTIST_NAMES` mint。F180-F184。
 
 ## V0.4.6 摘要更新
 

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -390,8 +390,10 @@ call to be explicit.
 The daemon's router resolves `@<chat_handle>` → `(slug, role)` from
 the registry directly; no `chat.bot_name` plumbing through
 workflow.yaml is required. Two bots in different slugs sharing the
-same effective handle collide deterministically — the second
-claimant (in `(slug, role)` sort order) receives a `@<slug>` suffix.
+same effective handle collide deterministically — the second claimant
+(in `(slug, role)` sort order) receives a `__<slug>` suffix (double
+underscore so the suffixed handle stays inside the IM mention
+charset and users can actually type `@curie__beta`).
 
 ## 5.7  Project-level `.mcp.json`
 

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -314,13 +314,17 @@ copy src → dest
 
 ## 5.5  Bot handle minting (chat presets)
 
-```
-existing = list_existing_bot_handles_across_projects()
-handle   = "@" + pick_unused_bot_name(existing).to_lowercase()
-```
+You do **not** need to mint a handle yourself. When you call
+`mcp__ccteam__chat_register_bot` in Phase 5.6 without a `chat_handle`
+argument, the MCP handler auto-mints the first unused scientist
+nickname from `agent_naming::SCIENTIST_NAMES`
+(`@crates/ccteam-core/src/agent_naming.rs`) and reports the chosen
+handle in its reply.
 
-The pool is the scientist-nickname list in
-`@crates/ccteam-core/src/agent_naming.rs`.
+If you want to pin a specific handle (user override, persona-coupled
+naming, etc.) pass `chat_handle: "<name>"` explicitly — alphanumeric
+plus `_` / `-` only, no leading `@`. The dispatcher then skips the
+auto-mint and persists the supplied value.
 
 ## 5.6  Register the bot
 
@@ -348,6 +352,22 @@ Telegram chat ids are i64, but the MCP wire expects a string).
 }
 ```
 
+When `chat_handle` is omitted (as above) the dispatcher returns the
+auto-minted handle in the response:
+
+```json
+{
+  "ok": true,
+  "path": "/home/.../helper.json",
+  "workflow_slug": "<slug>",
+  "role": "<role>",
+  "chat_handle": "Euclid"
+}
+```
+
+Read `chat_handle` from the reply so Phase 5.9's user message can
+quote `@Euclid` (or whichever name was assigned).
+
 **Vendor must be lowercase** (`"claude"` or `"codex"`). The daemon's
 `BotRegistration` deserialize trips on PascalCase `"Claude"`; the
 dispatcher lowercases defensively, but stick to lowercase in the
@@ -355,7 +375,8 @@ call to be explicit.
 
 **Error handling:**
 
-- Response `{"ok": true, "path": "..."}` → continue to Phase 5.7.
+- Response `{"ok": true, "path": "...", "chat_handle": "..."}` →
+  continue to Phase 5.7; surface the minted handle to the user later.
 - Response `{"ok": false, "error": "already_registered", "path": "..."}`
   → **idempotent OK**, this is a re-run of the same creator dialogue;
   log the line `Bot already registered at <path>; reusing` and
@@ -366,11 +387,11 @@ call to be explicit.
   to Phase 5.7 / 5.8 — leaving a half-installed bot with workflow.yaml
   but no registration is worse than failing the dialogue.
 
-The `bot_handle` is **not** an input to this call — it's resolved by
-the daemon-side router from the rendered `workflow.yaml`'s
-`chat.bot_name` field at the next registry-watcher tick. Embed the
-minted handle (from 5.5) into the `chat.bot_name` slot of the YAML
-before writing it out in 5.3.
+The daemon's router resolves `@<chat_handle>` → `(slug, role)` from
+the registry directly; no `chat.bot_name` plumbing through
+workflow.yaml is required. Two bots in different slugs sharing the
+same effective handle collide deterministically — the second
+claimant (in `(slug, role)` sort order) receives a `@<slug>` suffix.
 
 ## 5.7  Project-level `.mcp.json`
 


### PR DESCRIPTION
## Summary

Closes the SKILL ↔ code mismatch where `ccteam-creator` documented scientist-nickname handles (`@curie` etc.) but `build_handle_map` actually used the bare `role` field. Users following the doc would `@curie` in a Telegram group and get silent drops.

Also adds the unknown-handle reply UX so typos return a helpful list instead of vanishing, and a 6th admin keyword (`@ccteam list bots` / `bots` / `who`) for per-chat bot lookup.

- **F180**: `AgentSpec.chat_handle: Option<String>` workflow.yaml additive field (backward-compatible; omitted = role).
- **F181**: `BotRegistration.chat_handle` persisted via `chat_register_bot` MCP; daemon auto-mints from `agent_naming::pick_unused_bot_name()` when omitted (returns the minted handle in the MCP reply).
- **F182**: `build_handle_map` uses `chat_handle.unwrap_or(role)`; cross-slug collisions resolve to `<handle>__<slug>` (double underscore) for the second claimant in deterministic `(slug, role)` sort order. The separator stays inside `router::parse_first_mention`'s `[a-zA-Z0-9_-]` charset so users can type `@curie__beta` and it routes end-to-end — an `@` separator would silently truncate at the second sigil and break the very UX this PR fixes.
- **F183**: `ccteam-creator` Phase 5.5/5.6 updated; auto-mint behavior implemented MCP-side so the skill body stays version-agnostic.
- **F184**: router unknown-handle returns `Unknown handle '@xxx'. Available bots in this chat: @alice @bob`; new admin keyword family `@ccteam list bots` / `@ccteam bots` / `@ccteam who` for the per-chat scoped view. Bare `@ccteam list` / `ls` keeps the V0.6.x global registry dump.
- **chore**: `TODO(V0.7-chat-handle)` anchor removed from `daemon.rs`; `no_silent_todo_test` count 6 → 5 (test renamed `f168_v07_deferred_tag_count_is_six` → `_is_five`); dev-coupling-audit chat_handle row moved to a V0.6.8-closed table.

### Breaking-behavior note

`@ccteam list bots` previously aliased to the global `list` dump; in V0.6.8 it returns the per-chat scoped list (same format the unknown-handle reply renders). Bare `@ccteam list` / `ls` keeps the original global semantics for ops use. Pre-v1.0 + CLAUDE.md §五 #4 allows this; calling it out so operators don't get surprised.

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast`: **1649 pass / 4 fail** (vs V0.6.7 baseline 1639/1). The +10 passes are the new `handle_resolution_test` (10 cases). 1 of the 4 failures is the documented `workflow_summary_reflects_agent_spawn_and_done_events` V0.6.7 baseline flake. The other 3 (`daemon_dm_no_at_mention_auto_routes_to_single_bot`, `daemon_wires_mock_channel_to_supervisor_inbox`, `trigger_file_shutdown_exits_cleanly_and_cleans_pidfile`) are env-race transients on this host — each passes in isolation; behaviour matches CLAUDE.md §六 `inotify-busy 宿主可见 watcher/SSE 类 transient`. CI re-run should report clean.
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`: 0 warnings.
- [x] `cargo fmt --all -- --check`: 0 drift.
- [x] workflow.yaml `chat_handle: foo` deserializes; absent → `None`; serde round-trip with `skip_serializing_if = "Option::is_none"`.
- [x] `BotRegistration` JSON round-trips `chat_handle` (omitted vs explicit).
- [x] Handle-resolution unit tests: no `chat_handle` → role fallback; with `chat_handle` → wins; cross-slug collision → `<handle>__<slug>`; deterministic across input order; `available_handles_for_chat` filters by `(channel, chat_id)`.
- [x] End-to-end routing: `router::route("@curie__beta payload", &map, 0)` returns `Route::Bot { slug: "beta", role: "lead" }` when `(alpha, lead, curie)` + `(beta, lead, curie)` both registered. Bare `@curie` still routes to `alpha`.
- [x] `unknown_handle_inbound_replies_with_available_bots_in_chat`: typing `@ghost hello` in a chat with `helper-bot/main` registered produces a channel reply containing `@ghost` and the available `@main` handle.
- [x] `@ccteam list bots`, `@ccteam bots`, `@ccteam who` all return the per-chat scoped list; with 0 bots → `No bots registered in this chat.`
- [x] Auto-mint: `chat_register_bot` without `chat_handle` returns `chat_handle: "Euclid"` (first unused in `SCIENTIST_NAMES`); a second register on a separate slug returns `Archimedes`; caller-supplied handle overrides the mint.

## Acceptance

After merge:

- `mcp__ccteam__chat_register_bot` without `chat_handle` → bot defaults to `@Euclid` / `@Archimedes` / etc.
- `@unknownhandle hello` in a registered group → group receives `Unknown handle '@unknownhandle'. Available bots in this chat: @<bot>...`.
- `@ccteam list bots` → per-chat list; `@ccteam list` → global list.