### PR TITLE
v0.6.8: bot-to-bot @mention via daemon-internal mpsc (F193)

### DIFF
--- a/crates/ccteam-imd/src/bot_mpsc.rs
+++ b/crates/ccteam-imd/src/bot_mpsc.rs
@@ -54,10 +54,20 @@ pub struct InboxItem {
     /// Sanitized payload (router-stripped of the `@<handle>` mention).
     pub payload: String,
     /// On-disk envelope path — `unlink` after handle_inbound succeeds.
+    /// V0.6.8 F193 — synthesized cross-bot mentions carry an empty
+    /// `PathBuf`; the inbox dispatcher's `remove_file` silently fails
+    /// (no envelope file ever existed) which is the desired behaviour.
     pub path: PathBuf,
     /// Wall-clock millis when the daemon enqueued this item — the
     /// consumer logs `queue_age_ms` against `now - enqueue_unix_ms`.
     pub enqueue_unix_ms: u128,
+    /// V0.6.8 F193 — bot-to-bot loop-guard hop counter. User-IM-sourced
+    /// messages enter with `hop = 0`; the cross-bot fast-path in
+    /// `spawn_outbound_dispatcher` synthesizes items with
+    /// `hop = sender_hop + 1`. The fast-path mpsc lost this field before
+    /// F193; the on-disk `InboxEnvelope.hop` still carries it for
+    /// safety-net `drain_inboxes` recovery.
+    pub hop: u8,
 }
 
 /// One outbound assistant row ready for dispatch to the IM platform.
