### PR TITLE
v0.6.8: plugin sync + register-bot CLI + init --force self-host (F201/F202/F203)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ccteam",
       "description": "Multi-vendor (Claude + Codex) AI team orchestration on Claude Code — MCP-driven, file-system-as-control-plane, chat-mode 24/7 IM bots.",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "author": {
         "name": "FirstIntent"
       },
@@ -26,5 +26,5 @@
       ]
     }
   ],
-  "version": "0.6.6"
+  "version": "0.6.7"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccteam",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Multi-vendor AI team orchestration on Claude Code: 7 skills + 27 MCP tools + IM bots + multi-agent voting.",
   "author": {
     "name": "FirstIntent"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccteam",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Multi-vendor (Claude + Codex) AI dev-team orchestration: 7 skills + 27 MCP tools + IM bots + dual-LLM voting.",
   "author": {
     "name": "FirstIntent"

--- a/crates/ccteam-cli/src/commands.rs
+++ b/crates/ccteam-cli/src/commands.rs
@@ -148,12 +148,17 @@ pub fn run_init(paths: &CcteamPaths, opts: InitOptions) -> Result<String> {
     let target_team = opts.team.clone().unwrap_or_else(|| "dev".to_string());
 
     // -- 3a. Refuse install in the ccteam repo itself ----------------
-    if is_ccteam_repo(&target) {
+    // V0.6.8 F203 — `--force` escape: legitimate self-hosting /
+    // dogfooding / nested-research-project cases need to install a
+    // ccteam project inside the ccteam source tree. The default still
+    // refuses to avoid circular-hook surprises for casual users.
+    if is_ccteam_repo(&target) && !opts.force {
         return Err(anyhow::anyhow!(
             "refusing to install ccteam in the ccteam repo itself: {}\n\n\
              this directory contains the ccteam source — installing here would create \
              a circular hook setup. Pick a different directory (or `cd` into your own project \
-             and re-run).",
+             and re-run), or pass `--force` if you really want a ccteam project inside the \
+             ccteam source repo (e.g. for self-hosting / dogfooding).",
             target.display(),
         ));
     }
@@ -4556,6 +4561,142 @@ pub fn run_admin_add_tool(
     }))?)
 }
 
