### PR TITLE
v0.6.8: chat-squad fan-out fix (F175/F176/F177)

### DIFF
--- a/crates/ccteam-core/src/execution/claude_tui.rs
+++ b/crates/ccteam-core/src/execution/claude_tui.rs
@@ -46,7 +46,7 @@ use serde_json::{json, Value};
 use tokio::sync::mpsc;
 
 use crate::execution::transcript_tail::{
-    self, anthropic_project_dir, cursor_path, discover_active_session, encode_project_cwd,
+    self, active_session_id_path, anthropic_project_dir, cursor_path, encode_project_cwd,
     PendingTools, TranscriptCursor,
 };
 use crate::execution::turns_mirror;
@@ -144,6 +144,15 @@ pub fn ensure_chat_hooks_installed(project_dir: &Path, hook_sh: &str) -> Result<
 
 fn claude_bin() -> String {
     std::env::var(CLAUDE_BIN_ENV).unwrap_or_else(|_| "claude".to_string())
+}
+
+/// Build the env var pairs forwarded into the tmux session at spawn so
+/// the Claude Code hook subprocess can derive role/slug. The hook reads
+/// `CCTEAM_CHAT_ROLE` via `std::env::var`; without these the hook's
+/// `derive_role_from_payload` falls back to `None` and every chat-mode
+/// progress event ships with `role=""`.
+fn chat_spawn_env<'a>(role: &'a str, slug: &'a str) -> Vec<(&'static str, &'a str)> {
+    vec![("CCTEAM_CHAT_ROLE", role), ("CCTEAM_CHAT_SLUG", slug)]
 }
 
 /// F164 — Probe whether a tmux session's pane process looks like a
@@ -289,8 +298,9 @@ impl HarnessAdapter for ClaudeTuiAdapter {
                     "--resume",
                     &session_id_name,
                 ];
+                let env = chat_spawn_env(&spec.role, &ctx.slug);
                 session
-                    .start(&ctx.cwd, &argv)
+                    .start_with_env(&ctx.cwd, &argv, &env)
                     .map_err(|e| HarnessError::SpawnFailed(format!("tmux start: {e}")))?;
 
                 // Detect `--resume` failure: claude exits non-zero quickly
@@ -318,8 +328,9 @@ impl HarnessAdapter for ClaudeTuiAdapter {
                         "--name",
                         &session_id_name,
                     ];
+                    let env = chat_spawn_env(&spec.role, &ctx.slug);
                     session
-                        .start(&ctx.cwd, &fresh_argv)
+                        .start_with_env(&ctx.cwd, &fresh_argv, &env)
                         .map_err(|e| HarnessError::SpawnFailed(format!("tmux start fresh: {e}")))?;
                     // Best-effort emit `chat_session_reset` with
                     // explicit reason so IM / web surfaces show the
@@ -354,8 +365,9 @@ impl HarnessAdapter for ClaudeTuiAdapter {
                 "--name",
                 &session_id_name,
             ];
+            let env = chat_spawn_env(&spec.role, &ctx.slug);
             session
-                .start(&ctx.cwd, &argv)
+                .start_with_env(&ctx.cwd, &argv, &env)
                 .map_err(|e| HarnessError::SpawnFailed(format!("tmux start: {e}")))?;
         }
 
@@ -637,10 +649,15 @@ async fn tail_loop(
         "claude-tui tail: inotify watcher armed (parent dir CREATE+MODIFY)"
     );
 