@@ -82,6 +92,12 @@ pub struct OutboundItem {
     pub cursor_after: u64,
     /// Wall-clock millis when the daemon enqueued this row.
     pub enqueue_unix_ms: u128,
+    /// V0.6.8 F193 — hop value of the inbound turn that produced this
+    /// reply. Threaded from `BotSupervisor::current_hop` so the
+    /// outbound dispatcher can compute `next_hop = hop + 1` when it
+    /// detects an embedded `@<otherbot>` mention and synthesizes a
+    /// cross-bot `InboxItem`.
+    pub hop: u8,
 }
 
 /// Per-bot send-side handles. The daemon owns these (one entry per

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -40,7 +40,7 @@ use crate::inbound::{
 use crate::latency::now_unix_ms;
 use crate::nl_admin::AdminExecutor;
 use crate::outbound;
-use crate::router::HandleMap;
+use crate::router::{self, HandleMap};
 use crate::supervisor::{self, BotSupervisor};
 use crate::three_layer_sec::ThreeLayerSec;
 use crate::transport::providers::telegram::TelegramChannel;
@@ -572,6 +572,7 @@ fn spawn_inbound_consumer(
                         path,
                         payload,
                         cid: item_cid,
+                        hop,
                     } = outcome
                     {
                         let guard = bot_channels.lock().await;
@@ -583,6 +584,7 @@ fn spawn_inbound_consumer(
                                 payload,
                                 path,
                                 enqueue_unix_ms: now_unix_ms(),
+                                hop,
                             };
                             if let Err(err) = ch.inbox_tx.try_send(item) {
                                 tracing::warn!(
@@ -751,6 +753,11 @@ async fn ensure_bot_channels(
             outbound_cursor.clone(),
             slug_log,
             role_log,
+            // V0.6.8 F193 — hand the dispatcher a clone of the
+            // BotChannelMap so it can synthesize cross-bot `InboxItem`s
+            // when the reply contains `@<otherbot>`. Cheap: the map is
+            // `Arc<Mutex<HashMap<..>>>`, cloning is just an Arc bump.
+            bot_channels.clone(),
         ));
 
         // Tell the supervisor about the outbound side so its events
@@ -790,7 +797,7 @@ async fn spawn_inbox_dispatcher(
     while let Some(item) = rx.recv().await {
         let queue_age_ms = now_unix_ms().saturating_sub(item.enqueue_unix_ms) as u64;
         let submit_t0 = std::time::Instant::now();
-        match sup.handle_inbound(item.payload).await {
+        match sup.handle_inbound(item.payload, item.hop).await {
             Ok(turn_id) => {
                 tracing::info!(
                     event = "latency",
@@ -840,6 +847,7 @@ async fn spawn_inbox_dispatcher(
 /// this gives both writers a single source of truth and closes both
 /// the cursor-rewind loop and the per-row double-send window that
 /// the NAS-environment bug exposed.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_outbound_dispatcher(
     mut rx: mpsc::Receiver<OutboundItem>,
     channel: Arc<dyn Channel + Send + Sync>,
@@ -848,6 +856,7 @@ async fn spawn_outbound_dispatcher(
     cursor: Arc<outbound::OutboundCursor>,
     slug_log: String,
     role_log: String,
+    bot_channels: BotChannelMap,
 ) {
     while let Some(item) = rx.recv().await {
         // Already covered by drain_outboxes — skip the redundant TG
@@ -888,6 +897,15 @@ async fn spawn_outbound_dispatcher(
                     "latency imd.outbound.dispatch (mpsc)"
                 );
                 cursor.try_advance(item.cursor_after).await;
+
+                // V0.6.8 F193 — cross-bot @mention fast-path. After the
+                // reply hits IM, scan it for `@<otherhandle>` and push
+                // a synthetic InboxItem directly into the target bot's
+                // mpsc. Logic factored into a pub helper for direct
+                // testability (the dispatcher is otherwise private).
+                let bots_now = list_bots().unwrap_or_default();
+                dispatch_cross_bot_mention(&item, &slug_log, &role_log, &bots_now, &bot_channels)
+                    .await;
             }
             Err(err) => {
                 // Don't advance cursor on failure — the safety-net
@@ -907,6 +925,172 @@ async fn spawn_outbound_dispatcher(
         }
     }
     tracing::debug!(slug = %slug_log, role = %role_log, "imd: outbound dispatcher exited");
+}
+
+/// Outcome of one cross-bot @mention scan. Exposed mainly so tests can
+/// assert on the routing decision without inspecting tracing output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrossBotDispatch {
+    /// Reply had no `@<handle>` mention.
+    NoMention,
+    /// Handle parsed but no registered bot answers to it.
+    UnknownHandle {
+        /// The literal handle parsed (without `@`).
+        handle: String,
+    },
+    /// Handle resolved to the sender itself — dropped to avoid loops.
+    SelfMention,
+    /// Resolved + within budget + target mpsc wired — pushed.
+    Dispatched {
+        /// Target slug the synthetic InboxItem was sent to.
+        to_slug: String,
+        /// Target role the synthetic InboxItem was sent to.
+        to_role: String,
+        /// `sender_hop + 1`.
+        hop: u8,
+    },
+    /// Resolved + budget exhausted (`hop + 1 >= MAX_HOPS`).
+    HopExceeded {
+        /// Target slug that would have received the InboxItem.
+        to_slug: String,
+        /// Target role that would have received the InboxItem.
+        to_role: String,
+        /// The hop value that exceeded the budget (`sender_hop + 1`).
+        hop: u8,
+    },
+    /// Resolved but the target bot's mpsc isn't wired in
+    /// `bot_channels` yet (race: target registered after sender's
+    /// dispatcher spawned, supervisor tick hasn't run `ensure_bot_channels`
+    /// for it yet). Dropped — no envelope file exists so safety-net
+    /// drain doesn't cover this.
+    TargetNotWired {
+        /// Target slug the lookup resolved to.
+        to_slug: String,
+        /// Target role the lookup resolved to.
+        to_role: String,
+    },
+    /// Resolved + budget OK but the target inbox is full (try_send
+    /// returned Err). Dropped — same reason as TargetNotWired.
+    InboxFull {
+        /// Target slug whose inbox was full.
+        to_slug: String,
+        /// Target role whose inbox was full.
+        to_role: String,
+    },
+}
+
+/// V0.6.8 F193 — scan an OutboundItem's content for a `@<otherbot>`
+/// mention; if it resolves to a registered bot AND we have hop budget,
+/// synthesize a fresh `InboxItem` (hop = sender_hop + 1) and `try_send`
+/// it directly into that bot's `inbox_tx`. Returns the dispatch outcome
+/// for tests / structured logging.
+///
+/// Called from `spawn_outbound_dispatcher` immediately after a
+/// successful `channel.send` (assistant rows only — non-assistant rows
+/// short-circuit before the scan). Cursor-skip + non-assistant paths
+/// don't fire cross-mention by design: the safety-net drain doesn't
+/// emit synthetic mpsc items, so duplicating the scan there would
+/// double-route on overlap.
+///
+/// Self-mention guard uses the resolved `(slug, role)` tuple, NOT the
+/// handle string — a bot's `chat_handle` may override its role, and two
+/// slugs can legitimately share a role name (e.g. two squads with a
+/// `reporter`).
+pub async fn dispatch_cross_bot_mention(
+    item: &OutboundItem,
+    sender_slug: &str,
+    sender_role: &str,
+    bots: &[BotRegistration],
+    bot_channels: &BotChannelMap,
+) -> CrossBotDispatch {
+    let Some((handle, rest)) = router::parse_first_mention(&item.content) else {
+        return CrossBotDispatch::NoMention;
+    };
+    let handles = build_handle_map_from_bots(bots);
+    let Some((target_slug, target_role)) = handles.lookup(&handle) else {
+        return CrossBotDispatch::UnknownHandle { handle };
+    };
+    if target_slug.as_str() == sender_slug && target_role.as_str() == sender_role {
+        return CrossBotDispatch::SelfMention;
+    }
+    let next_hop = item.hop.saturating_add(1);
+    if !router::within_hop_budget(next_hop) {
+        tracing::info!(
+            event = "cross_bot_mention_hop_exceeded",
+            from_slug = %sender_slug,
+            from_role = %sender_role,
+            to_slug = %target_slug,
+            to_role = %target_role,
+            hop = next_hop,
+            max = router::MAX_HOPS,
+            "F193 mention dropped (hop budget exceeded)"
+        );
+        return CrossBotDispatch::HopExceeded {
+            to_slug: target_slug,
+            to_role: target_role,
+            hop: next_hop,
+        };
+    }
+    let guard = bot_channels.lock().await;
+    let Some(ch) = guard.get(&bot_key(&target_slug, &target_role)) else {
+        tracing::debug!(
+            from_slug = %sender_slug,
+            from_role = %sender_role,
+            to_slug = %target_slug,
+            to_role = %target_role,
+            "F193 target mpsc not yet wired; cross-mention dropped"
+        );
+        return CrossBotDispatch::TargetNotWired {
+            to_slug: target_slug,
+            to_role: target_role,
+        };
+    };
+    // Synthetic InboxItem: `path = PathBuf::new()` — there is no
+    // envelope file on disk. The inbox dispatcher's `remove_file` will
+    // silently fail (correct: nothing to unlink).
+    let item_synth = InboxItem {
+        cid: format!("cross-{}", item.turn_id),
+        slug: target_slug.clone(),
+        role: target_role.clone(),
+        payload: rest,
+        path: PathBuf::new(),
+        enqueue_unix_ms: now_unix_ms(),
+        hop: next_hop,
+    };
+    match ch.inbox_tx.try_send(item_synth) {
+        Ok(_) => {
+            tracing::info!(
+                event = "cross_bot_mention",
+                from_slug = %sender_slug,
+                from_role = %sender_role,
+                to_slug = %target_slug,
+                to_role = %target_role,
+                hop = next_hop,
+                turn_id = %item.turn_id,
+                "F193 cross-bot @mention routed via mpsc"
+            );
+            CrossBotDispatch::Dispatched {
+                to_slug: target_slug,
+                to_role: target_role,
+                hop: next_hop,
+            }
+        }
+        Err(err) => {
+            tracing::warn!(
+                event = "cross_bot_mention_drop",
+                from_slug = %sender_slug,
+                from_role = %sender_role,
+                to_slug = %target_slug,
+                to_role = %target_role,
+                error = %err,
+                "F193 target inbox saturated; dropped"
+            );
+            CrossBotDispatch::InboxFull {
+                to_slug: target_slug,
+                to_role: target_role,
+            }
+        }
+    }
 }
 
 /// V0.6.1 F132 — once per tick, for each registered bot:
@@ -982,7 +1166,11 @@ async fn drain_inboxes(
                     let received_ms = env.received_at.timestamp_millis().max(0) as u128;
                     let queue_age_ms = now_unix_ms().saturating_sub(received_ms) as u64;
                     let drain_t0 = std::time::Instant::now();
-                    match sup.handle_inbound(env.payload).await {
+                    // V0.6.8 F193 — thread the on-disk envelope's hop
+                    // through the safety-net drain too so a daemon
+                    // restart between cross-mention synth and consume
+                    // still respects the bot-to-bot loop budget.
+                    match sup.handle_inbound(env.payload, env.hop).await {
                         Ok(id) => {
                             tracing::info!(
                                 event = "latency",

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -903,9 +903,22 @@ async fn spawn_outbound_dispatcher(
                 // a synthetic InboxItem directly into the target bot's
                 // mpsc. Logic factored into a pub helper for direct
                 // testability (the dispatcher is otherwise private).
-                let bots_now = list_bots().unwrap_or_default();
-                dispatch_cross_bot_mention(&item, &slug_log, &role_log, &bots_now, &bot_channels)
+                //
+                // Short-circuit when the reply has no `@` at all so the
+                // common (no-mention) case skips the `list_bots()` disk
+                // read. `parse_first_mention` returns None anyway in
+                // that case, but checking here avoids the I/O entirely.
+                if item.content.contains('@') {
+                    let bots_now = list_bots().unwrap_or_default();
+                    dispatch_cross_bot_mention(
+                        &item,
+                        &slug_log,
+                        &role_log,
+                        &bots_now,
+                        &bot_channels,
+                    )
                     .await;
+                }
             }
             Err(err) => {
                 // Don't advance cursor on failure — the safety-net

--- a/crates/ccteam-imd/src/inbound.rs
+++ b/crates/ccteam-imd/src/inbound.rs
@@ -69,6 +69,11 @@ pub enum InboundOutcome {
         /// (e.g. `tg-{message_id}`). Used as the latency-log `cid` field
         /// in the downstream mpsc dispatcher.
         cid: String,
+        /// V0.6.8 F193 — hop counter for the bot-to-bot loop guard.
+        /// Echoes `process_inbound`'s `hop` argument so the downstream
+        /// fast-path `InboxItem` carries the same value the on-disk
+        /// `InboxEnvelope.hop` records.
+        hop: u8,
     },
     /// Routed to admin handler.
     Admin {
@@ -386,6 +391,7 @@ pub async fn process_inbound(
                 path,
                 payload: stripped,
                 cid: msg.id.clone(),
+                hop,
             })
         }
     }

--- a/crates/ccteam-imd/src/router.rs
+++ b/crates/ccteam-imd/src/router.rs
@@ -99,7 +99,12 @@ impl Default for HandleMap {
 
 /// Extract the **first** `@handle` in the text. Returns the handle
 /// (without `@`) plus the rest of the text with that mention stripped.
-fn parse_first_mention(text: &str) -> Option<(String, String)> {
+///
+/// V0.6.8 F193 — `pub` so the daemon's outbound dispatcher can scan a
+/// bot's reply for an embedded `@<otherbot>` and route it back through
+/// the in-daemon mpsc inbox (bot-to-bot @-addressing, no IM
+/// round-trip).
+pub fn parse_first_mention(text: &str) -> Option<(String, String)> {
     let mut handle = String::new();
     let mut start = None;
     for (i, ch) in text.char_indices() {

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -29,6 +29,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -346,6 +347,20 @@ pub struct BotSupervisor {
     /// `Some`, the events consumer additionally sends each assistant
     /// row through the channel for ~immediate dispatch.
     outbound_tx: Arc<Mutex<Option<mpsc::Sender<OutboundItem>>>>,
+    /// V0.6.8 F193 — hop counter of the most recent inbound turn the
+    /// supervisor accepted. Stored atomically so the spawned events
+    /// consumer (which builds the [`OutboundItem`] for each reply) can
+    /// stamp every outbound row with the inbound's hop. The daemon's
+    /// outbound dispatcher then computes `next_hop = item.hop + 1`
+    /// when it detects an embedded `@<otherbot>` mention and
+    /// synthesizes a cross-bot `InboxItem`.
+    ///
+    /// Set in `handle_inbound` before `submit_turn`; read per-event in
+    /// `spawn_events_consumer`. Replies from a turn we never observed
+    /// (host-probe direct `submit_turn`, daemon restart while a tmux
+    /// session is mid-conversation) inherit the default value `0`,
+    /// matching the "user-IM-sourced" hop semantic.
+    current_hop: Arc<AtomicU8>,
 }
 
 impl std::fmt::Debug for BotSupervisor {
@@ -393,6 +408,7 @@ impl BotSupervisor {
             heartbeat_task: Mutex::new(None),
             events_task: Mutex::new(None),
             outbound_tx: Arc::new(Mutex::new(None)),
+            current_hop: Arc::new(AtomicU8::new(0)),
         }
     }
 
@@ -716,6 +732,12 @@ impl BotSupervisor {
         // disable the fast path. Locking per event is fine — this is a
         // tokio Mutex held only for a `clone()`, single-task contention.
         let outbound_tx_arc = self.outbound_tx.clone();
+        // V0.6.8 F193 — clone the current_hop Arc so each event reads
+        // the hop value last stashed by `handle_inbound`. The atomic
+        // load is wait-free; the per-event read picks up the most
+        // recent value (across submit_turn await points + scheduler
+        // hand-off).
+        let current_hop_arc = self.current_hop.clone();
         let task = tokio::spawn(async move {
             let mut stream = adapter.events(&handle);
             while let Some(evt) = stream.next().await {
@@ -772,12 +794,14 @@ impl BotSupervisor {
                         // (e.g. supervisor restart mid-turn).
                         let tx_now = outbound_tx_arc.lock().await.clone();
                         if let Some(tx) = tx_now {
+                            let hop = current_hop_arc.load(Ordering::SeqCst);
                             let item = OutboundItem {
                                 turn_id: turn_id_log.clone(),
                                 role: "assistant".into(),
                                 content: record.assistant.clone(),
                                 cursor_after,
                                 enqueue_unix_ms: now_unix_ms(),
+                                hop,
                             };
                             // `try_send` because the dispatcher is
                             // bounded; if it's backlogged the safety-net
@@ -838,7 +862,20 @@ impl BotSupervisor {
     ///
     /// Returns an error when the thread isn't started yet — callers
     /// typically `ensure_started().await?` first.
-    pub async fn handle_inbound(&self, payload: String) -> Result<TurnId> {
+    ///
+    /// V0.6.8 F193 — `hop` is the bot-to-bot loop-guard counter of the
+    /// inbound turn. The supervisor stores it on `current_hop` so the
+    /// outbound events consumer can stamp every reply's
+    /// `OutboundItem.hop` with it; the outbound dispatcher reads that
+    /// value to compute `next_hop = hop + 1` when it detects an
+    /// embedded `@<otherbot>` mention and synthesizes a cross-bot
+    /// `InboxItem`. User-IM-sourced turns enter with `hop = 0`.
+    pub async fn handle_inbound(&self, payload: String, hop: u8) -> Result<TurnId> {
+        // V0.6.8 F193 — stash the inbound hop BEFORE submit_turn so the
+        // events consumer (which fires asynchronously when the adapter
+        // emits ItemCompleted) reads the right value when it builds
+        // the OutboundItem.
+        self.current_hop.store(hop, Ordering::SeqCst);
         let handle = {
             let st = self.state.lock().await;
             st.handle.clone().ok_or_else(|| {
@@ -863,6 +900,7 @@ impl BotSupervisor {
             slug = %self.reg.workflow_slug,
             role = %self.reg.role,
             turn = %id.0,
+            hop,
             "submitted user turn"
         );
         Ok(id)
@@ -1203,7 +1241,7 @@ mod bot_supervisor_tests {
         let tmp = TempDir::new().unwrap();
         let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
         sup.ensure_started().await.unwrap();
-        let id = sup.handle_inbound("hello".into()).await.unwrap();
+        let id = sup.handle_inbound("hello".into(), 0).await.unwrap();
         assert_eq!(id.0, "stub-turn");
         assert_eq!(stub.submits.load(Ordering::SeqCst), 1);
     }
@@ -1213,7 +1251,7 @@ mod bot_supervisor_tests {
         let stub = Arc::new(StubAdapter::default());
         let tmp = TempDir::new().unwrap();
         let sup = BotSupervisor::new(reg(), tmp.path(), stub.clone());
-        assert!(sup.handle_inbound("x".into()).await.is_err());
+        assert!(sup.handle_inbound("x".into(), 0).await.is_err());
         assert_eq!(stub.submits.load(Ordering::SeqCst), 0);
     }
 

--- a/crates/ccteam-imd/tests/chat_send_input_test.rs
+++ b/crates/ccteam-imd/tests/chat_send_input_test.rs
@@ -129,7 +129,7 @@ async fn mailbox_envelope_round_trips_through_handle_inbound() {
     // `drain_inboxes` runs this exact sequence).
     let body = std::fs::read_to_string(&path).unwrap();
     let env = parse_envelope(&body).unwrap();
-    sup.handle_inbound(env.payload).await.unwrap();
+    sup.handle_inbound(env.payload, env.hop).await.unwrap();
 
     // Adapter must have seen exactly the payload — no envelope yaml,
     // no extra wrapping. (CLAUDE.md §三 "No prompt injection".)
@@ -234,7 +234,7 @@ async fn mailbox_envelope_routes_through_registration_project_dir() {
     let path = write_envelope(&resolved_inbox, "@tech-helper plan");
     let body = std::fs::read_to_string(&path).unwrap();
     let env = parse_envelope(&body).unwrap();
-    sup.handle_inbound(env.payload).await.unwrap();
+    sup.handle_inbound(env.payload, env.hop).await.unwrap();
 
     let submitted = adapter.submitted.lock().unwrap().clone();
     assert_eq!(submitted, vec!["@tech-helper plan".to_string()]);
@@ -258,7 +258,7 @@ async fn mailbox_envelope_payload_preserves_special_chars() {
 
     let body = std::fs::read_to_string(&path).unwrap();
     let env = parse_envelope(&body).unwrap();
-    sup.handle_inbound(env.payload).await.unwrap();
+    sup.handle_inbound(env.payload, env.hop).await.unwrap();
 
     let submitted = adapter.submitted.lock().unwrap().clone();
     assert_eq!(submitted, vec![payload.to_string()]);

--- a/crates/ccteam-imd/tests/cross_bot_mention_test.rs
+++ b/crates/ccteam-imd/tests/cross_bot_mention_test.rs
@@ -1,0 +1,339 @@
+//! V0.6.8 F193 — bot-to-bot @mention via daemon-internal mpsc.
+//!
+//! Background: chat-squad's `hop_limit=3` design supports a bot reply
+//! mentioning `@<otherbot>` and getting routed to that other bot, but
+//! V0.6.x never wired the path from a bot's outbound reply back into
+//! another bot's inbox. Telegram's Bot API doesn't echo bot messages
+//! to other bots' `getUpdates` stream, so the mention silently
+//! disappeared.
+//!
+//! F193 closes the loop **purely inside the daemon**:
+//! `spawn_outbound_dispatcher` (after the `channel.send` succeeds)
+//! delegates to `dispatch_cross_bot_mention`, which:
+//!
+//! 1. parses the first `@<handle>` in the reply,
+//! 2. resolves it through `build_handle_map_from_bots`,
+//! 3. checks the self-mention guard (resolved tuple, not handle string),
+//! 4. checks `within_hop_budget(hop + 1)`,
+//! 5. `try_send`s a synthetic `InboxItem` into the target's `inbox_tx`.
+//!
+//! This test drives `dispatch_cross_bot_mention` directly with hand-built
+//! `BotChannelMap` entries (drained by hand instead of via a live
+//! supervisor) so we can assert the routing decisions without standing
+//! up tmux + adapters.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ccteam_core::harness::AgentVendor;
+use ccteam_imd::bot_mpsc::{bot_key, BotChannelMap, BotChannels, InboxItem, OutboundItem};
+use ccteam_imd::daemon::{dispatch_cross_bot_mention, CrossBotDispatch};
+use ccteam_imd::outbound::OutboundCursor;
+use ccteam_imd::BotRegistration;
+use tokio::sync::{mpsc, Mutex};
+
+fn reg(slug: &str, role: &str) -> BotRegistration {
+    BotRegistration {
+        workflow_slug: slug.into(),
+        role: role.into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "mock".into(),
+        im_chat_id: format!("chat-{slug}"),
+        chat_handle: None,
+        project_dir: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// Build a `BotChannelMap` containing one entry per `(slug, role)` in
+/// `bots`, returning the inbox receivers so the test can `recv` what
+/// the dispatcher pushed.
+async fn build_channels(
+    bots: &[BotRegistration],
+) -> (
+    BotChannelMap,
+    Vec<(String, String, mpsc::Receiver<InboxItem>)>,
+) {
+    let map: BotChannelMap = Arc::new(Mutex::new(Default::default()));
+    let mut receivers = Vec::with_capacity(bots.len());
+    for b in bots {
+        let (inbox_tx, inbox_rx) = mpsc::channel::<InboxItem>(64);
+        let (outbound_tx, _outbound_rx) = mpsc::channel::<OutboundItem>(64);
+        // Cursor doesn't matter for the cross-mention scan — the helper
+        // never reads it. Use a nonexistent path so load_from_disk
+        // seeds to zero (the constructor's documented behaviour).
+        let outbound_cursor =
+            OutboundCursor::load_from_disk(PathBuf::from("/nonexistent-cross-bot-test-cursor"));
+        map.lock().await.insert(
+            bot_key(&b.workflow_slug, &b.role),
+            BotChannels {
+                inbox_tx,
+                outbound_tx,
+                outbound_cursor,
+            },
+        );
+        receivers.push((b.workflow_slug.clone(), b.role.clone(), inbox_rx));
+    }
+    (map, receivers)
+}
+
+fn make_outbound(content: &str, hop: u8) -> OutboundItem {
+    OutboundItem {
+        turn_id: "t-1".into(),
+        role: "assistant".into(),
+        content: content.into(),
+        cursor_after: 1,
+        enqueue_unix_ms: 0,
+        hop,
+    }
+}
+
+// ---------------------------------------------------------------------
+// 1. Happy path — bot reply `@explorer please help` routes to explorer
+//    with hop=1, no IM round-trip.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatches_cross_bot_mention_to_target_inbox() {
+    let bots = vec![
+        reg("reno-squad", "reporter"),
+        reg("reno-squad", "explorer"),
+        reg("reno-squad", "coordinator"),
+    ];
+    let (channels, mut receivers) = build_channels(&bots).await;
+
+    // reporter's reply mentions @explorer. hop=0 → next_hop=1.
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("@explorer please help with this", 0),
+        "reno-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+
+    match outcome {
+        CrossBotDispatch::Dispatched {
+            to_slug,
+            to_role,
+            hop,
+        } => {
+            assert_eq!(to_slug, "reno-squad");
+            assert_eq!(to_role, "explorer");
+            assert_eq!(hop, 1);
+        }
+        other => panic!("expected Dispatched, got {other:?}"),
+    }
+
+    // explorer's inbox MUST have one synthetic InboxItem.
+    let (_, _, explorer_rx) = receivers
+        .iter_mut()
+        .find(|(_, role, _)| role == "explorer")
+        .expect("explorer inbox receiver");
+    let synth = explorer_rx
+        .try_recv()
+        .expect("explorer inbox should have one item");
+    assert_eq!(synth.slug, "reno-squad");
+    assert_eq!(synth.role, "explorer");
+    assert_eq!(synth.hop, 1);
+    assert_eq!(synth.payload, "please help with this");
+    assert_eq!(
+        synth.path,
+        PathBuf::new(),
+        "synthetic items have empty path"
+    );
+    assert!(
+        synth.cid.starts_with("cross-"),
+        "cid should be cross-prefixed for traceability"
+    );
+
+    // reporter + coordinator inboxes MUST be empty — no IM round-trip
+    // (the dispatcher is daemon-internal; no second `channel.send`
+    // happens for the synthesized item, only the original reply went
+    // to IM, which lives outside this helper).
+    let reporter_rx = receivers
+        .iter_mut()
+        .find(|(_, role, _)| role == "reporter")
+        .map(|(_, _, rx)| rx)
+        .unwrap();
+    assert!(reporter_rx.try_recv().is_err());
+    let coord_rx = receivers
+        .iter_mut()
+        .find(|(_, role, _)| role == "coordinator")
+        .map(|(_, _, rx)| rx)
+        .unwrap();
+    assert!(coord_rx.try_recv().is_err());
+}
+
+// ---------------------------------------------------------------------
+// 2. Hop budget — sender hop = MAX_HOPS - 1 → next_hop = MAX_HOPS → drop.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn drops_when_hop_budget_would_be_exceeded() {
+    use ccteam_imd::router::MAX_HOPS;
+
+    let bots = vec![reg("reno-squad", "reporter"), reg("reno-squad", "explorer")];
+    let (channels, mut receivers) = build_channels(&bots).await;
+
+    // sender_hop = MAX_HOPS - 1 → next_hop = MAX_HOPS, which fails
+    // `within_hop_budget(hop) = hop < MAX_HOPS`.
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("@explorer loop forever", MAX_HOPS - 1),
+        "reno-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+
+    match outcome {
+        CrossBotDispatch::HopExceeded { hop, .. } => assert_eq!(hop, MAX_HOPS),
+        other => panic!("expected HopExceeded, got {other:?}"),
+    }
+
+    // explorer must have received nothing.
+    let (_, _, explorer_rx) = receivers
+        .iter_mut()
+        .find(|(_, role, _)| role == "explorer")
+        .unwrap();
+    assert!(
+        explorer_rx.try_recv().is_err(),
+        "explorer inbox must be empty when hop budget exceeded"
+    );
+}
+
+// ---------------------------------------------------------------------
+// 3. Self-mention guard — reporter replying @reporter must NOT
+//    re-trigger itself (would loop).
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn does_not_route_self_mention() {
+    let bots = vec![reg("reno-squad", "reporter"), reg("reno-squad", "explorer")];
+    let (channels, mut receivers) = build_channels(&bots).await;
+
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("@reporter ack received", 0),
+        "reno-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+
+    assert_eq!(outcome, CrossBotDispatch::SelfMention);
+
+    // Neither inbox got anything.
+    for (_, _, rx) in receivers.iter_mut() {
+        assert!(rx.try_recv().is_err());
+    }
+}
+
+// ---------------------------------------------------------------------
+// 4. No mention — plain text reply has nothing to scan; fast-path noop.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn no_mention_returns_no_mention() {
+    let bots = vec![reg("reno-squad", "reporter"), reg("reno-squad", "explorer")];
+    let (channels, mut receivers) = build_channels(&bots).await;
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("just a plain assistant reply with no @", 0),
+        "reno-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+    assert_eq!(outcome, CrossBotDispatch::NoMention);
+    for (_, _, rx) in receivers.iter_mut() {
+        assert!(rx.try_recv().is_err());
+    }
+}
+
+// ---------------------------------------------------------------------
+// 5. Unknown handle — `@nobody` doesn't resolve; no inbox push.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn unknown_handle_does_not_dispatch() {
+    let bots = vec![reg("reno-squad", "reporter")];
+    let (channels, _receivers) = build_channels(&bots).await;
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("@nobody hi", 0),
+        "reno-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+    match outcome {
+        CrossBotDispatch::UnknownHandle { handle } => assert_eq!(handle, "nobody"),
+        other => panic!("expected UnknownHandle, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// 6. Target not wired — handle resolves but BotChannelMap doesn't have
+//    an entry yet (race: target registered after sender's dispatcher
+//    spawned, supervisor tick hasn't run ensure_bot_channels for it).
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn target_not_wired_when_channel_missing() {
+    let bots = vec![reg("reno-squad", "reporter"), reg("reno-squad", "explorer")];
+    // Channel map only contains reporter, not explorer.
+    let only_reporter = vec![reg("reno-squad", "reporter")];
+    let (channels, _) = build_channels(&only_reporter).await;
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("@explorer go", 0),
+        "reno-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+    match outcome {
+        CrossBotDispatch::TargetNotWired { to_slug, to_role } => {
+            assert_eq!(to_slug, "reno-squad");
+            assert_eq!(to_role, "explorer");
+        }
+        other => panic!("expected TargetNotWired, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// 7. Cross-slug collision — two squads both have a `reporter`. Bot in
+//    slug A replying `@reporter` MUST NOT loop back to itself; the
+//    self-mention guard works on the resolved (slug, role) tuple.
+//
+//    handle map's collision policy: first-claimant keeps the bare
+//    name. Sender = (alpha-squad, reporter) which sorts before
+//    (beta-squad, reporter), so `@reporter` resolves to alpha-squad
+//    too → self-mention → drop.
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn self_mention_guard_uses_resolved_tuple_across_slugs() {
+    let bots = vec![
+        reg("alpha-squad", "reporter"),
+        reg("beta-squad", "reporter"),
+    ];
+    let (channels, mut receivers) = build_channels(&bots).await;
+    let outcome = dispatch_cross_bot_mention(
+        &make_outbound("@reporter trying to ping the other squad", 0),
+        "alpha-squad",
+        "reporter",
+        &bots,
+        &channels,
+    )
+    .await;
+    // `@reporter` resolves to alpha-squad (first claimant by sort);
+    // sender IS alpha-squad → self-mention guard fires.
+    assert_eq!(outcome, CrossBotDispatch::SelfMention);
+    for (_, _, rx) in receivers.iter_mut() {
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/crates/ccteam-imd/tests/e2e_mock_test.rs
+++ b/crates/ccteam-imd/tests/e2e_mock_test.rs
@@ -192,7 +192,7 @@ async fn drain_inbox_into_supervisor(
     for entry in entries {
         let body = std::fs::read_to_string(entry.path()).unwrap();
         let env = ccteam_imd::inbound::parse_envelope(&body).unwrap();
-        sup.handle_inbound(env.payload).await.unwrap();
+        sup.handle_inbound(env.payload, env.hop).await.unwrap();
         std::fs::remove_file(entry.path()).unwrap();
         count += 1;
     }
@@ -355,7 +355,7 @@ async fn close_thread_cleanup_idempotent() {
     assert_eq!(adapter.closes.load(Ordering::SeqCst), 1);
     assert!(!sup.is_started().await);
     // handle_inbound should refuse after shutdown (no handle).
-    assert!(sup.handle_inbound("ignored".into()).await.is_err());
+    assert!(sup.handle_inbound("ignored".into(), 0).await.is_err());
 }
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

chat-squad's `hop_limit=3` design supports bot-to-bot `@`-addressing, but the wiring from a bot's reply → cross-bot inbox was never implemented. Bot A replying with `@botB` had its reply sent to Telegram, then dropped: Telegram's Bot API doesn't echo bot messages to other bots' `getUpdates` stream, so the second bot never saw the mention.

F193 closes the loop **purely inside the daemon** — no IM round-trip.

### Approach

- `spawn_outbound_dispatcher` (after the `channel.send` succeeds) delegates to a new pub helper `dispatch_cross_bot_mention`, which:
  1. parses the first `@<handle>` via `router::parse_first_mention`,
  2. resolves via a freshly-rebuilt `HandleMap` from `list_bots()` (so a bot registered after the dispatcher spawned is still reachable),
  3. self-mention guard on the resolved `(slug, role)` tuple (NOT the handle string — a bot's `chat_handle` can override role, and two slugs can share role names),
  4. `within_hop_budget(hop + 1)`,
  5. `try_send`s a synthetic `InboxItem` into the target's `inbox_tx` (path = `PathBuf::new()` — no envelope file; inbox dispatcher's `remove_file` silently fails, the desired behaviour).
- Returns a `CrossBotDispatch` enum so the integration test can assert routing decisions directly.
- Short-circuits the `list_bots()` disk read when content has no `@` at all (matches `spawn_inbound_consumer`'s precedent of `list_bots()` per inbound message).
- The fast-path mpsc structures (`InboxItem`, `OutboundItem`, `InboundOutcome::DroppedToBot`) gain a `hop: u8` field; on `BotSupervisor`, an `AtomicU8 current_hop` lets the events consumer stamp each outbound reply with its inbound's hop value.

### Files

- `crates/ccteam-imd/src/bot_mpsc.rs` — `hop` field on `InboxItem` + `OutboundItem`
- `crates/ccteam-imd/src/inbound.rs` — `hop` on `DroppedToBot` + thread through `process_inbound`
- `crates/ccteam-imd/src/router.rs` — `parse_first_mention` now `pub` (used by the outbound dispatcher)
- `crates/ccteam-imd/src/supervisor.rs` — `current_hop: Arc<AtomicU8>` on `BotSupervisor`; `handle_inbound(payload, hop)` signature; events consumer stamps the per-event hop
- `crates/ccteam-imd/src/daemon.rs` — new pub helper `dispatch_cross_bot_mention` + `CrossBotDispatch` enum; `spawn_outbound_dispatcher` gains `bot_channels: BotChannelMap` parameter and invokes the helper after a successful `channel.send`; inbound consumer + `drain_inboxes` thread `hop` into `InboxItem`

### Tests

- `crates/ccteam-imd/tests/cross_bot_mention_test.rs` (new, 7 tests) — happy path (3-bot squad, asserts cross-bot inbox push + hop increment + no second IM send for synthetic item), hop-limit drop, self-mention guard, no-mention noop, unknown-handle noop, target-not-wired drop, cross-slug collision self-mention guard.
- Existing tests updated for the new `hop` field + `handle_inbound(payload, hop)` signature (chat_send_input_test, e2e_mock_test).

## Test plan

- [x] `cargo test -p ccteam-imd --locked --no-fail-fast` — all green, 7 new tests pass
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — 0 drift
- [ ] CI to exercise full `cargo test --workspace` (local disk pressure from sibling worktrees prevented full workspace test run; ccteam-imd is the only crate with src changes, and workspace clippy compile-checks every consumer)

## Acceptance

In a 3-bot reno-squad-style workflow, typing `@reporter discuss with @explorer` causes both `reporter` and `explorer` to respond, with `explorer`'s turn carrying `hop = 1` in the supervisor state.