+/// V0.6.8 F202 — register a chat-mode bot via the CLI (the fallback
+/// when no daemon / MCP server is running). Mirrors the MCP path
+/// `dispatch_register_bot` in `mcp_chat_tools.rs`: same vendor
+/// normalization, same `chat_handle` auto-mint when caller omits it,
+/// same `project_dir` canonicalize + absolute-path guard. Non-clobber:
+/// re-registering an existing `(slug, role)` returns
+/// `ok:false, error:"already_registered"` instead of overwriting.
+#[allow(clippy::too_many_arguments)]
+pub fn run_admin_register_bot(
+    paths: &CcteamPaths,
+    slug: &str,
+    role: &str,
+    vendor_raw: &str,
+    platform_raw: &str,
+    chat_id: &str,
+    chat_handle_in: Option<&str>,
+    project_dir_in: Option<&std::path::Path>,
+) -> Result<String> {
+    use ccteam_core::harness::AgentVendor;
+    use ccteam_imd::{register_bot_checked_in, RegisterOutcome};
+
+    // Slug / role share the same validator as the MCP path
+    // (alphanumeric + `-` + `_`).
+    crate::mcp_chat_tools::validate_slug(slug, "slug")?;
+    crate::mcp_chat_tools::validate_slug(role, "role")?;
+
+    // Vendor: lowercase first so `Claude` still lands in the right variant.
+    let vendor = match vendor_raw.to_lowercase().as_str() {
+        "claude" => AgentVendor::Claude,
+        "codex" => AgentVendor::Codex,
+        other => {
+            return Err(anyhow::anyhow!(
+                "invalid vendor `{other}`: expected one of `claude`, `codex`"
+            ))
+        }
+    };
+
+    // IM platform: same enum the MCP dispatcher uses.
+    match platform_raw {
+        "telegram" | "slack" | "discord" | "mock" => {}
+        other => {
+            return Err(anyhow::anyhow!(
+                "invalid platform `{other}`: expected one of `telegram`, `slack`, `discord`, `mock`"
+            ));
+        }
+    }
+
+    if chat_id.is_empty() {
+        return Err(anyhow::anyhow!("`chat-id` must be non-empty"));
+    }
+
+    // Chat handle: caller wins; absent → auto-mint scientist nickname.
+    let chat_handle = match chat_handle_in {
+        Some(h) if !h.is_empty() => {
+            crate::mcp_chat_tools::validate_chat_handle(h)?;
+            h.to_string()
+        }
+        _ => crate::mcp_chat_tools::mint_unused_handle(&paths.root)?,
+    };
+
+    // Project dir: caller-supplied MUST be absolute. When omitted, default
+    // to cwd canonicalized (resolves symlinks too — daemon stores the
+    // post-canonical form). Identical to the MCP path so bot record
+    // semantics never diverge.
+    let project_dir = match project_dir_in {
+        Some(p) if !p.as_os_str().is_empty() => {
+            if !p.is_absolute() {
+                return Err(anyhow::anyhow!(
+                    "`--project-dir` must be an absolute path (got `{}`)",
+                    p.display()
+                ));
+            }
+            p.to_path_buf()
+        }
+        _ => std::env::current_dir().context("std::env::current_dir for default project_dir")?,
+    };
+    let project_dir = std::fs::canonicalize(&project_dir).with_context(|| {
+        format!(
+            "canonicalize project_dir `{}` (does the path exist?)",
+            project_dir.display()
+        )
+    })?;
+
+    let outcome = register_bot_checked_in(
+        &paths.root,
+        slug,
+        role,
+        vendor,
+        platform_raw,
+        chat_id,
+        None,
+        Some(chat_handle.as_str()),
+        Some(project_dir.as_path()),
+    )?;
+    match outcome {
+        RegisterOutcome::Registered(path) => {
+            Ok(serde_json::to_string_pretty(&serde_json::json!({
+                "ok": true,
+                "path": path.display().to_string(),
+                "workflow_slug": slug,
+                "role": role,
+                "chat_handle": chat_handle,
+                "project_dir": project_dir.display().to_string(),
+            }))?)
+        }
+        RegisterOutcome::AlreadyRegistered(path) => {
+            Ok(serde_json::to_string_pretty(&serde_json::json!({
+                "ok": false,
+                "error": "already_registered",
+                "path": path.display().to_string(),
+                "workflow_slug": slug,
+                "role": role,
+                "hint": "Unregister first with `ccteam admin unregister-bot`, then re-register.",
+            }))?)
+        }
+    }
+}
+
+/// V0.6.8 F202 — unregister a chat-mode bot via the CLI. Mirrors the
+/// MCP `ccteam__chat_unregister_bot` path: idempotent — returns
+/// `ok:true, removed:false` when no registration exists.
+pub fn run_admin_unregister_bot(paths: &CcteamPaths, slug: &str, role: &str) -> Result<String> {
+    use ccteam_imd::unregister_bot_in;
+
+    crate::mcp_chat_tools::validate_slug(slug, "slug")?;
+    crate::mcp_chat_tools::validate_slug(role, "role")?;
+    let (removed, path) = unregister_bot_in(&paths.root, slug, role)?;
+    Ok(serde_json::to_string_pretty(&serde_json::json!({
+        "ok": true,
+        "removed": removed,
+        "path": path.display().to_string(),
+        "workflow_slug": slug,
+        "role": role,
+    }))?)
+}
+
 /// V0.4.6 F81 — `ccteam remove <slug>` implementation.
 ///
 /// Steps (in order):
