### PR TITLE
v0.6.8: DM multi-bot hint + per-turn timeout watchdog (F194/F195)

### DIFF
--- a/crates/ccteam-core/src/progress.rs
+++ b/crates/ccteam-core/src/progress.rs
@@ -391,6 +391,67 @@ pub fn build_chat_bot_marker_stuck_event(role: &str, attempts: u32) -> Value {
     })
 }
 
+/// `chat_turn_running_long` — V0.6.8 F195. Per-turn watchdog crossed
+/// the first threshold (`1× turn_timeout_sec`, default 90s). The
+/// supervisor is **still** waiting on `chat_turn_completed`; this event
+/// signals the wait crossed the warning bar so IM / web surfaces can
+/// reassure the user the bot is alive. Hard rule: **does not kill the
+/// turn** — the underlying claude session keeps running.
+///
+/// Payload: `{role, slug, turn_id, elapsed_sec, ts}`.
+pub const CHAT_TURN_RUNNING_LONG: &str = "chat_turn_running_long";
+
+/// V0.6.8 F195 — build a `chat_turn_running_long` event JSON.
+pub fn build_chat_turn_running_long_event(
+    role: &str,
+    slug: &str,
+    turn_id: &str,
+    elapsed_sec: u64,
+) -> Value {
+    serde_json::json!({
+        "event": CHAT_TURN_RUNNING_LONG,
+        "role": role,
+        "slug": slug,
+        "turn_id": turn_id,
+        "elapsed_sec": elapsed_sec,
+        "ts": Utc::now().to_rfc3339(),
+    })
+}
+
+/// `chat_turn_timeout` — V0.6.8 F195. Per-turn watchdog crossed the
+/// second threshold (`2× turn_timeout_sec`, default 180s) without ever
+/// seeing `chat_turn_completed`. Carries a `stuck: true` flag so
+/// downstream consumers (web UI, ops dashboards) can distinguish from
+/// a slow-but-progressing turn. Hard rule: **does not kill the turn**
+/// — the watchdog only surfaces the silent stall; recovery is via
+/// user-driven `/clear` / signal-reset, not engine intervention (R5
+/// 守 from CLAUDE.md §三).
+///
+/// Payload: `{role, slug, turn_id, elapsed_sec, stuck, ts}`.
+pub const CHAT_TURN_TIMEOUT: &str = "chat_turn_timeout";
+
+/// V0.6.8 F195 — build a `chat_turn_timeout` event JSON. The `stuck`
+/// field is hard-coded `true`; it exists in the payload so a future
+/// `chat_turn_timeout_recovered` event (if we ever add one when the
+/// turn does eventually finish post-timeout) can be distinguished on
+/// the wire by flipping the flag.
+pub fn build_chat_turn_timeout_event(
+    role: &str,
+    slug: &str,
+    turn_id: &str,
+    elapsed_sec: u64,
+) -> Value {
+    serde_json::json!({
+        "event": CHAT_TURN_TIMEOUT,
+        "role": role,
+        "slug": slug,
+        "turn_id": turn_id,
+        "elapsed_sec": elapsed_sec,
+        "stuck": true,
+        "ts": Utc::now().to_rfc3339(),
+    })
+}
+
 // ---------------- V0.6.1 F98 plan-approval event kinds ----------------
 
 /// `plan_pending` — agent wrote a plan markdown to
@@ -469,7 +530,8 @@ pub fn build_plan_timeout_event(plan_id: &str, agent: &str, on_timeout: &str) ->
     })
 }
 
