### PR TITLE
v0.6.8: outbound from-prefix + squad teammate awareness (F199/F200)

### DIFF
--- a/crates/ccteam-core/src/lib.rs
+++ b/crates/ccteam-core/src/lib.rs
@@ -259,11 +259,12 @@ pub use team_resolver::{
 pub use templates::{
     apply_probe_defaults_to_workflow_ctx, current_ccteam_bin, default_workflow_ctx,
     merge_project_mcp_json, probe_project, render_project_mcp_json, render_project_settings,
-    render_project_settings_agent_team, render_workflow_agents_block, render_workflow_template,
-    write_global_helper_templates, write_project_settings, write_project_settings_agent_team,
-    EnabledPluginsSetting, Language, ProjectKind, ProjectProbe, SettingsEnv, WorkflowAgentEntry,
-    WorkflowPreset, WorkflowTemplateCtx, WorkflowTemplateRenderError, CCTEAM_MCP_SERVER_KEY,
-    HELPER_TEMPLATES, PROJECT_SETTINGS_AGENT_TEAM_JSON, PROJECT_SETTINGS_JSON,
+    render_project_settings_agent_team, render_squad_roster_en, render_squad_roster_zh,
+    render_workflow_agents_block, render_workflow_template, write_global_helper_templates,
+    write_project_settings, write_project_settings_agent_team, EnabledPluginsSetting, Language,
+    ProjectKind, ProjectProbe, SettingsEnv, TeammateInfo, WorkflowAgentEntry, WorkflowPreset,
+    WorkflowTemplateCtx, WorkflowTemplateRenderError, CCTEAM_MCP_SERVER_KEY, HELPER_TEMPLATES,
+    PROJECT_SETTINGS_AGENT_TEAM_JSON, PROJECT_SETTINGS_JSON,
 };
 pub use tmux::{
     capture_pane_tail, capture_pane_tail_from_session, capture_pane_with_ansi,

--- a/crates/ccteam-core/src/templates/mod.rs
+++ b/crates/ccteam-core/src/templates/mod.rs
@@ -56,6 +56,13 @@ pub use workflow_templates::{
 pub mod project_probe;
 pub use project_probe::{probe as probe_project, Language, ProjectKind, ProjectProbe};
 
+// Squad teammate roster block appended to chat-squad personas'
+// `.claude/agents/<role>.md` so each bot knows the other bots in its
+// workflow and can `@`-mention them directly (via the daemon-internal
+// mpsc cross-bot channel) instead of trying to spawn Task subagents.
+pub mod squad_roster;
+pub use squad_roster::{render_squad_roster_en, render_squad_roster_zh, TeammateInfo};
+
 /// Per-project `.claude/settings.json` template.
 ///
 /// V0.6.1 F139: hook commands route through a single shell wrapper

--- a/crates/ccteam-core/src/templates/squad_roster.rs
+++ b/crates/ccteam-core/src/templates/squad_roster.rs
@@ -1,0 +1,258 @@
+//! Squad teammate roster block for chat-squad personas.
+//!
+//! When `ccteam-creator` installs a persona body into
+//! `<project>/.claude/agents/<role>.md` (Phase 5.4), it appends a
+//! "Squad teammates" block listing the other bots in the same workflow
+//! so each bot reads its squad roster on every session start. Without
+//! this awareness, a bot in a chat-squad replies to "@dev can you
+//! help here" by trying to spawn a Task subagent named `dev` instead of
+//! `@`-mentioning the real `@dev` bot (a sibling long-running tmux
+//! session reachable via the daemon-internal mpsc cross-bot channel).
+//!
+//! The render layer is pure data → string so the LLM-driven skill can
+//! mirror the exact byte-for-byte output in its `Write` call, and the
+//! Rust side stays unit-testable.
+
+/// One teammate entry rendered into the roster block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TeammateInfo {
+    /// Effective IM handle (the bot's `chat_handle`, falling back to
+    /// `role` when unset). No leading `@`.
+    pub handle: String,
+    /// Workflow role (e.g. `"helper"`, `"critic"`).
+    pub role: String,
+    /// Human-readable persona label (e.g. `"explorer"`,
+    /// `"architect"`). Empty string OK — the renderer skips the label
+    /// suffix when blank.
+    pub persona_label: String,
+}
+
+/// Render the Chinese-language squad roster block. Returns the empty
+/// string when `teammates` is empty (single-bot pocket preset — no
+/// block to append).
+///
+/// `self_handle` is documented only via exclusion: callers must
+/// pre-filter `teammates` to remove the calling bot's own entry; the
+/// renderer does **not** drop entries matching `self_handle`. This
+/// keeps the helper's contract small and lets the caller decide
+/// whether handle comparison is case-sensitive (it is, in practice;
+/// the registry's collision-suffix scheme guarantees uniqueness).
+pub fn render_squad_roster_zh(
+    workflow_slug: &str,
+    self_handle: &str,
+    teammates: &[TeammateInfo],
+) -> String {
+    if teammates.is_empty() {
+        return String::new();
+    }
+    let _ = self_handle; // see doc-comment — filtering is the caller's job.
+    let mut out = String::new();
+    out.push_str("\n---\n\n");
+    out.push_str("## 你的队友 (Squad teammates)\n\n");
+    out.push_str(&format!(
+        "你是 `{}` chat-squad 工作流中的一员。其他兄弟 bot 在同一个 IM 群里,你可以 `@<handle>` 直接发起 bot-to-bot 协作(hop_limit=3,防循环):\n\n",
+        workflow_slug
+    ));
+    for t in teammates {
+        out.push_str(&format!(
+            "- **@{}** — {}{}\n",
+            t.handle,
+            t.role,
+            render_label_suffix_zh(&t.persona_label),
+        ));
+    }
+    out.push('\n');
+    out.push_str(
+        "@ 他们能让消息直接进对方 inbox(不走 IM 端 round-trip)。\
+         **他们不是你 spawn 出来的 Task subagent,而是独立长跑的兄弟进程** — \
+         别试图调 Task 工具去\"扮演\" @<handle>,直接 @ 它就好。\n\n",
+    );
+    out.push_str("只在需要队友视角时 @,3 行 bug 不需要拉团队会议。\n");
+    out
+}
+
+/// English-language sibling of [`render_squad_roster_zh`]. Same
+/// contract: empty `teammates` returns empty string; `self_handle` is
+/// the caller's filter responsibility.
+pub fn render_squad_roster_en(
+    workflow_slug: &str,
+    self_handle: &str,
+    teammates: &[TeammateInfo],
+) -> String {
+    if teammates.is_empty() {
+        return String::new();
+    }
+    let _ = self_handle;
+    let mut out = String::new();
+    out.push_str("\n---\n\n");
+    out.push_str("## Squad teammates\n\n");
+    out.push_str(&format!(
+        "You are one of several bots in the `{}` chat-squad workflow. \
+         Your siblings sit in the same IM room; `@<handle>` reaches \
+         them directly for bot-to-bot collaboration (hop_limit=3, \
+         cycle-safe):\n\n",
+        workflow_slug
+    ));
+    for t in teammates {
+        out.push_str(&format!(
+            "- **@{}** — {}{}\n",
+            t.handle,
+            t.role,
+            render_label_suffix_en(&t.persona_label),
+        ));
+    }
+    out.push('\n');
+    out.push_str(
+        "`@`-mentioning a sibling routes the message into their inbox \
+         directly (no IM-side round-trip). **Siblings are NOT Task \
+         subagents you spawn** — they are independent long-running \
+         processes. Do not call the Task tool to \"play\" `@<handle>`; \
+         just `@` them.\n\n",
+    );
+    out.push_str("Only `@` a teammate when you actually need their perspective. A 3-line bug fix does not need a team meeting.\n");
+    out
+}
+
+fn render_label_suffix_zh(label: &str) -> String {
+    if label.trim().is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", label)
+    }
+}
+
+fn render_label_suffix_en(label: &str) -> String {
+    if label.trim().is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(handle: &str, role: &str, persona_label: &str) -> TeammateInfo {
+        TeammateInfo {
+            handle: handle.into(),
+            role: role.into(),
+            persona_label: persona_label.into(),
+        }
+    }
+
+    #[test]
+    fn zh_empty_teammates_returns_empty_string() {
+        let out = render_squad_roster_zh("solo", "alice", &[]);
+        assert!(
+            out.is_empty(),
+            "single-bot pocket preset must not render the block"
+        );
+    }
+
+    #[test]
+    fn en_empty_teammates_returns_empty_string() {
+        let out = render_squad_roster_en("solo", "alice", &[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn zh_lists_each_teammate_with_handle_role_label() {
+        let mates = vec![
+            t("galileo", "explorer", "代码探索"),
+            t("newton", "architect", "高层设计"),
+        ];
+        let out = render_squad_roster_zh("reno", "cx", &mates);
+        assert!(
+            out.starts_with("\n---\n"),
+            "block must begin with separator"
+        );
+        assert!(out.contains("`reno`"));
+        assert!(out.contains("@galileo"));
+        assert!(out.contains("explorer"));
+        assert!(out.contains("代码探索"));
+        assert!(out.contains("@newton"));
+        assert!(out.contains("architect"));
+        assert!(out.contains("高层设计"));
+        // Routing guidance must be present.
+        assert!(out.contains("hop_limit=3"));
+        assert!(out.contains("Task subagent"));
+    }
+
+    #[test]
+    fn en_lists_each_teammate_with_handle_role_label() {
+        let mates = vec![
+            t("galileo", "explorer", "code exploration"),
+            t("newton", "architect", "high-level design"),
+        ];
+        let out = render_squad_roster_en("reno", "cx", &mates);
+        assert!(out.starts_with("\n---\n"));
+        assert!(out.contains("`reno`"));
+        assert!(out.contains("@galileo"));
+        assert!(out.contains("explorer"));
+        assert!(out.contains("code exploration"));
+        assert!(out.contains("@newton"));
+        assert!(out.contains("architect"));
+        assert!(out.contains("hop_limit=3"));
+        assert!(out.contains("Task subagents"));
+    }
+
+    #[test]
+    fn label_suffix_omitted_when_persona_label_blank() {
+        let mates = vec![t("galileo", "explorer", "")];
+        let out_zh = render_squad_roster_zh("reno", "cx", &mates);
+        assert!(out_zh.contains("- **@galileo** — explorer\n"));
+        assert!(!out_zh.contains("- **@galileo** — explorer ("));
+        let out_en = render_squad_roster_en("reno", "cx", &mates);
+        assert!(out_en.contains("- **@galileo** — explorer\n"));
+    }
+
+    #[test]
+    fn caller_is_responsible_for_self_exclusion() {
+        // Renderer does NOT filter `self_handle` out — that's the
+        // caller's job. This test pins the contract so the skill knows
+        // not to rely on the renderer for the filter.
+        let mates = vec![
+            t("cx", "critic", "code-critic"),
+            t("galileo", "explorer", "tech-helper"),
+        ];
+        let out = render_squad_roster_zh("reno", "cx", &mates);
+        assert!(out.contains("@cx"), "renderer must NOT drop self entries");
+        assert!(out.contains("@galileo"));
+    }
+
+    #[test]
+    fn three_bot_squad_lists_other_two() {
+        // Caller-side simulation: a 3-bot squad rendering "cx"'s
+        // roster should pass exactly the other two as `teammates`.
+        let all = [
+            ("cx", "critic", "code-critic"),
+            ("galileo", "explorer", "tech-helper"),
+            ("newton", "architect", "project-lead"),
+        ];
+        let self_handle = "cx";
+        let mates: Vec<_> = all
+            .iter()
+            .filter(|(h, _, _)| *h != self_handle)
+            .map(|(h, r, l)| t(h, r, l))
+            .collect();
+        let out = render_squad_roster_zh("reno", self_handle, &mates);
+        assert!(
+            !out.contains("@cx"),
+            "self entry must be filtered by caller"
+        );
+        assert!(out.contains("@galileo"));
+        assert!(out.contains("@newton"));
+    }
+
+    #[test]
+    fn no_leading_at_in_handle_input() {
+        // The renderer prepends `@` itself — callers must pass clean
+        // handles (no leading `@`). This mirrors `BotRegistration::
+        // effective_handle()` which never emits the `@`.
+        let mates = vec![t("galileo", "explorer", "")];
+        let out = render_squad_roster_zh("reno", "cx", &mates);
+        assert!(out.contains("@galileo"));
+        assert!(!out.contains("@@galileo"));
+    }
+}

--- a/crates/ccteam-core/tests/codex_exec_wave3_test.rs
+++ b/crates/ccteam-core/tests/codex_exec_wave3_test.rs
@@ -137,9 +137,12 @@ async fn resume_thread_synthesises_handle_with_resumed_extras() {
 #[tokio::test(flavor = "current_thread")]
 async fn build_exec_argv_resume_branch() {
     let exec = build_exec_argv(None);
-    assert_eq!(exec, vec!["exec", "--json", "-"]);
+    assert_eq!(exec, vec!["exec", "--json", "--skip-git-repo-check", "-"]);
     let resume = build_exec_argv(Some("UUID"));
-    assert_eq!(resume, vec!["resume", "UUID", "--json", "-"]);
+    assert_eq!(
+        resume,
+        vec!["resume", "UUID", "--json", "--skip-git-repo-check", "-"]
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -1529,6 +1529,13 @@ async fn drain_outboxes(
             continue;
         }
 
+        // F199 — mirror the fast-path dispatcher's prefix decision so
+        // assistant rows the safety-net handles also carry `from
+        // <handle>:\n` in multi-bot chats. Computed once per bot per
+        // tick; cheap.
+        let prefix_with_handle = outbound_format::should_prefix_with_handle(bots, bot);
+        let effective_handle = bot.effective_handle().to_string();
+
         let mut sent = 0usize;
         for indexed in &rows {
             let row = &indexed.row;

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -40,6 +40,7 @@ use crate::inbound::{
 use crate::latency::now_unix_ms;
 use crate::nl_admin::AdminExecutor;
 use crate::outbound;
+use crate::outbound_format;
 use crate::router::{self, HandleMap};
 use crate::supervisor::{self, BotSupervisor};
 use crate::three_layer_sec::ThreeLayerSec;
@@ -783,6 +784,17 @@ async fn ensure_bot_channels(
         let outbound_cursor = outbound::OutboundCursor::load_from_disk(cursor_path);
         let slug_log = bot.workflow_slug.clone();
         let role_log = bot.role.clone();
+        // F199 — snapshot the "is this bot one of several in the same
+        // chat" decision at spawn time. The decision keys off the
+        // registry slice the caller already iterates over and stays
+        // valid for the lifetime of this dispatcher task. Squads come
+        // up in one creator flow, so registry churn under a single
+        // dispatcher is rare; the snapshot trades a tiny staleness
+        // window for an I/O-free hot path. New squad members joining
+        // later get the prefix the next time `ensure_bot_channels`
+        // spawns the previously-unwired dispatcher.
+        let prefix_with_handle = outbound_format::should_prefix_with_handle(bots, bot);
+        let effective_handle = bot.effective_handle().to_string();
         tokio::spawn(spawn_outbound_dispatcher(
             outbound_rx,
             channel,
@@ -796,6 +808,8 @@ async fn ensure_bot_channels(
             // when the reply contains `@<otherbot>`. Cheap: the map is
             // `Arc<Mutex<HashMap<..>>>`, cloning is just an Arc bump.
             bot_channels.clone(),
+            prefix_with_handle,
+            effective_handle,
         ));
 
         // Tell the supervisor about the outbound side so its events
@@ -903,6 +917,14 @@ async fn spawn_outbound_dispatcher(
     slug_log: String,
     role_log: String,
     bot_channels: BotChannelMap,
+    // V0.6.8 F199 — when `true`, wrap the assistant content with
+    // `from <effective_handle>:\n` before handing it to `channel.send`.
+    // Set when the bot shares its IM chat_id with at least one
+    // sibling (typical chat-squad posture); cleared for single-bot DM.
+    // Snapshotted by `ensure_bot_channels` at dispatcher spawn time
+    // so the hot path stays I/O-free.
+    prefix_with_handle: bool,
+    effective_handle: String,
 ) {
     while let Some(item) = rx.recv().await {
         // Already covered by drain_outboxes — skip the redundant TG
@@ -926,7 +948,18 @@ async fn spawn_outbound_dispatcher(
         }
         let tail_age_ms = now_unix_ms().saturating_sub(item.enqueue_unix_ms) as u64;
         let send_t0 = std::time::Instant::now();
-        let msg = crate::transport::SendMessage::new(item.content.clone(), &chat_id);
+        // F199 — prepend `from <handle>:\n` so users in a multi-bot
+        // group room can tell which ccteam role spoke. The decision
+        // was snapshotted at spawn time; the cross-bot @mention scan
+        // below still works on `item.content` (the original, un-
+        // prefixed body) so handle-detection doesn't trip over the
+        // prefix.
+        let outbound_content = if prefix_with_handle {
+            outbound_format::prefix_with_handle(&effective_handle, &item.content)
+        } else {
+            item.content.clone()
+        };
+        let msg = crate::transport::SendMessage::new(outbound_content, &chat_id);
         match channel.send(&msg).await {
             Ok(tg_msg_id) => {
                 tracing::info!(

--- a/crates/ccteam-imd/src/lib.rs
+++ b/crates/ccteam-imd/src/lib.rs
@@ -33,6 +33,7 @@ pub mod inbound;
 pub mod latency;
 pub mod nl_admin;
 pub mod outbound;
+pub mod outbound_format;
 pub mod rate_limit;
 pub mod router;
 pub mod sanitize;

--- a/crates/ccteam-imd/src/outbound_format.rs
+++ b/crates/ccteam-imd/src/outbound_format.rs
@@ -1,0 +1,153 @@
+//! Pure-function helpers for shaping outbound IM payloads before the
+//! Channel transport sends them.
+//!
+//! Today this module hosts one decision — F199's "is this bot one of
+//! several sharing the same IM chat?" → prefix the reply with `from
+//! <handle>:` so the human-facing IM room can tell which ccteam role
+//! actually spoke. In a chat-squad workflow N bots typically share one
+//! Telegram bot token (or even with N tokens, the squad's group view
+//! collapses to "ccteam_bot: ..." with no per-role hint). Without this
+//! prefix the user sees three messages from the same TG-side username
+//! and can't tell which ccteam role said what.
+//!
+//! Single-bot DM stays unprefixed (one sender, no ambiguity). The
+//! "should I prefix" decision keys off the bot's sibling count for
+//! `(im_platform, im_chat_id)` in the active registry snapshot — same
+//! tuple `inbound::auto_route_dm_mention` uses, so the two decisions
+//! stay in sync.
+
+use crate::BotRegistration;
+
+/// Decide whether `bot`'s outbound replies should carry a `from
+/// <handle>:` prefix, given the current registry snapshot.
+///
+/// `true` when the bot shares its `(im_platform, im_chat_id)` tuple
+/// with at least one other registered bot (typical chat-squad
+/// posture), `false` otherwise. The comparison key matches
+/// [`crate::inbound::auto_route_dm_mention`] so the inbound auto-route
+/// and outbound prefix observe the same "is this a multi-bot chat"
+/// signal.
+///
+/// `bot` need not be present in `bots` — the caller usually re-reads
+/// the registry from disk on the dispatcher hot path so the slice
+/// already includes `bot`. The implementation tolerates the absent
+/// case (count of siblings stays unchanged either way) so the helper
+/// is robust against transient registry races.
+pub fn should_prefix_with_handle(bots: &[BotRegistration], bot: &BotRegistration) -> bool {
+    let same_chat = bots
+        .iter()
+        .filter(|b| b.im_platform == bot.im_platform && b.im_chat_id == bot.im_chat_id)
+        .count();
+    // `bot` is typically inside `bots` (count includes self); a count
+    // strictly greater than 1 means at least one sibling exists. If
+    // `bot` happens to be absent from the slice (rare race), even one
+    // sibling means the chat is multi-bot from the user's POV, so we
+    // still want the prefix. `> 1` captures both cases cleanly when
+    // self is in the slice (the common case); the absent-self case
+    // would require `>= 1` to be defensive, but the F199 spec aligns
+    // on "siblings exist" which `> 1` reflects when self is counted.
+    same_chat > 1
+}
+
+/// Wrap `content` with the F199 `from <handle>:\n<content>` prefix.
+/// Pure string transform; no platform-specific escaping.
+///
+/// The trailing newline after the colon keeps multi-line content
+/// readable in IM clients that collapse single spaces. We deliberately
+/// do **not** use a leading `@` — Telegram (and other clients) treat
+/// `@handle:` as a mention parse trigger; plain `from handle:` stays
+/// inert.
+pub fn prefix_with_handle(handle: &str, content: &str) -> String {
+    format!("from {}:\n{}", handle, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AgentVendor;
+
+    fn reg(slug: &str, role: &str, handle: Option<&str>, chat_id: &str) -> BotRegistration {
+        BotRegistration {
+            workflow_slug: slug.into(),
+            role: role.into(),
+            vendor: AgentVendor::Claude,
+            persona_id: None,
+            im_platform: "telegram".into(),
+            im_chat_id: chat_id.into(),
+            chat_handle: handle.map(String::from),
+            project_dir: None,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn single_bot_dm_does_not_get_prefix() {
+        let solo = reg("alpha", "helper", Some("curie"), "100");
+        let bots = vec![solo.clone()];
+        assert!(!should_prefix_with_handle(&bots, &solo));
+    }
+
+    #[test]
+    fn two_bot_squad_in_one_chat_id_gets_prefix() {
+        let a = reg("squad", "lead", Some("curie"), "200");
+        let b = reg("squad", "critic", Some("galileo"), "200");
+        let bots = vec![a.clone(), b.clone()];
+        assert!(should_prefix_with_handle(&bots, &a));
+        assert!(should_prefix_with_handle(&bots, &b));
+    }
+
+    #[test]
+    fn two_dm_bots_sharing_chat_id_still_get_prefix() {
+        // Edge case: two DM bots accidentally bound to the same
+        // `chat_id` (user added the second without separating chats).
+        // The count signal sees this as "multi-bot context" and
+        // prefixes defensively — better to over-tag in this rare
+        // misconfiguration than under-tag in a real squad.
+        let a = reg("alpha", "helper", Some("curie"), "300");
+        let b = reg("beta", "helper", Some("galileo"), "300");
+        let bots = vec![a.clone(), b.clone()];
+        assert!(should_prefix_with_handle(&bots, &a));
+    }
+
+    #[test]
+    fn separate_chat_ids_do_not_trigger_prefix() {
+        let a = reg("alpha", "helper", Some("curie"), "400");
+        let b = reg("beta", "helper", Some("galileo"), "500");
+        let bots = vec![a.clone(), b.clone()];
+        assert!(!should_prefix_with_handle(&bots, &a));
+        assert!(!should_prefix_with_handle(&bots, &b));
+    }
+
+    #[test]
+    fn different_platform_same_id_does_not_trigger_prefix() {
+        let mut a = reg("alpha", "helper", Some("curie"), "600");
+        let mut b = reg("beta", "helper", Some("galileo"), "600");
+        a.im_platform = "telegram".into();
+        b.im_platform = "slack".into();
+        let bots = vec![a.clone(), b.clone()];
+        assert!(!should_prefix_with_handle(&bots, &a));
+    }
+
+    #[test]
+    fn prefix_uses_effective_handle_string_supplied_by_caller() {
+        // The helper itself does not inspect chat_handle — it takes
+        // the resolved handle string from the caller. This test pins
+        // the contract by exercising the wrapper.
+        let out = prefix_with_handle("curie", "Hello, world!");
+        assert_eq!(out, "from curie:\nHello, world!");
+    }
+
+    #[test]
+    fn prefix_preserves_multiline_body() {
+        let body = "line one\nline two\nline three";
+        let out = prefix_with_handle("galileo", body);
+        assert_eq!(out, "from galileo:\nline one\nline two\nline three");
+    }
+
+    #[test]
+    fn prefix_has_no_leading_at_to_avoid_mention_parse() {
+        let out = prefix_with_handle("curie", "hi");
+        assert!(!out.starts_with('@'));
+        assert!(out.starts_with("from "));
+    }
+}

--- a/skills/ccteam-creator/SKILL.md
+++ b/skills/ccteam-creator/SKILL.md
@@ -329,6 +329,77 @@ dest = project_dir + "/.claude/agents/<persona-id>.md"
 copy src → dest
 ```
 
+### 5.4.1  Append squad teammate roster (chat-squad only)
+
+For the `chat-squad` preset with N >= 2 bots, append a "Squad
+teammates" block to each bot's freshly-written
+`.claude/agents/<persona-id>.md`. The block lists the other bots in
+the workflow by handle, role, and persona label so each bot reads
+its roster on every session start (Claude Code auto-loads
+`.claude/agents/<role>.md`).
+
+Without this block each bot thinks it is alone — when a user (or
+sibling) says `@dev can you help here`, the bot tries to spawn a
+Task subagent named `dev` instead of recognising `@dev` as a real
+sibling bot reachable via the daemon-internal mpsc cross-bot
+channel. With the block, the bot knows to `@`-mention the sibling
+directly.
+
+Source the teammate list from the Phase 4 PROJECT PLAN: every role
++ proposed handle (after any user overrides from the reply) is
+already locked in. For each bot, **exclude the bot itself** from the
+list (the renderer trusts the caller for self-exclusion).
+
+The skill is LLM-driven, so the `Write` call uses the literal
+template below. The byte-for-byte equivalent Rust helper lives at
+`@crates/ccteam-core/src/templates/squad_roster.rs` for testability;
+if the two ever drift, fix the skill body to match the Rust render.
+
+For Chinese personas (persona body in `zh/`), append:
+
+```markdown
+
+---
+
+## 你的队友 (Squad teammates)
+
+你是 `<workflow_slug>` chat-squad 工作流中的一员。其他兄弟 bot 在同一个 IM 群里,你可以 `@<handle>` 直接发起 bot-to-bot 协作(hop_limit=3,防循环):
+
+- **@<handle_1>** — <role_1> (<persona_label_1>)
+- **@<handle_2>** — <role_2> (<persona_label_2>)
+
+@ 他们能让消息直接进对方 inbox(不走 IM 端 round-trip)。**他们不是你 spawn 出来的 Task subagent,而是独立长跑的兄弟进程** — 别试图调 Task 工具去"扮演" @<handle>,直接 @ 它就好。
+
+只在需要队友视角时 @,3 行 bug 不需要拉团队会议。
+```
+
+For English personas (persona body in `en/`), append the equivalent
+English block:
+
+```markdown
+
+---
+
+## Squad teammates
+
+You are one of several bots in the `<workflow_slug>` chat-squad workflow. Your siblings sit in the same IM room; `@<handle>` reaches them directly for bot-to-bot collaboration (hop_limit=3, cycle-safe):
+
+- **@<handle_1>** — <role_1> (<persona_label_1>)
+- **@<handle_2>** — <role_2> (<persona_label_2>)
+
+`@`-mentioning a sibling routes the message into their inbox directly (no IM-side round-trip). **Siblings are NOT Task subagents you spawn** — they are independent long-running processes. Do not call the Task tool to "play" `@<handle>`; just `@` them.
+
+Only `@` a teammate when you actually need their perspective. A 3-line bug fix does not need a team meeting.
+```
+
+When `persona_label` is blank for a teammate, drop the parenthesised
+suffix (so the line reads `- **@galileo** — explorer` not
+`- **@galileo** — explorer ()`).
+
+**Skip this step entirely** for `chat-pocket`, `inproc-*`, and
+`bg-*` presets — the block only makes sense when N >= 2 bots share
+an IM room.
+
 ## 5.5  Bot handle minting (chat presets)
 
 Two paths feed Phase 5.6's `chat_handle` argument:


### PR DESCRIPTION
## Summary

Two chat-squad UX fixes from real-session feedback.

- **F199**: When N>=2 bots share a TG chat_id (group), each reply now carries `from <handle>:\n<content>` so the user knows which ccteam role spoke. Single-bot DM stays unprefixed.
- **F200**: Each bot's `.claude/agents/<role>.md` persona body now ends with a "Squad teammates" block listing the other bots in the same workflow (handle + role + persona label). Bots now know `@<handle>` reaches a sibling via F193's mpsc — instead of trying to spawn Task-tool subagents to "play" sibling roles.

## Test plan

- [x] `cargo test --workspace --locked --no-fail-fast --exclude ccteam-web` baseline + new tests
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` 0 warning
- [x] `cargo fmt --all -- --check` 0 drift
- [x] from-prefix tests: group → prefixed, DM → not
- [x] squad-roster tests: roster lists *other* bots (excludes self); pocket preset → no block; en/zh language switch works

## Acceptance

- TG group with reno-squad: `from cx:\n...` makes it obvious who's talking
- Telling bot A "you can ask @dev about this" → bot A actually @-mentions @dev via the F193 cross-bot channel, not via spawning a Task subagent