@@ -5811,6 +5952,52 @@ mod tests {
         assert!(
             msg.contains("ccteam repo itself"),
             "expected fail-loud message; got: {msg}",
+        );
+        assert!(
+            msg.contains("--force"),
+            "fail-loud message must point to the --force escape; got: {msg}",
+        );
+    }
+
+    /// V0.6.8 F203 — `--force` overrides the ccteam-repo refusal so
+    /// self-hosting / dogfooding installs inside the ccteam source tree
+    /// can proceed when the user explicitly opts in.
+    #[test]
+    fn run_init_force_overrides_ccteam_repo_refusal() {
+        let tmp = TempDir::new().unwrap();
+        let paths = fresh_paths(&tmp);
+        // Plant the two markers `is_ccteam_repo` checks for.
+        let fake_repo = tmp.path().join("ccteam-mirror");
+        std::fs::create_dir_all(fake_repo.join("crates").join("ccteam-cli")).unwrap();
+        std::fs::write(fake_repo.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+        let out = run_init(
+            &paths,
+            InitOptions {
+                install_in: Some(fake_repo.clone()),
+                slug: Some("self-host".into()),
+                force: true,
+                ..InitOptions::default()
+            },
+        )
+        .expect("--force must override ccteam-repo refusal");
+        assert!(
+            out.contains("ccteam init"),
+            "expected init summary header; got: {out}",
+        );
+
+        // Project install must have actually written the ccteam files.
+        let state_path = fake_repo.join(".ccteam").join("state.json");
+        assert!(
+            state_path.exists(),
+            "state.json must exist after --force init; checked {}",
+            state_path.display()
+        );
+        let workflow_path = fake_repo.join(".ccteam").join("workflow.yaml");
+        assert!(
+            workflow_path.exists(),
+            "workflow.yaml must exist after --force init; checked {}",
+            workflow_path.display()
         );
     }
 

--- a/crates/ccteam-cli/src/main.rs
+++ b/crates/ccteam-cli/src/main.rs
@@ -717,6 +717,48 @@ enum AdminAction {
         /// Tool descriptor (verbatim — taken as-is into the CSV).
         tool_descriptor: String,
     },
+    /// V0.6.8 F202 — register a chat-mode bot directly via the CLI.
+    /// Mirrors the `mcp__ccteam__chat_register_bot` MCP tool. Useful as
+    /// a scripted / no-daemon fallback when the MCP server isn't
+    /// registered yet (first-time setup, automation, MCP-less envs).
+    RegisterBot {
+        /// Project slug (workflow.yaml's `name` field).
+        #[arg(long)]
+        slug: String,
+        /// Role within the workflow (matches the `agents.<role>` key).
+        #[arg(long)]
+        role: String,
+        /// Harness vendor — `claude` or `codex`.
+        #[arg(long, default_value = "claude")]
+        vendor: String,
+        /// IM platform — `telegram`, `slack`, `discord`, or `mock`.
+        #[arg(long, default_value = "telegram")]
+        platform: String,
+        /// Platform chat id (Telegram chat_id, Slack channel id, etc.).
+        #[arg(long)]
+        chat_id: String,
+        /// Optional IM mention this bot answers to (without leading
+        /// `@`). When omitted, auto-mints an unused scientist nickname
+        /// from `ccteam_core::agent_naming::SCIENTIST_NAMES`. Letters,
+        /// digits, `_`, `-` only.
+        #[arg(long)]
+        chat_handle: Option<String>,
+        /// Optional absolute path to the project hosting
+        /// `.ccteam/workflow.yaml`. Defaults to cwd (canonicalized).
+        #[arg(long)]
+        project_dir: Option<PathBuf>,
+    },
+    /// V0.6.8 F202 — unregister a chat-mode bot. Mirrors the
+    /// `mcp__ccteam__chat_unregister_bot` MCP tool. Idempotent —
+    /// returns `ok:true, removed:false` when no registration exists.
+    UnregisterBot {
+        /// Project slug.
+        #[arg(long)]
+        slug: String,
+        /// Role within the workflow.
+        #[arg(long)]
+        role: String,
+    },
 }
 
 /// V0.6.0 Wave 3 F112 §C — `ccteam prefs` subcommand surface.
@@ -1192,6 +1234,33 @@ fn main() -> Result<()> {
                     tool_descriptor,
                 } => {
                     let out = commands::run_admin_add_tool(&paths, &slug, &bot, &tool_descriptor)?;
+                    println!("{out}");
+                    Ok(())
+                }
+                AdminAction::RegisterBot {
+                    slug,
+                    role,
+                    vendor,
+                    platform,
+                    chat_id,
+                    chat_handle,
+                    project_dir,
+                } => {
+                    let out = commands::run_admin_register_bot(
+                        &paths,
+                        &slug,
+                        &role,
+                        &vendor,
+                        &platform,
+                        &chat_id,
+                        chat_handle.as_deref(),
+                        project_dir.as_deref(),
+                    )?;
+                    println!("{out}");
+                    Ok(())
+                }
+                AdminAction::UnregisterBot { slug, role } => {
+                    let out = commands::run_admin_unregister_bot(&paths, &slug, &role)?;
                     println!("{out}");
                     Ok(())
                 }