-/// True if `kind` is one of the F108/F118 chat-mode event names.
+/// True if `kind` is one of the chat-mode event names (F108 / F118 /
+/// F192c / F195 / F196).
 pub fn is_chat_event(kind: &str) -> bool {
     matches!(
         kind,
@@ -480,6 +542,11 @@ pub fn is_chat_event(kind: &str) -> bool {
             | CHAT_SESSION_RESET_WITH_RECOVERY
             | CHAT_COMPACT_DONE
             | CHAT_HOP_ESCALATE
+            | CHAT_BOT_PERMANENT_FAILURE
+            | CHAT_MARKER_SELF_HEAL_ATTEMPT
+            | CHAT_BOT_MARKER_STUCK
+            | CHAT_TURN_RUNNING_LONG
+            | CHAT_TURN_TIMEOUT
     )
 }
 
@@ -889,7 +956,7 @@ mod tests {
     }
 
     #[test]
-    fn is_chat_event_recognises_all_seven() {
+    fn is_chat_event_recognises_all_chat_kinds() {
         for kind in [
             CHAT_SESSION_STARTED,
             CHAT_TURN_USER_PROMPT,
@@ -898,11 +965,36 @@ mod tests {
             CHAT_SESSION_RESET_WITH_RECOVERY,
             CHAT_COMPACT_DONE,
             CHAT_HOP_ESCALATE,
+            CHAT_BOT_PERMANENT_FAILURE,
+            CHAT_TURN_RUNNING_LONG,
+            CHAT_TURN_TIMEOUT,
         ] {
             assert!(is_chat_event(kind), "{kind} should be a chat event");
         }
         assert!(!is_chat_event("Stop"));
         assert!(!is_chat_event("agent_done"));
+    }
+
+    #[test]
+    fn build_chat_turn_running_long_event_shape() {
+        let ev = build_chat_turn_running_long_event("alice", "dev-foo", "turn-42", 95);
+        assert_eq!(ev["event"], CHAT_TURN_RUNNING_LONG);
+        assert_eq!(ev["role"], "alice");
+        assert_eq!(ev["slug"], "dev-foo");
+        assert_eq!(ev["turn_id"], "turn-42");
+        assert_eq!(ev["elapsed_sec"], 95);
+        assert!(ev["ts"].is_string());
+    }
+
+    #[test]
+    fn build_chat_turn_timeout_event_carries_stuck_flag() {
+        let ev = build_chat_turn_timeout_event("alice", "dev-foo", "turn-42", 200);
+        assert_eq!(ev["event"], CHAT_TURN_TIMEOUT);
+        assert_eq!(ev["role"], "alice");
+        assert_eq!(ev["slug"], "dev-foo");
+        assert_eq!(ev["turn_id"], "turn-42");
+        assert_eq!(ev["elapsed_sec"], 200);
+        assert_eq!(ev["stuck"], true);
     }
 
     #[test]

--- a/crates/ccteam-core/src/workflow.rs
+++ b/crates/ccteam-core/src/workflow.rs
@@ -485,6 +485,17 @@ pub struct ChatSpec {
     /// group the IM channel hands us (Wave 2 default; F113 hardens).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chat_acl: Option<ChatAcl>,
+    /// V0.6.8 F195: per-turn watchdog timeout in seconds. The IMD
+    /// daemon arms a deadline on `submit_turn`; at `1×` the deadline
+    /// it emits `chat_turn_running_long` + a "still working" IM reply,
+    /// at `2×` it emits `chat_turn_timeout` + a "stuck" IM reply.
+    /// **Never kills the turn** (R5 守) — the watchdog only surfaces
+    /// silent stalls. Defaults to [`DEFAULT_TURN_TIMEOUT_SECS`] (90s)
+    /// when omitted. `0` is rejected by validation (use a positive
+    /// integer; there's no "disabled" mode for V0.6.8 — silent stalls
+    /// are exactly what F195 closes).
+    #[serde(default = "default_turn_timeout_sec")]
+    pub turn_timeout_sec: u32,
 }
 
 /// V0.6.0 F108 hop-limit default — 3 hops matches the V0.4.x fix-loop
@@ -498,6 +509,21 @@ pub fn default_hop_limit() -> u32 {
 /// initial-context budget.
 pub fn default_recover_last_n_turns() -> usize {
     20
+}
+
+/// V0.6.8 F195 — per-turn watchdog default (seconds).
+///
+/// 90s leaves enough headroom for normal multi-tool turns to finish
+/// without triggering the "still working" notice, while keeping the
+/// silent-stall feedback loop tight enough that a stuck Stop hook /
+/// tail loop / claude hang doesn't go unsurfaced for minutes.
+pub const DEFAULT_TURN_TIMEOUT_SECS: u32 = 90;
+
+/// V0.6.8 F195 — serde-default constructor for [`ChatSpec::turn_timeout_sec`].
+/// Kept as a function (not a `const` directly) because `#[serde(default = "...")]`
+/// only accepts a function pointer.
+pub fn default_turn_timeout_sec() -> u32 {
+    DEFAULT_TURN_TIMEOUT_SECS
 }
 
 /// V0.6.0 F108 — optional ACL gate for `mode: chat` bots. Empty vecs
@@ -1025,6 +1051,14 @@ impl WorkflowSpec {
                         return Err(WorkflowError::ValidationFailed(
                             "chat.hop_limit must be >= 1 (0 disables bot-to-bot consultation \
                              entirely; use omit-field if that's what you want)"
+                                .to_string(),
+                        ));
+                    }
+                    if chat.turn_timeout_sec == 0 {
+                        return Err(WorkflowError::ValidationFailed(
+                            "chat.turn_timeout_sec must be >= 1 (V0.6.8 F195 watchdog has no \
+                             'disabled' mode — silent stalls are exactly what it closes; omit \
+                             the field for the 90s default)"
                                 .to_string(),
                         ));
                     }
@@ -1778,5 +1812,67 @@ agents:
         let (target, hop) = parse_squad_route("backend--hx--task.md").unwrap();
         assert_eq!(target, "backend");
         assert_eq!(hop, 0);
+    }
+
+    // V0.6.8 F195 — per-turn watchdog schema field round-trip + validation.
+
+    #[test]
+    fn chat_spec_turn_timeout_defaults_to_90_when_absent() {
+        let yaml = "
+name: dev-foo
+mode: chat
+chat:
+  bot_name: alice
+agents:
+  alice:
+    trigger: manual
+";
+        let spec: WorkflowSpec = serde_yaml::from_str(yaml).expect("parse");
+        let chat = spec.chat.as_ref().expect("chat block");
+        assert_eq!(
+            chat.turn_timeout_sec, DEFAULT_TURN_TIMEOUT_SECS,
+            "absent field must default to {DEFAULT_TURN_TIMEOUT_SECS}s"
+        );
+        spec.validate().expect("default 90 is valid");
+    }
+
+    #[test]
+    fn chat_spec_turn_timeout_round_trips_explicit_value() {
+        let yaml = "
+name: dev-foo
+mode: chat
+chat:
+  bot_name: alice
+  turn_timeout_sec: 45
+agents:
+  alice:
+    trigger: manual
+";
+        let spec: WorkflowSpec = serde_yaml::from_str(yaml).expect("parse");
+        assert_eq!(spec.chat.unwrap().turn_timeout_sec, 45);
+    }
+
+    #[test]
+    fn chat_spec_turn_timeout_zero_is_rejected() {
+        let yaml = "
+name: dev-foo
+mode: chat
+chat:
+  bot_name: alice
+  turn_timeout_sec: 0
+agents:
+  alice:
+    trigger: manual
+";
+        let spec: WorkflowSpec = serde_yaml::from_str(yaml).expect("parse");
+        match spec.validate() {
+            Err(WorkflowError::ValidationFailed(msg)) => {
+                assert!(
+                    msg.contains("turn_timeout_sec"),
+                    "error must mention the field, got {msg}"
+                );
+            }
+            other => panic!("expected ValidationFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -34,8 +34,8 @@ use crate::acl::AclPolicy;
 use crate::bot_mpsc::{bot_key, BotChannelMap, BotChannels, InboxItem, OutboundItem, CHANNEL_BUF};
 use crate::credentials::{self, Credentials};
 use crate::inbound::{
-    auto_route_dm_mention, parse_envelope, process_inbound_admin_aware, DefaultMailboxResolver,
-    InboundOutcome, MailboxResolver,
+    auto_route_dm_mention, format_ambiguous_dm_reply, parse_envelope, process_inbound_admin_aware,
+    DefaultMailboxResolver, DmRoutingHint, InboundOutcome, MailboxResolver,
 };
 use crate::latency::now_unix_ms;
 use crate::nl_admin::AdminExecutor;
@@ -398,6 +398,14 @@ where
                     &projects_root,
                 )
                 .await;
+                // V0.6.8 F195 — per-turn watchdog poll. Runs after
+                // `tick_supervisors_with_config` so any freshly-spawned
+                // supervisor is observable, and after
+                // `ensure_bot_channels` so the IM channel is wired when
+                // a notice needs to reply. Hard rule (R5): the
+                // watchdog only emits events + IM replies; it never
+                // kills the turn or restarts the bot.
+                check_turn_watchdogs(&bots, &registry, &channels).await;
 
                 if let Some(max) = args.max_runtime {
                     if started.elapsed() >= max {
@@ -527,7 +535,7 @@ fn spawn_inbound_consumer(
             //   this anchor now sits purely on the perf-budget axis.
             // Tracking: docs/dev-coupling-audit.md V0.7-deferred index.
             let bots_for_route = list_bots().unwrap_or_default();
-            auto_route_dm_mention(&mut msg, &bots_for_route);
+            let dm_hint = auto_route_dm_mention(&mut msg, &bots_for_route);
             let handles = build_handle_map();
             let Some(channel) = channels.get(&msg.channel).cloned() else {
                 tracing::debug!(
@@ -537,6 +545,36 @@ fn spawn_inbound_consumer(
                 );
                 continue;
             };
+            // V0.6.8 F194 — multi-bot DM ambiguity short-circuit. Reply
+            // to the originating chat with the list of available handles
+            // and skip normal routing (no @ prepended, no mailbox write).
+            // This closes the V0.6.x silent-drop gap when 2+ chat-squad
+            // bots share one (channel, chat_id) and the user sent an
+            // unaddressed message.
+            if let DmRoutingHint::Ambiguous { available } = dm_hint {
+                let text = format_ambiguous_dm_reply(&available);
+                let out = crate::transport::SendMessage::new(text, msg.reply_target.clone())
+                    .in_thread(msg.thread_ts.clone());
+                if let Err(err) = channel.send(&out).await {
+                    tracing::warn!(
+                        cid = %cid,
+                        channel = %msg.channel,
+                        chat_id = %msg.reply_target,
+                        available = available.len(),
+                        error = %err,
+                        "imd: F194 ambiguity-hint reply send failed"
+                    );
+                } else {
+                    tracing::info!(
+                        cid = %cid,
+                        channel = %msg.channel,
+                        chat_id = %msg.reply_target,
+                        available = available.len(),
+                        "imd: F194 ambiguity-hint reply sent"
+                    );
+                }
+                continue;
+            }
             match process_inbound_admin_aware(
                 &msg,
                 &sec,
@@ -1110,6 +1148,128 @@ pub async fn dispatch_cross_bot_mention(
                 to_slug: target_slug,
                 to_role: target_role,
             }
+        }
+    }
+}
+
+/// V0.6.8 F195 — once per tick, for each live supervisor:
+///
+/// 1. Call [`BotSupervisor::check_turn_watchdog`] to advance the
+///    deadline state machine and pull out at most one notification.
+/// 2. Append the matching progress.jsonl event
+///    (`chat_turn_running_long` / `chat_turn_timeout`).
+/// 3. Send the user-facing IM reply via the bot's
+///    `(im_platform, im_chat_id)` channel.
+///
+/// Best-effort end-to-end: a missing `CcteamPaths` (no `CCTEAM_HOME`
+/// env), a missing channel (bot bound to a vendor we don't yet support
+/// in [`build_channels`]), or a `channel.send` failure are all
+/// warn-logged + skipped so one flaky bot doesn't stall the rest of the
+/// tick.
+///
+/// Hard rule (CLAUDE.md §三 R5): does **not** kill the turn. Recovery
+/// is user-driven (`/clear` + retry); the watchdog only surfaces the
+/// silent stall so the user knows the bot isn't ignoring them.
+async fn check_turn_watchdogs(
+    bots: &[BotRegistration],
+    registry: &Arc<Mutex<SupervisorRegistry>>,
+    channels: &ChannelMap,
+) {
+    let supervisors: Vec<(BotRegistration, Arc<BotSupervisor>)> = {
+        let reg = registry.lock().await;
+        bots.iter()
+            .filter_map(|b| reg.lookup(b).map(|s| (b.clone(), s)))
+            .collect()
+    };
+    for (bot, sup) in supervisors {
+        let notice = match sup.check_turn_watchdog().await {
+            Some(n) => n,
+            None => continue,
+        };
+        let (event_json, im_text, kind, turn_id, elapsed) = match &notice {
+            supervisor::TurnWatchdogNotice::RunningLong {
+                turn_id,
+                elapsed_sec,
+            } => {
+                let ev = ccteam_core::progress::build_chat_turn_running_long_event(
+                    &bot.role,
+                    &bot.workflow_slug,
+                    turn_id,
+                    *elapsed_sec,
+                );
+                let text = format!(
+                    "Still working on your message (turn running {}s). Continuing.",
+                    elapsed_sec
+                );
+                (ev, text, "running_long", turn_id.clone(), *elapsed_sec)
+            }
+            supervisor::TurnWatchdogNotice::Timeout {
+                turn_id,
+                elapsed_sec,
+            } => {
+                let ev = ccteam_core::progress::build_chat_turn_timeout_event(
+                    &bot.role,
+                    &bot.workflow_slug,
+                    turn_id,
+                    *elapsed_sec,
+                );
+                let text = format!(
+                    "Turn appears stuck after {}s. Check the daemon log; \
+                     you can /clear and retry.",
+                    elapsed_sec
+                );
+                (ev, text, "timeout", turn_id.clone(), *elapsed_sec)
+            }
+        };
+
+        // Progress.jsonl append (best-effort — missing CCTEAM_HOME in
+        // tests is the normal posture, the tracing log below is the
+        // audit trail).
+        if let Ok(paths) = ccteam_core::CcteamPaths::from_env() {
+            let progress_path = paths.progress_jsonl(&bot.workflow_slug);
+            if let Err(err) = ccteam_core::progress::append_event(&progress_path, &event_json) {
+                tracing::warn!(
+                    slug = %bot.workflow_slug,
+                    role = %bot.role,
+                    turn_id = %turn_id,
+                    kind,
+                    error = %err,
+                    "F195: progress append failed"
+                );
+            }
+        }
+
+        // IM reply (best-effort — a missing channel is a no-op).
+        if let Some(channel) = channels.get(&bot.im_platform) {
+            let msg = crate::transport::SendMessage::new(im_text, bot.im_chat_id.clone());
+            if let Err(err) = channel.send(&msg).await {
+                tracing::warn!(
+                    slug = %bot.workflow_slug,
+                    role = %bot.role,
+                    turn_id = %turn_id,
+                    kind,
+                    elapsed_sec = elapsed,
+                    error = %err,
+                    "F195: watchdog IM reply send failed"
+                );
+            } else {
+                tracing::info!(
+                    slug = %bot.workflow_slug,
+                    role = %bot.role,
+                    turn_id = %turn_id,
+                    kind,
+                    elapsed_sec = elapsed,
+                    "F195: watchdog notice surfaced"
+                );
+            }
+        } else {
+            tracing::debug!(
+                slug = %bot.workflow_slug,
+                role = %bot.role,
+                platform = %bot.im_platform,
+                kind,
+                "F195: no channel for bot's platform; watchdog notice not sent (progress.jsonl still appended)"
+            );
         }
     }
 }

--- a/crates/ccteam-imd/src/inbound.rs
+++ b/crates/ccteam-imd/src/inbound.rs
@@ -196,26 +196,77 @@ impl MailboxResolver for DefaultMailboxResolver {
     }
 }
 
-/// V0.6.1 F135 — DM auto-route preprocessor.
+/// V0.6.8 F194 — outcome of the DM auto-route preprocessor.
 ///
-/// Mutates `msg.content` in-place by prepending `@<role> ` when:
-/// 1. The content has no existing `@<handle>` mention, AND
-/// 2. Exactly one registered bot's `(im_platform, im_chat_id)` matches
-///    `(msg.channel, msg.reply_target)`.
+/// The caller (the daemon's inbound consumer) inspects this to decide
+/// whether to:
+/// - continue normal routing ([`DmRoutingHint::Routed`] /
+///   [`DmRoutingHint::NoMatch`] — `msg.content` already mutated by
+///   [`auto_route_dm_mention`] in the single-bot case, untouched
+///   otherwise);
+/// - short-circuit with a user-facing "disambiguate which bot" reply
+///   ([`DmRoutingHint::Ambiguous`]) without forwarding the message to
+///   the router. Reusing F184's `format_unknown_handle_reply` would be
+///   misleading ("Unknown handle '@xxx'") because the user didn't type
+///   one — we render a parallel "Multiple bots in this chat" line via
+///   [`format_ambiguous_dm_reply`] instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DmRoutingHint {
+    /// Single registered bot owns `(channel, chat_id)`; `msg.content`
+    /// has been mutated in-place to prepend `@<role> ` so the router
+    /// resolves the message to that bot.
+    Routed {
+        /// The bot role we prepended.
+        to_role: String,
+    },
+    /// Two or more bots share `(channel, chat_id)` (group-style chat,
+    /// chat-squad fan-out). Caller should send the
+    /// `format_ambiguous_dm_reply(available)` text back to the chat and
+    /// **not** continue normal routing — the user has to retype with an
+    /// explicit `@<handle>`.
+    Ambiguous {
+        /// The handles the user can pick from. Same ordering / collision
+        /// rules as [`crate::router::available_handles_for_chat`] so the
+        /// hint always matches `@ccteam list bots` for the same chat.
+        available: Vec<String>,
+    },
+    /// Zero registered bots own this chat. Same as legacy F135 silent
+    /// path — let the router drop the message naturally (no IM reply,
+    /// no admin processing).
+    NoMatch,
+}
+
+/// V0.6.1 F135 + V0.6.8 F194 — DM auto-route preprocessor.
 ///
-/// The router contract drops "no @mention" messages; without this
-/// preprocessor a user DMing a single bot would have to type
-/// `@<role> hi` to be heard, which defeats the "natural DM" UX
-/// promise. The 2+ bot case (group with multiple bots sharing a
-/// chat_id) still falls through to the router's drop path so explicit
-/// @ mentions remain the disambiguator there.
+/// Behavior:
+/// 1. Existing `@<handle>` in the content → return [`DmRoutingHint::Routed`]
+///    with `to_role` empty-ish (caller should treat as no-op; the router
+///    will resolve the explicit mention itself). For clarity we return
+///    `NoMatch` in that branch — the caller's contract is "did we mutate
+///    `msg`?", and we didn't.
+/// 2. No `@`, exactly one bot owns `(channel, chat_id)` → mutate
+///    `msg.content` to prepend `@<role> ` and return
+///    [`DmRoutingHint::Routed`].
+/// 3. No `@`, **two or more** bots own `(channel, chat_id)` (the V0.6.8
+///    F194 anchor) → leave `msg.content` untouched and return
+///    [`DmRoutingHint::Ambiguous { available }`]. The caller renders the
+///    hint reply via [`format_ambiguous_dm_reply`] and short-circuits
+///    out of the inbound pipeline.
+/// 4. No `@`, zero bots own the chat → return [`DmRoutingHint::NoMatch`]
+///    (legacy F135 silent drop path).
 ///
-/// Helper [`has_at_mention`] does the @ detection; kept public so
-/// unit tests can probe the boundary cases (e.g. bare "@" with no
+/// Helper [`has_at_mention`] does the `@` detection; kept public so
+/// unit tests can probe the boundary cases (e.g. bare `@` with no
 /// handle char).
-pub fn auto_route_dm_mention(msg: &mut ChannelMessage, bots: &[crate::BotRegistration]) {
+pub fn auto_route_dm_mention(
+    msg: &mut ChannelMessage,
+    bots: &[crate::BotRegistration],
+) -> DmRoutingHint {
     if has_at_mention(&msg.content) {
-        return;
+        // Caller treats this the same as NoMatch (no mutation, normal
+        // router pass). We don't fabricate a `to_role` here — the user
+        // already specified one.
+        return DmRoutingHint::NoMatch;
     }
     let matches: Vec<&crate::BotRegistration> = bots
         .iter()
@@ -234,6 +285,7 @@ pub fn auto_route_dm_mention(msg: &mut ChannelMessage, bots: &[crate::BotRegistr
                 role
             );
             msg.content = new_content;
+            DmRoutingHint::Routed { to_role: role }
         }
         0 => {
             tracing::debug!(
@@ -241,16 +293,50 @@ pub fn auto_route_dm_mention(msg: &mut ChannelMessage, bots: &[crate::BotRegistr
                 chat_id = %msg.reply_target,
                 "imd: F135 DM auto-route skipped (no bot bound to this chat)"
             );
+            DmRoutingHint::NoMatch
         }
         n => {
-            tracing::debug!(
+            // V0.6.8 F194 — instead of the legacy silent drop, compute
+            // the available-handle list now so the caller can send the
+            // disambiguation hint reply. We reuse
+            // `available_handles_for_chat` so the suggested handles
+            // mirror what `@ccteam list bots` shows for this chat
+            // (including F184 cross-slug collision suffixes).
+            let available = available_handles_for_chat(bots, &msg.channel, &msg.reply_target);
+            tracing::info!(
                 count = n,
+                available = available.len(),
                 platform = %msg.channel,
                 chat_id = %msg.reply_target,
-                "imd: F135 DM auto-route skipped (multiple bots share chat_id; group-style @ required)"
+                "imd: F194 DM auto-route ambiguous (multiple bots share chat_id); replying with hint"
             );
+            DmRoutingHint::Ambiguous { available }
         }
     }
+}
+
+/// V0.6.8 F194 — render the user-facing "multiple bots in this chat"
+/// reply.
+///
+/// Parallel to F184's [`crate::router::format_unknown_handle_reply`]
+/// but for a different trigger: the user sent a message with no `@`
+/// mention into a chat where 2+ bots are registered. We can't pick one
+/// arbitrarily (that would route conversations to the wrong agent
+/// silently) so we list every bot reachable from this chat and ask
+/// the user to retype with `@<handle>`.
+///
+/// Falls back to a "No bots available" line when `available` is empty
+/// — guards the race window where a bot unregistered between the
+/// inbound listener's read of [`crate::list_bots`] and this render call.
+pub fn format_ambiguous_dm_reply(available: &[String]) -> String {
+    if available.is_empty() {
+        return "No bots available in this chat.".to_string();
+    }
+    let mentions: Vec<String> = available.iter().map(|h| format!("@{h}")).collect();
+    format!(
+        "Multiple bots in this chat. Specify one: {}",
+        mentions.join(" ")
+    )
 }
 
 /// V0.6.1 F135 — true iff `text` contains an `@` followed by at least

--- a/crates/ccteam-imd/src/supervisor.rs
+++ b/crates/ccteam-imd/src/supervisor.rs
@@ -189,6 +189,54 @@ pub enum MarkerHealAction {
     PermanentFailure,
 }
 
+/// V0.6.8 F195 — per-turn watchdog state held inside
+/// [`BotSupervisor::active_turn`].
+///
+/// Set when [`BotSupervisor::handle_inbound`] successfully calls
+/// `adapter.submit_turn`; cleared on `ItemCompleted/AgentMessage`
+/// (assistant turn done from the harness's perspective), `shutdown`,
+/// `reset_session`. Two latches — `long_emitted`, `timeout_emitted` —
+/// stop the daemon's tick from re-firing the same notification on
+/// every 5s pass.
+#[derive(Debug, Clone)]
+pub struct TurnDeadline {
+    /// Adapter-assigned turn id, copied from the `submit_turn` return.
+    pub turn_id: TurnId,
+    /// When [`BotSupervisor::handle_inbound`] called `submit_turn`.
+    /// `Instant` (monotonic) so wall-clock drift can't reset the timer.
+    pub started_at: Instant,
+    /// True once the `chat_turn_running_long` notification fired.
+    pub long_emitted: bool,
+    /// True once the `chat_turn_timeout` notification fired.
+    pub timeout_emitted: bool,
+}
+
+/// V0.6.8 F195 — one notification the watchdog wants to surface for an
+/// outstanding turn. Returned from
+/// [`BotSupervisor::check_turn_watchdog`] so the daemon owns the IO
+/// (progress.jsonl append + `channel.send`) — the supervisor stays a
+/// pure decision-maker, mirroring `decide_with_config`'s split.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnWatchdogNotice {
+    /// First threshold (`1× turn_timeout_sec`). User-facing IM line:
+    /// "Still working on your message (turn started <HH:MM:SS>).
+    /// Continuing."
+    RunningLong {
+        /// Adapter turn id.
+        turn_id: String,
+        /// Seconds since `submit_turn`.
+        elapsed_sec: u64,
+    },
+    /// Second threshold (`2× turn_timeout_sec`). User-facing IM line
+    /// includes recovery instructions ("/clear and retry").
+    Timeout {
+        /// Adapter turn id.
+        turn_id: String,
+        /// Seconds since `submit_turn`.
+        elapsed_sec: u64,
+    },
+}
+
 /// Decision the supervisor makes for one bot on a single tick.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SupervisorAction {
@@ -429,13 +477,8 @@ pub struct BotSupervisor {
     /// stamp every outbound row with the inbound's hop. The daemon's
     /// outbound dispatcher then computes `next_hop = item.hop + 1`
     /// when it detects an embedded `@<otherbot>` mention and
-    /// synthesizes a cross-bot `InboxItem`.
-    ///
-    /// Set in `handle_inbound` before `submit_turn`; read per-event in
-    /// `spawn_events_consumer`. Replies from a turn we never observed
-    /// (host-probe direct `submit_turn`, daemon restart while a tmux
-    /// session is mid-conversation) inherit the default value `0`,
-    /// matching the "user-IM-sourced" hop semantic.
+    /// synthesizes a cross-bot `InboxItem`. User-IM-sourced turns enter
+    /// with `hop = 0`.
     current_hop: Arc<AtomicU8>,
     /// V0.6.8 F196 — self-Weak captured during
     /// `register_as_marker_reporter` so the [`MarkerReporter`] trait
@@ -444,6 +487,26 @@ pub struct BotSupervisor {
     /// past its rightful drop. Set once; subsequent registrations
     /// (restart / reset) reuse the same Weak.
     self_weak: std::sync::OnceLock<Weak<Self>>,
+    /// V0.6.8 F195 — outstanding-turn watchdog state. Set by
+    /// `handle_inbound` after a successful `submit_turn`, cleared by
+    /// the `events()` consumer on `ItemCompleted/AgentMessage` (the
+    /// HarnessAdapter's local view of "turn completed"), and also
+    /// cleared in `shutdown` / `reset_session`. The daemon's tick loop
+    /// calls [`check_turn_watchdog`] each pass to drain
+    /// [`TurnWatchdogNotice`]s that crossed a threshold.
+    ///
+    /// `Arc<Mutex<_>>` so the spawned events-consumer task can hold its
+    /// own clone and clear the deadline without re-locking the
+    /// supervisor's main `state`.
+    active_turn: Arc<Mutex<Option<TurnDeadline>>>,
+    /// V0.6.8 F195 — per-turn watchdog threshold (seconds). First
+    /// crossing emits `chat_turn_running_long`; second crossing (at
+    /// `2× turn_timeout_sec`) emits `chat_turn_timeout`. Defaults to
+    /// [`ccteam_core::workflow::DEFAULT_TURN_TIMEOUT_SECS`] when
+    /// callers use [`Self::new`] / [`Self::new_with_config`]; a future
+    /// patch will plumb `workflow.yaml::chat.turn_timeout_sec` through
+    /// here once the daemon learns to load workflow specs at startup.
+    pub turn_timeout_sec: u32,
 }
 
 impl std::fmt::Debug for BotSupervisor {
@@ -493,7 +556,28 @@ impl BotSupervisor {
             outbound_tx: Arc::new(Mutex::new(None)),
             current_hop: Arc::new(AtomicU8::new(0)),
             self_weak: std::sync::OnceLock::new(),
+            active_turn: Arc::new(Mutex::new(None)),
+            turn_timeout_sec: ccteam_core::workflow::DEFAULT_TURN_TIMEOUT_SECS,
         }
+    }
+
+    /// V0.6.8 F195 — full constructor including the watchdog timeout
+    /// override. Production callers stick with
+    /// [`Self::new`] / [`Self::new_with_config`] (default 90s); tests
+    /// pass a tight value (e.g. 1s) so threshold assertions fit under
+    /// `max_runtime`. A future patch will thread
+    /// `workflow.yaml::chat.turn_timeout_sec` through here once the
+    /// daemon learns to load workflow specs at startup.
+    pub fn new_with_turn_timeout(
+        reg: BotRegistration,
+        projects_root: impl Into<PathBuf>,
+        adapter: Arc<dyn HarnessAdapter + Send + Sync>,
+        config_projects: HashMap<String, PathBuf>,
+        turn_timeout_sec: u32,
+    ) -> Self {
+        let mut sup = Self::new_with_config(reg, projects_root, adapter, config_projects);
+        sup.turn_timeout_sec = turn_timeout_sec;
+        sup
     }
 
     /// V0.6.1 fast-path — daemon main loop calls this once per bot
@@ -994,6 +1078,12 @@ impl BotSupervisor {
         // recent value (across submit_turn await points + scheduler
         // hand-off).
         let current_hop_arc = self.current_hop.clone();
+        // V0.6.8 F195 — clone the `active_turn` Arc into the spawned
+        // task so it can clear the watchdog deadline the moment the
+        // adapter emits the matching `ItemCompleted/AgentMessage`. The
+        // task can't reach `self` (lifetime), so we hand the Arc in
+        // explicitly. Mirrors the `outbound_tx` pattern above.
+        let active_turn_arc = self.active_turn.clone();
         let task = tokio::spawn(async move {
             let mut stream = adapter.events(&handle);
             while let Some(evt) = stream.next().await {
@@ -1007,6 +1097,18 @@ impl BotSupervisor {
                 };
                 if text.is_empty() {
                     continue;
+                }
+                // V0.6.8 F195 — assistant text means the harness saw
+                // the turn finish. Clear the watchdog so a subsequent
+                // post-timeout reply doesn't keep firing the daemon's
+                // tick notifications. We clear unconditionally (rather
+                // than match on turn_id) because in steady-state the
+                // bot serializes one turn at a time; the rare edge
+                // case where a stale post-clear turn lands is benign
+                // (next `handle_inbound` re-arms the deadline anyway).
+                {
+                    let mut guard = active_turn_arc.lock().await;
+                    *guard = None;
                 }
                 let assistant_len = text.len();
                 let turn_id_log = item.id.clone();
@@ -1126,6 +1228,16 @@ impl BotSupervisor {
     /// value to compute `next_hop = hop + 1` when it detects an
     /// embedded `@<otherbot>` mention and synthesizes a cross-bot
     /// `InboxItem`. User-IM-sourced turns enter with `hop = 0`.
+    ///
+    /// V0.6.8 F195 — on a successful submit, arms the per-turn watchdog
+    /// by storing a fresh [`TurnDeadline`] in `active_turn`. The
+    /// daemon's tick loop polls [`check_turn_watchdog`] each pass; when
+    /// the elapsed time crosses `1× turn_timeout_sec` (default 90s) the
+    /// daemon emits `chat_turn_running_long` + a "still working" IM
+    /// reply; at `2×` it emits `chat_turn_timeout` + a "stuck" IM
+    /// reply. The deadline is cleared when the events consumer sees
+    /// the matching `ItemCompleted/AgentMessage` (turn done) or when
+    /// the supervisor is shut down / reset.
     pub async fn handle_inbound(&self, payload: String, hop: u8) -> Result<TurnId> {
         // V0.6.8 F193 — stash the inbound hop BEFORE submit_turn so the
         // events consumer (which fires asynchronously when the adapter
@@ -1152,6 +1264,21 @@ impl BotSupervisor {
                     self.reg.workflow_slug, self.reg.role
                 )
             })?;
+        // V0.6.8 F195 — arm the watchdog *after* submit_turn succeeds.
+        // On submit failure we leave any previous deadline alone — a
+        // pre-existing in-flight turn from an earlier `handle_inbound`
+        // is still a legitimate stall to surface. (Practically the bot
+        // serializes turns through tmux, so back-to-back submits land
+        // sequentially; the rare overlap window is benign.)
+        {
+            let mut guard = self.active_turn.lock().await;
+            *guard = Some(TurnDeadline {
+                turn_id: id.clone(),
+                started_at: Instant::now(),
+                long_emitted: false,
+                timeout_emitted: false,
+            });
+        }
         tracing::debug!(
             slug = %self.reg.workflow_slug,
             role = %self.reg.role,
@@ -1160,6 +1287,69 @@ impl BotSupervisor {
             "submitted user turn"
         );
         Ok(id)
+    }
+
+    /// V0.6.8 F195 — snapshot the outstanding turn (test / observability).
+    pub async fn active_turn_snapshot(&self) -> Option<TurnDeadline> {
+        self.active_turn.lock().await.clone()
+    }
+
+    /// V0.6.8 F195 — poll the watchdog for one bot.
+    ///
+    /// Returns the notification (if any) the daemon should surface this
+    /// tick AND latches `long_emitted` / `timeout_emitted` so the next
+    /// tick doesn't re-fire the same notice. Pure decision-side: no
+    /// progress.jsonl writes, no `channel.send` — those happen on the
+    /// daemon side (which already owns the [`ChannelMap`] +
+    /// [`CcteamPaths`] surface needed for the IO).
+    ///
+    /// Hard rule (CLAUDE.md §三 R5): this method never touches the
+    /// underlying claude / tmux session. The watchdog only **observes**
+    /// the silent stall and surfaces it; recovery is user-driven.
+    ///
+    /// Returns at most one notice per call (the earliest unlatched
+    /// threshold the deadline has crossed). The daemon calls this once
+    /// per 5s tick per bot; in steady-state a stalled turn emits
+    /// `RunningLong` on the tick after the 90s mark, then `Timeout` on
+    /// the tick after the 180s mark, then nothing.
+    pub async fn check_turn_watchdog(&self) -> Option<TurnWatchdogNotice> {
+        let mut guard = self.active_turn.lock().await;
+        let deadline = guard.as_mut()?;
+        let elapsed = deadline.started_at.elapsed();
+        let timeout_sec = self.turn_timeout_sec.max(1) as u64;
+        let elapsed_sec = elapsed.as_secs();
+        // Second threshold (2x) wins over first when both are crossed
+        // and `RunningLong` was already emitted — we always advance
+        // forward through the thresholds, never re-emit.
+        if !deadline.timeout_emitted && elapsed_sec >= timeout_sec.saturating_mul(2) {
+            deadline.timeout_emitted = true;
+            // Set `long_emitted` too so a daemon that skipped the
+            // intermediate tick (e.g. busy tokio scheduler) doesn't
+            // back-fire `RunningLong` next pass.
+            deadline.long_emitted = true;
+            return Some(TurnWatchdogNotice::Timeout {
+                turn_id: deadline.turn_id.0.clone(),
+                elapsed_sec,
+            });
+        }
+        if !deadline.long_emitted && elapsed_sec >= timeout_sec {
+            deadline.long_emitted = true;
+            return Some(TurnWatchdogNotice::RunningLong {
+                turn_id: deadline.turn_id.0.clone(),
+                elapsed_sec,
+            });
+        }
+        None
+    }
+
+    /// V0.6.8 F195 — clear the outstanding-turn watchdog. Called by the
+    /// events consumer when `ItemCompleted/AgentMessage` fires (turn
+    /// done from the harness's view) and by `shutdown` /
+    /// `reset_session` so a stale deadline doesn't survive a session
+    /// teardown. Idempotent — clearing an already-cleared slot is a
+    /// no-op.
+    pub async fn clear_active_turn(&self) {
+        *self.active_turn.lock().await = None;
     }
 
     /// Gracefully close the underlying thread (`adapter.close_thread`)
@@ -1173,6 +1363,10 @@ impl BotSupervisor {
         // tail loop (if still alive on a respawn) doesn't fire heal
         // attempts against a closing supervisor.
         self.unregister_marker_reporter();
+        // V0.6.8 F195 — drop any outstanding watchdog deadline so a
+        // post-shutdown daemon tick doesn't keep emitting timeout
+        // notices for a bot whose session is gone.
+        self.clear_active_turn().await;
         let handle = {
             let mut st = self.state.lock().await;
             st.shutting_down = true;
@@ -1201,6 +1395,9 @@ impl BotSupervisor {
         // tasks before tearing it down; `ensure_started` will respawn
         // them against the fresh handle.
         self.abort_background_tasks().await;
+        // V0.6.8 F195 — drop the watchdog deadline: the old session is
+        // being torn down, any in-flight turn it owned is gone.
+        self.clear_active_turn().await;
         // Close first.
         let handle = self.state.lock().await.handle.take();
         if let Some(h) = handle {
@@ -1258,6 +1455,10 @@ impl BotSupervisor {
     /// any turn was taken).
     pub async fn reset_session(&self) -> Result<Option<PathBuf>> {
         self.abort_background_tasks().await;
+        // V0.6.8 F195 — wipe the watchdog deadline. A reset means the
+        // user explicitly asked for a fresh session; any pre-reset
+        // turn's stall is no longer actionable.
+        self.clear_active_turn().await;
 
         // 2. Archive the existing turns.jsonl.
         let bot_dir = self.bot_dir();

--- a/crates/ccteam-imd/tests/dm_autoroute_test.rs
+++ b/crates/ccteam-imd/tests/dm_autoroute_test.rs
@@ -24,7 +24,9 @@ use ccteam_core::harness::{
     ThreadEvent, ThreadHandle, TurnId, TurnInput,
 };
 use ccteam_imd::daemon::{run_daemon_with_shutdown, AdapterFactory, ChannelMap, DaemonArgs};
-use ccteam_imd::inbound::{auto_route_dm_mention, has_at_mention};
+use ccteam_imd::inbound::{
+    auto_route_dm_mention, format_ambiguous_dm_reply, has_at_mention, DmRoutingHint,
+};
 use ccteam_imd::register_bot;
 use ccteam_imd::transport::providers::mock::MockChannel;
 use ccteam_imd::transport::{Channel, ChannelMessage};
@@ -95,38 +97,100 @@ fn has_at_mention_ignores_bare_at() {
 fn auto_route_dm_prepends_for_single_match() {
     let bots = vec![mk_bot("dev-foo", "lead", "telegram", "chat-1")];
     let mut msg = mk_msg("hi", "chat-1", "telegram");
-    auto_route_dm_mention(&mut msg, &bots);
+    let hint = auto_route_dm_mention(&mut msg, &bots);
     assert_eq!(msg.content, "@lead hi");
+    assert_eq!(
+        hint,
+        DmRoutingHint::Routed {
+            to_role: "lead".into()
+        }
+    );
 }
 
 #[test]
 fn auto_route_dm_skips_when_zero_bots() {
     let bots: Vec<BotRegistration> = vec![];
     let mut msg = mk_msg("hi", "chat-1", "telegram");
-    auto_route_dm_mention(&mut msg, &bots);
+    let hint = auto_route_dm_mention(&mut msg, &bots);
     assert_eq!(msg.content, "hi", "no bots → no mutation");
+    assert_eq!(hint, DmRoutingHint::NoMatch);
 }
 
 #[test]
-fn auto_route_dm_skips_when_multiple_bots_share_chat_id() {
+fn auto_route_dm_ambiguous_when_multiple_bots_share_chat_id() {
+    // V0.6.8 F194 — the V0.6.x silent-drop path now returns
+    // DmRoutingHint::Ambiguous so the daemon can reply with an
+    // available-bots hint instead of dropping the message.
     let bots = vec![
         mk_bot("dev-foo", "lead", "telegram", "chat-1"),
         mk_bot("dev-bar", "reviewer", "telegram", "chat-1"),
     ];
     let mut msg = mk_msg("hi", "chat-1", "telegram");
-    auto_route_dm_mention(&mut msg, &bots);
-    assert_eq!(msg.content, "hi", "group-style → require explicit @");
+    let hint = auto_route_dm_mention(&mut msg, &bots);
+    assert_eq!(
+        msg.content, "hi",
+        "ambiguous → message untouched (caller short-circuits with a reply)"
+    );
+    match hint {
+        DmRoutingHint::Ambiguous { available } => {
+            assert_eq!(
+                available,
+                vec!["lead".to_string(), "reviewer".to_string()],
+                "available handles sorted alphabetically"
+            );
+        }
+        other => panic!("expected Ambiguous, got {other:?}"),
+    }
+}
+
+#[test]
+fn auto_route_dm_ambiguous_three_bots_lists_all_handles() {
+    // F194 — same trigger as above but with three bots to confirm the
+    // hint covers all reachable handles (not just two).
+    let bots = vec![
+        mk_bot("dev-a", "alice", "telegram", "chat-1"),
+        mk_bot("dev-b", "bob", "telegram", "chat-1"),
+        mk_bot("dev-c", "carol", "telegram", "chat-1"),
+    ];
+    let mut msg = mk_msg("hello team", "chat-1", "telegram");
+    let hint = auto_route_dm_mention(&mut msg, &bots);
+    match hint {
+        DmRoutingHint::Ambiguous { available } => {
+            assert_eq!(available.len(), 3);
+            assert!(available.contains(&"alice".into()));
+            assert!(available.contains(&"bob".into()));
+            assert!(available.contains(&"carol".into()));
+        }
+        other => panic!("expected Ambiguous, got {other:?}"),
+    }
+}
+
+#[test]
+fn format_ambiguous_dm_reply_renders_handles() {
+    let text = format_ambiguous_dm_reply(&["alice".into(), "bob".into()]);
+    assert_eq!(text, "Multiple bots in this chat. Specify one: @alice @bob");
+}
+
+#[test]
+fn format_ambiguous_dm_reply_handles_empty_race() {
+    // Race: bots unregistered between probe and reply → graceful
+    // fallback so the user still gets *something*.
+    let text = format_ambiguous_dm_reply(&[]);
+    assert_eq!(text, "No bots available in this chat.");
 }
 
 #[test]
 fn auto_route_dm_skips_when_message_already_has_mention() {
     let bots = vec![mk_bot("dev-foo", "lead", "telegram", "chat-1")];
     let mut msg = mk_msg("@lead already", "chat-1", "telegram");
-    auto_route_dm_mention(&mut msg, &bots);
+    let hint = auto_route_dm_mention(&mut msg, &bots);
     assert_eq!(
         msg.content, "@lead already",
         "existing @ → idempotent (no double-prepend)"
     );
+    // We treat "user typed their own @" identically to NoMatch — the
+    // router resolves the explicit mention itself.
+    assert_eq!(hint, DmRoutingHint::NoMatch);
 }
 
 #[test]
@@ -134,14 +198,16 @@ fn auto_route_dm_filters_by_platform_and_chat_id() {
     // Right chat_id, wrong platform → no match.
     let bots = vec![mk_bot("dev-foo", "lead", "slack", "chat-1")];
     let mut msg = mk_msg("hi", "chat-1", "telegram");
-    auto_route_dm_mention(&mut msg, &bots);
+    let hint = auto_route_dm_mention(&mut msg, &bots);
     assert_eq!(msg.content, "hi");
+    assert_eq!(hint, DmRoutingHint::NoMatch);
 
     // Right platform, wrong chat_id → no match.
     let bots = vec![mk_bot("dev-foo", "lead", "telegram", "chat-OTHER")];
     let mut msg = mk_msg("hi", "chat-1", "telegram");
-    auto_route_dm_mention(&mut msg, &bots);
+    let hint = auto_route_dm_mention(&mut msg, &bots);
     assert_eq!(msg.content, "hi");
+    assert_eq!(hint, DmRoutingHint::NoMatch);
 }
 
 // ----- end-to-end: daemon + MockChannel + registered bot ------------
@@ -271,14 +337,19 @@ async fn daemon_dm_no_at_mention_auto_routes_to_single_bot() {
 
 #[allow(clippy::await_holding_lock)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn daemon_dm_multiple_bots_same_chat_id_drops() {
+async fn daemon_dm_multiple_bots_same_chat_id_replies_with_ambiguity_hint() {
+    // V0.6.8 F194 — what used to be a silent drop is now an active
+    // hint: the daemon answers with the available-bots list so the
+    // user knows their message was received and how to address it.
+    // R1 (no progress.jsonl write for this synthetic reply) + R12 (no
+    // turn submitted) still hold: only the IM channel.send fires.
     let _g = env_lock();
     let home = isolate_home();
     let projects_root = home.path().join("projects");
     std::fs::create_dir_all(&projects_root).unwrap();
 
-    // Two bots bound to the same telegram chat_id → group-style: must
-    // require explicit @ to disambiguate.
+    // Two bots bound to the same telegram chat_id → group-style: V0.6.8
+    // F194 surfaces a hint reply instead of dropping silently.
     register_bot(
         "dev-foo",
         "lead",
@@ -337,7 +408,25 @@ async fn daemon_dm_multiple_bots_same_chat_id_drops() {
     assert_eq!(
         adapter.submits.load(Ordering::SeqCst),
         0,
-        "group with 2 bots + no @ must drop (got submits={})",
+        "group with 2 bots + no @ must NOT submit a turn (got submits={})",
         adapter.submits.load(Ordering::SeqCst)
     );
+
+    let outbox = mock.outbox().await;
+    let hints: Vec<&ccteam_imd::transport::SendMessage> = outbox
+        .iter()
+        .filter(|m| m.content.starts_with("Multiple bots in this chat."))
+        .collect();
+    assert_eq!(
+        hints.len(),
+        1,
+        "F194: expected exactly 1 ambiguity-hint reply, got {} (outbox: {outbox:?})",
+        hints.len()
+    );
+    let text = &hints[0].content;
+    assert!(
+        text.contains("@lead") && text.contains("@reviewer"),
+        "F194: hint must list both bots' handles, got {text:?}"
+    );
+    assert_eq!(hints[0].recipient, "chat-group");
 }

--- a/crates/ccteam-imd/tests/turn_timeout_test.rs
+++ b/crates/ccteam-imd/tests/turn_timeout_test.rs
@@ -1,0 +1,267 @@
+//! V0.6.8 F195 — per-turn timeout watchdog integration test.
+//!
+//! Scenario: a bot's `submit_turn` succeeds but the harness never
+//! emits the matching `ItemCompleted/AgentMessage` (simulating a
+//! silently-hung claude session / broken Stop hook / stuck tail loop).
+//! Today this leaves the user with zero feedback. F195 arms a
+//! per-turn watchdog on `handle_inbound`; at `1×` `turn_timeout_sec`
+//! the daemon emits `chat_turn_running_long` + IM "still working"
+//! reply; at `2×` it emits `chat_turn_timeout` + IM "stuck" reply.
+//! Third tick onward: nothing (latches suppress repeats).
+//!
+//! The test uses a tight `turn_timeout_sec = 1` so the windows fit
+//! into a 3.5s `max_runtime` budget.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use ccteam_core::harness::{
+    AgentSpecBrief, AgentVendor, ExecutionMode, HarnessAdapter, HarnessError, SpawnCtx,
+    ThreadEvent, ThreadHandle, TurnId, TurnInput,
+};
+use ccteam_imd::supervisor::{BotSupervisor, TurnWatchdogNotice};
+use ccteam_imd::BotRegistration;
+use futures::stream::BoxStream;
+use tempfile::TempDir;
+
+#[derive(Debug, Default)]
+struct StuckAdapter {
+    submits: AtomicUsize,
+}
+
+#[async_trait]
+impl HarnessAdapter for StuckAdapter {
+    fn name(&self) -> &'static str {
+        "f195-stuck"
+    }
+    fn vendor(&self) -> AgentVendor {
+        AgentVendor::Claude
+    }
+    async fn start_thread(
+        &self,
+        spec: &AgentSpecBrief,
+        ctx: &SpawnCtx,
+    ) -> Result<ThreadHandle, HarnessError> {
+        Ok(ThreadHandle {
+            vendor: AgentVendor::Claude,
+            mode: ExecutionMode::Chat,
+            identity: format!("stuck-{}-{}", ctx.slug, spec.role),
+            started_at: chrono::Utc::now(),
+            raw_extras: serde_json::json!({}),
+        })
+    }
+    async fn submit_turn(
+        &self,
+        _h: &ThreadHandle,
+        _input: TurnInput,
+    ) -> Result<TurnId, HarnessError> {
+        self.submits.fetch_add(1, Ordering::SeqCst);
+        Ok(TurnId::new("stuck-turn-1"))
+    }
+    fn events(&self, _h: &ThreadHandle) -> BoxStream<'static, ThreadEvent> {
+        // Never emit anything → simulates a hung Stop hook / silent
+        // claude turn. The watchdog has to surface the stall on its own.
+        Box::pin(futures::stream::pending())
+    }
+    async fn resume_thread(&self, _id: &str) -> Result<ThreadHandle, HarnessError> {
+        Err(HarnessError::NotImplemented {
+            reason: "stuck".into(),
+        })
+    }
+    async fn close_thread(&self, _h: &ThreadHandle) -> Result<(), HarnessError> {
+        Ok(())
+    }
+}
+
+fn mk_reg() -> BotRegistration {
+    BotRegistration {
+        workflow_slug: "dev-foo".into(),
+        role: "lead".into(),
+        vendor: AgentVendor::Claude,
+        persona_id: None,
+        im_platform: "mock".into(),
+        im_chat_id: "chat-1".into(),
+        chat_handle: None,
+        project_dir: None,
+        created_at: chrono::Utc::now(),
+    }
+}
+
+/// Drive a fresh BotSupervisor through the F195 threshold sequence
+/// using a tight 1s timeout. Asserts:
+/// 1. Before submit_turn → no notice.
+/// 2. After submit_turn, before 1× → no notice yet.
+/// 3. After 1× crossing → RunningLong fires (once).
+/// 4. Subsequent calls before 2× → no notice (latched).
+/// 5. After 2× crossing → Timeout fires (once).
+/// 6. Subsequent calls → no notice (both latches set).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watchdog_fires_running_long_then_timeout_then_suppresses() {
+    let stub = Arc::new(StuckAdapter::default());
+    let tmp = TempDir::new().unwrap();
+    let sup = Arc::new(BotSupervisor::new_with_turn_timeout(
+        mk_reg(),
+        tmp.path(),
+        stub.clone(),
+        std::collections::HashMap::new(),
+        1,
+    ));
+
+    sup.ensure_started().await.unwrap();
+    // Step 1: pre-submit → no notice.
+    assert_eq!(sup.check_turn_watchdog().await, None);
+
+    // Step 2: submit, then poll immediately → no notice yet (0s elapsed).
+    let id = sup.handle_inbound("hi".into(), 0).await.unwrap();
+    assert_eq!(id.0, "stuck-turn-1");
+    assert_eq!(stub.submits.load(Ordering::SeqCst), 1);
+    let immediately = sup.check_turn_watchdog().await;
+    assert!(
+        immediately.is_none(),
+        "watchdog must not fire before 1x threshold (got {immediately:?})"
+    );
+    let snap = sup.active_turn_snapshot().await.expect("turn armed");
+    assert_eq!(snap.turn_id.0, "stuck-turn-1");
+    assert!(!snap.long_emitted);
+    assert!(!snap.timeout_emitted);
+
+    // Step 3: wait past 1× threshold.
+    let t0 = Instant::now();
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    let notice = sup
+        .check_turn_watchdog()
+        .await
+        .expect("RunningLong must fire after 1.1s with timeout=1s");
+    match notice {
+        TurnWatchdogNotice::RunningLong {
+            turn_id,
+            elapsed_sec,
+        } => {
+            assert_eq!(turn_id, "stuck-turn-1");
+            assert!(
+                elapsed_sec >= 1,
+                "elapsed_sec >= timeout; got {elapsed_sec}"
+            );
+        }
+        other => panic!("expected RunningLong, got {other:?}"),
+    }
+
+    // Step 4: poll again before 2× → no notice (long_emitted latched).
+    let immediately = sup.check_turn_watchdog().await;
+    assert!(
+        immediately.is_none(),
+        "RunningLong must NOT re-fire while long_emitted latched (got {immediately:?})"
+    );
+
+    // Step 5: wait past 2× threshold (total ~2.2s since submit).
+    let elapsed_so_far = t0.elapsed();
+    if elapsed_so_far < Duration::from_millis(2200) {
+        tokio::time::sleep(Duration::from_millis(2200) - elapsed_so_far).await;
+    }
+    let notice = sup
+        .check_turn_watchdog()
+        .await
+        .expect("Timeout must fire after 2.2s with timeout=1s");
+    match notice {
+        TurnWatchdogNotice::Timeout {
+            turn_id,
+            elapsed_sec,
+        } => {
+            assert_eq!(turn_id, "stuck-turn-1");
+            assert!(
+                elapsed_sec >= 2,
+                "elapsed_sec >= 2x timeout; got {elapsed_sec}"
+            );
+        }
+        other => panic!("expected Timeout, got {other:?}"),
+    }
+
+    // Step 6: 3× tick (~3.3s) → still no further notice.
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    let third = sup.check_turn_watchdog().await;
+    assert!(
+        third.is_none(),
+        "no third notice (both latches set); got {third:?}"
+    );
+
+    // R5 sanity: the supervisor is still running. We never killed it.
+    assert!(
+        sup.is_started().await,
+        "R5: watchdog must not kill the long session"
+    );
+}
+
+/// Clearing `active_turn` (the events consumer's behaviour when the
+/// harness finally emits `ItemCompleted`) must disarm the watchdog so
+/// subsequent ticks return None even past the 1× / 2× thresholds.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watchdog_clears_on_turn_completion_signal() {
+    let stub = Arc::new(StuckAdapter::default());
+    let tmp = TempDir::new().unwrap();
+    let sup = Arc::new(BotSupervisor::new_with_turn_timeout(
+        mk_reg(),
+        tmp.path(),
+        stub.clone(),
+        std::collections::HashMap::new(),
+        1,
+    ));
+
+    sup.ensure_started().await.unwrap();
+    sup.handle_inbound("hi".into(), 0).await.unwrap();
+
+    // Cross the 1× threshold + fire RunningLong.
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+    let notice = sup.check_turn_watchdog().await;
+    assert!(matches!(
+        notice,
+        Some(TurnWatchdogNotice::RunningLong { .. })
+    ));
+
+    // Simulate the events consumer's clear (what fires on
+    // `ItemCompleted/AgentMessage`).
+    sup.clear_active_turn().await;
+    assert!(sup.active_turn_snapshot().await.is_none());
+
+    // Wait past 2× threshold; nothing should fire.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert_eq!(
+        sup.check_turn_watchdog().await,
+        None,
+        "completed turn must not surface a post-completion Timeout"
+    );
+}
+
+/// `shutdown` / `reset_session` must also clear the deadline so a
+/// stale turn doesn't survive a session teardown.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watchdog_cleared_by_shutdown_and_reset() {
+    let stub = Arc::new(StuckAdapter::default());
+    let tmp = TempDir::new().unwrap();
+    let sup = Arc::new(BotSupervisor::new_with_turn_timeout(
+        mk_reg(),
+        tmp.path(),
+        stub.clone(),
+        std::collections::HashMap::new(),
+        1,
+    ));
+
+    sup.ensure_started().await.unwrap();
+    sup.handle_inbound("hi".into(), 0).await.unwrap();
+    assert!(sup.active_turn_snapshot().await.is_some());
+    sup.shutdown().await.unwrap();
+    assert!(
+        sup.active_turn_snapshot().await.is_none(),
+        "shutdown must wipe the watchdog deadline"
+    );
+
+    sup.ensure_started().await.unwrap();
+    sup.handle_inbound("hi again".into(), 0).await.unwrap();
+    assert!(sup.active_turn_snapshot().await.is_some());
+    sup.reset_session().await.unwrap();
+    assert!(
+        sup.active_turn_snapshot().await.is_none(),
+        "reset_session must wipe the watchdog deadline"
+    );
+}


### PR DESCRIPTION
## Summary

Two UX fixes that close silent-failure modes users hit during chat-squad testing.

- **F194**: When N>=2 bots share the same DM chat_id, an unaddressed message used to silently drop. `auto_route_dm_mention` now returns `DmRoutingHint::{Routed, Ambiguous, NoMatch}`; the daemon's inbound consumer answers `Ambiguous` with a hint listing available handles ("Multiple bots in this chat. Specify one: @alice @bob"), reusing `available_handles_for_chat` so the suggestion list matches what `@ccteam list bots` reports.
- **F195**: New per-turn watchdog. `BotSupervisor::handle_inbound` arms a `TurnDeadline` after a successful `submit_turn`; the daemon's existing 5s tick polls `check_turn_watchdog`, which emits `chat_turn_running_long` + IM "Still working" at 1× `turn_timeout_sec` (default 90s), then `chat_turn_timeout` + IM "stuck" reply at 2×. Latches suppress repeats. **Does NOT kill the turn** — only surfaces silent stalls (R5 守). Deadline clears on the first assistant `ItemCompleted` from the harness's `events()` stream, plus `shutdown` / `restart` / `reset_session`.

## Notes

- `ChatSpec` gains `turn_timeout_sec: u32` with `#[serde(default = "default_turn_timeout_sec")]` (90); validation rejects `0`. The daemon currently passes the default constant to every `BotSupervisor`; full workflow.yaml plumbing lands in a follow-up patch when the daemon learns to load workflow specs at startup. `new_with_turn_timeout` is the test seam today.
- The watchdog clears `active_turn` on the first assistant text from the harness's `ItemCompleted/AgentMessage` (the practical "turn done" signal supervisor sees), not on `chat_turn_completed` from progress.jsonl (the daemon never reads progress.jsonl). Partial-stream-then-hang is a less common pathology; the next `handle_inbound` re-arms the deadline.
- Workspace version stays at `0.6.7` per PRD.

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast --exclude ccteam-web` — 1527 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — 0 drift
- [x] Extended `dm_autoroute_test.rs`: 2-bot + 3-bot ambiguous → `Ambiguous { available }`; daemon e2e asserts the hint reply text + recipient; empty-race graceful fallback; existing single-bot auto-route still passes
- [x] New `turn_timeout_test.rs`: 1× → `RunningLong`; 2× → `Timeout`; 3× → suppressed; completion → cleared; shutdown / reset cleared
- [x] Rebased onto current `main` (F193 + F196 landed mid-flight)

## Acceptance

- Telegram group with 2 chat-squad bots, sending `"hi"` (no @): bot replies `"Multiple bots in this chat. Specify one: @alice @bob"`.
- A bot whose Stop hook / tail loop / claude turn silently hangs: user-facing "Still working" reply after `turn_timeout_sec`, then "stuck" reply at 2x. The session keeps running — recovery is `/clear` + retry, not engine intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)