### PR TITLE
v0.6.8: MailboxResolver config.yaml fallback + Codex spawn-error surfacing + retry cap (F190/F192)

### DIFF
--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -309,6 +309,34 @@ pub fn build_chat_hop_escalate_event(role: &str, hop_count: u32, last_bot: &str)
     })
 }
 
+/// `chat_bot_permanent_failure` — V0.6.8 F192c. Emitted after a bot's
+/// `HarnessAdapter::start_thread` has failed `MAX_START_THREAD_ATTEMPTS`
+/// times in a row. The supervisor latches `permanent_failure = true`,
+/// stops retrying, and the daemon's tick loop returns `Quarantine` on
+/// every subsequent decision pass for this bot. Recovery requires
+/// `ccteam restart-bot <slug>/<role>` or a daemon restart.
+///
+/// Payload: `{role, reason, attempts, ts}`.
+pub const CHAT_BOT_PERMANENT_FAILURE: &str = "chat_bot_permanent_failure";
+
+/// V0.6.8 F192c — build a `chat_bot_permanent_failure` event JSON.
+/// `reason` is a short human string summarizing the latest failure
+/// (typically the underlying tmux / spawn stderr, truncated to keep
+/// progress.jsonl scannable). `attempts` is the number of consecutive
+/// failed start_thread attempts (always 3 at the moment but kept as a
+/// field so future tuning of `MAX_START_THREAD_ATTEMPTS` lands on the
+/// wire without a schema bump).
+pub fn build_chat_bot_permanent_failure_event(role: &str, reason: &str, attempts: u32) -> Value {
+    let trimmed: String = reason.chars().take(512).collect();
+    serde_json::json!({
+        "event": CHAT_BOT_PERMANENT_FAILURE,
+        "role": role,
+        "reason": trimmed,
+        "attempts": attempts,
+        "ts": Utc::now().to_rfc3339(),
+    })
+}
+
 // ---------------- V0.6.1 F98 plan-approval event kinds ----------------
 
 /// `plan_pending` — agent wrote a plan markdown to

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -157,22 +157,40 @@ impl SupervisorRegistry {
     }
 
     /// Add a supervisor for `reg` if one isn't already registered.