--- a/crates/ccteam-cli/src/mcp_chat_tools.rs
+++ b/crates/ccteam-cli/src/mcp_chat_tools.rs
@@ -352,7 +352,11 @@ pub(crate) fn dispatch_register_bot(paths: &CcteamPaths, args: &Value) -> Result
 /// role as the handle. The match is case-insensitive in
 /// `pick_unused_bot_name` so registries that stored handles in mixed
 /// case still claim the right slot.
-fn mint_unused_handle(ccteam_root: &Path) -> Result<String> {
+///
+/// V0.6.8 F202 — `pub(crate)` so the `ccteam admin register-bot` CLI
+/// dispatcher in `commands.rs` can re-use the same auto-mint logic
+/// without copy-paste.
+pub(crate) fn mint_unused_handle(ccteam_root: &Path) -> Result<String> {
     let existing = list_bots_in(ccteam_root, None).unwrap_or_default();
     let in_use: Vec<String> = existing
         .iter()
@@ -363,7 +367,10 @@ fn mint_unused_handle(ccteam_root: &Path) -> Result<String> {
 
 /// Caller-supplied handles share the slug validator rules so registry
 /// filenames + router parse paths stay clean (alphanumeric / `_` / `-`).
-fn validate_chat_handle(s: &str) -> Result<()> {
+///
+/// V0.6.8 F202 — `pub(crate)` so the `ccteam admin register-bot` CLI
+/// dispatcher can re-use the same validator.
+pub(crate) fn validate_chat_handle(s: &str) -> Result<()> {
     if s.is_empty() {
         return Err(anyhow!("`chat_handle` must be non-empty"));
     }
@@ -652,7 +659,12 @@ fn parse_vendor(args: &Value) -> Result<AgentVendor> {
     }
 }
 
-fn validate_slug(s: &str, field: &str) -> Result<()> {
+/// V0.6.8 F202 — `pub(crate)` so the `ccteam admin register-bot` CLI
+/// dispatcher can re-use the same slug/role validator the MCP path
+/// uses (alphanumerics + `-` + `_`). Distinct from
+/// `ccteam_core::validate_slug_format`, which is stricter (lowercase
+/// + digits + dashes only) and gates init-time project slugs.
+pub(crate) fn validate_slug(s: &str, field: &str) -> Result<()> {
     if s.is_empty() {
         return Err(anyhow!("`{field}` must be non-empty"));
     }

--- a/crates/ccteam-cli/tests/admin_register_bot_test.rs
+++ b/crates/ccteam-cli/tests/admin_register_bot_test.rs
@@ -1,0 +1,222 @@
+//! V0.6.8 F202 — `ccteam admin register-bot` / `ccteam admin
+//! unregister-bot` CLI smoke tests.
+//!
+//! Mirrors the MCP `chat_register_bot` / `chat_unregister_bot` path —
+//! same on-disk JSON shape under
+//! `<CCTEAM_HOME>/imd/registry/<slug>/<role>.json`. The CLI is the
+//! scripted / no-daemon fallback for environments where MCP isn't
+//! registered yet.
+
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn ccteam_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_ccteam")
+}
+
+/// Run `ccteam admin <subcommand> <args...>` against a tempdir
+/// `CCTEAM_HOME`. Returns parsed stdout JSON. Asserts exit success.
+fn run_admin(home: &std::path::Path, args: &[&str]) -> Value {
+    let mut cmd = Command::new(ccteam_bin());
+    cmd.arg("admin")
+        .args(args)
+        .env("CCTEAM_HOME", home)
+        .env("CCTEAM_DISABLE_TOOL_SURFACE_BOOTSTRAP", "1");
+    let out = cmd.output().expect("spawn ccteam admin");
+    assert!(
+        out.status.success(),
+        "`ccteam admin {}` exited non-zero ({}): stderr=`{}` stdout=`{}`",
+        args.join(" "),
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("parse admin stdout JSON ({e}): `{stdout}`"))
+}
+
+/// V0.6.8 F202 — round-trip: register a fresh bot, assert the registry
+/// JSON file exists with the expected shape, then unregister and
+/// confirm the file is gone.
+#[test]
+fn admin_register_bot_writes_registry_json_then_unregister_removes_it() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&home).unwrap();
+
+    // Provide a real project_dir on disk so canonicalize() resolves.
+    let project_dir = tmp.path().join("my-project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let body = run_admin(
+        &home,
+        &[
+            "register-bot",
+            "--slug",
+            "demo",
+            "--role",
+            "helper",
+            "--platform",
+            "mock",
+            "--chat-id",
+            "12345",
+            "--project-dir",
+            project_dir.to_str().unwrap(),
+        ],
+    );
+
+    assert_eq!(
+        body["ok"], true,
+        "register-bot must return ok=true; got {body}"
+    );
+    assert_eq!(body["workflow_slug"], "demo");
+    assert_eq!(body["role"], "helper");
+
+    let registry_file = home.join("imd/registry/demo/helper.json");
+    assert!(
+        registry_file.exists(),
+        "registry JSON must exist at {}",
+        registry_file.display()
+    );
+
+    let on_disk: Value =
+        serde_json::from_str(&std::fs::read_to_string(&registry_file).unwrap()).unwrap();
+    assert_eq!(on_disk["workflow_slug"], "demo");
+    assert_eq!(on_disk["role"], "helper");
+    assert_eq!(on_disk["vendor"], "claude", "default vendor must be claude");
+    assert_eq!(on_disk["im_platform"], "mock");
+    assert_eq!(on_disk["im_chat_id"], "12345");
+    // Auto-minted chat_handle (caller did not pass --chat-handle).
+    assert!(
+        on_disk["chat_handle"].is_string(),
+        "chat_handle must be auto-minted to a string; got {on_disk}",
+    );
+    let handle = on_disk["chat_handle"].as_str().unwrap();
+    assert!(
+        !handle.is_empty(),
+        "auto-minted chat_handle must be non-empty"
+    );
+
+    // Unregister the bot — round-trip the registry back to clean.
+    let body = run_admin(
+        &home,
+        &["unregister-bot", "--slug", "demo", "--role", "helper"],
+    );
+    assert_eq!(body["ok"], true, "unregister-bot must return ok=true");
+    assert_eq!(
+        body["removed"], true,
+        "first unregister must report removed=true"
+    );
+    assert!(
+        !registry_file.exists(),
+        "registry JSON must be gone after unregister; still at {}",
+        registry_file.display()
+    );
+
+    // Idempotent miss — second unregister returns ok=true, removed=false.
+    let body = run_admin(
+        &home,
+        &["unregister-bot", "--slug", "demo", "--role", "helper"],
+    );
+    assert_eq!(
+        body["ok"], true,
+        "idempotent unregister must return ok=true"
+    );
+    assert_eq!(
+        body["removed"], false,
+        "second unregister must report removed=false (idempotent miss)"
+    );
+}
+
+/// V0.6.8 F202 — explicit `--chat-handle` wins over auto-mint.
+#[test]
+fn admin_register_bot_respects_explicit_chat_handle() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&home).unwrap();
+    let project_dir = tmp.path().join("p");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let body = run_admin(
+        &home,
+        &[
+            "register-bot",
+            "--slug",
+            "demo2",
+            "--role",
+            "lead",
+            "--platform",
+            "mock",
+            "--chat-id",
+            "999",
+            "--chat-handle",
+            "captain",
+            "--project-dir",
+            project_dir.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["chat_handle"], "captain");
+
+    let registry_file = home.join("imd/registry/demo2/lead.json");
+    let on_disk: Value =
+        serde_json::from_str(&std::fs::read_to_string(&registry_file).unwrap()).unwrap();
+    assert_eq!(on_disk["chat_handle"], "captain");
+}
+
+/// V0.6.8 F202 — re-registering the same `(slug, role)` is non-clobber
+/// (matches the MCP `chat_register_bot` semantics).
+#[test]
+fn admin_register_bot_refuses_duplicate_without_unregister() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("ccteam-home");
+    std::fs::create_dir_all(&home).unwrap();
+    let project_dir = tmp.path().join("p");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let first = run_admin(
+        &home,
+        &[
+            "register-bot",
+            "--slug",
+            "demo3",
+            "--role",
+            "lead",
+            "--platform",
+            "mock",
+            "--chat-id",
+            "1",
+            "--project-dir",
+            project_dir.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(first["ok"], true);
+
+    let dup = run_admin(
+        &home,
+        &[
+            "register-bot",
+            "--slug",
+            "demo3",
+            "--role",
+            "lead",
+            "--platform",
+            "mock",
+            "--chat-id",
+            "1",
+            "--project-dir",
+            project_dir.to_str().unwrap(),
+        ],
+    );
+    assert_eq!(
+        dup["ok"], false,
+        "duplicate registration must report ok=false"
+    );
+    assert_eq!(
+        dup["error"], "already_registered",
+        "duplicate must surface the `already_registered` sentinel"
+    );
+}

--- a/crates/ccteam-cli/tests/plugin_manifest_version_test.rs
+++ b/crates/ccteam-cli/tests/plugin_manifest_version_test.rs
@@ -1,0 +1,122 @@
+//! V0.6.8 F201 — assert the plugin manifest JSON files + the workspace
+//! `Cargo.toml` pin all agree on the current ccteam version.
+//!
+//! Drift between `Cargo.toml::workspace.package.version` and the four
+//! `version` strings carried by the Claude + Codex plugin manifests is
+//! invisible to `cargo build` / `cargo test` and was discovered (twice)
+//! during V0.6.7 / V0.6.8 ship prep — the binary shipped one version
+//! and the marketplace metadata advertised an older one. This test
+//! turns that drift into a CI failure so the ship-gate catches it.
+//!
+//! Sources of truth (all four must equal `workspace.package.version`):
+//!   1. `.claude-plugin/plugin.json::version`
+//!   2. `.claude-plugin/marketplace.json::version`
+//!   3. `.claude-plugin/marketplace.json::plugins[0].version`
+//!   4. `.codex-plugin/plugin.json::version`
+//!
+//! When adding a new plugin manifest file, add it here too.
+
+use std::path::{Path, PathBuf};
+
+/// Walk up from this crate's manifest dir (`crates/ccteam-cli/`) to
+/// the workspace root.
+fn repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/ccteam-cli/ → workspace root is two levels up.
+    manifest_dir
+        .parent()
+        .and_then(Path::parent)
+        .expect("repo_root: CARGO_MANIFEST_DIR must have two parents")
+        .to_path_buf()
+}
+
+/// Read `workspace.package.version` from the workspace `Cargo.toml`
+/// without pulling in a TOML dep — the file is small and the field is
+/// stable. We look for the first `version = "X.Y.Z"` after the
+/// `[workspace.package]` header.
+fn parse_workspace_version(repo_root: &Path) -> String {
+    let cargo_toml = repo_root.join("Cargo.toml");
+    let body =
+        std::fs::read_to_string(&cargo_toml).expect("read workspace Cargo.toml for version probe");
+    let after_header = body
+        .split_once("[workspace.package]")
+        .map(|(_, rest)| rest)
+        .unwrap_or_else(|| panic!("Cargo.toml missing [workspace.package] section"));
+    for line in after_header.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("version") {
+            // Expect `version = "X.Y.Z"`.
+            let rest = rest.trim_start_matches([' ', '\t', '=']);
+            let quoted = rest
+                .trim()
+                .trim_start_matches('"')
+                .trim_end_matches('"')
+                .trim_end_matches(',');
+            return quoted.to_string();
+        }
+        if trimmed.starts_with('[') {
+            break;
+        }
+    }
+    panic!("Cargo.toml::[workspace.package].version not found");
+}
+
+/// Read a single top-level `"version"` string from a JSON manifest.
+fn parse_json_top_version(path: &Path) -> String {
+    let body =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("parse {} as JSON: {e}", path.display()));
+    v.get("version")
+        .and_then(|x| x.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| panic!("{} missing top-level `version` string", path.display()))
+}
+
+/// Read the nested `plugins[0].version` from the marketplace manifest.
+fn parse_marketplace_plugin_version(path: &Path) -> String {
+    let body =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let v: serde_json::Value = serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("parse {} as JSON: {e}", path.display()));
+    v.get("plugins")
+        .and_then(|p| p.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|p0| p0.get("version"))
+        .and_then(|x| x.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| panic!("{} missing `plugins[0].version` string", path.display()))
+}
+
+#[test]
+fn plugin_manifests_match_workspace_version() {
+    let root = repo_root();
+    let workspace_version = parse_workspace_version(&root);
+
+    let claude_plugin = parse_json_top_version(&root.join(".claude-plugin/plugin.json"));
+    let codex_plugin = parse_json_top_version(&root.join(".codex-plugin/plugin.json"));
+    let marketplace_top = parse_json_top_version(&root.join(".claude-plugin/marketplace.json"));
+    let marketplace_plugin =
+        parse_marketplace_plugin_version(&root.join(".claude-plugin/marketplace.json"));
+
+    assert_eq!(
+        claude_plugin, workspace_version,
+        ".claude-plugin/plugin.json::version ({claude_plugin}) must match \
+         workspace.package.version ({workspace_version})"
+    );
+    assert_eq!(
+        codex_plugin, workspace_version,
+        ".codex-plugin/plugin.json::version ({codex_plugin}) must match \
+         workspace.package.version ({workspace_version})"
+    );
+    assert_eq!(
+        marketplace_top, workspace_version,
+        ".claude-plugin/marketplace.json::version ({marketplace_top}) must match \
+         workspace.package.version ({workspace_version})"
+    );
+    assert_eq!(
+        marketplace_plugin, workspace_version,
+        ".claude-plugin/marketplace.json::plugins[0].version ({marketplace_plugin}) must \
+         match workspace.package.version ({workspace_version})"
+    );
+}


