### PR TITLE
v0.6.8: BotRegistration.project_dir for non-default project layouts (F185)

### DIFF
--- a/crates/ccteam-cli/src/mcp_chat_tools.rs
+++ b/crates/ccteam-cli/src/mcp_chat_tools.rs
@@ -80,7 +80,8 @@ pub fn chat_tool_definitions() -> Vec<Value> {
                     },
                     "im_chat_id": { "type": "string", "description": "Platform-specific chat id (string)." },
                     "persona_id": { "type": "string", "description": "Optional stable persona id for display name / avatar." },
-                    "chat_handle": { "type": "string", "description": "Optional IM mention this bot answers to (without leading `@`). Omit to auto-mint an unused scientist nickname. Letters, digits, `_`, `-` only." }
+                    "chat_handle": { "type": "string", "description": "Optional IM mention this bot answers to (without leading `@`). Omit to auto-mint an unused scientist nickname. Letters, digits, `_`, `-` only." },
+                    "project_dir": { "type": "string", "description": "Absolute path to the project directory hosting .ccteam/workflow.yaml. When omitted, defaults to the MCP server's current working directory (canonicalized). The daemon resolves the bot's working dir as `<project_dir>/.ccteam/chat/<role>/`. Use this when the project lives outside `~/projects/<slug>/` (NAS share, dir basename differs from workflow slug)." }
                 },
                 "required": ["workflow_slug", "role", "vendor", "im_platform", "im_chat_id"],
             }),
@@ -158,10 +159,56 @@ pub fn dispatch(paths: &CcteamPaths, name: &str, args: &Value) -> Result<Option<
         "ccteam__chat_register_bot" => Ok(Some(dispatch_register_bot(paths, args)?)),
         "ccteam__chat_unregister_bot" => Ok(Some(dispatch_unregister_bot(paths, args)?)),
         "ccteam__chat_list_bots" => Ok(Some(dispatch_list_bots(paths, args)?)),
-        "ccteam__chat_send_input" => Ok(Some(dispatch_send_input_in(&paths.projects_root, args)?)),
-        "ccteam__chat_history" => Ok(Some(dispatch_history_in(&paths.projects_root, args)?)),
-        "ccteam__chat_reset" => Ok(Some(dispatch_reset_in(&paths.projects_root, args)?)),
+        "ccteam__chat_send_input" => Ok(Some(dispatch_send_input_in(
+            &paths.root,
+            &paths.projects_root,
+            args,
+        )?)),
+        "ccteam__chat_history" => Ok(Some(dispatch_history_in(
+            &paths.root,
+            &paths.projects_root,
+            args,
+        )?)),
+        "ccteam__chat_reset" => Ok(Some(dispatch_reset_in(
+            &paths.root,
+            &paths.projects_root,
+            args,
+        )?)),
         _ => Ok(None),
+    }
+}
+
+/// F185 — look up a registration by `(slug, role)` so the chat MCP
+/// dispatchers can honor the bot's persisted `project_dir`. Returns a
+/// synthetic registration with `project_dir = None` (legacy fallback
+/// layout) when the bot isn't registered — pre-registration MCP calls
+/// continue to resolve against `<projects_root>/<slug>/`, matching
+/// the historical contract.
+fn lookup_or_synthesize_reg(
+    ccteam_root: &Path,
+    workflow_slug: &str,
+    role: &str,
+) -> ccteam_imd::BotRegistration {
+    let regs = list_bots_in(ccteam_root, Some(workflow_slug)).unwrap_or_default();
+    if let Some(r) = regs
+        .into_iter()
+        .find(|b| b.workflow_slug == workflow_slug && b.role == role)
+    {
+        return r;
+    }
+    ccteam_imd::BotRegistration {
+        workflow_slug: workflow_slug.to_string(),
+        role: role.to_string(),
+        // Vendor / im_platform / im_chat_id are unused on the
+        // path-resolution code paths; we still need *some* values to
+        // build the struct.
+        vendor: ccteam_core::harness::AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "mcp".to_string(),
+        im_chat_id: "0".to_string(),
+        chat_handle: None,
+        project_dir: None,
+        created_at: chrono::Utc::now(),
     }
 }
 
@@ -201,6 +248,30 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
         _ => Some(mint_unused_handle(&paths.root)?),
     };
 