-    // One initial sweep — `read_new` against the most-recently-modified
-    // session file. Catches any content written between Claude start
-    // and our watcher arming.
-    if let Some((sid, path)) = discover_active_session(&cwd) {
+    // F177 — initial sweep targets the marker's sid. The marker is
+    // written by the chat-progress hook on SessionStart and carries
+    // Anthropic's real session_id. Each bot in a squad has its own
+    // marker under `<project>/.ccteam/chat/<role>/active-session-id`
+    // so three bots in one project dir never cross-fire (the V0.6.7
+    // fan-out bug — three tail loops all read whichever jsonl was
+    // most recently modified).
+    let marker_file = active_session_id_path(&project_dir, &role);
+    if let Some((sid, path)) = read_marker_target(&marker_file, &parent_dir) {
         if cursor.switch_session(&sid, encode_project_cwd(&cwd)) {
             pending.clear();
         }
@@ -660,6 +677,11 @@ async fn tail_loop(
                 if !matches!(evt.kind, EventKind::Create(_) | EventKind::Modify(_)) {
                     continue;
                 }
+                // Re-read the marker on every fs event — `/clear` /
+                // `/compact` rotates the sid and the hook overwrites
+                // the marker. Skip if missing (hook hasn't fired yet
+                // → wait for next event).
+                let Some(target_sid) = read_marker_sid(&marker_file) else { continue };
                 for affected in evt.paths.iter() {
                     if affected.extension().and_then(|s| s.to_str()) != Some("jsonl") {
                         continue;
@@ -667,6 +689,13 @@ async fn tail_loop(
                     let Some(sid) = affected.file_stem().and_then(|s| s.to_str()) else {
                         continue;
                     };
+                    // F177 — only drain the bot's target jsonl. Other
+                    // bots in the same project dir write their own
+                    // jsonls; we must NOT read them here or we fan-
+                    // out the same content to every bot's IM channel.
+                    if sid != target_sid {
+                        continue;
+                    }
                     // Switch via `TranscriptCursor::switch_session` so a
                     // sid we've seen before resumes at its prior offset
                     // — never re-reads. Closes the main-session ↔
@@ -682,9 +711,9 @@ async fn tail_loop(
                 // Safety-net poll. inotify rarely drops events on local
                 // ext4/btrfs, but a half-flushed line that didn't fire
                 // a MODIFY yet, or a fs that buffers writes, can leave
-                // bytes on disk we haven't observed. Just re-discover +
-                // read_new; usually a no-op.
-                if let Some((sid, path)) = discover_active_session(&cwd) {
+                // bytes on disk we haven't observed. Re-read marker +
+                // drain the targeted jsonl.
+                if let Some((sid, path)) = read_marker_target(&marker_file, &parent_dir) {
                     if cursor.switch_session(&sid, encode_project_cwd(&cwd)) {
                         pending.clear();
                     }
@@ -693,6 +722,34 @@ async fn tail_loop(
             }
         }
     }
+}
+
+/// Read just the sid from `<project>/.ccteam/chat/<role>/active-session-id`.
+/// Returns `None` when the marker is absent (hook hasn't fired yet) or
+/// unreadable. Trims whitespace because the hook writes the raw sid
+/// without a trailing newline but a future writer might.
+fn read_marker_sid(marker: &Path) -> Option<String> {
+    let body = std::fs::read_to_string(marker).ok()?;
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Resolve the marker to a `(sid, transcript_path)` pair the tail loop
+/// can drain. Returns `None` when the marker is missing OR when the
+/// targeted `<sid>.jsonl` doesn't exist yet under `<parent_dir>` — both
+/// are transient cold-start conditions; caller waits for the next fs
+/// event / safety-net tick.
+fn read_marker_target(marker: &Path, parent_dir: &Path) -> Option<(String, PathBuf)> {
+    let sid = read_marker_sid(marker)?;
+    let path = parent_dir.join(format!("{sid}.jsonl"));
+    if !path.exists() {
+        return None;
+    }
+    Some((sid, path))
 }
 
 /// Shared between the inotify-driven path and the safety-net branch:
@@ -741,6 +798,18 @@ async fn tail_loop_polling(
     tx: mpsc::Sender<ThreadEvent>,
 ) {
     let cursor_file = cursor_path(&project_dir, &role);
+    let marker_file = active_session_id_path(&project_dir, &role);
+    let parent_dir = match anthropic_project_dir(&cwd) {
+        Some(p) => p,
+        None => {
+            tracing::warn!(
+                cwd = %cwd.display(),
+                role,
+                "claude-tui tail (polling): HOME unset; cannot resolve anthropic projects dir"
+            );
+            return;
+        }
+    };
     let mut cursor = TranscriptCursor::load(&cursor_file).unwrap_or_default();
     let mut pending = PendingTools::new();
     let mut sleep_ms: u64 = 200;
@@ -749,7 +818,10 @@ async fn tail_loop_polling(
         if tx.is_closed() {
             return;
         }
-        let (sid, transcript_path) = match discover_active_session(&cwd) {
+        // F177 — marker-driven instead of `discover_active_session`.
+        // No fallback to most-recently-modified jsonl; if the hook
+        // hasn't published a marker yet, we wait.
+        let (sid, transcript_path) = match read_marker_target(&marker_file, &parent_dir) {
             Some(pair) => pair,
             None => {
                 tokio::time::sleep(Duration::from_millis(sleep_ms)).await;

--- a/crates/ccteam-core/src/execution/transcript_tail.rs
+++ b/crates/ccteam-core/src/execution/transcript_tail.rs
@@ -177,6 +177,18 @@ pub fn cursor_path(project_dir: &Path, bot_role: &str) -> PathBuf {
     super::turns_mirror::chat_dir(project_dir, bot_role).join("transcript-cursor.json")
 }
 
+/// Path to the marker file holding the bot's currently-active Anthropic
+/// session_id (the `<sid>.jsonl` basename under
+/// `~/.claude/projects/<encoded-cwd>/`). The `chat-progress` hook
+/// rewrites this on every `SessionStart` and clears it on
+/// `SessionEnd { reason: "clear" }`. The chat-mode tail loop reads it
+/// to target the correct jsonl deterministically — three bots in one
+/// project dir each get their own marker, so the tail loops can't
+/// cross-fire.
+pub fn active_session_id_path(project_dir: &Path, bot_role: &str) -> PathBuf {
+    super::turns_mirror::chat_dir(project_dir, bot_role).join("active-session-id")
+}
+
 /// Pick the most recently-modified **main-session** `<sid>.jsonl`
 /// under `~/.claude/projects/<encoded>/`. Returns `None` when the dir
 /// is missing, empty, or contains only subagent jsonls.

--- a/crates/ccteam-core/src/tmux.rs
+++ b/crates/ccteam-core/src/tmux.rs
@@ -88,6 +88,27 @@ impl TmuxSession {
     /// long phase prompts visible without truncation; user `tmux
     /// attach` resizes to the client window automatically.
     pub fn start(&self, working_dir: &Path, argv: &[&str]) -> Result<()> {
+        self.start_with_env(working_dir, argv, &[])
+    }
+
+    /// Like [`start`](Self::start) but injects extra environment
+    /// variables into the new session via `tmux new-session -e KEY=VAL`.
+    /// Each `(key, value)` pair becomes a single `-e KEY=VAL` flag placed
+    /// before `-s <name>` (the position tmux requires). Values are passed
+    /// via `Command::arg` so embedded whitespace or shell metacharacters
+    /// survive without manual quoting.
+    ///
+    /// Chat-mode spawn uses this to forward `CCTEAM_CHAT_ROLE` /
+    /// `CCTEAM_CHAT_SLUG` to the Claude Code hook subprocess so it can
+    /// derive the bot's role correctly when emitting `chat_*` progress
+    /// events (otherwise role lands as `""` and per-bot turns.jsonl /
+    /// active-session-id marker can't be addressed).
+    pub fn start_with_env(
+        &self,
+        working_dir: &Path,
+        argv: &[&str],
+        env: &[(&str, &str)],
+    ) -> Result<()> {
         if self.exists() {
             bail!("tmux session already exists: {}", self.name);
         }
@@ -99,9 +120,11 @@ impl TmuxSession {
             .ok_or_else(|| anyhow!("working_dir is not valid UTF-8: {}", working_dir.display()))?;
 
         let mut cmd = Command::new("tmux");
+        cmd.arg("new-session").arg("-d");
+        for (key, value) in env {
+            cmd.arg("-e").arg(format!("{key}={value}"));
+        }
         cmd.args([
-            "new-session",
-            "-d",
             "-s",
             &self.name,
             "-c",

--- a/crates/ccteam-core/tests/claude_tui_env_test.rs
+++ b/crates/ccteam-core/tests/claude_tui_env_test.rs
@@ -1,0 +1,100 @@
+//! F175 — verify chat-mode tmux spawn injects `CCTEAM_CHAT_ROLE` /
+//! `CCTEAM_CHAT_SLUG` into the new session's environment so the Claude
+//! Code hook subprocess can derive the bot role correctly.
+//!
+//! Without these env vars, `derive_role_from_payload` in
+//! `ccteam-hooks::chat_progress` falls back to `None`, and every
+//! `chat_*` progress event ships with `role=""` — breaking per-bot
+//! turns.jsonl routing and the F176 active-session-id marker.
+//!
+//! The test models on `claude_tui_resume_test.rs`: fake-claude shell
+//! script + `CCTEAM_CLAUDE_BIN` redirect + `tmux show-environment` to
+//! inspect the session's env table.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use ccteam_core::execution::claude_tui::{chat_session_name, ClaudeTuiAdapter};
+use ccteam_core::harness::{AgentSpecBrief, HarnessAdapter, SpawnCtx, CLAUDE_BIN_ENV};
+use serial_test::serial;
+
+fn kill_session_quiet(name: &str) {
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", name])
+        .output();
+}
+
+fn fake_claude_sleep_script(tmp: &tempfile::TempDir) -> PathBuf {
+    let p = tmp.path().join("fake-claude");
+    std::fs::write(&p, "#!/bin/sh\nsleep 999\n").unwrap();
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+fn make_ctx(slug: &str, tmp: &tempfile::TempDir) -> SpawnCtx {
+    SpawnCtx {
+        slug: slug.to_string(),
+        sid: "chat-f175".into(),
+        cwd: tmp.path().to_path_buf(),
+        project_dir: tmp.path().to_path_buf(),
+        extra_args: vec![],
+        model_id: None,
+    }
+}
+
+fn show_env(session: &str, key: &str) -> Option<String> {
+    let out = std::process::Command::new("tmux")
+        .args(["show-environment", "-t", session, key])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(s)
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn fresh_spawn_injects_chat_role_and_slug_env() {
+    if !ccteam_core::tmux::tmux_available() {
+        eprintln!("skip: tmux not available");
+        return;
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let bin = fake_claude_sleep_script(&tmp);
+
+    let slug = format!("f175-env-{}", std::process::id());
+    let role = "alpha";
+    let session_name = chat_session_name(&slug, role);
+    kill_session_quiet(&session_name);
+
+    std::env::set_var(CLAUDE_BIN_ENV, bin.to_str().unwrap());
+    let brief = AgentSpecBrief {
+        role: role.to_string(),
+    };
+    let ctx = make_ctx(&slug, &tmp);
+
+    ClaudeTuiAdapter::new()
+        .start_thread(&brief, &ctx)
+        .await
+        .expect("fresh spawn must succeed");
+
+    // tmux `show-environment -t <session> KEY` prints `KEY=VAL` to stdout.
+    let role_line = show_env(&session_name, "CCTEAM_CHAT_ROLE")
+        .expect("CCTEAM_CHAT_ROLE must be set on the tmux session");
+    assert_eq!(role_line, format!("CCTEAM_CHAT_ROLE={role}"));
+
+    let slug_line = show_env(&session_name, "CCTEAM_CHAT_SLUG")
+        .expect("CCTEAM_CHAT_SLUG must be set on the tmux session");
+    assert_eq!(slug_line, format!("CCTEAM_CHAT_SLUG={slug}"));
+
+    kill_session_quiet(&session_name);
+    std::env::remove_var(CLAUDE_BIN_ENV);
+}

--- a/crates/ccteam-core/tests/claude_tui_fanout_test.rs
+++ b/crates/ccteam-core/tests/claude_tui_fanout_test.rs
@@ -1,0 +1,197 @@
+//! F177 — squad-mode fan-out acceptance test.
+//!
+//! Three bots share one project dir → three `tail_loop`s simultaneously.
+//! Before F177, each loop called `discover_active_session(cwd)` which
+//! picked the most-recently-modified `<sid>.jsonl` under
+//! `~/.claude/projects/<encoded-cwd>/`, so all three loops read whichever
+//! jsonl bot-A just wrote → fan-out (every `@<bot>` in the group chat
+//! triggered three identical replies).
+//!
+//! With F177 each bot's tail loop is targeted at the sid recorded in
+//! `<project>/.ccteam/chat/<role>/active-session-id` (written by the
+//! F176 chat-progress hook on SessionStart). When bot-A appends a turn
+//! to its own jsonl, only bot-A's event stream should observe it.
+//!
+//! This test exercises the tail loop end-to-end via
+//! `ClaudeTuiAdapter::events`, plants the markers + transcripts that
+//! the production hook + Anthropic CLI would have created, then asserts
+//! per-stream isolation. It doesn't depend on tmux because the tail
+//! loop only reads from disk.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use ccteam_core::execution::claude_tui::ClaudeTuiAdapter;
+use ccteam_core::execution::transcript_tail::{active_session_id_path, encode_project_cwd};
+use ccteam_core::harness::{
+    AgentVendor, ExecutionMode, HarnessAdapter, ThreadEvent, ThreadHandle, ThreadItemDetails,
+};
+use futures::StreamExt;
+use serde_json::json;
+use serial_test::serial;
+use tempfile::TempDir;
+
+/// Assemble a `ThreadHandle` that drives `ClaudeTuiAdapter::events`
+/// straight into a tail loop pointed at our hermetic temp tree.
+fn make_handle(project_dir: &Path, cwd: &Path, role: &str) -> ThreadHandle {
+    ThreadHandle {
+        vendor: AgentVendor::Claude,
+        mode: ExecutionMode::Chat,
+        identity: format!("ccteam-chat-fanout-{role}"),
+        started_at: chrono::Utc::now(),
+        raw_extras: json!({
+            "tmux_session": format!("ccteam-chat-fanout-{role}"),
+            "role": role,
+            "project_dir": project_dir.to_string_lossy(),
+            "cwd": cwd.to_string_lossy(),
+            "slug": "fanout",
+        }),
+    }
+}
+
+/// Plant the active-session-id marker the way the F176 hook would.
+fn plant_marker(project_dir: &Path, role: &str, sid: &str) {
+    let marker = active_session_id_path(project_dir, role);
+    std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+    std::fs::write(&marker, sid).unwrap();
+}
+
+/// Path to a bot's Anthropic transcript jsonl under the hermetic HOME
+/// we point `dirs::home_dir` at via the `HOME` env var.
+fn transcript_path(home: &Path, cwd: &Path, sid: &str) -> PathBuf {
+    home.join(".claude")
+        .join("projects")
+        .join(encode_project_cwd(cwd))
+        .join(format!("{sid}.jsonl"))
+}
+
+/// Append one assistant-text transcript record to `path`. Models
+/// Anthropic's transcript jsonl line shape so `parse_transcript_line`
+/// emits an `ItemCompleted(AgentMessage)` event.
+fn append_assistant_turn(path: &Path, uuid: &str, text: &str) {
+    use std::io::Write as _;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    let row = serde_json::to_string(&json!({
+        "type": "assistant",
+        "uuid": uuid,
+        "message": {"content": [{"type": "text", "text": text}]}
+    }))
+    .unwrap();
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .unwrap();
+    writeln!(f, "{row}").unwrap();
+    f.sync_all().unwrap();
+}
+
+/// Drain a `BoxStream<ThreadEvent>` for up to `max_ms`, collecting
+/// every `ItemCompleted::AgentMessage` text seen. Returns when the
+/// budget elapses without a new event — short timeouts keep the
+/// negative-assertion fast.
+async fn collect_agent_messages(
+    mut stream: futures::stream::BoxStream<'static, ThreadEvent>,
+    max_ms: u64,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(max_ms);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, stream.next()).await {
+            Ok(Some(ThreadEvent::ItemCompleted { item })) => {
+                if let ThreadItemDetails::AgentMessage(text) = item.details {
+                    out.push(text);
+                }
+            }
+            Ok(Some(_)) => continue,
+            Ok(None) | Err(_) => break,
+        }
+    }
+    out
+}
+
+/// Three bots in one project dir. Only bot-A's transcript gets a new
+/// line; bots B/C must observe nothing on their event streams.
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn three_bots_one_project_only_target_bot_observes_turn() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    std::fs::create_dir_all(&home).unwrap();
+    std::env::set_var("HOME", &home);
+
+    let project_dir = tmp.path().join("proj");
+    let cwd = project_dir.clone();
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    // The Anthropic projects dir must exist before tail_loop arms its
+    // inotify watcher (otherwise it loops on the existence check).
+    let anth_dir = home
+        .join(".claude")
+        .join("projects")
+        .join(encode_project_cwd(&cwd));
+    std::fs::create_dir_all(&anth_dir).unwrap();
+
+    // Plant one marker per bot, pointing at a distinct sid.
+    let bots: [(&str, &str); 3] = [
+        ("alice", "sid-aaaa"),
+        ("bob", "sid-bbbb"),
+        ("carol", "sid-cccc"),
+    ];
+    for (role, sid) in bots {
+        plant_marker(&project_dir, role, sid);
+        // Pre-create each bot's jsonl as empty so `read_marker_target`
+        // sees it. Pre-creating also matters because the tail loop's
+        // initial sweep would otherwise return None until first MODIFY.
+        let path = transcript_path(&home, &cwd, sid);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "").unwrap();
+    }
+
+    let adapter = ClaudeTuiAdapter::new();
+    let h_a = make_handle(&project_dir, &cwd, bots[0].0);
+    let h_b = make_handle(&project_dir, &cwd, bots[1].0);
+    let h_c = make_handle(&project_dir, &cwd, bots[2].0);
+    let s_a = adapter.events(&h_a);
+    let s_b = adapter.events(&h_b);
+    let s_c = adapter.events(&h_c);
+
+    // Let the watchers arm before we trigger the event.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Bot-A receives a new turn. B and C jsonls remain unchanged.
+    let path_a = transcript_path(&home, &cwd, bots[0].1);
+    append_assistant_turn(&path_a, "uuid-a-1", "hello from alice");
+
+    // Concurrent collection — each stream gets the same wall-clock
+    // window to surface any cross-fire. The fanout bug would have all
+    // three streams emit "hello from alice"; F177 confines it to A.
+    let (msgs_a, msgs_b, msgs_c) = tokio::join!(
+        collect_agent_messages(s_a, 2000),
+        collect_agent_messages(s_b, 2000),
+        collect_agent_messages(s_c, 2000),
+    );
+
+    assert!(
+        msgs_a.iter().any(|t| t == "hello from alice"),
+        "bot A must observe its own turn; got: {msgs_a:?}"
+    );
+    assert!(
+        msgs_b.is_empty(),
+        "bot B must NOT observe bot A's turn (this is the fan-out bug); got: {msgs_b:?}"
+    );
+    assert!(
+        msgs_c.is_empty(),
+        "bot C must NOT observe bot A's turn (this is the fan-out bug); got: {msgs_c:?}"
+    );
+
+    std::env::remove_var("HOME");
+}

--- a/crates/ccteam-hooks/src/chat_progress.rs
+++ b/crates/ccteam-hooks/src/chat_progress.rs
@@ -25,6 +25,7 @@ use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 use std::path::Path;
 
+use ccteam_core::execution::transcript_tail::active_session_id_path;
 use ccteam_core::progress::{
     append_event, build_chat_compact_done_event, build_chat_session_reset_event,
     build_chat_session_started_event, build_chat_turn_completed_event,
@@ -51,7 +52,33 @@ pub fn handle_chat_progress(paths: &CcteamPaths, event: &str, stdin: &Value) -> 
     let target = paths.progress_jsonl_for_context(&context);
 
     let mut ev: Value = match event {
-        "session-start" => build_chat_session_started_event(&role, &project_dir),
+        "session-start" => {
+            // F176 — persist the bot's currently-active Anthropic
+            // session_id so the chat-mode tail loop can target the
+            // correct jsonl deterministically. Without this marker
+            // three bots in one project dir all read whichever jsonl
+            // was most recently modified (the F177 fan-out bug).
+            //
+            // Only write when both role and session_id are present;
+            // otherwise we'd clobber a valid marker with empty data.
+            if !role.is_empty() {
+                if let Some(sid) = stdin.get("session_id").and_then(|v| v.as_str()) {
+                    if !sid.is_empty() {
+                        let marker = active_session_id_path(Path::new(cwd), &role);
+                        if let Err(err) = write_marker_atomic(&marker, sid) {
+                            tracing::warn!(
+                                role = %role,
+                                session_id = %sid,
+                                path = %marker.display(),
+                                error = %err,
+                                "chat-progress: failed to write active-session-id marker"
+                            );
+                        }
+                    }
+                }
+            }
+            build_chat_session_started_event(&role, &project_dir)
+        }
         "user-prompt" => {
             let prompt = stdin.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
             let turn_id = stdin
@@ -89,6 +116,24 @@ pub fn handle_chat_progress(paths: &CcteamPaths, event: &str, stdin: &Value) -> 
                 .unwrap_or("other");
             // `/clear` / `clear` `/exit` `exit` all map to session reset.
             if reason == "clear" {
+                // F176 — clear the active-session-id marker on the
+                // rotation event. Other `session-end` reasons (process
+                // exit, daemon kill, network drop) do NOT rotate the
+                // sid — leave the marker alone so the next SessionStart
+                // hook overwrites with the new sid atomically.
+                if !role.is_empty() {
+                    let marker = active_session_id_path(Path::new(cwd), &role);
+                    if marker.exists() {
+                        if let Err(err) = std::fs::remove_file(&marker) {
+                            tracing::warn!(
+                                role = %role,
+                                path = %marker.display(),
+                                error = %err,
+                                "chat-progress: failed to clear active-session-id marker"
+                            );
+                        }
+                    }
+                }
                 build_chat_session_reset_event(&role)
             } else {
                 json!({
@@ -119,6 +164,21 @@ pub fn handle_chat_progress(paths: &CcteamPaths, event: &str, stdin: &Value) -> 
     }
 
     append_event(&target, &ev)?;
+    Ok(())
+}
+
+/// Atomic write of `body` to `path` via `<path>.tmp` + rename. Same
+/// pattern as `TranscriptCursor::save`. Creates parent dirs as needed
+/// because the hook subprocess may race ahead of the orchestrator's
+/// `ensure_dir` call on a brand-new spawn.
+fn write_marker_atomic(path: &Path, body: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| anyhow!("create {}: {e}", parent.display()))?;
+    }
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, body).map_err(|e| anyhow!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| anyhow!("rename {} -> {}: {e}", tmp.display(), path.display()))?;
     Ok(())
 }
 

--- a/crates/ccteam-hooks/tests/chat_progress_test.rs
+++ b/crates/ccteam-hooks/tests/chat_progress_test.rs
@@ -155,6 +155,178 @@ fn session_end_with_clear_reason_emits_chat_session_reset() {
 
 #[test]
 #[serial]
+fn session_start_writes_active_session_id_marker() {
+    // F176 — the hook persists Anthropic's real session_id (carried
+    // in stdin) to `<project>/.ccteam/chat/<role>/active-session-id`
+    // so the chat-mode tail loop can target the correct jsonl
+    // deterministically. This is the only reliable source for the sid
+    // because `--name` is just an internal label, not the filename.
+    let tmp = TempDir::new().unwrap();
+    let slug = "tcp-marker-write";
+    let (paths, project_dir) = setup_project(&tmp, slug);
+    std::env::set_var("CCTEAM_CHAT_ROLE", "alice");
+
+    let sid = "11111111-2222-3333-4444-555555555555";
+    let stdin = json!({
+        "hook_event_name": "SessionStart",
+        "session_id": sid,
+        "cwd": project_dir.to_string_lossy(),
+        "source": "startup",
+    });
+    handle_chat_progress(&paths, "session-start", &stdin).unwrap();
+
+    let marker = project_dir.join(".ccteam/chat/alice/active-session-id");
+    assert!(
+        marker.exists(),
+        "active-session-id marker must be written on session-start; expected at {}",
+        marker.display()
+    );
+    let body = std::fs::read_to_string(&marker).unwrap();
+    assert_eq!(body, sid, "marker body must be the raw sid (no JSON wrap)");
+
+    std::env::remove_var("CCTEAM_CHAT_ROLE");
+}
+
+#[test]
+#[serial]
+fn session_start_overwrites_marker_after_rotation() {
+    // /clear emits SessionEnd(reason=clear) then SessionStart with a
+    // fresh sid. The marker must point at the NEW sid; the old one
+    // shouldn't survive the rotation.
+    let tmp = TempDir::new().unwrap();
+    let slug = "tcp-marker-rotate";
+    let (paths, project_dir) = setup_project(&tmp, slug);
+    std::env::set_var("CCTEAM_CHAT_ROLE", "bob");
+
+    let sid_old = "aaaa-old";
+    handle_chat_progress(
+        &paths,
+        "session-start",
+        &json!({
+            "hook_event_name": "SessionStart",
+            "session_id": sid_old,
+            "cwd": project_dir.to_string_lossy(),
+            "source": "startup",
+        }),
+    )
+    .unwrap();
+
+    let sid_new = "bbbb-new";
+    handle_chat_progress(
+        &paths,
+        "session-start",
+        &json!({
+            "hook_event_name": "SessionStart",
+            "session_id": sid_new,
+            "cwd": project_dir.to_string_lossy(),
+            "source": "clear",
+        }),
+    )
+    .unwrap();
+
+    let marker = project_dir.join(".ccteam/chat/bob/active-session-id");
+    assert_eq!(std::fs::read_to_string(&marker).unwrap(), sid_new);
+
+    std::env::remove_var("CCTEAM_CHAT_ROLE");
+}
+
+#[test]
+#[serial]
+fn session_end_clear_removes_active_session_id_marker() {
+    // SessionEnd { reason: "clear" } means the user invoked /clear —
+    // the sid is about to rotate. Drop the marker so the tail loop
+    // waits for the next SessionStart instead of pointing at a now-
+    // stale jsonl.
+    let tmp = TempDir::new().unwrap();
+    let slug = "tcp-marker-clear";
+    let (paths, project_dir) = setup_project(&tmp, slug);
+    std::env::set_var("CCTEAM_CHAT_ROLE", "carol");
+
+    // Plant the marker first.
+    let sid = "doomed-sid";
+    handle_chat_progress(
+        &paths,
+        "session-start",
+        &json!({
+            "hook_event_name": "SessionStart",
+            "session_id": sid,
+            "cwd": project_dir.to_string_lossy(),
+            "source": "startup",
+        }),
+    )
+    .unwrap();
+    let marker = project_dir.join(".ccteam/chat/carol/active-session-id");
+    assert!(marker.exists());
+
+    // Now signal /clear.
+    handle_chat_progress(
+        &paths,
+        "session-end",
+        &json!({
+            "hook_event_name": "SessionEnd",
+            "session_id": sid,
+            "cwd": project_dir.to_string_lossy(),
+            "reason": "clear",
+        }),
+    )
+    .unwrap();
+    assert!(
+        !marker.exists(),
+        "session-end (clear) must remove the marker; still present at {}",
+        marker.display()
+    );
+
+    std::env::remove_var("CCTEAM_CHAT_ROLE");
+}
+
+#[test]
+#[serial]
+fn session_end_non_clear_leaves_marker_intact() {
+    // Process exit / daemon kill / network drop send SessionEnd with
+    // a non-`clear` reason. The sid hasn't rotated; the marker must
+    // survive so a daemon restart can pick up where it left off.
+    let tmp = TempDir::new().unwrap();
+    let slug = "tcp-marker-exit";
+    let (paths, project_dir) = setup_project(&tmp, slug);
+    std::env::set_var("CCTEAM_CHAT_ROLE", "dora");
+
+    let sid = "surviving-sid";
+    handle_chat_progress(
+        &paths,
+        "session-start",
+        &json!({
+            "hook_event_name": "SessionStart",
+            "session_id": sid,
+            "cwd": project_dir.to_string_lossy(),
+            "source": "startup",
+        }),
+    )
+    .unwrap();
+    let marker = project_dir.join(".ccteam/chat/dora/active-session-id");
+    assert!(marker.exists());
+
+    handle_chat_progress(
+        &paths,
+        "session-end",
+        &json!({
+            "hook_event_name": "SessionEnd",
+            "session_id": sid,
+            "cwd": project_dir.to_string_lossy(),
+            "reason": "exit",
+        }),
+    )
+    .unwrap();
+    assert!(
+        marker.exists(),
+        "session-end with reason != 'clear' must NOT remove the marker"
+    );
+    assert_eq!(std::fs::read_to_string(&marker).unwrap(), sid);
+
+    std::env::remove_var("CCTEAM_CHAT_ROLE");
+}
+
+#[test]
+#[serial]
 fn unknown_event_arg_falls_back_to_chat_prefix() {
     let tmp = TempDir::new().unwrap();
     let slug = "tcp-future";


### PR DESCRIPTION
## Summary

Fixes squad-mode chat unusability — 3 bots in one workflow were forwarding the same Telegram reply to the group (cross-fire).

Root cause: `tail_loop` used `discover_active_session(cwd)` which picks the most-recently-modified jsonl in the project dir. All 3 bots share one project dir → all 3 tail loops read the same file.

Three-layer fix:

- **F175**: spawn-time env injection (`CCTEAM_CHAT_ROLE`/`CCTEAM_CHAT_SLUG`) into tmux so the hook subprocess derives role correctly. Previously progress events shipped with `role: ""` because the env var was only set in tests.
- **F176**: SessionStart hook persists the real Anthropic session_id to `<project>/.ccteam/chat/<role>/active-session-id`. `--name` is an Anthropic-internal label, the jsonl is still UUID-named on disk — the hook payload is the only reliable source.
- **F177**: tail_loop reads the marker, targets that specific jsonl. `discover_active_session` fallback removed from chat-mode tail path. Watcher still arms on parent dir for rotation detection.

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast --exclude ccteam-web`: 1435 PASS / 0 FAIL (ccteam-web ws tests excluded due to local inotify-busy host hang — known per CLAUDE.md §六, CI will exercise that crate cleanly).
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 warning
- [x] `cargo fmt --all -- --check` 0 drift
- [x] New `claude_tui_fanout_test.rs` simulates 3 bots in one project dir + asserts only the target bot's turns.jsonl gains the turn
- [x] New `claude_tui_env_test.rs` asserts `tmux show-environment` after spawn contains both CCTEAM_CHAT_ROLE and CCTEAM_CHAT_SLUG
- [x] Marker write/clear test in `chat_progress_test.rs`

## Acceptance

After merge + ship, `reno-squad` group `@<bot>` → only that bot replies; other 2 bots silent.

Refs `docs/versions/v0-6-8/README.md` §2.1.