### PR DESCRIPTION
## Summary

Three polish fixes preparing V0.6.8 for ship.

- **F201**: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (both top-level and `plugins[0]`), and `.codex-plugin/plugin.json` were pinned `0.6.6` while workspace was `0.6.7` — two versions of drift. Synced all four to workspace + new workspace test that asserts they match (so the V0.6.8 ship gate doesn't miss this again).
- **F202**: `ccteam admin register-bot` + `unregister-bot` CLI subcommands wrap the existing `register_bot_checked_in` / `unregister_bot_in` library calls. Fallback for environments without a running daemon / MCP server. Auto-mints scientist nickname when `--chat-handle` is omitted (same logic as the MCP path); same `project_dir` canonicalize + absolute-path guard so bot record semantics never diverge.
- **F203**: `ccteam init` inside the ccteam source repo previously refused with no escape. Now `--force` overrides + the error message mentions it.

No workspace version bump in this PR.

## Test plan

- [x] `cargo fmt --all -- --check` 0 drift
- [x] New `plugin_manifests_match_workspace_version` test: asserts the four manifest version strings agree with `workspace.package.version`
- [x] New `admin_register_bot_test` suite (3 tests): CLI register + unregister round-trip, explicit `--chat-handle` override, duplicate-registration refusal
- [x] Extended `run_init_refuses_to_install_in_ccteam_repo` to also assert the error mentions `--force`; new `run_init_force_overrides_ccteam_repo_refusal` covers the success branch (writes `state.json` + `workflow.yaml`)
- [x] `cargo run -- admin register-bot --help` renders all `--slug` / `--role` / `--vendor` / `--platform` / `--chat-id` / `--chat-handle` / `--project-dir` help text cleanly

## Inherited pre-existing breakage (NOT addressed in this PR)

- `cargo test -p ccteam-core --test codex_exec_wave3_test build_exec_argv_resume_branch` — fails on bare `origin/main` HEAD. Introduced by `109e293 codex --skip-git-repo-check` which adds the flag to `build_exec_argv` without updating the test.
- `cargo clippy --workspace --all-targets -- -D warnings` — 2 unused-variable warnings in `crates/ccteam-imd/src/daemon.rs:1536-1537` (`prefix_with_handle`, `effective_handle`) introduced by the F199/F200 PR (`9ecd2d6`). Locally-computed values not wired through to the downstream send path yet.
- `daemon_dm_no_at_mention_auto_routes_to_single_bot` / `daemon_wires_mock_channel_to_supervisor_inbox` — inotify-busy transients on this host (`fs.inotify.max_user_instances=128`, per CLAUDE.md §六). Pass when run in isolation.

`gh run list --branch main` confirms `main` itself is currently red on both F197/F198 and F199/F200 — the inherited breakage is not from this PR.

## Acceptance

- `ccteam admin register-bot --slug foo --role helper --chat-id 12345 --platform mock` writes `~/.ccteam/imd/registry/foo/helper.json` with an auto-minted `chat_handle`.
- `ccteam admin unregister-bot --slug foo --role helper` removes it; running again returns `ok:true, removed:false` (idempotent).
- `ccteam init --force` inside the ccteam repo succeeds when explicitly requested.
- The plugin manifest test catches any future drift between `Cargo.toml::version` and the four plugin JSON fields.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>