+    // F185 — caller-supplied `project_dir` MUST be absolute. When
+    // omitted, default to the MCP server's `current_dir` canonicalized
+    // through the filesystem (resolves symlinks too — daemon stores the
+    // post-canonical form so a moved symlink doesn't silently rebind).
+    let project_dir = match args.get("project_dir").and_then(|v| v.as_str()) {
+        Some(p) if !p.is_empty() => {
+            let path = std::path::PathBuf::from(p);
+            if !path.is_absolute() {
+                return Err(anyhow!(
+                    "`project_dir` must be an absolute path (got `{}`)",
+                    p
+                ));
+            }
+            path
+        }
+        _ => std::env::current_dir().context("std::env::current_dir for default project_dir")?,
+    };
+    let project_dir = std::fs::canonicalize(&project_dir).with_context(|| {
+        format!(
+            "canonicalize project_dir `{}` (does the path exist?)",
+            project_dir.display()
+        )
+    })?;
+
     let outcome = register_bot_checked_in(
         &paths.root,
         &workflow_slug,
@@ -210,6 +281,7 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
         &im_chat_id,
         persona_id.as_deref(),
         chat_handle.as_deref(),
+        Some(project_dir.as_path()),
     )?;
     match outcome {
         RegisterOutcome::Registered(path) => Ok(serde_json::to_string_pretty(&json!({
@@ -218,6 +290,7 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
             "workflow_slug": workflow_slug,
             "role": role,
             "chat_handle": chat_handle,
+            "project_dir": project_dir.display().to_string(),
         }))?),
         RegisterOutcome::AlreadyRegistered(path) => Ok(serde_json::to_string_pretty(&json!({
             "ok": false,
@@ -294,8 +367,7 @@ pub(crate) fn dispatch_list_bots(paths: &CcteamPaths, args: &Value) -> Result<St
         .into_iter()
         .map(|reg| {
             let running = bot_running_status_in(&paths.root, &reg.workflow_slug, &reg.role);
-            let last = last_turn_at(&paths.projects_root, &reg.workflow_slug, &reg.role)
-                .map(|dt| dt.to_rfc3339());
+            let last = last_turn_at(&paths.projects_root, &reg).map(|dt| dt.to_rfc3339());
             // vendor is serialized via AgentVendor's `rename_all = "lowercase"`
             // — see ccteam_core::harness::AgentVendor — so the wire shape is
             // guaranteed `"claude"` / `"codex"` (Bug A防线).
@@ -307,6 +379,7 @@ pub(crate) fn dispatch_list_bots(paths: &CcteamPaths, args: &Value) -> Result<St
                 "im_chat_id": reg.im_chat_id,
                 "persona_id": reg.persona_id,
                 "chat_handle": reg.chat_handle,
+                "project_dir": reg.project_dir,
                 "created_at": reg.created_at.to_rfc3339(),
                 "running": running,
                 "last_turn_at": last,
@@ -321,8 +394,18 @@ pub(crate) fn dispatch_list_bots(paths: &CcteamPaths, args: &Value) -> Result<St
 
 /// V0.6.5 F147 — `ccteam__chat_send_input` dispatcher (tempdir-aware
 /// variant for tests). Production callers go through [`dispatch`] which
-/// substitutes `paths.projects_root` for `projects_root`.
-pub fn dispatch_send_input_in(projects_root: &Path, args: &Value) -> Result<String> {
+/// substitutes `paths.{root,projects_root}` for the two roots.
+///
+/// F185 — looks up the bot's registration so the envelope is written
+/// to `<reg.project_dir>/.ccteam/chat/<role>/inbox/` when the
+/// registration carries an explicit `project_dir`. Pre-registration
+/// callers (no matching reg yet) fall back to the legacy
+/// `<projects_root>/<slug>/` layout via [`lookup_or_synthesize_reg`].
+pub fn dispatch_send_input_in(
+    ccteam_root: &Path,
+    projects_root: &Path,
+    args: &Value,
+) -> Result<String> {
     let workflow_slug = arg_str(args, "workflow_slug")?;
     validate_slug(&workflow_slug, "workflow_slug")?;
     let role = arg_str(args, "role")?;
@@ -336,7 +419,8 @@ pub fn dispatch_send_input_in(projects_root: &Path, args: &Value) -> Result<Stri
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    let inbox = chat_inbox_dir(projects_root, &workflow_slug, &role);
+    let reg = lookup_or_synthesize_reg(ccteam_root, &workflow_slug, &role);
+    let inbox = chat_inbox_dir(projects_root, &reg);
     fs::create_dir_all(&inbox).with_context(|| format!("mkdir -p {}", inbox.display()))?;
 
     // Compose a router-shaped envelope. We bypass the IM security
@@ -380,7 +464,14 @@ pub fn dispatch_send_input_in(projects_root: &Path, args: &Value) -> Result<Stri
 
 /// V0.6.5 F147 — `ccteam__chat_history` dispatcher (tempdir-aware
 /// variant for tests).
-pub fn dispatch_history_in(projects_root: &Path, args: &Value) -> Result<String> {
+///
+/// F185 — reads under the bot's registered `project_dir` (when set)
+/// rather than the legacy `<projects_root>/<slug>/` join.
+pub fn dispatch_history_in(
+    ccteam_root: &Path,
+    projects_root: &Path,
+    args: &Value,
+) -> Result<String> {
     let workflow_slug = arg_str(args, "workflow_slug")?;
     validate_slug(&workflow_slug, "workflow_slug")?;
     let role = arg_str(args, "role")?;
@@ -395,8 +486,9 @@ pub fn dispatch_history_in(projects_root: &Path, args: &Value) -> Result<String>
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let project_dir = projects_root.join(&workflow_slug);
-    let turns_path = turns_jsonl_path(projects_root, &workflow_slug, &role);
+    let reg = lookup_or_synthesize_reg(ccteam_root, &workflow_slug, &role);
+    let project_dir = reg.project_root(projects_root);
+    let turns_path = turns_jsonl_path(projects_root, &reg);
 
     // Missing file = bot registered but no turn yet. Return empty list
     // rather than erroring so caller can treat "no history" uniformly.
@@ -441,13 +533,17 @@ pub fn dispatch_history_in(projects_root: &Path, args: &Value) -> Result<String>
 
 /// V0.6.5 F147 — `ccteam__chat_reset` dispatcher (tempdir-aware variant
 /// for tests).
-pub fn dispatch_reset_in(projects_root: &Path, args: &Value) -> Result<String> {
+///
+/// F185 — writes the signal under the bot's registered `project_dir`
+/// when set; falls back to `<projects_root>/<slug>/` otherwise.
+pub fn dispatch_reset_in(ccteam_root: &Path, projects_root: &Path, args: &Value) -> Result<String> {
     let workflow_slug = arg_str(args, "workflow_slug")?;
     validate_slug(&workflow_slug, "workflow_slug")?;
     let role = arg_str(args, "role")?;
     validate_slug(&role, "role")?;
 
-    let sig = chat_reset_signal_path(projects_root, &workflow_slug, &role);
+    let reg = lookup_or_synthesize_reg(ccteam_root, &workflow_slug, &role);
+    let sig = chat_reset_signal_path(projects_root, &reg);
     if let Some(parent) = sig.parent() {
         fs::create_dir_all(parent).with_context(|| format!("mkdir -p {}", parent.display()))?;
     }

--- a/crates/ccteam-cli/tests/e2e_creator_full_path_test.rs
+++ b/crates/ccteam-cli/tests/e2e_creator_full_path_test.rs
@@ -377,15 +377,15 @@ fn t_creator_skill_phase_5_6_documents_mcp_tool_not_rust_function() {
         "Phase 5.6 must document the `already_registered` idempotent-OK branch; got: {phase_5_6_body}",
     );
 
-    // Phase 5.9 reply template must mention the registry path so the
+    // Phase 5.8 reply template must mention the registry path so the
     // user sees the bot actually landed somewhere.
-    let phase_5_9 = body
-        .split("## 5.9")
+    let phase_5_8 = body
+        .split("## 5.8")
         .nth(1)
-        .expect("SKILL.md must have a `## 5.9` Phase 5.9 section");
-    let phase_5_9_body = phase_5_9.split("\n## ").next().unwrap_or(phase_5_9);
+        .expect("SKILL.md must have a `## 5.8` Phase 5.8 section");
+    let phase_5_8_body = phase_5_8.split("\n## ").next().unwrap_or(phase_5_8);
     assert!(
-        phase_5_9_body.contains("imd/registry/"),
-        "Phase 5.9 reply must mention `imd/registry/<slug>/<role>.json` so the user sees the bot was registered; got: {phase_5_9_body}",
+        phase_5_8_body.contains("imd/registry/"),
+        "Phase 5.8 reply must mention `imd/registry/<slug>/<role>.json` so the user sees the bot was registered; got: {phase_5_8_body}",
     );
 }

--- a/crates/ccteam-cli/tests/remove_test.rs
+++ b/crates/ccteam-cli/tests/remove_test.rs
@@ -515,6 +515,7 @@ fn seed_imd_registry(fx: &Fixture, role: &str) -> (std::path::PathBuf, std::path
         "42",
         Some(role),
         None,
+        None,
     )
     .expect("seed registry");
     let reg_path = match outcome {

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -688,8 +688,7 @@ async fn ensure_bot_channels(
         // same monotonic primitive.
         let chat_id = bot.im_chat_id.clone();
         let platform = bot.im_platform.clone();
-        let cursor_path =
-            outbound::outbound_cursor_path(projects_root, &bot.workflow_slug, &bot.role);
+        let cursor_path = outbound::outbound_cursor_path(projects_root, bot);
         let outbound_cursor = outbound::OutboundCursor::load_from_disk(cursor_path);
         let slug_log = bot.workflow_slug.clone();
         let role_log = bot.role.clone();
@@ -880,12 +879,10 @@ async fn drain_inboxes(
             .collect()
     };
     for (bot, sup) in supervisors {
-        let inbox = projects_root
-            .join(&bot.workflow_slug)
-            .join(".ccteam")
-            .join("chat")
-            .join(&bot.role)
-            .join("inbox");
+        // F185 — honor `reg.project_dir` so projects living outside
+        // `~/projects/<slug>/` (NAS shares, dir basename ≠ slug)
+        // resolve correctly.
+        let inbox = crate::chat_inbox_dir(projects_root, &bot);
         if !inbox.exists() {
             continue;
         }
@@ -1012,7 +1009,7 @@ async fn drain_outboxes(
             );
             continue;
         };
-        let path = outbound::turns_jsonl_path(projects_root, &bot.workflow_slug, &bot.role);
+        let path = outbound::turns_jsonl_path(projects_root, bot);
 
         // Prefer the shared OutboundCursor owned by the fast-path
         // dispatcher (so we update the same in-memory state and the
@@ -1027,11 +1024,7 @@ async fn drain_outboxes(
             match guard.get(&key) {
                 Some(ch) => ch.outbound_cursor.clone(),
                 None => {
-                    let cursor_path = outbound::outbound_cursor_path(
-                        projects_root,
-                        &bot.workflow_slug,
-                        &bot.role,
-                    );
+                    let cursor_path = outbound::outbound_cursor_path(projects_root, bot);
                     outbound::OutboundCursor::load_from_disk(cursor_path)
                 }
             }
@@ -1360,6 +1353,7 @@ mod tests {
             im_platform: "telegram".into(),
             im_chat_id: "1".into(),
             chat_handle: None,
+            project_dir: None,
             created_at: chrono::Utc::now(),
         };
 
@@ -1423,6 +1417,7 @@ mod tests {
             im_platform: "telegram".into(),
             im_chat_id: "1".into(),
             chat_handle: None,
+            project_dir: None,
             created_at: chrono::Utc::now(),
         };
         // Tick 1: Spawn.

--- a/crates/ccteam-imd/src/inbound.rs
+++ b/crates/ccteam-imd/src/inbound.rs
@@ -96,13 +96,24 @@ pub enum InboundOutcome {
 /// Per-bot mailbox path resolver. The daemon owns this; it's a
 /// closure-style trait so tests can substitute a tempdir-based
 /// implementation.
+///
+/// F185 — takes the full [`crate::BotRegistration`] so resolvers can
+/// honor `reg.project_dir` (absolute path written at registration
+/// time). Resolvers fall back to the historical
+/// `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/inbox/` layout
+/// when `reg.project_dir = None` (legacy registrations).
 pub trait MailboxResolver: Send + Sync {
-    /// Return `<project>/.ccteam/chat/<bot>/inbox/` for the given
-    /// (slug, role).
-    fn inbox_dir(&self, slug: &str, role: &str) -> Result<PathBuf>;
+    /// Return `<project>/.ccteam/chat/<role>/inbox/` for the given
+    /// bot. The resolver decides how to interpret
+    /// `reg.project_dir` vs the fallback `projects_root` layout.
+    fn inbox_dir(&self, reg: &crate::BotRegistration) -> Result<PathBuf>;
 }
 
-/// Default resolver: rooted at `<projects_root>/<slug>/.ccteam/chat/<role>/inbox/`.
+/// Default resolver: rooted at the bot's chat dir
+/// (`<project>/.ccteam/chat/<role>/inbox/`). When the registration
+/// carries an explicit `project_dir`, that absolute path is used
+/// directly; otherwise the resolver joins the configured
+/// `projects_root` with `workflow_slug` for the legacy layout.
 /// `projects_root` is normally `~/projects` (production) but tests
 /// pass an override via [`Self::with_projects_root`].
 pub struct DefaultMailboxResolver {
@@ -133,14 +144,8 @@ impl Default for DefaultMailboxResolver {
 }
 
 impl MailboxResolver for DefaultMailboxResolver {
-    fn inbox_dir(&self, slug: &str, role: &str) -> Result<PathBuf> {
-        Ok(self
-            .projects_root
-            .join(slug)
-            .join(".ccteam")
-            .join("chat")
-            .join(role)
-            .join("inbox"))
+    fn inbox_dir(&self, reg: &crate::BotRegistration) -> Result<PathBuf> {
+        Ok(crate::chat_inbox_dir(&self.projects_root, reg))
     }
 }
 
@@ -220,10 +225,20 @@ pub fn has_at_mention(text: &str) -> bool {
 }
 
 /// Process one inbound IM event end-to-end.
+///
+/// `bots` is the registry slice the router resolves against; F185 uses
+/// it to look up the [`crate::BotRegistration`] matching the routed
+/// `(slug, role)` so the mailbox resolver can honor the bot's
+/// `project_dir`. When no matching registration is found (race
+/// window: registration removed between route resolution and mailbox
+/// resolution), we synthesize a transient `BotRegistration` with
+/// `project_dir = None` so the fallback layout still works — better
+/// than erroring out the inbound pipeline.
 pub async fn process_inbound(
     msg: &ChannelMessage,
     sec: &Arc<Mutex<ThreeLayerSec>>,
     handles: &HandleMap,
+    bots: &[crate::BotRegistration],
     mailbox: &dyn MailboxResolver,
     hop: u8,
     seq: u64,
@@ -271,7 +286,34 @@ pub async fn process_inbound(
             payload: stripped,
         } => {
             let t0 = std::time::Instant::now();
-            let dir = mailbox.inbox_dir(&slug, &role)?;
+            // F185 — find the live BotRegistration so the mailbox
+            // resolver can honor its `project_dir`. Synthesize a
+            // fallback reg (project_dir = None) when the routed
+            // (slug, role) isn't present in `bots` so a race between
+            // unregister and route doesn't error out the pipeline —
+            // the fallback layout keeps the inbound path live.
+            let owned_reg;
+            let reg_ref: &crate::BotRegistration = match bots
+                .iter()
+                .find(|b| b.workflow_slug == slug && b.role == role)
+            {
+                Some(b) => b,
+                None => {
+                    owned_reg = crate::BotRegistration {
+                        workflow_slug: slug.clone(),
+                        role: role.clone(),
+                        vendor: ccteam_core::harness::AgentVendor::Claude,
+                        persona_id: None,
+                        im_platform: msg.channel.clone(),
+                        im_chat_id: msg.reply_target.clone(),
+                        chat_handle: None,
+                        project_dir: None,
+                        created_at: chrono::Utc::now(),
+                    };
+                    &owned_reg
+                }
+            };
+            let dir = mailbox.inbox_dir(reg_ref)?;
             fs::create_dir_all(&dir).with_context(|| format!("mkdir -p {}", dir.display()))?;
             let ts = Utc::now().format("%Y%m%dT%H%M%S").to_string();
             let path = dir.join(format!("msg-{ts}-{seq:03}.md"));
@@ -335,7 +377,7 @@ pub async fn process_inbound_admin_aware(
     hop: u8,
     seq: u64,
 ) -> Result<(InboundOutcome, Option<AdminReply>)> {
-    let outcome = process_inbound(msg, sec, handles, mailbox, hop, seq).await?;
+    let outcome = process_inbound(msg, sec, handles, bots, mailbox, hop, seq).await?;
     let admin_reply = match &outcome {
         InboundOutcome::Admin { verb_and_args } => {
             let cmd = nl_admin::parse(verb_and_args);
@@ -418,6 +460,7 @@ mod tests {
             &sample_msg("telegram", "hello world"),
             &sec,
             &HandleMap::new(),
+            &[],
             &mailbox,
             0,
             1,
@@ -438,6 +481,7 @@ mod tests {
             &sample_msg("telegram", "@lead please plan"),
             &sec,
             &handles,
+            &[],
             &mailbox,
             0,
             7,
@@ -469,6 +513,7 @@ mod tests {
             &sample_msg("telegram", "@ccteam status"),
             &sec,
             &HandleMap::new(),
+            &[],
             &mailbox,
             0,
             0,
@@ -492,10 +537,10 @@ mod tests {
         let mut handles = HandleMap::new();
         handles.insert("lead", "dev-foo", "lead");
         let m = sample_msg("telegram", "@lead one");
-        let _ = process_inbound(&m, &sec, &handles, &mailbox, 0, 1)
+        let _ = process_inbound(&m, &sec, &handles, &[], &mailbox, 0, 1)
             .await
             .unwrap();
-        let res = process_inbound(&m, &sec, &handles, &mailbox, 0, 2)
+        let res = process_inbound(&m, &sec, &handles, &[], &mailbox, 0, 2)
             .await
             .unwrap();
         match res {

--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -80,6 +80,20 @@ pub struct BotRegistration {
     /// when the caller omits this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_handle: Option<String>,
+    /// Absolute path to the project directory hosting
+    /// `.ccteam/workflow.yaml`. When present, daemon resolves bot
+    /// working dirs as `<project_dir>/.ccteam/chat/<role>/` directly.
+    /// When `None` (legacy registrations pre-`project_dir`), daemon
+    /// falls back to the historical
+    /// `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/` layout.
+    /// The field is additive — `chat_register_bot` MCP accepts it as
+    /// an optional input and the dispatcher defaults to
+    /// `std::env::current_dir()` (canonicalized) so projects living
+    /// outside `~/projects/<slug>/` (NAS shares, dir basename ≠
+    /// workflow slug) resolve correctly. Pre-v1.0 — no migration: the
+    /// `Option<PathBuf>` branch handles old registrations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_dir: Option<PathBuf>,
     /// RFC3339 timestamp.
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
@@ -192,51 +206,51 @@ pub fn bot_running_status(slug: &str, role: &str) -> bool {
 
 /// V0.6.5 F146 — read `last_turn_at` (mtime of the ccteam-owned
 /// `turns.jsonl`) from the project tree. Returns `None` if the file
-/// doesn't exist yet (bot registered but no turn taken).
+/// doesn't exist yet (bot registered but no turn taken). Honors
+/// `reg.project_dir` (F185) — when set, reads under the absolute
+/// project path; otherwise falls back to
+/// `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/turns.jsonl`.
 pub fn last_turn_at(
     projects_root: &Path,
-    slug: &str,
-    role: &str,
+    reg: &BotRegistration,
 ) -> Option<chrono::DateTime<chrono::Utc>> {
-    let meta = fs::metadata(turns_jsonl_path(projects_root, slug, role)).ok()?;
+    let meta = fs::metadata(turns_jsonl_path(projects_root, reg)).ok()?;
     let mtime = meta.modified().ok()?;
     Some(chrono::DateTime::<chrono::Utc>::from(mtime))
 }
 
-/// V0.6.5 F147 — resolve `<projects_root>/<slug>/.ccteam/chat/<role>/inbox/`.
-/// The mailbox path the daemon's `drain_inboxes` / per-bot mpsc
-/// fast-path consume. MCP `chat_send_input` writes a router-style
+/// V0.6.5 F147 — resolve `<project>/.ccteam/chat/<role>/inbox/` for
+/// this bot. The mailbox path the daemon's `drain_inboxes` / per-bot
+/// mpsc fast-path consume. MCP `chat_send_input` writes a router-style
 /// envelope here; daemon picks it up either via the fast-path (when
 /// the per-bot mpsc is wired) or via the safety-net drain tick.
-pub fn chat_inbox_dir(projects_root: &Path, slug: &str, role: &str) -> PathBuf {
-    projects_root
-        .join(slug)
-        .join(".ccteam")
-        .join("chat")
-        .join(role)
-        .join("inbox")
+///
+/// F185 — prefers `reg.project_dir` (absolute path) over the historic
+/// `<projects_root>/<workflow_slug>/` fallback so projects living
+/// outside `~/projects/<slug>/` (NAS shares, dir basename ≠ slug)
+/// resolve correctly.
+pub fn chat_inbox_dir(projects_root: &Path, reg: &BotRegistration) -> PathBuf {
+    reg.chat_dir(projects_root).join("inbox")
 }
 
-/// V0.6.5 F147 — resolve `<projects_root>/<slug>/.ccteam/chat/<role>/signals/reset.signal`.
-/// MCP `chat_reset` writes this file; the supervisor's next tick reads
-/// it via `signal_present(.., RESET_SIGNAL)` and applies the
-/// ResetSession action (archive + close + start + cursor wipe).
-pub fn chat_reset_signal_path(projects_root: &Path, slug: &str, role: &str) -> PathBuf {
-    projects_root
-        .join(slug)
-        .join(".ccteam")
-        .join("chat")
-        .join(role)
+/// V0.6.5 F147 — resolve `<project>/.ccteam/chat/<role>/signals/reset.signal`
+/// for this bot. MCP `chat_reset` writes this file; the supervisor's
+/// next tick reads it via `signal_present(.., RESET_SIGNAL)` and
+/// applies the ResetSession action (archive + close + start + cursor
+/// wipe). Honors `reg.project_dir` (F185).
+pub fn chat_reset_signal_path(projects_root: &Path, reg: &BotRegistration) -> PathBuf {
+    reg.chat_dir(projects_root)
         .join("signals")
         .join("reset.signal")
 }
 
-/// V0.6.5 F147 — resolve `<projects_root>/<slug>/.ccteam/chat/<role>/turns.jsonl`.
-/// Source-of-truth file `chat_history` tails. Re-exports
+/// V0.6.5 F147 — resolve `<project>/.ccteam/chat/<role>/turns.jsonl`
+/// for this bot. Source-of-truth file `chat_history` tails. Re-exports
 /// [`outbound::turns_jsonl_path`] under a top-level name so MCP /
 /// integration callers don't have to reach into the outbound module.
-pub fn turns_jsonl_path(projects_root: &Path, slug: &str, role: &str) -> PathBuf {
-    outbound::turns_jsonl_path(projects_root, slug, role)
+/// Honors `reg.project_dir` (F185).
+pub fn turns_jsonl_path(projects_root: &Path, reg: &BotRegistration) -> PathBuf {
+    outbound::turns_jsonl_path(projects_root, reg)
 }
 
 impl BotRegistration {
@@ -246,6 +260,29 @@ impl BotRegistration {
     /// before the schema field landed.
     pub fn effective_handle(&self) -> &str {
         self.chat_handle.as_deref().unwrap_or(&self.role)
+    }
+
+    /// Resolve the project root for this bot — the directory holding
+    /// `.ccteam/workflow.yaml`. Prefers the registration's explicit
+    /// `project_dir` (absolute path written by `chat_register_bot` at
+    /// registration time). Falls back to the historical
+    /// `<projects_root>/<workflow_slug>/` layout for legacy
+    /// registrations that have `project_dir = None`.
+    pub fn project_root(&self, projects_root: &Path) -> PathBuf {
+        match self.project_dir.as_deref() {
+            Some(p) => p.to_path_buf(),
+            None => projects_root.join(&self.workflow_slug),
+        }
+    }
+
+    /// Resolve `<project>/.ccteam/chat/<role>/` for this bot. The
+    /// per-bot working dir used by the supervisor, mailbox writer,
+    /// transcript tail, outbound cursor, and all `chat_*` MCP paths.
+    pub fn chat_dir(&self, projects_root: &Path) -> PathBuf {
+        self.project_root(projects_root)
+            .join(".ccteam")
+            .join("chat")
+            .join(&self.role)
     }
 }
 
@@ -281,6 +318,7 @@ pub fn register_bot_checked_in(
     im_chat_id: &str,
     persona_id: Option<&str>,
     chat_handle: Option<&str>,
+    project_dir: Option<&Path>,
 ) -> Result<RegisterOutcome> {
     let path = registration_path_in(ccteam_root, workflow_slug, role);
     if path.exists() {
@@ -294,6 +332,7 @@ pub fn register_bot_checked_in(
         im_platform: im_platform.to_string(),
         im_chat_id: im_chat_id.to_string(),
         chat_handle: chat_handle.map(String::from),
+        project_dir: project_dir.map(PathBuf::from),
         created_at: chrono::Utc::now(),
     };
     if let Some(parent) = path.parent() {
@@ -327,6 +366,7 @@ pub fn register_bot_in(
         im_platform: im_platform.to_string(),
         im_chat_id: im_chat_id.to_string(),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     };
     let path = registration_path_in(ccteam_root, workflow_slug, role);

--- a/crates/ccteam-imd/src/outbound.rs
+++ b/crates/ccteam-imd/src/outbound.rs
@@ -131,33 +131,29 @@ pub struct TailCursor {
 }
 
 /// Resolve `<project>/.ccteam/chat/<role>/turns.jsonl` for the given
-/// `(projects_root, slug, role)` triple.
-pub fn turns_jsonl_path(projects_root: &std::path::Path, slug: &str, role: &str) -> PathBuf {
-    projects_root
-        .join(slug)
-        .join(".ccteam")
-        .join("chat")
-        .join(role)
-        .join("turns.jsonl")
+/// bot. Honors `reg.project_dir` (F185) — when set, uses the absolute
+/// path; otherwise falls back to
+/// `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/turns.jsonl`.
+pub fn turns_jsonl_path(projects_root: &std::path::Path, reg: &crate::BotRegistration) -> PathBuf {
+    reg.chat_dir(projects_root).join("turns.jsonl")
 }
 
 /// V0.6.1 F134 — persistent byte-offset state for one bot's
 /// `turns.jsonl` tailer. Stored at
-/// `<projects_root>/<slug>/.ccteam/chat/<role>/outbound.cursor` as a
-/// JSON blob `{"position": N}` (serde-derived on [`TailCursor`]).
+/// `<project>/.ccteam/chat/<role>/outbound.cursor` as a JSON blob
+/// `{"position": N}` (serde-derived on [`TailCursor`]).
 ///
 /// Daemon restart re-loads this file so messages forwarded across a
 /// previous run aren't re-sent to the user. Missing / malformed file
 /// → fall back to the zero cursor (re-forward everything; safer than
 /// dropping content silently, and `turns.jsonl` grows monotonically
 /// so a stale cursor would only ever under-skip, never over-skip).
-pub fn outbound_cursor_path(projects_root: &std::path::Path, slug: &str, role: &str) -> PathBuf {
-    projects_root
-        .join(slug)
-        .join(".ccteam")
-        .join("chat")
-        .join(role)
-        .join("outbound.cursor")
+/// F185 — honors `reg.project_dir`.
+pub fn outbound_cursor_path(
+    projects_root: &std::path::Path,
+    reg: &crate::BotRegistration,
+) -> PathBuf {
+    reg.chat_dir(projects_root).join("outbound.cursor")
 }
 
 /// Load a [`TailCursor`] from disk. Missing file or parse failure

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -184,13 +184,13 @@ pub fn decide(
     }
 }
 
-/// Per-bot dir: `<projects_root>/<slug>/.ccteam/chat/<role>/`.
+/// Per-bot dir: `<project>/.ccteam/chat/<role>/`. F185 — prefers
+/// `reg.project_dir` (absolute path written by `chat_register_bot` at
+/// registration time). Falls back to the historical
+/// `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/` layout for
+/// pre-F185 registrations that have `project_dir = None`.
 pub fn bot_dir(projects_root: &Path, reg: &BotRegistration) -> PathBuf {
-    projects_root
-        .join(&reg.workflow_slug)
-        .join(".ccteam")
-        .join("chat")
-        .join(&reg.role)
+    reg.chat_dir(projects_root)
 }
 
 fn signal_present(bot_dir: &Path, name: &str) -> bool {
@@ -307,9 +307,12 @@ impl BotSupervisor {
         bot_dir(&self.projects_root, &self.reg)
     }
 
-    /// `<projects_root>/<slug>/`.
+    /// Root dir for the project hosting this bot's
+    /// `.ccteam/workflow.yaml`. F185 — prefers `reg.project_dir` when
+    /// set; falls back to `<projects_root>/<workflow_slug>/` for
+    /// legacy registrations.
     pub fn project_dir(&self) -> PathBuf {
-        self.projects_root.join(&self.reg.workflow_slug)
+        self.reg.project_root(&self.projects_root)
     }
 
     /// True iff `start_thread` has been called and `close_thread` has
@@ -943,6 +946,7 @@ mod bot_supervisor_tests {
             im_platform: "mock".into(),
             im_chat_id: "1".into(),
             chat_handle: None,
+            project_dir: None,
             created_at: chrono::Utc::now(),
         }
     }
@@ -1029,6 +1033,7 @@ mod tests {
             im_platform: "mock".into(),
             im_chat_id: "1".into(),
             chat_handle: None,
+            project_dir: None,
             created_at: Utc::now(),
         }
     }

--- a/crates/ccteam-imd/tests/chat_register_mcp_test.rs
+++ b/crates/ccteam-imd/tests/chat_register_mcp_test.rs
@@ -33,6 +33,7 @@ fn register_bot_checked_writes_registration_at_documented_path() {
         "42",
         None,
         None,
+        None,
     )
     .unwrap();
     let path = match outcome {
@@ -66,6 +67,7 @@ fn register_bot_checked_does_not_clobber_existing() {
         "42",
         None,
         None,
+        None,
     )
     .unwrap();
     let original_bytes = std::fs::read(registration_path_in(&r, "demo", "helper")).unwrap();
@@ -79,6 +81,7 @@ fn register_bot_checked_does_not_clobber_existing() {
         AgentVendor::Codex,
         "slack",
         "C999",
+        None,
         None,
         None,
     )
@@ -170,6 +173,7 @@ fn register_bot_persists_caller_supplied_chat_handle() {
         "42",
         None,
         Some("curie"),
+        None,
     )
     .unwrap();
     assert!(matches!(outcome, RegisterOutcome::Registered(_)));
@@ -197,6 +201,7 @@ fn register_bot_chat_handle_none_persists_as_omitted_then_falls_back_to_role() {
         "42",
         None,
         None,
+        None,
     )
     .unwrap();
     let bots = list_bots_in(&r, None).unwrap();
@@ -207,13 +212,91 @@ fn register_bot_chat_handle_none_persists_as_omitted_then_falls_back_to_role() {
 }
 
 #[test]
+fn register_bot_persists_caller_supplied_project_dir() {
+    // F185 — when MCP `chat_register_bot` passes a `project_dir`, the
+    // registry JSON on disk must round-trip the absolute path through
+    // serde so the daemon's path resolvers can honor it.
+    let tmp = TempDir::new().unwrap();
+    let r = root(&tmp);
+    let proj = tmp.path().join("vol4/1000/nasworkspace/ccteam");
+    std::fs::create_dir_all(&proj).unwrap();
+    let outcome = register_bot_checked_in(
+        &r,
+        "research-squad",
+        "helper",
+        AgentVendor::Claude,
+        "telegram",
+        "42",
+        None,
+        None,
+        Some(&proj),
+    )
+    .unwrap();
+    assert!(matches!(outcome, RegisterOutcome::Registered(_)));
+    let path = registration_path_in(&r, "research-squad", "helper");
+    let on_disk: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    assert_eq!(
+        on_disk["project_dir"].as_str().unwrap(),
+        proj.to_string_lossy()
+    );
+
+    // Re-listing the registry round-trips project_dir through serde.
+    let bots = list_bots_in(&r, None).unwrap();
+    assert_eq!(bots.len(), 1);
+    assert_eq!(bots[0].project_dir.as_deref(), Some(proj.as_path()));
+}
+
+#[test]
+fn register_bot_project_dir_none_persists_as_omitted_field() {
+    // Legacy / non-F185 callers don't supply `project_dir`. The serde
+    // `skip_serializing_if = "Option::is_none"` must keep the field
+    // out of the on-disk JSON entirely so older readers / round-trip
+    // assertions don't trip on a `null` they didn't expect.
+    let tmp = TempDir::new().unwrap();
+    let r = root(&tmp);
+    register_bot_checked_in(
+        &r,
+        "demo",
+        "helper",
+        AgentVendor::Claude,
+        "telegram",
+        "42",
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    let path = registration_path_in(&r, "demo", "helper");
+    let body = std::fs::read_to_string(path).unwrap();
+    assert!(
+        !body.contains("project_dir"),
+        "JSON must omit project_dir when None: {}",
+        body
+    );
+    let bots = list_bots_in(&r, None).unwrap();
+    assert!(bots[0].project_dir.is_none());
+}
+
+#[test]
 fn last_turn_at_returns_none_when_file_missing_and_mtime_when_present() {
     let tmp = TempDir::new().unwrap();
     let projects = tmp.path().join("projects");
     std::fs::create_dir_all(&projects).unwrap();
-    assert!(last_turn_at(&projects, "demo", "helper").is_none());
+    let reg = ccteam_imd::BotRegistration {
+        workflow_slug: "demo".into(),
+        role: "helper".into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "telegram".into(),
+        im_chat_id: "42".into(),
+        chat_handle: None,
+        project_dir: None,
+        created_at: chrono::Utc::now(),
+    };
+    assert!(last_turn_at(&projects, &reg).is_none());
     let turns_dir = projects.join("demo/.ccteam/chat/helper");
     std::fs::create_dir_all(&turns_dir).unwrap();
     std::fs::write(turns_dir.join("turns.jsonl"), b"{}\n").unwrap();
-    assert!(last_turn_at(&projects, "demo", "helper").is_some());
+    assert!(last_turn_at(&projects, &reg).is_some());
 }

--- a/crates/ccteam-imd/tests/chat_reset_signal_test.rs
+++ b/crates/ccteam-imd/tests/chat_reset_signal_test.rs
@@ -87,12 +87,13 @@ fn reg() -> BotRegistration {
         im_platform: "mcp".into(),
         im_chat_id: "0".into(),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }
 
-fn write_reset_signal(projects_root: &std::path::Path, slug: &str, role: &str) {
-    let sig = ccteam_imd::chat_reset_signal_path(projects_root, slug, role);
+fn write_reset_signal(projects_root: &std::path::Path, r: &BotRegistration) {
+    let sig = ccteam_imd::chat_reset_signal_path(projects_root, r);
     std::fs::create_dir_all(sig.parent().unwrap()).unwrap();
     std::fs::write(&sig, format!("{}", chrono::Utc::now().timestamp_millis())).unwrap();
 }
@@ -101,7 +102,7 @@ fn write_reset_signal(projects_root: &std::path::Path, slug: &str, role: &str) {
 fn decide_returns_reset_session_when_signal_present() {
     let tmp = TempDir::new().unwrap();
     let r = reg();
-    write_reset_signal(tmp.path(), &r.workflow_slug, &r.role);
+    write_reset_signal(tmp.path(), &r);
     // Provide a fresh heartbeat so the noop / restart path doesn't fire.
     let dir = bot_dir(tmp.path(), &r);
     std::fs::create_dir_all(&dir).unwrap();
@@ -130,7 +131,7 @@ fn decide_reset_session_beats_restart_budget_exhaustion() {
     // in `decide()` for exactly this reason.
     let tmp = TempDir::new().unwrap();
     let r = reg();
-    write_reset_signal(tmp.path(), &r.workflow_slug, &r.role);
+    write_reset_signal(tmp.path(), &r);
     let st = BotState {
         handle: Some(ThreadHandle {
             vendor: AgentVendor::Claude,
@@ -158,7 +159,7 @@ fn decide_shutdown_still_beats_reset_signal() {
     // to kill.
     let tmp = TempDir::new().unwrap();
     let r = reg();
-    write_reset_signal(tmp.path(), &r.workflow_slug, &r.role);
+    write_reset_signal(tmp.path(), &r);
     // ALSO drop shutdown.signal.
     let sig_dir = bot_dir(tmp.path(), &r).join("signals");
     std::fs::create_dir_all(&sig_dir).unwrap();
@@ -202,7 +203,7 @@ async fn reset_session_archives_turns_jsonl_and_clears_transcript_cursor() {
     std::fs::write(bd.join("outbound.cursor"), r#"{"position":5000}"#).unwrap();
 
     // Drop the reset.signal file the MCP tool would have written.
-    write_reset_signal(&projects_root, &r.workflow_slug, &r.role);
+    write_reset_signal(&projects_root, &r);
 
     let archived = sup.reset_session().await.unwrap();
     let archived_path = archived.expect("archive path returned");
@@ -226,7 +227,7 @@ async fn reset_session_archives_turns_jsonl_and_clears_transcript_cursor() {
         "outbound cursor must be cleared on reset"
     );
     // Signal is unlinked so the next tick doesn't loop.
-    let sig = ccteam_imd::chat_reset_signal_path(&projects_root, &r.workflow_slug, &r.role);
+    let sig = ccteam_imd::chat_reset_signal_path(&projects_root, &r);
     assert!(!sig.exists(), "reset.signal must be consumed");
     // Adapter saw close + fresh start.
     assert_eq!(adapter.closes.load(Ordering::SeqCst), 1);
@@ -279,7 +280,7 @@ fn reset_signal_const_matches_documented_filename() {
     // contract.
     assert_eq!(RESET_SIGNAL, "reset.signal");
     let tmp = TempDir::new().unwrap();
-    let sig = ccteam_imd::chat_reset_signal_path(tmp.path(), "demo", "helper");
+    let sig = ccteam_imd::chat_reset_signal_path(tmp.path(), &reg());
     assert!(
         sig.ends_with("signals/reset.signal"),
         "MCP signal path filename must match supervisor RESET_SIGNAL: {}",

--- a/crates/ccteam-imd/tests/chat_send_input_test.rs
+++ b/crates/ccteam-imd/tests/chat_send_input_test.rs
@@ -86,6 +86,7 @@ fn reg() -> BotRegistration {
         im_platform: "mcp".into(),
         im_chat_id: "0".into(),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }
@@ -121,7 +122,7 @@ async fn mailbox_envelope_round_trips_through_handle_inbound() {
 
     // Drop the envelope into the documented mailbox path (same path
     // `chat_send_input` writes to via `chat_inbox_dir`).
-    let inbox = chat_inbox_dir(&projects_root, "demo", "helper");
+    let inbox = chat_inbox_dir(&projects_root, &reg());
     let path = write_envelope(&inbox, "please plan");
 
     // Daemon-side parse + dispatch (the production safety-net
@@ -173,6 +174,73 @@ fn envelope_filename_collision_window_is_realistic() {
 }
 
 #[tokio::test]
+async fn mailbox_envelope_routes_through_registration_project_dir() {
+    // F185 — when the BotRegistration carries an explicit absolute
+    // `project_dir` that differs from `<projects_root>/<workflow_slug>/`
+    // (e.g. NAS-shared project: `/vol4/.../ccteam` with slug
+    // `research-squad`), the mailbox writer + supervisor must resolve
+    // *both* sides under the explicit path. Asserting both the resolver
+    // path and the file actually showing up there is the regression
+    // anchor for "MCP write went to `~/projects/research-squad/...`
+    // while the daemon supervisor watched `/vol4/.../ccteam/...`" —
+    // a partial F185 would silently route them past each other.
+    let tmp = TempDir::new().unwrap();
+    let projects_root = tmp.path().join("projects");
+    std::fs::create_dir_all(&projects_root).unwrap();
+    // The real project lives outside `projects_root/<slug>/`.
+    let project_dir = tmp.path().join("vol4/ccteam");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    // Registration explicitly binds to the absolute project_dir; slug
+    // intentionally does NOT match the dir basename.
+    let reg = ccteam_imd::BotRegistration {
+        workflow_slug: "research-squad".into(),
+        role: "tech-helper".into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "mcp".into(),
+        im_chat_id: "0".into(),
+        chat_handle: None,
+        project_dir: Some(project_dir.clone()),
+        created_at: chrono::Utc::now(),
+    };
+
+    let adapter = Arc::new(CapturingAdapter::default());
+    let sup = ccteam_imd::supervisor::BotSupervisor::new(
+        reg.clone(),
+        projects_root.clone(),
+        adapter.clone(),
+    );
+    sup.ensure_started().await.unwrap();
+
+    // Supervisor's `project_dir()` and `chat_inbox_dir(...)` must both
+    // land under the registration's absolute path — NOT `projects_root/slug`.
+    let expected_inbox = project_dir.join(".ccteam/chat/tech-helper/inbox");
+    let resolved_inbox = ccteam_imd::chat_inbox_dir(&projects_root, &reg);
+    assert_eq!(
+        resolved_inbox, expected_inbox,
+        "chat_inbox_dir must resolve under reg.project_dir"
+    );
+
+    // The legacy slug-based path under projects_root MUST NOT be the
+    // mailbox path — guard against a silent fallback regression.
+    let legacy_inbox = projects_root.join("research-squad/.ccteam/chat/tech-helper/inbox");
+    assert_ne!(resolved_inbox, legacy_inbox);
+
+    // End-to-end: write the envelope into the resolved inbox (the path
+    // the daemon's `drain_inboxes` would read), parse + submit, and
+    // confirm the bot saw the payload — proving the round trip works
+    // when projects sit outside the default home/projects tree.
+    let path = write_envelope(&resolved_inbox, "@tech-helper plan");
+    let body = std::fs::read_to_string(&path).unwrap();
+    let env = parse_envelope(&body).unwrap();
+    sup.handle_inbound(env.payload).await.unwrap();
+
+    let submitted = adapter.submitted.lock().unwrap().clone();
+    assert_eq!(submitted, vec!["@tech-helper plan".to_string()]);
+}
+
+#[tokio::test]
 async fn mailbox_envelope_payload_preserves_special_chars() {
     // Slash commands, backticks, newlines, multiline markdown — must
     // round-trip verbatim. This is the regression anchor for "user
@@ -184,7 +252,7 @@ async fn mailbox_envelope_payload_preserves_special_chars() {
     let sup = BotSupervisor::new(reg(), projects_root.clone(), adapter.clone());
     sup.ensure_started().await.unwrap();
 
-    let inbox = chat_inbox_dir(&projects_root, "demo", "helper");
+    let inbox = chat_inbox_dir(&projects_root, &reg());
     let payload = "Line 1\n```rust\nfn main() {}\n```\n@mention `/clear` end";
     let path = write_envelope(&inbox, payload);
 

--- a/crates/ccteam-imd/tests/dm_autoroute_test.rs
+++ b/crates/ccteam-imd/tests/dm_autoroute_test.rs
@@ -67,6 +67,7 @@ fn mk_bot(slug: &str, role: &str, platform: &str, chat_id: &str) -> BotRegistrat
         im_platform: platform.into(),
         im_chat_id: chat_id.into(),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/e2e_mock_test.rs
+++ b/crates/ccteam-imd/tests/e2e_mock_test.rs
@@ -151,6 +151,7 @@ fn reg(slug: &str, role: &str) -> BotRegistration {
         im_platform: "mock".into(),
         im_chat_id: format!("chat-{slug}-{role}"),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }
@@ -215,9 +216,17 @@ async fn happy_path_im_to_bot_to_im() {
     let mut handles = HandleMap::new();
     handles.insert("lead", slug, role);
 
-    let res = process_inbound(&im_msg("@lead what's up?"), &sec, &handles, &mailbox, 0, 1)
-        .await
-        .unwrap();
+    let res = process_inbound(
+        &im_msg("@lead what's up?"),
+        &sec,
+        &handles,
+        &[],
+        &mailbox,
+        0,
+        1,
+    )
+    .await
+    .unwrap();
     assert!(matches!(res, InboundOutcome::DroppedToBot { .. }));
 
     // Wire supervisor + adapter; start the thread.
@@ -386,7 +395,7 @@ async fn multi_bot_parallel() {
     let mut seq = 0_u64;
     for content in ["@lead one", "@lead two", "@ops three"] {
         seq += 1;
-        let outcome = process_inbound(&im_msg(content), &sec, &handles, &mailbox, 0, seq)
+        let outcome = process_inbound(&im_msg(content), &sec, &handles, &[], &mailbox, 0, seq)
             .await
             .unwrap();
         assert!(matches!(outcome, InboundOutcome::DroppedToBot { .. }));
@@ -463,7 +472,7 @@ async fn channel_listen_to_inbound_pipeline() {
     let mut count = 0_u64;
     while let Ok(msg) = rx.try_recv() {
         count += 1;
-        let outcome = process_inbound(&msg, &sec, &handles, &mailbox, 0, count)
+        let outcome = process_inbound(&msg, &sec, &handles, &[], &mailbox, 0, count)
             .await
             .unwrap();
         assert!(matches!(outcome, InboundOutcome::DroppedToBot { .. }));

--- a/crates/ccteam-imd/tests/handle_resolution_test.rs
+++ b/crates/ccteam-imd/tests/handle_resolution_test.rs
@@ -25,6 +25,7 @@ fn mk(slug: &str, role: &str, handle: Option<&str>, platform: &str, chat: &str) 
         im_platform: platform.into(),
         im_chat_id: chat.into(),
         chat_handle: handle.map(String::from),
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/heartbeat_writer_test.rs
+++ b/crates/ccteam-imd/tests/heartbeat_writer_test.rs
@@ -83,6 +83,7 @@ fn reg() -> BotRegistration {
         im_platform: "mock".into(),
         im_chat_id: "1".into(),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/crates/ccteam-imd/tests/outbound_wiring_test.rs
+++ b/crates/ccteam-imd/tests/outbound_wiring_test.rs
@@ -32,8 +32,28 @@ use ccteam_imd::outbound;
 use ccteam_imd::register_bot;
 use ccteam_imd::transport::providers::mock::MockChannel;
 use ccteam_imd::transport::Channel;
+use ccteam_imd::BotRegistration;
 use futures::stream::BoxStream;
 use tempfile::TempDir;
+
+/// Build a transient `BotRegistration` for path-helper calls. F185
+/// path resolvers take `&BotRegistration` so they can honor a per-bot
+/// `project_dir`; these tests stay on the slug-fallback layout
+/// (`project_dir = None`), matching the legacy `<projects_root>/<slug>/`
+/// shape register_bot() persists.
+fn bot_reg(slug: &str, role: &str) -> BotRegistration {
+    BotRegistration {
+        workflow_slug: slug.into(),
+        role: role.into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "telegram".into(),
+        im_chat_id: "0".into(),
+        chat_handle: None,
+        project_dir: None,
+        created_at: chrono::Utc::now(),
+    }
+}
 
 // ----- env isolation helpers (mirrors tests/inbound_wiring_test.rs) ---
 
@@ -181,7 +201,7 @@ async fn daemon_forwards_turns_jsonl_to_channel() {
     assert_eq!(outbox[1].recipient, "chat-42");
 
     // Cursor file was persisted so a daemon restart wouldn't re-forward.
-    let cursor_path = outbound::outbound_cursor_path(&projects_root, "dev-foo", "lead");
+    let cursor_path = outbound::outbound_cursor_path(&projects_root, &bot_reg("dev-foo", "lead"));
     assert!(
         cursor_path.exists(),
         "cursor file should exist at {}",
@@ -299,7 +319,7 @@ async fn drain_handles_truncation_without_repeat_forwarding() {
     // Seed an outbound.cursor that points well past the new EOF —
     // simulates a turns.jsonl that was much longer before and got
     // rotated / truncated while the daemon was offline.
-    let cursor_path = outbound::outbound_cursor_path(&projects_root, "dev-trunc", "lead");
+    let cursor_path = outbound::outbound_cursor_path(&projects_root, &bot_reg("dev-trunc", "lead"));
     std::fs::write(&cursor_path, r#"{"position": 10000}"#).unwrap();
     assert!(
         new_eof < 10000,
@@ -400,7 +420,7 @@ async fn drain_no_op_when_cursor_already_at_eof() {
 
     // Cursor pre-positioned at EOF — simulates the steady-state where
     // the fast-path dispatcher already shipped every row.
-    let cursor_path = outbound::outbound_cursor_path(&projects_root, "dev-eof", "lead");
+    let cursor_path = outbound::outbound_cursor_path(&projects_root, &bot_reg("dev-eof", "lead"));
     std::fs::write(&cursor_path, format!(r#"{{"position": {eof}}}"#)).unwrap();
 
     let mock = Arc::new(MockChannel::new());

--- a/crates/ccteam-imd/tests/project_dir_resolve_test.rs
+++ b/crates/ccteam-imd/tests/project_dir_resolve_test.rs
@@ -1,0 +1,195 @@
+//! F185 — `BotRegistration.project_dir` path-resolution coverage.
+//!
+//! Anchors the contract `supervisor::bot_dir` /
+//! `inbound::DefaultMailboxResolver::inbox_dir` /
+//! `outbound::{turns_jsonl_path, outbound_cursor_path}` honor on top of
+//! the new optional field:
+//!
+//! 1. When the registration carries an explicit `project_dir`, every
+//!    resolver lays out paths under that absolute path directly.
+//! 2. When `project_dir = None`, every resolver falls back to the
+//!    historical `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/`
+//!    layout — pre-F185 registrations keep routing the same way.
+//! 3. `BotRegistration` serde round-trips the field — JSON with
+//!    `project_dir` populates it; JSON without it stays `None`
+//!    (the `skip_serializing_if = "Option::is_none"` keeps the wire
+//!    shape clean for legacy callers).
+
+use std::path::PathBuf;
+
+use ccteam_core::harness::AgentVendor;
+use ccteam_imd::inbound::{DefaultMailboxResolver, MailboxResolver};
+use ccteam_imd::supervisor::bot_dir;
+use ccteam_imd::{chat_inbox_dir, chat_reset_signal_path, turns_jsonl_path, BotRegistration};
+
+fn mk_reg(slug: &str, role: &str, project_dir: Option<PathBuf>) -> BotRegistration {
+    BotRegistration {
+        workflow_slug: slug.into(),
+        role: role.into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "telegram".into(),
+        im_chat_id: "1".into(),
+        chat_handle: None,
+        project_dir,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+#[test]
+fn bot_dir_honors_explicit_project_dir() {
+    let reg = mk_reg(
+        "research-squad",
+        "tech-helper",
+        Some(PathBuf::from("/vol4/1000/nasworkspace/ccteam")),
+    );
+    // projects_root is irrelevant when project_dir is set — assert that.
+    let dir = bot_dir(std::path::Path::new("/home/ubuntu/projects"), &reg);
+    assert_eq!(
+        dir,
+        PathBuf::from("/vol4/1000/nasworkspace/ccteam/.ccteam/chat/tech-helper")
+    );
+}
+
+#[test]
+fn bot_dir_falls_back_to_projects_root_when_project_dir_none() {
+    let reg = mk_reg("dev-foo", "lead", None);
+    let dir = bot_dir(std::path::Path::new("/home/user/projects"), &reg);
+    assert_eq!(
+        dir,
+        PathBuf::from("/home/user/projects/dev-foo/.ccteam/chat/lead")
+    );
+}
+
+#[test]
+fn chat_inbox_dir_honors_explicit_project_dir() {
+    let reg = mk_reg(
+        "dir-basename-ne-slug",
+        "ops",
+        Some(PathBuf::from("/srv/ccteam")),
+    );
+    let inbox = chat_inbox_dir(std::path::Path::new("/home/user/projects"), &reg);
+    assert_eq!(inbox, PathBuf::from("/srv/ccteam/.ccteam/chat/ops/inbox"));
+}
+
+#[test]
+fn chat_inbox_dir_falls_back_when_project_dir_none() {
+    let reg = mk_reg("legacy-bot", "lead", None);
+    let inbox = chat_inbox_dir(std::path::Path::new("/home/user/projects"), &reg);
+    assert_eq!(
+        inbox,
+        PathBuf::from("/home/user/projects/legacy-bot/.ccteam/chat/lead/inbox")
+    );
+}
+
+#[test]
+fn chat_reset_signal_path_honors_explicit_project_dir() {
+    let reg = mk_reg(
+        "any-slug",
+        "helper",
+        Some(PathBuf::from("/abs/path/to/project")),
+    );
+    let sig = chat_reset_signal_path(std::path::Path::new("/home/user/projects"), &reg);
+    assert_eq!(
+        sig,
+        PathBuf::from("/abs/path/to/project/.ccteam/chat/helper/signals/reset.signal")
+    );
+}
+
+#[test]
+fn turns_jsonl_path_honors_explicit_project_dir() {
+    let reg = mk_reg("squad", "support", Some(PathBuf::from("/vol4/ccteam")));
+    let turns = turns_jsonl_path(std::path::Path::new("/home/user/projects"), &reg);
+    assert_eq!(
+        turns,
+        PathBuf::from("/vol4/ccteam/.ccteam/chat/support/turns.jsonl")
+    );
+}
+
+#[test]
+fn default_mailbox_resolver_honors_explicit_project_dir() {
+    let reg = mk_reg(
+        "research-squad",
+        "tech-helper",
+        Some(PathBuf::from("/vol4/ccteam")),
+    );
+    let mailbox = DefaultMailboxResolver::with_projects_root("/home/user/projects");
+    let dir = mailbox.inbox_dir(&reg).unwrap();
+    assert_eq!(
+        dir,
+        PathBuf::from("/vol4/ccteam/.ccteam/chat/tech-helper/inbox")
+    );
+}
+
+#[test]
+fn default_mailbox_resolver_falls_back_when_project_dir_none() {
+    let reg = mk_reg("dev-foo", "lead", None);
+    let mailbox = DefaultMailboxResolver::with_projects_root("/home/user/projects");
+    let dir = mailbox.inbox_dir(&reg).unwrap();
+    assert_eq!(
+        dir,
+        PathBuf::from("/home/user/projects/dev-foo/.ccteam/chat/lead/inbox")
+    );
+}
+
+#[test]
+fn serde_round_trips_project_dir_when_present() {
+    let reg = mk_reg(
+        "demo",
+        "helper",
+        Some(PathBuf::from("/vol4/1000/nasworkspace/ccteam")),
+    );
+    let body = serde_json::to_string(&reg).unwrap();
+    assert!(
+        body.contains("\"project_dir\":\"/vol4/1000/nasworkspace/ccteam\""),
+        "serialized JSON should include project_dir: {}",
+        body
+    );
+    let parsed: BotRegistration = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        parsed.project_dir,
+        Some(PathBuf::from("/vol4/1000/nasworkspace/ccteam"))
+    );
+}
+
+#[test]
+fn serde_omits_project_dir_when_none_and_parses_legacy_json() {
+    // Legacy on-disk shape: BotRegistration JSON written before F185
+    // had no `project_dir` key. Must still parse — serde `#[serde(default)]`
+    // gives us the `None` fallback.
+    let legacy_json = r#"{
+      "workflow_slug": "dev-foo",
+      "role": "lead",
+      "vendor": "claude",
+      "im_platform": "telegram",
+      "im_chat_id": "42",
+      "created_at": "2026-05-24T00:00:00Z"
+    }"#;
+    let parsed: BotRegistration = serde_json::from_str(legacy_json).unwrap();
+    assert!(parsed.project_dir.is_none(), "legacy JSON parses to None");
+
+    // Round-trip a None reg: `skip_serializing_if = "Option::is_none"`
+    // keeps the field out of the serialized form — important for
+    // pre-F185 callers who don't expect the extra key.
+    let body = serde_json::to_string(&parsed).unwrap();
+    assert!(
+        !body.contains("project_dir"),
+        "serialized JSON should omit project_dir when None: {}",
+        body
+    );
+}
+
+#[test]
+fn project_root_helper_resolves_explicit_and_fallback() {
+    let reg_explicit = mk_reg("any", "any", Some(PathBuf::from("/srv/myproj")));
+    assert_eq!(
+        reg_explicit.project_root(std::path::Path::new("/home/u/projects")),
+        PathBuf::from("/srv/myproj")
+    );
+
+    let reg_fallback = mk_reg("legacy-slug", "any", None);
+    assert_eq!(
+        reg_fallback.project_root(std::path::Path::new("/home/u/projects")),
+        PathBuf::from("/home/u/projects/legacy-slug")
+    );
+}

--- a/crates/ccteam-imd/tests/turns_mirror_consumer_test.rs
+++ b/crates/ccteam-imd/tests/turns_mirror_consumer_test.rs
@@ -101,6 +101,7 @@ fn reg() -> BotRegistration {
         im_platform: "mock".into(),
         im_chat_id: "1".into(),
         chat_handle: None,
+        project_dir: None,
         created_at: chrono::Utc::now(),
     }
 }

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -338,6 +338,14 @@ daemon's registry watcher picks it up and spawns the tmux session.
 Phase 5.1: take `telegram.allowed_chat_ids[0]` (cast to string —
 Telegram chat ids are i64, but the MCP wire expects a string).
 
+Always pass `project_dir` (absolute path of the directory holding
+`.ccteam/workflow.yaml`, i.e. the `project_dir` you used in Phase 5.3 /
+5.4 above) so the daemon can find the project no matter where the
+user keeps it. Projects outside the default `~/projects/<slug>/`
+layout (NAS shares, dir basename ≠ workflow slug) only resolve when
+this field is set. Omitting it falls back to the MCP server's current
+working directory.
+
 ```json
 {
   "name": "mcp__ccteam__chat_register_bot",
@@ -347,13 +355,15 @@ Telegram chat ids are i64, but the MCP wire expects a string).
     "vendor": "claude",
     "im_platform": "telegram",
     "im_chat_id": "<allowed_chat_ids[0]>",
-    "persona_id": "<persona_id from Phase 3>"
+    "persona_id": "<persona_id from Phase 3>",
+    "project_dir": "<absolute path of the dir containing .ccteam/workflow.yaml>"
   }
 }
 ```
 
 When `chat_handle` is omitted (as above) the dispatcher returns the
-auto-minted handle in the response:
+auto-minted handle (and echoes the resolved `project_dir`) in the
+response:
 
 ```json
 {
@@ -361,7 +371,8 @@ auto-minted handle in the response:
   "path": "/home/.../helper.json",
   "workflow_slug": "<slug>",
   "role": "<role>",
-  "chat_handle": "Euclid"
+  "chat_handle": "Euclid",
+  "project_dir": "/abs/path/to/project"
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes daemon's inability to find projects that live outside `~/projects/<slug>/`. Two real cases this unblocks:

- Projects on NAS / non-home paths (e.g. `/vol4/1000/nasworkspace/ccteam`).
- Project directory basename differs from workflow slug (dir `ccteam`, slug `research-squad`).

### Approach

- **Additive schema**: `BotRegistration.project_dir: Option<PathBuf>` (serde-default-skip; legacy JSON without the field still parses).
- **Resolver fallback**: `supervisor::bot_dir` and `inbound::DefaultMailboxResolver` prefer `reg.project_dir` when set; fall back to the historical `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/` when `None`.
- **MCP input**: `chat_register_bot` gains an optional `project_dir` parameter. When omitted, the dispatcher defaults to `std::env::current_dir()` (canonicalized via `std::fs::canonicalize`).
- **Skill**: `ccteam-creator` Phase 5.6 now passes `project_dir` (the directory holding `.ccteam/workflow.yaml`) when registering bots.

No version bump, no migration tooling — pre-v1.0 policy (CLAUDE.md §五 third bullet). Old registrations continue to work via fallback.

### Drive-by

`e2e_creator_full_path_test` carried a stale assertion referencing `## 5.9` Phase 5.9 — that section was renumbered to 5.8 in #146 when the broken `ccteam internal daemon ensure-running` reference was removed. Fixed here so the workspace test gate is clean.

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast --exclude ccteam-web`: 1469 pass / 0 F185-related failures. Excluded `ccteam-web` due to local inotify-busy host hang on `ws_*` tests (known per CLAUDE.md §六); CI exercises it cleanly. Two remaining transient failures both reproduce on bare main and pass in isolation (`cost_summary::t09_memoize_second_call_no_reread` — concurrent file-watch race; `dm_autoroute::daemon_dm_no_at_mention_auto_routes_to_single_bot` — env-race flake CLAUDE.md §六 documents).
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 warning
- [x] `cargo fmt --all -- --check` 0 drift
- [x] New `project_dir_resolve_test.rs`: explicit `project_dir` path used; absent → fallback to `projects_root/slug`
- [x] Extended `chat_register_mcp_test.rs`: serde round-trip with new field
- [x] End-to-end test on supervisor + mailbox honors `reg.project_dir` over `projects_root`

## Acceptance

User scenario:

```
mkdir -p /vol4/1000/nasworkspace/ccteam/.ccteam
cd /vol4/1000/nasworkspace/ccteam   # creator writes workflow.yaml here
# register bot (skill auto-passes project_dir = $PWD)
ccteam start
# daemon finds /vol4/1000/nasworkspace/ccteam/.ccteam/chat/<role>/ — works
```

Refs `docs/versions/v0-6-8/README.md` (F185 will be folded into the version archive in a follow-up sweep alongside the other V0.6.8 additions).