-    /// Returns the live (existing-or-new) supervisor handle.
+    /// Returns the live (existing-or-new) supervisor handle. Wrapper
+    /// around [`Self::ensure_with_config`] that passes an empty F190
+    /// config-yaml tier (legacy / test callers without a config map).
     pub fn ensure(
         &mut self,
         reg: &BotRegistration,
         projects_root: &Path,
         factory: &AdapterFactory,
     ) -> Arc<BotSupervisor> {
+        self.ensure_with_config(reg, projects_root, factory, &HashMap::new())
+    }
+
+    /// V0.6.8 F190 — config-yaml-aware companion to [`Self::ensure`].
+    /// Wires the loaded `~/.ccteam/config.yaml::projects[]` slug → path
+    /// map into the new [`BotSupervisor`] so its
+    /// `project_dir()` / `bot_dir()` resolution honors the F190 tier
+    /// for legacy registrations.
+    pub fn ensure_with_config(
+        &mut self,
+        reg: &BotRegistration,
+        projects_root: &Path,
+        factory: &AdapterFactory,
+        config_projects: &std::collections::HashMap<String, PathBuf>,
+    ) -> Arc<BotSupervisor> {
         let k = Self::key(reg);
         self.inner
             .entry(k)
             .or_insert_with(|| {
                 let adapter = factory(reg.vendor);
-                Arc::new(BotSupervisor::new(
+                Arc::new(BotSupervisor::new_with_config(
                     reg.clone(),
                     projects_root.to_path_buf(),
                     adapter,
+                    config_projects.clone(),
                 ))
             })
             .clone()
@@ -220,6 +238,33 @@ where
         .unwrap_or_else(default_adapter_factory);
     let registry: Arc<Mutex<SupervisorRegistry>> =
         Arc::new(Mutex::new(SupervisorRegistry::default()));
+
+    // V0.6.8 F190 — load `~/.ccteam/config.yaml::projects[]` once at
+    // startup so legacy bots (no `reg.project_dir`) whose project
+    // lives outside the projects_root tree resolve correctly. Daemon
+    // restart is the standard "config changed" workflow, so a one-shot
+    // disk read here is enough (no live reload). A missing config.yaml
+    // / parse error yields an empty map; the third tier of
+    // `resolve_project_dir` (projects_root/slug) still applies.
+    let config_projects: std::collections::HashMap<String, PathBuf> = {
+        let ccteam_root = crate::default_ccteam_root_public();
+        match crate::load_config_projects_map(&ccteam_root) {
+            Ok(map) => {
+                tracing::info!(
+                    entries = map.len(),
+                    "F190: loaded ~/.ccteam/config.yaml::projects[] for legacy bot resolution"
+                );
+                map
+            }
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "F190: failed to load config.yaml; legacy bots fall through to projects_root/slug"
+                );
+                std::collections::HashMap::new()
+            }
+        }
+    };
 
     // V0.6.1 F132 — projects_root used for both supervisor bot_dir
     // resolution and the mailbox writer. Mirrors `tick_supervisors`'s
@@ -273,8 +318,13 @@ where
     // admin executor). `Arc` so the consumer task owns its own clones
     // without re-locking the daemon loop.
     let sec = Arc::new(Mutex::new(ThreeLayerSec::new(AclPolicy::default())));
-    let mailbox: Arc<dyn MailboxResolver> = Arc::new(DefaultMailboxResolver::with_projects_root(
+    // V0.6.8 F190 — mailbox resolver honors the three-tier project_dir
+    // priority chain (reg.project_dir > config.yaml::projects[slug] >
+    // projects_root/slug). Daemon's `config_projects` map is loaded
+    // above.
+    let mailbox: Arc<dyn MailboxResolver> = Arc::new(DefaultMailboxResolver::with_config_projects(
         projects_root.clone(),
+        config_projects.clone(),
     ));
     let executor = Arc::new(AdminExecutor::new(projects_root.clone()));
 
@@ -331,12 +381,13 @@ where
                         Vec::new()
                     }
                 };
-                tick_supervisors(
+                tick_supervisors_with_config(
                     &bots,
                     &registry,
                     Some(&projects_root),
                     &factory,
                     Some(&bot_channels),
+                    &config_projects,
                 )
                 .await;
                 ensure_bot_channels(
@@ -1174,12 +1225,38 @@ pub async fn run_daemon(args: DaemonArgs) -> Result<()> {
 /// pipeline wired), the cursor reset is skipped and the supervisor's
 /// disk-side wipe still applies; the next `load_from_disk` will pick
 /// up the cleared cursor on the next daemon restart.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn tick_supervisors(
     bots: &[BotRegistration],
     registry: &Arc<Mutex<SupervisorRegistry>>,
     projects_root_override: Option<&Path>,
     factory: &AdapterFactory,
     bot_channels: Option<&BotChannelMap>,
+) {
+    tick_supervisors_with_config(
+        bots,
+        registry,
+        projects_root_override,
+        factory,
+        bot_channels,
+        &HashMap::new(),
+    )
+    .await
+}
+
+/// V0.6.8 F190 — config-yaml-aware companion to [`tick_supervisors`].
+/// Daemon main loop reads `~/.ccteam/config.yaml::projects[]` once at
+/// startup and passes the slug → path map through here so legacy bots
+/// (no `reg.project_dir`) whose project lives outside the
+/// projects_root tree resolve to the right bot_dir for signal /
+/// heartbeat decisions.
+pub(crate) async fn tick_supervisors_with_config(
+    bots: &[BotRegistration],
+    registry: &Arc<Mutex<SupervisorRegistry>>,
+    projects_root_override: Option<&Path>,
+    factory: &AdapterFactory,
+    bot_channels: Option<&BotChannelMap>,
+    config_projects: &HashMap<String, PathBuf>,
 ) {
     let owned;
     let projects_root: &Path = match projects_root_override {
@@ -1192,12 +1269,15 @@ pub(crate) async fn tick_supervisors(
         }
     };
 
-    // First pass: ensure a supervisor exists per bot.
+    // First pass: ensure a supervisor exists per bot. F190 — pass the
+    // config-yaml map so the new supervisor's `project_dir()` /
+    // `bot_dir()` honors the slug → path lookup for legacy
+    // registrations.
     let supervisors: Vec<(BotRegistration, Arc<BotSupervisor>)> = {
         let mut reg = registry.lock().await;
         bots.iter()
             .map(|b| {
-                let sup = reg.ensure(b, projects_root, factory);
+                let sup = reg.ensure_with_config(b, projects_root, factory, config_projects);
                 (b.clone(), sup)
             })
             .collect()
@@ -1205,10 +1285,17 @@ pub(crate) async fn tick_supervisors(
 
     // Second pass: decide + apply per bot (drop the registry lock for
     // each adapter call so a slow start_thread doesn't stall other
-    // bots' decisions).
+    // bots' decisions). F190 — use `decide_with_config` so signal /
+    // heartbeat path resolution mirrors the supervisor's spawn path.
     for (bot, sup) in supervisors {
         let state = sup.state_snapshot().await;
-        let action = supervisor::decide(projects_root, &bot, &state, SystemTime::now());
+        let action = supervisor::decide_with_config(
+            projects_root,
+            &bot,
+            &state,
+            SystemTime::now(),
+            config_projects,
+        );
         tracing::debug!(
             slug = %bot.workflow_slug,
             role = %bot.role,

--- a/crates/ccteam-imd/src/inbound.rs
+++ b/crates/ccteam-imd/src/inbound.rs
@@ -10,6 +10,7 @@
 //! per bot); this module's responsibility ends at writing the
 //! mailbox file the adapter watches.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -110,29 +111,68 @@ pub trait MailboxResolver: Send + Sync {
 }
 
 /// Default resolver: rooted at the bot's chat dir
-/// (`<project>/.ccteam/chat/<role>/inbox/`). When the registration
-/// carries an explicit `project_dir`, that absolute path is used
-/// directly; otherwise the resolver joins the configured
-/// `projects_root` with `workflow_slug` for the legacy layout.
+/// (`<project>/.ccteam/chat/<role>/inbox/`). Resolution honors the
+/// three-tier F190 priority chain (see
+/// [`crate::resolve_project_dir`]):
+///
+/// 1. `reg.project_dir` (F185 explicit field).
+/// 2. `config_projects[reg.workflow_slug]` (F190 —
+///    `~/.ccteam/config.yaml::projects[]` slug → path SoT). Daemon
+///    loads this once at startup and passes it in via
+///    [`Self::with_config_projects`]; legacy registrations without an
+///    explicit `project_dir` route correctly even when the project
+///    lives outside `~/projects/<slug>/` (NAS share, dir basename ≠
+///    workflow slug).
+/// 3. `<projects_root>/<workflow_slug>/` (historical layout).
+///
 /// `projects_root` is normally `~/projects` (production) but tests
-/// pass an override via [`Self::with_projects_root`].
+/// pass an override via [`Self::with_projects_root`]. Tests that want
+/// to assert the config-yaml tier construct with
+/// [`Self::with_config_projects`].
 pub struct DefaultMailboxResolver {
     projects_root: PathBuf,
+    /// V0.6.8 F190 — slug → absolute project path map sourced from
+    /// `~/.ccteam/config.yaml::projects[]`. Empty when the resolver was
+    /// constructed without config (legacy code path / unit tests that
+    /// don't exercise the F190 tier).
+    config_projects: HashMap<String, PathBuf>,
 }
 
 impl DefaultMailboxResolver {
-    /// Build pointing at `~/projects` (or `/` if HOME is unset).
+    /// Build pointing at `~/projects` (or `/` if HOME is unset). No
+    /// config-yaml tier — callers that want F190 behavior should use
+    /// [`Self::with_config_projects`].
     pub fn new() -> Self {
         let projects_root = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("/"))
             .join("projects");
-        Self { projects_root }
+        Self {
+            projects_root,
+            config_projects: HashMap::new(),
+        }
     }
 
-    /// Build pointing at an explicit projects root (tests).
+    /// Build pointing at an explicit projects root (tests). No
+    /// config-yaml tier — see [`Self::with_config_projects`].
     pub fn with_projects_root(projects_root: impl Into<PathBuf>) -> Self {
         Self {
             projects_root: projects_root.into(),
+            config_projects: HashMap::new(),
+        }
+    }
+
+    /// V0.6.8 F190 — build with both `projects_root` and the
+    /// `~/.ccteam/config.yaml::projects[]` slug → path map. Daemon
+    /// startup wires this so legacy registrations with
+    /// `project_dir = None` resolve through the config-yaml tier
+    /// before falling through to the projects_root tier.
+    pub fn with_config_projects(
+        projects_root: impl Into<PathBuf>,
+        config_projects: HashMap<String, PathBuf>,
+    ) -> Self {
+        Self {
+            projects_root: projects_root.into(),
+            config_projects,
         }
     }
 }
@@ -145,7 +185,9 @@ impl Default for DefaultMailboxResolver {
 
 impl MailboxResolver for DefaultMailboxResolver {
     fn inbox_dir(&self, reg: &crate::BotRegistration) -> Result<PathBuf> {
-        Ok(crate::chat_inbox_dir(&self.projects_root, reg))
+        Ok(reg
+            .chat_dir_with_config(&self.projects_root, &self.config_projects)
+            .join("inbox"))
     }
 }
 

--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -40,6 +40,7 @@ pub mod supervisor;
 pub mod three_layer_sec;
 pub mod transport;
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant, SystemTime};
@@ -268,11 +269,37 @@ impl BotRegistration {
     /// registration time). Falls back to the historical
     /// `<projects_root>/<workflow_slug>/` layout for legacy
     /// registrations that have `project_dir = None`.
+    ///
+    /// F190 — consult [`project_root_with_config`](Self::project_root_with_config)
+    /// when the caller has access to `~/.ccteam/config.yaml::projects[]`
+    /// (the slug → path SoT). This base form is kept for callers (MCP
+    /// path helpers, unit tests) that don't have the config map on hand.
     pub fn project_root(&self, projects_root: &Path) -> PathBuf {
         match self.project_dir.as_deref() {
             Some(p) => p.to_path_buf(),
             None => projects_root.join(&self.workflow_slug),
         }
+    }
+
+    /// V0.6.8 F190 — three-tier project-root resolver. Priority chain:
+    ///
+    /// 1. `reg.project_dir` (F185 — written by `chat_register_bot`).
+    /// 2. `config_projects[slug]` (F190 — `~/.ccteam/config.yaml::projects[]`
+    ///    slug → path SoT introduced in V0.4.2 F73).
+    /// 3. `<projects_root>/<workflow_slug>/` (historical layout).
+    ///
+    /// The daemon hands a populated `config_projects` to
+    /// [`DefaultMailboxResolver::with_config_projects`] and
+    /// [`BotSupervisor::new_with_config`] so legacy registrations (no
+    /// `project_dir`) whose project lives outside the home tree
+    /// (NAS shares, dir basename ≠ workflow slug) still route correctly
+    /// without re-registering every bot.
+    pub fn project_root_with_config(
+        &self,
+        projects_root: &Path,
+        config_projects: &HashMap<String, PathBuf>,
+    ) -> PathBuf {
+        resolve_project_dir(self, projects_root, config_projects)
     }
 
     /// Resolve `<project>/.ccteam/chat/<role>/` for this bot. The
@@ -284,6 +311,66 @@ impl BotRegistration {
             .join("chat")
             .join(&self.role)
     }
+
+    /// V0.6.8 F190 — config-yaml-aware companion to [`chat_dir`](Self::chat_dir).
+    /// Same `.ccteam/chat/<role>/` layout, but the project-root tier-2
+    /// lookup picks the path out of `config_projects` when
+    /// `reg.project_dir = None`.
+    pub fn chat_dir_with_config(
+        &self,
+        projects_root: &Path,
+        config_projects: &HashMap<String, PathBuf>,
+    ) -> PathBuf {
+        self.project_root_with_config(projects_root, config_projects)
+            .join(".ccteam")
+            .join("chat")
+            .join(&self.role)
+    }
+}
+
+/// V0.6.8 F190 — three-tier project-root resolver.
+///
+/// Returns the absolute path of the project this bot lives in. Priority
+/// chain (first hit wins):
+///
+/// 1. `reg.project_dir` — F185 explicit field written by
+///    `chat_register_bot` at registration time.
+/// 2. `config_projects[reg.workflow_slug]` — F190 lookup against
+///    `~/.ccteam/config.yaml::projects[]` (the slug → path SoT V0.4.2
+///    F73 introduced). The daemon loads `CcteamConfig` once at startup
+///    and builds this map; pass an empty map when the caller has no
+///    config available (MCP helpers, unit tests).
+/// 3. `projects_root.join(reg.workflow_slug)` — historical
+///    `<projects_root>/<slug>/` layout used by pre-F185 registrations.
+///
+/// The MailboxResolver + BotSupervisor + daemon `tick_supervisors` /
+/// `decide` paths funnel through this helper so the same priority chain
+/// applies everywhere; resolvers don't re-implement the logic.
+pub fn resolve_project_dir(
+    reg: &BotRegistration,
+    projects_root: &Path,
+    config_projects: &HashMap<String, PathBuf>,
+) -> PathBuf {
+    if let Some(p) = reg.project_dir.as_deref() {
+        return p.to_path_buf();
+    }
+    if let Some(p) = config_projects.get(&reg.workflow_slug) {
+        return p.clone();
+    }
+    projects_root.join(&reg.workflow_slug)
+}
+
+/// V0.6.8 F190 — load `~/.ccteam/config.yaml::projects[]` into a
+/// `slug -> absolute path` map suitable for [`resolve_project_dir`].
+///
+/// Errors load loud (corrupt yaml is fail-fast — same semantics as
+/// `ccteam_core::config::load`). A missing / empty file returns an
+/// empty map (no config-yaml tier applies, resolvers fall through to
+/// the projects_root tier).
+pub fn load_config_projects_map(ccteam_root: &Path) -> Result<HashMap<String, PathBuf>> {
+    let cfg = ccteam_core::config::load(ccteam_root)
+        .with_context(|| format!("load ccteam config from {}", ccteam_root.display()))?;
+    Ok(cfg.projects.into_iter().map(|p| (p.slug, p.path)).collect())
 }
 
 /// V0.6.5 F146 — outcome of [`register_bot_checked_in`].

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -85,7 +85,32 @@ pub struct BotState {
     pub shutting_down: bool,
     /// True once `drain.signal` has been observed (no new turns).
     pub draining: bool,
+    /// V0.6.8 F192c — consecutive `HarnessAdapter::start_thread`
+    /// failures. Incremented in `ensure_started` on adapter error,
+    /// reset to 0 on a successful start. Cap is
+    /// [`MAX_START_THREAD_ATTEMPTS`]; on hitting the cap the supervisor
+    /// flips [`Self::permanent_failure`] and stops retrying.
+    pub fail_count: u32,
+    /// V0.6.8 F192c — once the supervisor has burned through
+    /// [`MAX_START_THREAD_ATTEMPTS`] consecutive `start_thread`
+    /// failures, this flag latches `true`. `decide_with_config`
+    /// short-circuits to `Quarantine` on every subsequent tick so the
+    /// daemon stops spamming identical WARN entries every 5 seconds.
+    /// Recovery: `ccteam restart-bot <slug>/<role>` (which removes the
+    /// registration and re-registers, building a fresh `BotState`) or
+    /// a daemon restart.
+    pub permanent_failure: bool,
 }
+
+/// V0.6.8 F192c — maximum consecutive `start_thread` attempts before
+/// the supervisor latches `permanent_failure`. After this many
+/// back-to-back failures the supervisor emits one
+/// `chat_bot_permanent_failure` progress event and stops retrying.
+/// The current tick interval (5s) means the give-up wall-clock is
+/// roughly `MAX_START_THREAD_ATTEMPTS * tick = 15s` — enough to catch
+/// a transient flake on the first or second tick while not letting a
+/// permanently-broken bot flood logs with identical WARNs.
+pub const MAX_START_THREAD_ATTEMPTS: u32 = 3;
 
 /// Decision the supervisor makes for one bot on a single tick.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,13 +151,32 @@ pub fn refresh_global_heartbeat() -> Result<()> {
 ///
 /// Pure decision function — no IO besides reading existing signal
 /// files + heartbeat file. The daemon's main loop applies the action.
+/// Wrapper around [`decide_with_config`] that passes an empty config
+/// map (the daemon's production path uses the config-aware form so
+/// F190's `~/.ccteam/config.yaml::projects[]` tier applies).
 pub fn decide(
     projects_root: &Path,
     reg: &BotRegistration,
     state: &BotState,
     now: SystemTime,
 ) -> SupervisorAction {
-    let bot_dir = bot_dir(projects_root, reg);
+    decide_with_config(projects_root, reg, state, now, &HashMap::new())
+}
+
+/// V0.6.8 F190 — config-yaml-aware variant of [`decide`]. The daemon's
+/// `tick_supervisors` reads `~/.ccteam/config.yaml::projects[]` once at
+/// startup and threads the slug → path map through this entry so a
+/// legacy bot (no `reg.project_dir`) whose project lives outside the
+/// projects_root tree still hits the right bot_dir for signal /
+/// heartbeat checks.
+pub fn decide_with_config(
+    projects_root: &Path,
+    reg: &BotRegistration,
+    state: &BotState,
+    now: SystemTime,
+    config_projects: &HashMap<String, PathBuf>,
+) -> SupervisorAction {
+    let bot_dir = bot_dir_with_config(projects_root, reg, config_projects);
 
     // Layer A — shutdown beats everything else (terminal).
     if signal_present(&bot_dir, SHUTDOWN_SIGNAL) || state.shutting_down {
@@ -148,9 +192,24 @@ pub fn decide(
     // restart loop, but loses to shutdown / drain (terminal states).
     // Independent of restart budget — a manual reset is an intentional
     // action, not a flap, and should always succeed even when the bot
-    // has burned through its hourly Restart budget.
+    // has burned through its hourly Restart budget. Reset also clears
+    // F192c `permanent_failure` (the supervisor's `reset_session`
+    // wipes `fail_count` + `permanent_failure` so a recovered config
+    // can retry).
     if signal_present(&bot_dir, RESET_SIGNAL) {
         return SupervisorAction::ResetSession;
+    }
+
+    // V0.6.8 F192c — `start_thread` retry budget exhausted. The
+    // supervisor's `ensure_started` flips this latch after
+    // `MAX_START_THREAD_ATTEMPTS` consecutive failures and emits one
+    // `chat_bot_permanent_failure` progress event. Subsequent ticks
+    // return `Quarantine` so the daemon stops spamming identical
+    // WARNs every 5 seconds. User-issued reset / drain / shutdown
+    // still cut through above; Quarantine maps to `NoOp` in
+    // `apply_action`, no further adapter calls are made.
+    if state.permanent_failure {
+        return SupervisorAction::Quarantine;
     }
 
     // Layer C — restart budget exhausted → quarantine.
@@ -189,8 +248,27 @@ pub fn decide(
 /// registration time). Falls back to the historical
 /// `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/` layout for
 /// pre-F185 registrations that have `project_dir = None`.
+///
+/// F190 wrapper — see [`bot_dir_with_config`] for the config-yaml-aware
+/// resolver the daemon uses; this base form keeps the legacy / test
+/// signature stable (callers without a config map pass through here).
 pub fn bot_dir(projects_root: &Path, reg: &BotRegistration) -> PathBuf {
     reg.chat_dir(projects_root)
+}
+
+/// V0.6.8 F190 — config-yaml-aware variant of [`bot_dir`]. Resolves
+/// `<project>/.ccteam/chat/<role>/` honoring the full three-tier
+/// priority chain (`reg.project_dir` → `config_projects[slug]` →
+/// `<projects_root>/<slug>/`). Daemon `tick_supervisors` uses this
+/// via [`decide_with_config`] so legacy bots whose project lives
+/// outside the projects_root tree hit the right signal / heartbeat
+/// path.
+pub fn bot_dir_with_config(
+    projects_root: &Path,
+    reg: &BotRegistration,
+    config_projects: &HashMap<String, PathBuf>,
+) -> PathBuf {
+    reg.chat_dir_with_config(projects_root, config_projects)
 }
 
 fn signal_present(bot_dir: &Path, name: &str) -> bool {
@@ -227,6 +305,14 @@ pub struct BotSupervisor {
     pub reg: BotRegistration,
     /// Projects root (`<projects_root>/<slug>/.ccteam/chat/<role>/`).
     pub projects_root: PathBuf,
+    /// V0.6.8 F190 — `~/.ccteam/config.yaml::projects[]` slug → path
+    /// map. Daemon loads this once at startup and passes it through
+    /// [`Self::new_with_config`] so legacy bots (no `reg.project_dir`)
+    /// whose project lives outside the projects_root tree still
+    /// resolve correctly via the F190 tier of
+    /// [`crate::resolve_project_dir`]. Empty map for tests / callers
+    /// that skip the config tier.
+    pub config_projects: HashMap<String, PathBuf>,
     /// Wave 3 — the adapter the daemon picked for this vendor/mode
     /// pair. Owned via `Arc` so the supervisor can hand a clone to
     /// the outbound tail task.
@@ -275,15 +361,33 @@ impl std::fmt::Debug for BotSupervisor {
 
 impl BotSupervisor {
     /// Build a fresh supervisor for `reg`, using `adapter` for every
-    /// HarnessAdapter call. Initial state is empty (no handle).
+    /// HarnessAdapter call. Initial state is empty (no handle). The
+    /// F190 config-yaml tier is empty — callers that want the daemon's
+    /// `~/.ccteam/config.yaml::projects[]` lookup should use
+    /// [`Self::new_with_config`].
     pub fn new(
         reg: BotRegistration,
         projects_root: impl Into<PathBuf>,
         adapter: Arc<dyn HarnessAdapter + Send + Sync>,
     ) -> Self {
+        Self::new_with_config(reg, projects_root, adapter, HashMap::new())
+    }
+
+    /// V0.6.8 F190 — full constructor wiring the
+    /// `~/.ccteam/config.yaml::projects[]` slug → path map so
+    /// `project_dir()` / `bot_dir()` resolution honors the F190 tier
+    /// for legacy registrations whose project lives outside the
+    /// projects_root tree.
+    pub fn new_with_config(
+        reg: BotRegistration,
+        projects_root: impl Into<PathBuf>,
+        adapter: Arc<dyn HarnessAdapter + Send + Sync>,
+        config_projects: HashMap<String, PathBuf>,
+    ) -> Self {
         Self {
             reg,
             projects_root: projects_root.into(),
+            config_projects,
             adapter,
             state: Mutex::new(BotState::default()),
             heartbeat_task: Mutex::new(None),
@@ -302,17 +406,21 @@ impl BotSupervisor {
     }
 
     /// `<projects_root>/<slug>/.ccteam/chat/<role>/`. Helper so the
-    /// background tasks share one resolution path with `decide`.
+    /// background tasks share one resolution path with `decide`. F190 —
+    /// honors `config_projects` so the legacy registration tier picks
+    /// the right path out of `~/.ccteam/config.yaml::projects[]`.
     fn bot_dir(&self) -> PathBuf {
-        bot_dir(&self.projects_root, &self.reg)
+        bot_dir_with_config(&self.projects_root, &self.reg, &self.config_projects)
     }
 
     /// Root dir for the project hosting this bot's
     /// `.ccteam/workflow.yaml`. F185 — prefers `reg.project_dir` when
-    /// set; falls back to `<projects_root>/<workflow_slug>/` for
-    /// legacy registrations.
+    /// set; F190 — falls back to `config_projects[slug]` when
+    /// `reg.project_dir = None`; final fallback is the historical
+    /// `<projects_root>/<workflow_slug>/` layout.
     pub fn project_dir(&self) -> PathBuf {
-        self.reg.project_root(&self.projects_root)
+        self.reg
+            .project_root_with_config(&self.projects_root, &self.config_projects)
     }
 
     /// True iff `start_thread` has been called and `close_thread` has
@@ -334,13 +442,117 @@ impl BotSupervisor {
         self.state.lock().await.clone()
     }
 
+    /// V0.6.8 F192b/c — book-keep one `start_thread` failure. Logs a
+    /// WARN line carrying the full anyhow chain (which includes the
+    /// adapter's `SpawnFailed` body — for tmux-backed adapters that's
+    /// `tmux new-session` stderr already embedded), increments
+    /// `BotState::fail_count`, and on hitting
+    /// [`MAX_START_THREAD_ATTEMPTS`] consecutive failures latches
+    /// `BotState::permanent_failure` and emits one
+    /// `chat_bot_permanent_failure` progress event.
+    async fn record_start_failure(&self, err: &anyhow::Error) {
+        let mut st = self.state.lock().await;
+        st.fail_count = st.fail_count.saturating_add(1);
+        let attempts = st.fail_count;
+        let permanent = attempts >= MAX_START_THREAD_ATTEMPTS;
+        if permanent {
+            st.permanent_failure = true;
+        }
+        drop(st);
+
+        // The full anyhow chain (`{err:#}`) includes the underlying
+        // adapter SpawnFailed body, which for tmux-backed adapters
+        // already embeds `tmux new-session` stderr. Truncate to 1 KB
+        // so a perpetually-failing flap doesn't bloat the log file.
+        let chain = format!("{err:#}");
+        let chain_trunc: String = chain.chars().take(1024).collect();
+
+        if permanent {
+            tracing::warn!(
+                slug = %self.reg.workflow_slug,
+                role = %self.reg.role,
+                adapter = self.adapter.name(),
+                attempts,
+                error_chain = %chain_trunc,
+                "F192c: start_thread failed {} times in a row; latching permanent_failure (no more retries)",
+                attempts,
+            );
+            // Best-effort emit `chat_bot_permanent_failure` so IM /
+            // web surfaces show the user the bot is stuck. Path
+            // resolution honors `CCTEAM_HOME` so tests land in their
+            // tempdir layout. A missing CcteamPaths (no env) is the
+            // normal `cargo test` posture — we silently skip the
+            // append; the WARN above is the audit trail.
+            if let Ok(paths) = ccteam_core::CcteamPaths::from_env() {
+                let progress_path = paths.progress_jsonl(&self.reg.workflow_slug);
+                let ev = ccteam_core::progress::build_chat_bot_permanent_failure_event(
+                    &self.reg.role,
+                    &chain_trunc,
+                    attempts,
+                );
+                if let Err(append_err) = ccteam_core::progress::append_event(&progress_path, &ev) {
+                    tracing::warn!(
+                        slug = %self.reg.workflow_slug,
+                        role = %self.reg.role,
+                        error = %append_err,
+                        "F192c: failed to append chat_bot_permanent_failure event to progress.jsonl"
+                    );
+                }
+            }
+        } else {
+            tracing::warn!(
+                slug = %self.reg.workflow_slug,
+                role = %self.reg.role,
+                adapter = self.adapter.name(),
+                attempts,
+                max = MAX_START_THREAD_ATTEMPTS,
+                error_chain = %chain_trunc,
+                "F192b: start_thread failed (attempt {}/{}); will retry next tick",
+                attempts,
+                MAX_START_THREAD_ATTEMPTS,
+            );
+        }
+    }
+
     /// Idempotent: start the underlying tmux session via
     /// `adapter.start_thread` if not already running.
+    ///
+    /// V0.6.8 F192b/c — on `start_thread` failure this method:
+    /// 1. Logs a WARN line carrying the full anyhow error chain
+    ///    (`{err:#}` includes the adapter's `SpawnFailed` body, which
+    ///    for tmux-backed adapters already embeds `tmux new-session`
+    ///    stderr — see `crates/ccteam-core/src/tmux.rs::start_with_env`).
+    /// 2. Increments `BotState::fail_count`. On hitting
+    ///    [`MAX_START_THREAD_ATTEMPTS`] consecutive failures, latches
+    ///    `BotState::permanent_failure = true` and emits one
+    ///    `chat_bot_permanent_failure` progress event so the daemon's
+    ///    next `decide_with_config` short-circuits to `Quarantine` and
+    ///    stops spamming identical WARNs every 5 seconds.
+    /// 3. Returns the underlying error to the caller (daemon's
+    ///    `apply_action`) — `tick_supervisors_with_config` logs at
+    ///    WARN level but continues running other bots.
     pub async fn ensure_started(&self) -> Result<()> {
         {
             let st = self.state.lock().await;
             if st.handle.is_some() {
                 return Ok(());
+            }
+            // V0.6.8 F192c — once we've latched permanent failure,
+            // refuse to retry until reset / restart-bot clears it.
+            // The daemon's tick path returns `Quarantine` first so we
+            // shouldn't normally get here, but `apply_action(Spawn)`
+            // direct callers (e.g. tests) still hit this guard.
+            if st.permanent_failure {
+                return Err(anyhow!(
+                    "bot {}/{} is in permanent_failure state \
+                     (start_thread failed {} times in a row); \
+                     run `ccteam restart-bot {}/{}` or restart the daemon",
+                    self.reg.workflow_slug,
+                    self.reg.role,
+                    st.fail_count,
+                    self.reg.workflow_slug,
+                    self.reg.role,
+                ));
             }
         }
         let spec = AgentSpecBrief {
@@ -358,7 +570,7 @@ impl BotSupervisor {
             // path (try_spawn_with_prompt) plumbs through workflow.yaml.
             model_id: None,
         };
-        let handle = self
+        let start_result = self
             .adapter
             .start_thread(&spec, &ctx)
             .await
@@ -369,9 +581,22 @@ impl BotSupervisor {
                     self.reg.role,
                     self.adapter.name()
                 )
-            })?;
+            });
+        let handle = match start_result {
+            Ok(h) => h,
+            Err(err) => {
+                self.record_start_failure(&err).await;
+                return Err(err);
+            }
+        };
         let mut st = self.state.lock().await;
         st.handle = Some(handle.clone());
+        // V0.6.8 F192c — success path resets the consecutive-failure
+        // counter. (`permanent_failure` is only cleared on reset /
+        // restart-bot; once latched the supervisor refuses to retry
+        // even after a successful manual restart, which is the
+        // intended hard-stop semantic.)
+        st.fail_count = 0;
         drop(st);
         tracing::info!(
             slug = %self.reg.workflow_slug,
@@ -795,8 +1020,18 @@ impl BotSupervisor {
             }
         }
 
-        // 4. Close the old handle (best-effort).
-        let handle = self.state.lock().await.handle.take();
+        // 4. Close the old handle (best-effort). V0.6.8 F192c — also
+        //    clear `fail_count` + `permanent_failure` so reset is a
+        //    legitimate recovery path: an operator who fixed the
+        //    underlying breakage (config typo, missing binary, dead
+        //    tmux session) can re-arm the supervisor by writing
+        //    `signals/reset.signal` instead of restarting the daemon.
+        let handle = {
+            let mut st = self.state.lock().await;
+            st.fail_count = 0;
+            st.permanent_failure = false;
+            st.handle.take()
+        };
         if let Some(h) = handle {
             if let Err(err) = self.adapter.close_thread(&h).await {
                 tracing::warn!(
@@ -1014,6 +1249,114 @@ mod bot_supervisor_tests {
         assert_eq!(stub.starts.load(Ordering::SeqCst), 1);
         sup.apply_action(SupervisorAction::Shutdown).await.unwrap();
         assert_eq!(stub.closes.load(Ordering::SeqCst), 1);
+    }
+
+    // ---- V0.6.8 F192c — start_thread retry budget + permanent failure ----
+
+    #[tokio::test]
+    async fn ensure_started_increments_fail_count_on_spawn_error() {
+        let stub = Arc::new(StubAdapter {
+            fail_start: true,
+            ..StubAdapter::default()
+        });
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+
+        // First failure: fail_count -> 1, not yet permanent.
+        let res = sup.ensure_started().await;
+        assert!(res.is_err());
+        let st = sup.state_snapshot().await;
+        assert_eq!(st.fail_count, 1);
+        assert!(!st.permanent_failure);
+
+        // Second failure: fail_count -> 2, still not permanent.
+        let res = sup.ensure_started().await;
+        assert!(res.is_err());
+        let st = sup.state_snapshot().await;
+        assert_eq!(st.fail_count, 2);
+        assert!(!st.permanent_failure);
+
+        // Third failure: fail_count -> 3, latches permanent_failure.
+        let res = sup.ensure_started().await;
+        assert!(res.is_err());
+        let st = sup.state_snapshot().await;
+        assert_eq!(st.fail_count, MAX_START_THREAD_ATTEMPTS);
+        assert!(
+            st.permanent_failure,
+            "expected permanent_failure latch after {MAX_START_THREAD_ATTEMPTS} consecutive fails"
+        );
+
+        // After latching, further `ensure_started` calls refuse without
+        // invoking the adapter. The stub's call counter should not have
+        // ticked past 3 — proving "no more retries" once latched.
+        let _ = sup.ensure_started().await;
+        assert_eq!(
+            stub.starts.load(Ordering::SeqCst),
+            MAX_START_THREAD_ATTEMPTS as usize,
+            "F192c: latched supervisor MUST NOT invoke adapter.start_thread again"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_started_resets_fail_count_on_success() {
+        let stub = Arc::new(StubAdapter::default()); // succeeds
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        // Pre-seed fail_count to simulate one earlier transient failure.
+        {
+            let mut st = sup.state.lock().await;
+            st.fail_count = 2;
+            assert!(!st.permanent_failure);
+        }
+        sup.ensure_started().await.unwrap();
+        let st = sup.state_snapshot().await;
+        assert_eq!(
+            st.fail_count, 0,
+            "successful start_thread must reset fail_count"
+        );
+        assert!(!st.permanent_failure);
+    }
+
+    #[tokio::test]
+    async fn decide_returns_quarantine_when_permanent_failure_latched() {
+        // Pure decide() check: state.permanent_failure short-circuits
+        // to Quarantine regardless of handle/heartbeat presence, so
+        // the daemon stops re-calling Spawn on a flap-locked bot.
+        let tmp = TempDir::new().unwrap();
+        let r = reg();
+        let st = BotState {
+            permanent_failure: true,
+            fail_count: MAX_START_THREAD_ATTEMPTS,
+            ..Default::default()
+        };
+        let action = decide(tmp.path(), &r, &st, SystemTime::now());
+        assert_eq!(action, SupervisorAction::Quarantine);
+    }
+
+    #[tokio::test]
+    async fn reset_session_clears_permanent_failure() {
+        // F192c — `signals/reset.signal` is the operator's recovery
+        // path. reset_session must wipe both fail_count and the
+        // permanent_failure latch so the next tick can attempt
+        // start_thread again (now that the operator presumably fixed
+        // whatever broke the spawn).
+        let stub = Arc::new(StubAdapter::default()); // will succeed on reset
+        let tmp = TempDir::new().unwrap();
+        let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
+        {
+            let mut st = sup.state.lock().await;
+            st.fail_count = MAX_START_THREAD_ATTEMPTS;
+            st.permanent_failure = true;
+        }
+        sup.reset_session().await.unwrap();
+        let st = sup.state_snapshot().await;
+        assert_eq!(st.fail_count, 0);
+        assert!(!st.permanent_failure);
+        assert_eq!(
+            stub.starts.load(Ordering::SeqCst),
+            1,
+            "reset_session ends with one ensure_started call"
+        );
     }
 }
 

--- a/crates/ccteam-imd/tests/project_dir_resolve_test.rs
+++ b/crates/ccteam-imd/tests/project_dir_resolve_test.rs
@@ -1,26 +1,34 @@
-//! F185 — `BotRegistration.project_dir` path-resolution coverage.
+//! F185 + V0.6.8 F190 — `BotRegistration.project_dir` /
+//! `~/.ccteam/config.yaml::projects[]` path-resolution coverage.
 //!
 //! Anchors the contract `supervisor::bot_dir` /
 //! `inbound::DefaultMailboxResolver::inbox_dir` /
 //! `outbound::{turns_jsonl_path, outbound_cursor_path}` honor on top of
-//! the new optional field:
+//! the F185 optional field + F190 three-tier priority chain:
 //!
 //! 1. When the registration carries an explicit `project_dir`, every
 //!    resolver lays out paths under that absolute path directly.
-//! 2. When `project_dir = None`, every resolver falls back to the
-//!    historical `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/`
-//!    layout — pre-F185 registrations keep routing the same way.
-//! 3. `BotRegistration` serde round-trips the field — JSON with
+//! 2. F190 — when `reg.project_dir = None` AND the bot's slug is
+//!    present in the `config.yaml::projects[]` map, resolvers use the
+//!    config-recorded path. Lets legacy registrations (pre-F185) work
+//!    on hosts whose project lives outside `~/projects/<slug>/`.
+//! 3. When both `reg.project_dir = None` AND the slug is absent from
+//!    config, every resolver falls back to the historical
+//!    `<projects_root>/<workflow_slug>/.ccteam/chat/<role>/` layout.
+//! 4. `BotRegistration` serde round-trips the field — JSON with
 //!    `project_dir` populates it; JSON without it stays `None`
 //!    (the `skip_serializing_if = "Option::is_none"` keeps the wire
 //!    shape clean for legacy callers).
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use ccteam_core::harness::AgentVendor;
 use ccteam_imd::inbound::{DefaultMailboxResolver, MailboxResolver};
-use ccteam_imd::supervisor::bot_dir;
-use ccteam_imd::{chat_inbox_dir, chat_reset_signal_path, turns_jsonl_path, BotRegistration};
+use ccteam_imd::supervisor::{bot_dir, bot_dir_with_config};
+use ccteam_imd::{
+    chat_inbox_dir, chat_reset_signal_path, resolve_project_dir, turns_jsonl_path, BotRegistration,
+};
 
 fn mk_reg(slug: &str, role: &str, project_dir: Option<PathBuf>) -> BotRegistration {
     BotRegistration {
@@ -192,4 +200,165 @@ fn project_root_helper_resolves_explicit_and_fallback() {
         reg_fallback.project_root(std::path::Path::new("/home/u/projects")),
         PathBuf::from("/home/u/projects/legacy-slug")
     );
+}
+
+// -------- V0.6.8 F190 — three-tier priority chain coverage ----------
+
+#[test]
+fn resolve_project_dir_prefers_explicit_over_config() {
+    // Tier 1 wins even when tier 2 has a different path: explicit
+    // `reg.project_dir` from F185 is the highest-priority source.
+    let reg = mk_reg(
+        "research-squad",
+        "code-critic",
+        Some(PathBuf::from("/from/explicit")),
+    );
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert(
+        "research-squad".into(),
+        PathBuf::from("/from/config/should-not-win"),
+    );
+    let got = resolve_project_dir(&reg, std::path::Path::new("/home/u/projects"), &cfg);
+    assert_eq!(got, PathBuf::from("/from/explicit"));
+}
+
+#[test]
+fn resolve_project_dir_uses_config_when_reg_none_and_slug_present() {
+    // Tier 2 — legacy registration (project_dir = None) but slug is in
+    // config.yaml::projects[]. The config path wins over the
+    // projects_root fallback. This is the F190 NAS-share / out-of-tree
+    // project unlock.
+    let reg = mk_reg("nas-bot", "lead", None);
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert("nas-bot".into(), PathBuf::from("/vol4/1000/ccteam"));
+    let got = resolve_project_dir(&reg, std::path::Path::new("/home/u/projects"), &cfg);
+    assert_eq!(got, PathBuf::from("/vol4/1000/ccteam"));
+}
+
+#[test]
+fn resolve_project_dir_falls_through_to_projects_root_when_slug_absent() {
+    // Tier 3 — neither reg.project_dir nor config map contains the
+    // slug. Resolver falls through to the historical layout.
+    let reg = mk_reg("orphan-slug", "lead", None);
+    let cfg: HashMap<String, PathBuf> = HashMap::new(); // empty
+    let got = resolve_project_dir(&reg, std::path::Path::new("/home/u/projects"), &cfg);
+    assert_eq!(got, PathBuf::from("/home/u/projects/orphan-slug"));
+}
+
+#[test]
+fn resolve_project_dir_falls_through_with_unrelated_config_entries() {
+    // Tier 3 sanity — slug missing from config, but config isn't
+    // empty (other projects present). Still falls through to the
+    // projects_root tier; we don't grab the first entry or anything
+    // silly like that.
+    let reg = mk_reg("orphan", "lead", None);
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert("other-project".into(), PathBuf::from("/srv/other"));
+    let got = resolve_project_dir(&reg, std::path::Path::new("/home/u/projects"), &cfg);
+    assert_eq!(got, PathBuf::from("/home/u/projects/orphan"));
+}
+
+#[test]
+fn bot_dir_with_config_uses_config_when_reg_none() {
+    let reg = mk_reg("legacy-bot", "lead", None);
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert("legacy-bot".into(), PathBuf::from("/srv/legacy"));
+    let dir = bot_dir_with_config(std::path::Path::new("/home/u/projects"), &reg, &cfg);
+    assert_eq!(dir, PathBuf::from("/srv/legacy/.ccteam/chat/lead"));
+}
+
+#[test]
+fn bot_dir_with_config_explicit_wins_over_config() {
+    let reg = mk_reg(
+        "any-slug",
+        "lead",
+        Some(PathBuf::from("/from/explicit/project")),
+    );
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert("any-slug".into(), PathBuf::from("/from/config"));
+    let dir = bot_dir_with_config(std::path::Path::new("/home/u/projects"), &reg, &cfg);
+    assert_eq!(
+        dir,
+        PathBuf::from("/from/explicit/project/.ccteam/chat/lead")
+    );
+}
+
+#[test]
+fn default_mailbox_resolver_consults_config_when_reg_none() {
+    // F190 — resolver constructed via `with_config_projects` honors
+    // tier 2 of the priority chain when the registration lacks an
+    // explicit `project_dir`.
+    let reg = mk_reg("nas-bot", "lead", None);
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert("nas-bot".into(), PathBuf::from("/vol4/1000/ccteam"));
+    let mailbox = DefaultMailboxResolver::with_config_projects("/home/u/projects", cfg);
+    let dir = mailbox.inbox_dir(&reg).unwrap();
+    assert_eq!(
+        dir,
+        PathBuf::from("/vol4/1000/ccteam/.ccteam/chat/lead/inbox")
+    );
+}
+
+#[test]
+fn default_mailbox_resolver_falls_through_when_slug_absent_from_config() {
+    // F190 — slug not in the config map. Resolver falls through to
+    // projects_root layout (pre-F190 behavior preserved).
+    let reg = mk_reg("orphan", "lead", None);
+    let cfg: HashMap<String, PathBuf> = HashMap::new(); // empty
+    let mailbox = DefaultMailboxResolver::with_config_projects("/home/u/projects", cfg);
+    let dir = mailbox.inbox_dir(&reg).unwrap();
+    assert_eq!(
+        dir,
+        PathBuf::from("/home/u/projects/orphan/.ccteam/chat/lead/inbox")
+    );
+}
+
+#[test]
+fn default_mailbox_resolver_explicit_project_dir_beats_config() {
+    // F190 — when both reg.project_dir AND config map have entries
+    // for the slug, reg.project_dir wins (F185 priority preserved).
+    let reg = mk_reg("dual", "lead", Some(PathBuf::from("/from/explicit")));
+    let mut cfg: HashMap<String, PathBuf> = HashMap::new();
+    cfg.insert("dual".into(), PathBuf::from("/from/config"));
+    let mailbox = DefaultMailboxResolver::with_config_projects("/home/u/projects", cfg);
+    let dir = mailbox.inbox_dir(&reg).unwrap();
+    assert_eq!(dir, PathBuf::from("/from/explicit/.ccteam/chat/lead/inbox"));
+}
+
+#[test]
+fn load_config_projects_map_missing_file_returns_empty() {
+    // Simulates a fresh install with no `~/.ccteam/config.yaml`. The
+    // helper must yield an empty map (not an error) so resolvers fall
+    // through cleanly to the projects_root tier.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let got = ccteam_imd::load_config_projects_map(tmp.path()).unwrap();
+    assert!(got.is_empty(), "expected empty map, got {:?}", got);
+}
+
+#[test]
+fn load_config_projects_map_populates_from_config_yaml() {
+    use ccteam_core::config::{save, CcteamConfig, ProjectEntry};
+    let tmp = tempfile::TempDir::new().unwrap();
+    let cfg = CcteamConfig {
+        projects: vec![
+            ProjectEntry {
+                slug: "alpha".into(),
+                path: PathBuf::from("/vol4/alpha"),
+                team: "dev".into(),
+                installed_at: chrono::Utc::now(),
+            },
+            ProjectEntry {
+                slug: "beta".into(),
+                path: PathBuf::from("/srv/beta"),
+                team: "research".into(),
+                installed_at: chrono::Utc::now(),
+            },
+        ],
+        ..Default::default()
+    };
+    save(tmp.path(), &cfg).unwrap();
+    let got = ccteam_imd::load_config_projects_map(tmp.path()).unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got.get("alpha"), Some(&PathBuf::from("/vol4/alpha")));
+    assert_eq!(got.get("beta"), Some(&PathBuf::from("/srv/beta")));
 }


### PR DESCRIPTION
## Summary

- **F190** — extends F185's path-resolution priority chain. Legacy registrations without `project_dir` now consult `~/.ccteam/config.yaml::projects[]` (the slug -> path SoT V0.4.2 F73 introduced) before falling through to the historical `<projects_root>/<slug>/`. The resolver lives in `ccteam_imd::resolve_project_dir(reg, projects_root, config_projects)` and is called from both `DefaultMailboxResolver::inbox_dir` (via `with_config_projects` constructor) and `supervisor::bot_dir_with_config` / `decide_with_config`. Daemon loads `CcteamConfig` once at startup and threads the slug -> path map through `BotSupervisor::new_with_config` + `tick_supervisors_with_config`.
- **F192a** — verified the existing `ccteam doctor --check-codex-auto-critic` (V0.6.5 F155) already runs a real `codex exec --json --skip-git-repo-check` canary with stderr capture in the failure body. No code change required.
- **F192b** — Codex / Claude chat-mode `start_thread` failure WARN now carries the full anyhow chain (`{err:#}`) truncated to 1 KB. For tmux-backed adapters this string already embeds `tmux new-session` stderr from `tmux::start_with_env` (the adapter's `SpawnFailed` body is the underlying source of truth — there is no separate stdout/stderr pipeline because the tmux abstraction owns the spawn boundary).
- **F192c** — per-bot retry policy: 3 attempts at supervisor-tick rate (~15s wall-clock). On the third consecutive `start_thread` failure the supervisor latches `BotState::permanent_failure = true`, emits one `chat_bot_permanent_failure` progress event, and `decide_with_config` short-circuits to `Quarantine` on every subsequent tick. No more identical-WARN-every-5-seconds floods. Recovery: `signals/reset.signal` clears `fail_count` + `permanent_failure` (see `reset_session`), or restart the daemon.

State-machine intent: `permanent_failure` is cleared only by `reset_session` (operator-issued recovery), NOT by `restart()`. The `restart()` heartbeat-stale path is unreachable once latched because `decide_with_config`'s tier ordering puts `Quarantine` above `Restart`.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` clean (full workspace, including `ccteam-web`)
- [x] `cargo test -p ccteam-imd -p ccteam-core -p ccteam-cli --locked --no-fail-fast --tests` all pass — including 11 new F190 tests (config-yaml tier coverage in `project_dir_resolve_test.rs`) and 4 new F192c tests in `supervisor::bot_supervisor_tests`
- [ ] Known pre-existing flake: `daemon_dm_no_at_mention_auto_routes_to_single_bot` in `ccteam_imd::dm_autoroute_test` is flaky on `cargo test --workspace` (timing race in the daemon's first-tick consumption). Reproduces on clean `origin/main` HEAD; not introduced by this PR. Matches the CLAUDE.md baseline pattern of WSL2-only / scheduler-sensitive transients.

## Acceptance

- Legacy bot whose project lives on NAS (`/vol4/...`) works without re-registering: daemon reads `config.yaml::projects` and routes inbox/outbox/signals/heartbeat to the correct path.
- A bot stuck in a spawn-failure loop emits one `chat_bot_permanent_failure` event and stops flooding logs after 3 consecutive failures (~15s).
- WARN log on `start_thread` failure includes the full error chain (tmux stderr) so operators can diagnose without re-running by hand.
- `ccteam doctor --check-codex-auto-critic` returns `available: false` with stderr captured when `codex exec` is broken (already shipped in V0.6.5 F155).

## Files changed

- `crates/ccteam-imd/src/lib.rs` — `resolve_project_dir`, `load_config_projects_map`, `BotRegistration::{project_root,chat_dir}_with_config`
- `crates/ccteam-imd/src/inbound.rs` — `DefaultMailboxResolver::with_config_projects` + config-aware `inbox_dir`
- `crates/ccteam-imd/src/supervisor.rs` — `BotState::{fail_count, permanent_failure}`, `MAX_START_THREAD_ATTEMPTS`, `bot_dir_with_config`, `decide_with_config`, `BotSupervisor::new_with_config` + `record_start_failure`, reset_session clears latch
- `crates/ccteam-imd/src/daemon.rs` — loads `CcteamConfig` once at startup; `SupervisorRegistry::ensure_with_config`; `tick_supervisors_with_config`; `mailbox` uses `with_config_projects`
- `crates/ccteam-core/src/progress.rs` — `CHAT_BOT_PERMANENT_FAILURE` const + `build_chat_bot_permanent_failure_event`
- `crates/ccteam-imd/tests/project_dir_resolve_test.rs` — 11 new tests covering the F190 three-tier priority chain + `load_config_projects_map`

Closes V0.6.8 F190/F192.