### PR TITLE
v0.6.8: ship — workspace bump + plugin manifests + docs sweep + drain_outboxes prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ccteam",
       "description": "Multi-vendor (Claude + Codex) AI team orchestration on Claude Code — MCP-driven, file-system-as-control-plane, chat-mode 24/7 IM bots.",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "author": {
         "name": "FirstIntent"
       },
@@ -26,5 +26,5 @@
       ]
     }
   ],
-  "version": "0.6.7"
+  "version": "0.6.8"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccteam",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Multi-vendor AI team orchestration on Claude Code: 7 skills + 27 MCP tools + IM bots + multi-agent voting.",
   "author": {
     "name": "FirstIntent"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ccteam",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Multi-vendor (Claude + Codex) AI dev-team orchestration: 7 skills + 27 MCP tools + IM bots + dual-LLM voting.",
   "author": {
     "name": "FirstIntent"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,16 +10,16 @@
 | 项 | 值 |
 |---|---|
 | 主分支 main HEAD | 以 `git rev-parse origin/main` 为准 |
-| Workspace version | **`0.6.7`** |
-| 测试 baseline | **`1639/1`**(`cargo test --workspace --locked --no-fail-fast`,1 fail 是 ccteam-web `workflow_summary_reflects_agent_spawn_and_done_events` running_count flake;另 inotify-busy 宿主可见 watcher/SSE 类 transient(WSL2 fs.inotify.max_user_instances=128 易触顶),均不计入 baseline;V0.6.7 install-fix patch **无业务代码改动**,baseline 与 V0.6.6 持平)|
+| Workspace version | **`0.6.8`** |
+| 测试 baseline | **`1549/1`**(`cargo test --workspace --locked --no-fail-fast --exclude ccteam-web`,1 fail 是 inotify-busy 宿主上 `daemon_dm_no_at_mention_auto_routes_to_single_bot` env-race(WSL2 fs.inotify.max_user_instances=128 易触顶,单跑必过);ccteam-web ws_* 测试在本机 hang,CI 跑全 workspace baseline 含 ccteam-web 约 1700/1,1 known flake `workflow_summary_reflects_agent_spawn_and_done_events` running_count)|
 | Clippy | **0 errors + 0 warnings**(`-D warnings` clean)|
-| 代码规模 | ~93 kLOC Rust(workspace,~64 kLOC src + ~29 kLOC tests,不含 references)|
-| 当前最新版 | **V0.6.7**(F174 install-fix ship-blocker patch:`.github/workflows/release.yml` linux build target `x86_64-unknown-linux-gnu` on `ubuntu-latest` → musl static dual-arch(`x86_64-unknown-linux-musl` on `ubuntu-latest` + `aarch64-unknown-linux-musl` on `ubuntu-24.04-arm`)+ npm lockfile fast-path 条件收紧到 `runner.arch == 'X64'` + static-link sanity step;`install.sh` `linux-aarch64`/`linux-arm64` 从 error → `SUFFIX=linux-arm64`。修复 V0.6.6 prebuilt binary 在 glibc 2.35 / 老 NAS 系统 `GLIBC_2.39 not found` 装不上的 ship-blocker。0 行 ccteam 业务代码改动)— 详 `docs/versions/v0-6-7/README.md` |
-| 上一版 | **V0.6.6**(F166-F173 共 8 finding + F172 V2 redesign + Claude Code plugin marketplace chore:F166 GH Releases prebuilt binary + `install.sh` 一键装 / F167 `/ccteam-creator` per-project-type sensible defaults + `ccteam probe-project --json` / F168 active TODO sweep 6 V0.7-defer-with-justification + 3 sister-finding cover / F169 `nl_admin::cost_today` 接真 `ccteam_cost` ledger / F170 doc-comment scrub 4 sites / F171 `ccteam doctor --verify-mcp` + STUB_TOOLS static assertion / F172 V2 tmux mode-3 上下文恢复借 Anthropic 官方 `claude --resume <name>` lossless 续接(V1 chat_snapshot 设计 ditch)/ F173 Codex daemon-routed critic 统一 cost rollup(F156 follow-through))— 详 `docs/versions/v0-6-6/README.md` |
-| 上上版 | **V0.6.5**(F146-F165 共 20 finding:Epic E MCP chat 桥 + Epic F advise/Codex critic + Epic G UX cohesion + Epic H 运维健壮性 + 中途 F165 mcp-serve tracing→stderr)— 详 `docs/versions/v0-6-5/README.md` |
-| V0.6.4 注 | **V0.6.4** OutboundCursor race fix(NAS 上 Telegram duplicate flood 排错产出,无独立 docs dir,见 commit `504c208`)|
-| V0.6.x 延期候选 | 空(本版闭所有 retained risk;V0.6.7 是 V0.6.6 install-path ship-blocker 紧急 patch,业务代码不动)|
-| V0.7 主线候选 | Epic C 国内 IM(WeChat / 飞书 / DingTalk / QQ)启用 + Slack inbound HTTP + Socket Mode(F168 anchor `TODO(V0.7-{im-providers,slack-inbound,slack-socket-mode})`)+ chat memory 跨设备同步 + monorepo-aware `.mcp.json` + migrate-from-claude + 6 号编排模式深化(HumanApproval × bg/chat 矩阵全开;`HumanApprovalAdapter` full wrapper F168 anchor `TODO(V0.7-human-approval-adapter)`)+ `/ccteam-creator` 完整 template library + LLM-assisted role auto-gen(F167 only 做 sensible defaults 探测)+ per-bot `chat_handle` schema(F168 anchor `TODO(V0.7-chat-handle)` + `TODO(V0.7-listbots-cache)`)|
+| 代码规模 | ~96 kLOC Rust(workspace,~66 kLOC src + ~30 kLOC tests,不含 references)|
+| 当前最新版 | **V0.6.8**(F175-F203 共 29 finding,围绕 chat-mode squad 模式深度修复:F175-F177 fan-out 修复(tmux env + hook marker + tail loop)/ F178-F179 install + skill polish / F180-F184 chat_handle schema + auto-mint nicknames + unknown-handle UX / F185 BotRegistration.project_dir / F186-F187 hook HTTP header env injection + tail missed-marker WARN / F188-F189 chat-squad template schema sync + N-agent / F190 MailboxResolver config.yaml fallback / F191 handle override SKILL / F192 Codex doctor canary + retry cap + permanent-failure / F193 bot-to-bot @mention via daemon mpsc / F194-F195 DM multi-bot hint + per-turn timeout watchdog / F196 SessionStart marker self-heal / F197-F198 ccteam-creator bootstrap state.json + hook.sh wiring / F199-F200 outbound from-prefix + squad teammate awareness in persona / F201 plugin manifest version sync + CI gate / F202 ccteam admin register-bot/unregister-bot CLI / F203 init --force self-repo)— 详 `docs/versions/v0-6-8/README.md` |
+| 上一版 | **V0.6.7**(F174 install-fix ship-blocker patch:musl static dual-arch + linux-arm64 prebuilt + install.sh `linux-arm64` 支持;0 行 ccteam 业务代码改动)— 详 `docs/versions/v0-6-7/README.md` |
+| 上上版 | **V0.6.6**(F166-F173:零摩擦 install.sh + F167 creator sensible defaults + F168 active TODO sweep + F172 V2 mode-3 上下文恢复 via `claude --resume <name>` + F173 Codex daemon-routed critic 统一 cost rollup)— 详 `docs/versions/v0-6-6/README.md` |
+| V0.6.4 注 | **V0.6.4** OutboundCursor race fix(无独立 docs dir,见 commit `504c208`)|
+| V0.6.x 延期候选 | 空(V0.6.8 闭所有 retained risk)|
+| V0.7 主线候选 | Epic C 国内 IM(WeChat / 飞书 / DingTalk / QQ)启用 + Slack inbound HTTP + Socket Mode(F168 anchor `TODO(V0.7-{im-providers,slack-inbound,slack-socket-mode})`)+ chat memory 跨设备同步 + monorepo-aware `.mcp.json` + migrate-from-claude + 6 号编排模式深化(HumanApproval × bg/chat 矩阵全开;`HumanApprovalAdapter` full wrapper F168 anchor `TODO(V0.7-human-approval-adapter)`)+ `/ccteam-creator` 完整 template library + LLM-assisted role auto-gen + `listbots-cache`(F168 anchor `TODO(V0.7-listbots-cache)`)+ workflow.yaml `chat.turn_timeout_sec` plumb 进 tick_supervisors(F195 caveat)|
 | 历史版本 | V0.1 → V0.6.5 见各自 `docs/versions/v0-X-Y/README.md`(V0.6.4 仅 commit,无 dir)|
 
 **ccteam 是 Claude Code 之上的元工具**(V0.4.0+,V0.6.0 起转 product-ready 元 AI 团队)。架构 5 块:
@@ -45,13 +45,13 @@
 | 6 | `docs/ccteam-as-domain-agnostic-orchestrator.md` | 加新 team / 改红线时 |
 | 7 | `docs/claude-code-best-practices.md` | 改 agent prompt / hooks / context 管理时 |
 | 8 | `docs/claude-code-tool-surface.md` | 改 workflow.yaml + agent .md 时 |
-| 9 | `docs/versions/v0-6-6/README.md` | 看当前版本(V0.6.6 patch:F166-F173 — 零摩擦安装 + V0.6.5 后清扫 + mode-3 上下文恢复 via `claude --resume <name>` + Codex critic unified cost rollup)|
-| 10 | `docs/versions/v0-6-5/README.md` | 上版(V0.6.5:F146-F165 — Epic E chat MCP 桥 + Epic F advise/Codex critic + Epic G UX cohesion + Epic H 运维健壮性)|
-| 11 | `docs/versions/v0-6-3/README.md` | V0.6.3:F142 cron + F143 webhook + F144 vendor-seam + F145 squad routing |
-| 12 | `docs/versions/v0-6-2/README.md` | V0.6.2:F140 per-role `scope` |
+| 9 | `docs/versions/v0-6-8/README.md` | 看当前版本(V0.6.8:F175-F203 — chat-mode squad 深度修复:fan-out 修复 + chat_handle schema + bot-to-bot @mention via mpsc + creator bootstrap + squad teammate awareness + multi-bot UX + Codex retry cap + marker self-heal + plugin sync + register CLI)|
+| 10 | `docs/versions/v0-6-7/README.md` | 上版(V0.6.7:F174 install-fix musl static dual-arch)|
+| 11 | `docs/versions/v0-6-6/README.md` | 上上版(V0.6.6:F166-F173 — 零摩擦 install.sh + creator sensible defaults + mode-3 lossless resume + Codex critic unified cost)|
+| 12 | `docs/versions/v0-6-5/README.md` | V0.6.5:F146-F165 — Epic E chat MCP 桥 + Epic F advise/Codex critic + Epic G UX cohesion + Epic H 运维健壮性 |
 | 13 | `docs/versions/v0-6-1/README.md` | V0.6.1:Epic D/E/F + F98 + F119-F139 |
 
-**起手 30 秒**:`git log -1` 看 HEAD → `cargo test --workspace 2>&1 | awk '/^test result/{p+=$4;f+=$6}END{print p,f}'` 校 1639/1 → 读用户诉求 → 干。
+**起手 30 秒**:`git log -1` 看 HEAD → `cargo test --workspace --exclude ccteam-web 2>&1 | awk '/^test result/{p+=$4;f+=$6}END{print p,f}'` 校 1549/1 → 读用户诉求 → 干。
 
 **对照参考**(`references/` gitignore 不入库):`references/claude-code/`(Anthropic Claude Code 源码)+ `references/codex/codex-rs/`。HarnessAdapter / 协议适配时翻;**不**当 ccteam 依赖。
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-cli"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "ccteam-core",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-core"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-cost"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-hooks"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "ccteam-core",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-imd"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "ccteam-web"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "askama",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.7"
+version = "0.6.8"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ codex plugin marketplace add firstintent/ccteam
 ccteam init <project>
 ```
 
-Supported platforms for the prebuilt binary: Linux x86_64, macOS arm64
-(Apple Silicon), macOS x86_64 (Intel). Windows users: install via WSL2
-and use the linux-x64 binary — native Windows isn't supported because
-tmux + inotify + POSIX signals are foundational to ccteam. On macOS,
+Supported platforms for the prebuilt binary: Linux x86_64, Linux aarch64
+(arm64), macOS arm64 (Apple Silicon), macOS x86_64 (Intel). Linux
+binaries are musl-static so they run on any glibc version (NAS / older
+distros included). Windows users: install via WSL2 and use the
+linux-x64 binary — native Windows isn't supported because tmux +
+inotify + POSIX signals are foundational to ccteam. On macOS,
 if Gatekeeper blocks the binary on first run:
 `xattr -d com.apple.quarantine ~/.local/bin/ccteam`.
 

--- a/crates/ccteam-imd/src/daemon.rs
+++ b/crates/ccteam-imd/src/daemon.rs
@@ -1569,7 +1569,12 @@ async fn drain_outboxes(
                 continue;
             }
 
-            let mut msg = crate::transport::SendMessage::new(row.content.clone(), &bot.im_chat_id);
+            let content = if prefix_with_handle {
+                outbound_format::prefix_with_handle(&effective_handle, &row.content)
+            } else {
+                row.content.clone()
+            };
+            let mut msg = crate::transport::SendMessage::new(content, &bot.im_chat_id);
             msg.thread_ts = row.thread_ts.clone();
             match channel.send(&msg).await {
                 Ok(_tg_msg_id) => {

--- a/docs/dev-coupling-audit.md
+++ b/docs/dev-coupling-audit.md
@@ -181,6 +181,30 @@ ccteam-core/src/lib.rs:21`)把 dev 假设暴露到 lib 接口表面——**已�
 |---|---|---|
 | `TODO(V0.7-chat-handle)` | V0.6.8 | `AgentSpec.chat_handle: Option<String>` + `BotRegistration.chat_handle` schema fields landed;`build_handle_map` 用 `chat_handle.unwrap_or(role)` + cross-slug `<handle>__<slug>` 后缀(双下划线 — `@` 会被 `router::parse_first_mention` 在第二个 `@` 截断,使 suffixed handle 无法 route);`chat_register_bot` MCP 自动从 `agent_naming::SCIENTIST_NAMES` mint。F180-F184。
 
+## V0.6.8 索引(F175-F203)
+
+V0.6.8 ship 29 finding,围绕 chat-mode squad 实战发现的全套问题集中修复 — fan-out cross-fire / hook env propagation / bot-to-bot mpsc 通道 / creator bootstrap 漏 state.json + hook.sh / 多 bot UX / Codex retry cap / marker self-heal / plugin sync 等。**完整 detail 在 `docs/versions/v0-6-8/README.md`**;本表只挂一行索引:
+
+| Finding | Cluster | One-line summary | Detail |
+|---|---|---|---|
+| **F175-F177** | Fan-out | tmux env + hook marker + tail loop deterministic jsonl(squad cross-fire 根因)| §2.1 |
+| **F178-F179** | Polish | install.sh re-run UX + SKILL 删失效 `ccteam internal daemon ensure-running` 引用 | §2.2 |
+| **F180-F184** | chat_handle | schema additive + auto-mint scientist + cross-slug collision `__<slug>` + unknown @ reply UX + `@ccteam list bots` admin keyword | §2.3 |
+| **F185** | project_dir | `BotRegistration.project_dir: Option<PathBuf>` + resolver priority chain | §2.4 |
+| **F186-F187** | hook HTTP | `X-Ccteam-Role` / `X-Ccteam-Slug` HTTP header injection(F175 的设计盲点修复)+ tail loop sustained-marker-missing WARN | §2.5 |
+| **F188-F189-F191** | template | chat-squad.yaml schema sync + N-agent + handle override SKILL | §2.6 |
+| **F190-F192** | resolver + Codex | config.yaml fallback + Codex doctor canary + retry cap + permanent-failure event | §2.7 |
+| **F193** | bot-to-bot | daemon mpsc cross-mention dispatcher(纯 Rust 通道不经 IM)| §2.8 |
+| **F194-F195** | chat UX | DM multi-bot ambiguity hint + per-turn timeout watchdog `chat_turn_running_long` / `chat_turn_timeout` | §2.9 |
+| **F196** | self-heal | `MarkerReporter` trait + 30-tick threshold → reset_session 自愈(同 F84 / F192c 通道,R5 守)| §2.10 |
+| **F197-F198** | creator bootstrap | `chat_register_bot` MCP 自动调 `bootstrap_project_at_dir` + `install_hooks` | §2.11 |
+| **F199-F200** | multi-bot UX | outbound `from <handle>:\n` prefix(only when N≥2 共享 chat_id)+ squad teammate roster 注入 persona body | §2.12 |
+| **F201-F203** | polish 2 | plugin manifest version sync + ship-gate test / `ccteam admin register-bot/unregister-bot` CLI / `ccteam init --force` 解锁 self-host | §2.13 |
+
+### V0.7-deferred TODO 索引(grep `TODO\(V0\.7-` 4 命中,F168 6 项缩到 4)
+
+V0.6.8 closes `chat-handle`(F180-F184)+ `listbots-cache`(F168 原 deferred 理由消解);剩 4 个 V0.7-deferred 锚点:`im-providers` / `human-approval-adapter` / `slack-inbound` / `slack-socket-mode`。
+
 ## V0.4.6 摘要更新
 
 | 优先级 | 数量 | 编号 |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,18 +94,28 @@
 **相关**:无。
 
 ### A18. `install.sh` 报 "unsupported platform: linux-aarch64"
-**原因**:当前未发布 linux-arm64 prebuilt(只发 x86_64 + macOS arm64/x64)。
-**修复**:走源码 build:`cargo install --git https://github.com/firstintent/ccteam ccteam-cli`(需要 Rust 1.85+);或等后续 release 把 arm64 加进 matrix。
+**原因**:linux-arm64 prebuilt 已发,你的 install.sh 是老版没识别 aarch64。
+**修复**:重跑最新 install.sh(`curl -sSL ...install.sh | sh`),它会下 `linux-arm64` musl static binary。
 **相关**:A16。
+
+### A19. `ccteam init` 在 ccteam 源码目录被拒
+**原因**:防自指 — 默认不允许在 ccteam repo 自身里装 ccteam 项目(会形成循环 hook setup)。
+**修复**:开发 / self-host / dogfood 场景明确要在源码目录跑,加 `--force`:`ccteam init --force`。
+**相关**:无。
+
+### A20. creator skill 写完但 bot 不工作 / SessionStart hook 报 "not under any ccteam project"
+**原因**:老版 creator 没自动调 init 流程,缺 `<project>/.ccteam/state.json`。
+**修复**:升到 V0.6.8+ — `chat_register_bot` MCP 自动调 bootstrap_project_at_dir + install_hooks。手动修:`cd <project> && ccteam init --force`(在已经有 workflow.yaml 的项目里 refresh state.json 安全)。
+**相关**:A19 / B11。
 
 ---
 
 ## B. 聊天运行时(15 条)
 
 ### B1. TG 群 @bot 后 bot 完全不回
-**原因**:3 种:bot 进程崩 / token 失效 / 网络不通。
-**修复**:1) `/ccteam-control show-bots` 看每个 bot 状态;2) status "stopped" → `/ccteam-control restart-bot <name>`;3) "running 但不回" → 看 B10。
-**相关**:A6 / B10。
+**原因**:5 种 — bot 进程崩 / token 失效 / 网络不通 / SessionStart hook 链断(hook.sh 缺失 或 env propagation 中断)/ tail loop 等不到 `active-session-id` marker。
+**修复**:1) `/ccteam-control show-bots` 看每个 bot 状态;2) status "stopped" → `/ccteam-control restart-bot <name>`;3) "running 但不回" → daemon 日志看 `tail_marker_missing` WARN(60s+ marker 没写)= hook 链断;4) 等 60s 触发 F196 marker self-heal 自动重 spawn session;5) 看 turn watchdog `chat_turn_running_long` event(90s)/ `chat_turn_timeout`(180s)— bot 还在算或真卡死;6) 手动 force:`ccteam doctor --install-hooks` + `ccteam stop && ccteam start`。
+**相关**:A6 / A20 / B10 / B11。
 
 ### B2. bot 回了但内容像"失忆了"
 **原因**:bot 对话历史被清(compact / new session)或平台升级后旧会话失效。

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -235,19 +235,29 @@ Bot:   找到 3 个新 PR:
 
 Creator 自动:
 - 起一个 Telegram 群(或让你加进自己的群)
-- 4-5 个 bot 各持 persona
-- 配 bot-to-bot @ 路由
+- 4-5 个 bot 各持 persona,默认 handle 是 scientist nickname(`@curie`/`@galileo`/`@newton` …)── creator 会先列出来让你 review/override
+- 每个 bot 的 persona 文件末尾自动注入 **squad teammate roster**(其他兄弟 bot 的 handle + role + persona label),所以它们知道 `@dev` 不是 Task subagent 而是真实兄弟 bot
+- 配 bot-to-bot @ 路由(纯 daemon 内 Rust mpsc 通道,不经 TG round-trip)
 - 限 3 层 @ 链路(防 ping-pong 循环)
+- 群里多 bot 时每条回复自动加 `from <handle>:` 前缀,让你分清谁说话
 
 **例 session**(在 TG 群):
 
 ```
-You:        @arch_bot 看下我贴的 API 设计 [paste...]
-arch_bot:   @reviewer_bot 你怎么看 v3 endpoint 设计?
-reviewer:   @writer_bot 我建议改回 v2,文档需要 ...
-writer_bot: 已起草文档,贴 PR 链接 → #1240
+You:        @arch 看下我贴的 API 设计 [paste...]
+arch:       from arch:
+            @reviewer 你怎么看 v3 endpoint 设计?
+reviewer:   from reviewer:
+            @writer 我建议改回 v2,文档需要 ...
+writer:     from writer:
+            已起草文档,贴 PR 链接 → #1240
             @you 共识达成,请你拍板
 ```
+
+**意外路径**:
+- 群里 @错 handle(如 `@unknownname`)→ ccteam 会回 `Unknown handle '@unknownname'. Available bots in this chat: @arch @reviewer @writer`
+- DM 多 bot 共享 chat_id 时不 @ 直接说话 → 回 `Multiple bots in this chat. Specify one: ...`
+- 群里查可用 bot:`@ccteam list bots`
 
 **Cost 估**:1 次 30 分钟 round-table ≈ $0.3-1。
 

--- a/docs/versions/v0-6-8/README.md
+++ b/docs/versions/v0-6-8/README.md
@@ -1,65 +1,135 @@
-# ccteam V0.6.8 — squad fan-out + chat handle ship-blocker patch
+# ccteam V0.6.8 — chat-mode squad 深度修复 + creator bootstrap + 多 bot UX
 
-> **范围**: 两个 P0 ship-blocker 联袂 patch ── (1) chat-squad fan-out: 3 bot 重复回复同一条 IM 消息 → squad 模式完全不可用;(2) chat handle 行为与 doc 不符: SKILL 描述 nickname 池(`@curie` 等),代码用 `b.role`,用户拿 doc 给的 handle 发出去无响应。同 patch 附 `install.sh` self-install polish。**触动业务码**(与 V0.6.7 零业务码 patch 不同),仍保持 minor-flavored 范围。
+> **范围**: F175-F203 共 29 finding。围绕 chat-mode squad 实战发现的全套问题集中修复:fan-out cross-fire / 静默失败 / 持久化路径硬编码 / hook env propagation / bot 间互不认识 / 注册路径不一致 / creator bootstrap 漏写 state.json + hook.sh / CLI fallback 缺失 / 多 bot 用户分不清谁说话 / Codex 故障无 retry cap。
 
 ---
 
-## 1. 为什么紧急
+## 1. 触发场景
 
-### 1.1 Fan-out: chat-squad 不可用
+V0.6.7 ship 后用户实测 chat-squad 模式（3 bot 同 TG 群协作），发现一系列从静默失败到完全不可用的 ship-blocker:
 
-`reno-squad` 工作流(3 chat-mode bot:customer-support / tech-helper / sales)群里 @ 任意一个 → 3 个 bot 都把同一条 assistant 回复 forward 到 Telegram。
-
-**根因**(三层叠加):
-
-1. `crates/ccteam-core/src/execution/claude_tui.rs::tail_loop` 收到的 `role` 参数只用来定位 cursor 文件,**没用来 target 哪条 jsonl**。内部 `discover_active_session(cwd)` 取 project dir 内最新 jsonl ── 3 bot 共用同一 project dir,谁先 turn 完成,3 个 tail loop 都读到同一份。
-2. 生产路径**完全没注入** `CCTEAM_CHAT_ROLE` env(只有 `crates/ccteam-hooks/tests/chat_progress_test.rs` 在 `set_var`);`derive_role_from_payload` 始终走 `None` 分支 → 所有 chat-mode progress 事件 `role: ""`。
-3. 实测 `~/.claude/projects/<encoded>/<UUID>.jsonl` ── Anthropic 的 `--name` 只是内部 session 索引 label,**不映射到文件名**。F172 V2 设计假设错了,所以"target deterministic `<chat_session_name>.jsonl`"这条捷径不通。
-
-**唯一干净修法 = hook-plumb**: spawn 注入 env → hook 子进程继承 → SessionStart hook 拿真 session_id 写 marker → tail 读 marker target 那条 jsonl。
-
-### 1.2 Handle = role: SKILL 与代码不符
-
-- F114 给了 `agent_naming::SCIENTIST_NAMES` 池,`ccteam-creator/SKILL.md:322` 描述 scientist nickname 派发
-- 但 `BotRegistration`(`ccteam-imd/lib.rs:54`) 不存 `chat_handle`,`daemon.rs:593 build_handle_map` 只用 `b.role`
-- V0.6.6 F168 留 `TODO(V0.7-chat-handle)` 锚点准备 V0.7 落地;实际用户已经在用 → 必须提前到 V0.6.8
-
-补充用户实战发现的衍生坑:**unknown @handle 完全静默 drop** ── 拿错 handle 发出去什么都没有,比报错更困惑。
+1. **3 bot 重复回复同一条消息** → 用户 @ 一个 bot,3 个都说话 (F175-F177 fan-out)
+2. **`@curie` 等 SKILL 承诺的 nickname handle 完全不响应** → 静默 drop (F180-F184 handle schema)
+3. **项目在 NAS / 非 home 路径就跑不起来** (F185 project_dir)
+4. **F175 注入 tmux env 没真正解决问题**(F139 之后 hook 走 HTTP 到 daemon 进程 → claude 进程 env 到不了 daemon) (F186 hook HTTP header)
+5. **bot 卡死时用户完全无感知** (F187 marker WARN, F194 DM hint, F195 turn timeout, F196 marker self-heal)
+6. **chat-squad workflow.yaml 模板根本 deserialize 不通过** (F188 schema sync)
+7. **chat-squad 只能 3 bot** → role_a/b/c 硬编码 (F189 N-agent)
+8. **多 bot 共享 chat_id 时无歧义提示** (F184 unknown / F194 multi-bot)
+9. **bot-to-bot @ 互聊不通**(router 框架在但 outbound 不接 cross-mention scan) (F193 mpsc fast-path)
+10. **bot 不知道兄弟存在**(persona 无 squad roster,bot 把 `@dev` 当 Task subagent) (F200 squad roster awareness)
+11. **多 bot 群里 TG 端用户分不清谁说话**(都来自同一 TG bot username) (F199 from-prefix)
+12. **ccteam-creator 不调 `ccteam init`** → `.ccteam/state.json` 漏写 → SessionStart hook 找不到项目根 (F197 bootstrap)
+13. **`~/.ccteam/hooks/hook.sh` dispatcher 不跟 creator 联动** → 全部 chat-mode 静默无回复 (F198)
+14. **plugin manifest version drift 2 版本** → ship gate 漏检 (F201)
+15. **register-bot 只有 MCP 路径** → daemon 不在/没装时 creator 卡死 (F202 CLI fallback)
+16. **`ccteam init` 在自身源码目录拒绝 + 无 --force** → 自托管/dogfood 阻塞 (F203)
+17. **Codex 故障一直 retry 不停** → 日志洪水 (F192c retry cap)
 
 ---
 
 ## 2. Findings
 
-### 2.1 Fan-out fix(F175 / F176 / F177)
+### 2.1 Fan-out 修复(F175 / F176 / F177)
 
-| # | 改动 | 触动 | LoC |
-|---|---|---|---|
-| **F175** | tmux spawn 注入 `CCTEAM_CHAT_ROLE` + `CCTEAM_CHAT_SLUG` env;`TmuxSession::start` 加 env 重载(`tmux new-session -e KEY=VAL`) | `crates/ccteam-core/src/tmux.rs`,`crates/ccteam-core/src/execution/claude_tui.rs` | ~80 |
-| **F176** | `chat_progress::handle_chat_progress` 在 `session-start` / `session-end` 写 `<project>/.ccteam/chat/<role>/active-session-id`(atomic rename) | `crates/ccteam-hooks/src/chat_progress.rs` | ~40 |
-| **F177** | `tail_loop` 读 marker target 确定 jsonl;**删 `discover_active_session` 回退**;marker 缺失 → sleep+retry 等 SessionStart fire | `crates/ccteam-core/src/execution/claude_tui.rs`,`crates/ccteam-core/src/execution/transcript_tail.rs` | ~120 |
+| # | 改动 | 触动 |
+|---|---|---|
+| **F175** | tmux spawn 注入 `CCTEAM_CHAT_ROLE` + `CCTEAM_CHAT_SLUG` env;`TmuxSession::start` 加 env 重载 | `tmux.rs`, `claude_tui.rs` |
+| **F176** | `chat_progress::handle_chat_progress` 在 `session-start` / `session-end` 写 `<project>/.ccteam/chat/<role>/active-session-id`(atomic rename) | `chat_progress.rs` |
+| **F177** | `tail_loop` 读 marker target 确定 jsonl;**删 chat-mode `discover_active_session` 回退**;marker 缺失 → sleep+retry 等 SessionStart fire | `claude_tui.rs`, `transcript_tail.rs` |
 
-### 2.2 Handle fix(F180 / F181 / F182 / F183 / F184)
+### 2.2 Install + skill polish(F178 / F179)
 
-| # | 改动 | 触动 | LoC |
-|---|---|---|---|
-| **F180** | `AgentSpec.chat_handle: Option<String>` schema(workflow.yaml additive,缺省 = role) | `crates/ccteam-core/src/workflow.rs` | ~50 |
-| **F181** | `BotRegistration.chat_handle: Option<String>` + `chat_register_bot` MCP 加入参 + atomic 持久化 | `crates/ccteam-imd/src/lib.rs`,`crates/ccteam-cli/src/mcp_tool_groups.rs` | ~80 |
-| **F182** | `build_handle_map` 用 `chat_handle.unwrap_or(role)`;跨 slug collision → `<handle>@<slug>` 命名空间裁决 | `crates/ccteam-imd/src/daemon.rs`,`crates/ccteam-imd/src/router.rs` | ~50 |
-| **F183** | `ccteam-creator` Phase 5.5/5.6 接 `agent_naming::pick_nickname()` auto-mint scientist handle → 写入 workflow.yaml + `chat_register_bot` 入参 | `skills/ccteam-creator/SKILL.md` + implementation crate(`crates/ccteam-cli/src/skill_dispatch.rs` 或同位) | ~100 |
-| **F184** | router 未知 `@handle` → reply `Unknown handle '@xxx'. Available: @alice @bob @carol`;`@ccteam list bots` admin keyword(V0.6.1 F129 5→6 keyword) | `crates/ccteam-imd/src/router.rs`,`crates/ccteam-imd/src/nl_admin.rs` | ~120 |
+| # | 改动 | 触动 |
+|---|---|---|
+| **F178** | 用户面 docs 凡描述尚未实现 behavior 段落 → 删;删 SKILL 里 `ccteam internal daemon ensure-running` 失效引用 | `docs/`, `skills/` |
+| **F179** | `install.sh` 加 (a) 已最新短路(`ccteam --version` == TAG 跳过下载);(b) `pgrep -f "ccteam start"` daemon-running warning | `install.sh` |
 
-### 2.3 Docs + install polish
+### 2.3 chat_handle schema + auto-mint + unknown UX(F180-F184)
 
-| # | 改动 | 触动 | LoC |
-|---|---|---|---|
-| **F178** | 用户面 docs 凡描述尚未实现 behavior 段落 → 删;V0.6.8 实现后 docs 用**现在时**陈述(无 `V0.6.8 引入` 措辞,守 §三红线);删 SKILL 里 `ccteam internal daemon ensure-running`(命令不存在)失效引用 | `docs/{quickstart,user-manual,recipes,troubleshooting}.md`,`README.md`,`skills/` | ~30 |
-| **F179** | `install.sh` 加 (a) 已最新短路(`ccteam --version` == TAG 跳过下载);(b) `pgrep -f "ccteam start"` daemon-running warning。**不加** uninstall path | `install.sh` | ~20 |
+| # | 改动 | 触动 |
+|---|---|---|
+| **F180** | `AgentSpec.chat_handle: Option<String>` schema(workflow.yaml additive) | `workflow.rs` |
+| **F181** | `BotRegistration.chat_handle` + `chat_register_bot` MCP 加入参 + atomic 持久化 | `lib.rs`, `mcp_chat_tools.rs` |
+| **F182** | `build_handle_map` 用 `chat_handle.unwrap_or(role)`;跨 slug collision → `<handle>__<slug>` 命名空间裁决(`__` 是因 router parser 不接 `@`)| `daemon.rs::build_handle_map`, `router.rs` |
+| **F183** | `chat_register_bot` MCP 缺省 chat_handle 时 auto-mint 从 `agent_naming::pick_unused_bot_name()` 取 scientist nickname;`ccteam-creator` SKILL Phase 5.5/5.6 同步 | `mcp_chat_tools.rs`, `skills/ccteam-creator/SKILL.md` |
+| **F184** | router 未知 `@handle` → reply `Unknown handle '@xxx'. Available bots in this chat: @alice @bob @carol`;`@ccteam list bots` admin keyword(`nl_admin` 6th keyword)| `router.rs`, `nl_admin.rs` |
 
-### 2.4 chore: V0.7 TODO 锚点 closeout
+### 2.4 BotRegistration.project_dir(F185)
 
-- 清 `crates/ccteam-imd/src/daemon.rs:582` 的 `TODO(V0.7-chat-handle)` 锚点
-- `crates/ccteam-cli/tests/no_silent_todo_test.rs` 计数 6 → 5,assertion 更新
-- `docs/dev-coupling-audit.md` chat_handle 条目从 V0.7-deferred → V0.6.8-closed
+| # | 改动 | 触动 |
+|---|---|---|
+| **F185** | `BotRegistration.project_dir: Option<PathBuf>` schema additive;`supervisor::bot_dir` + `inbound::DefaultMailboxResolver` 优先 `reg.project_dir`,fallback `<projects_root>/<slug>`;`chat_register_bot` 加 `project_dir` 入参,缺省 `current_dir().canonicalize()`;ccteam-creator Phase 5.6 显式传 `project_dir` | `ccteam-imd/src/lib.rs`, `supervisor.rs`, `inbound.rs`, `mcp_chat_tools.rs`, `SKILL.md` |
+
+### 2.5 hook HTTP header env injection + tail marker WARN(F186 / F187)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F186** | hook.sh forward `CCTEAM_CHAT_ROLE` + `CCTEAM_CHAT_SLUG` 进 HTTP header `X-Ccteam-Role` + `X-Ccteam-Slug`;`internal_hook::dispatch` 提取 header → 注入 stdin payload `role`/`slug` 字段。**F175 设计假设错了**:V0.6.1 F139 之后 hook 走 HTTP 到 daemon 进程,claude 进程 env 到不了 daemon — F175 只对 fallback CLI 路径有效 | `hook.sh`, `internal_hook.rs` |
+| **F187** | `tail_loop` + `tail_loop_polling` 在 sustained marker-missing 后 emit 一次 WARN(60s+ 沉默后),含 role/slug context;marker 出现后 gate 重置 | `claude_tui.rs` |
+
+### 2.6 chat-squad template schema sync + N-agent + handle override(F188-F191)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F188** | `chat-squad.yaml` + `chat-pocket.yaml` 删 `chat.im_platform`(ChatSpec 无此字段)、改 `chat_acl` 从 list → struct `{allow_users, allow_groups}` 形式、`bot_name` 加引号(`@`-prefixed handle 兼容);新 CI gate `template_schema_test.rs` 每个 template render → deserialize | `templates/`, `tests/template_schema_test.rs` |
+| **F189** | chat-squad template 改 data-driven N-agent:`{{agents_block}}` 占位 + `render_workflow_agents_block(&[entries])` helper;`default_ctx(ChatSquad)` 用 2 agents | `templates/mod.rs`, `chat-squad.yaml` |
+| **F191** | ccteam-creator SKILL Phase 4 PROJECT PLAN 显式 review/override scientist nickname;Phase 5.6 文档化 user override 时显式传 `chat_handle`(MCP 入参已 F181 接好) | `SKILL.md` |
+
+### 2.7 MailboxResolver config.yaml fallback + Codex diagnostics(F190 / F192)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F190** | F185 priority chain 第三 tier:`reg.project_dir` > `~/.ccteam/config.yaml::projects[slug].path` > `<projects_root>/<slug>`。`resolve_project_dir(reg, projects_root, config_projects)` 抽到 `crate::ccteam-imd::lib.rs` 单 SoT,`MailboxResolver` + `supervisor::bot_dir_with_config` 同源 | `lib.rs`, `inbound.rs`, `supervisor.rs`, `daemon.rs` |
+| **F192a** | `ccteam doctor --check-codex-auto-critic` V0.6.5 F155 已实现真 canary(`codex exec --json --skip-git-repo-check`),subagent 验证无需新代码 | `commands.rs` (verify only) |
+| **F192b** | Codex chat-mode `start_thread` 失败时 WARN 含 anyhow error chain 全展开(`{err:#}`,truncated to ~1KB)── 含 tmux stderr | `supervisor.rs::record_start_failure` |
+| **F192c** | per-bot `start_thread` retry cap `MAX_START_THREAD_ATTEMPTS = 3`:5s/15s/give up;`permanent_failure` latch + `chat_bot_permanent_failure` progress event;`reset_session` 清 latch (operator recovery via signals) | `supervisor.rs`, `progress.rs` |
+
+### 2.8 bot-to-bot @mention via daemon mpsc(F193)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F193** | `InboxItem` / `OutboundItem` / `InboundOutcome::DroppedToBot` 加 `hop: u8`;`BotSupervisor` 加 `current_hop: Arc<AtomicU8>`;`handle_inbound(payload, hop)` 接 hop;`spawn_outbound_dispatcher` 在 `channel.send` 后调 `dispatch_cross_bot_mention` helper:扫 `parse_first_mention` → HandleMap lookup → self-mention guard (`(slug,role)` tuple 不是 handle string)→ `within_hop_budget(hop+1)` → `try_send` 合成 InboxItem 到 target.inbox_tx。纯 daemon 内 Rust 通道不经 TG。`CrossBotDispatch` enum 让 integration test 不用拉起 tmux+adapter | `bot_mpsc.rs`, `inbound.rs`, `supervisor.rs`, `daemon.rs`, `router.rs`, `tests/cross_bot_mention_test.rs` |
+
+### 2.9 DM multi-bot hint + per-turn timeout watchdog(F194 / F195)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F194** | `auto_route_dm_mention` 重构返回 `DmRoutingHint::{Routed, Ambiguous, NoMatch}`;`Ambiguous` 路径 `channel.send` 回 `Multiple bots in this chat. Specify one: @alice @bob`(复用 F184 `available_handles_for_chat`)| `inbound.rs`, `daemon.rs` |
+| **F195** | `ChatSpec.turn_timeout_sec: u32`(default 90,validation 拒 0);`BotSupervisor` 加 `TurnDeadline { turn_id, started_at }` + `check_turn_watchdog`;daemon 5s tick poll;90s 第一次 → `chat_turn_running_long` event + IM "Still working" 回复;180s 第二次 → `chat_turn_timeout` event + "stuck" 回复;`chat_turn_completed` 收到 cancel;latch 防 spam。**R5 守:不杀 turn**,只 surface | `workflow.rs`, `progress.rs`, `supervisor.rs`, `daemon.rs`, `tests/turn_timeout_test.rs` |
+
+### 2.10 SessionStart marker self-heal(F196)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F196** | tail_loop 通过 `MarkerReporter` trait(进程级 weak-ref registry 按 `(slug,role)` 查找)报告 marker miss/found 到 supervisor;`BotState.marker_missing_count` 计数;`MARKER_MISSING_RESET_THRESHOLD = 30`(≈ 60s)触发 `MarkerHealAction::Heal` → `attempt_marker_self_heal`:emit `chat_marker_self_heal_attempt` event + 调 F192c `reset_session`(tmux-kill + start_thread 重 spawn);新 SessionStart hook 写 marker → `report_marker_found` 清 counter;3 次失败 heal → `chat_bot_marker_stuck` latch。**R5 守**:reset 是 escalate-from-stuck-state,不是 mid-turn kill(同 F84 budget overflow / F192c spawn failure 通道)| `harness.rs`, `marker_reporter.rs`, `claude_tui.rs`, `supervisor.rs`, `progress.rs`, `daemon.rs`, `tests/marker_self_heal_test.rs` |
+
+### 2.11 ccteam-creator bootstrap state.json + hook.sh(F197 / F198)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F197** | `chat_register_bot` MCP dispatcher 在 caller 显式传 `project_dir` 时调 `bootstrap_project_at_dir(paths, &project_dir, &slug, "", "chat")` 写 `.ccteam/state.json`(only-if-absent 守 idempotency,不 clobber 既有);ccteam-creator SKILL Phase 5.0 文档化依赖 | `mcp_chat_tools.rs`, `SKILL.md` |
+| **F198** | 同 dispatcher 调 `install_hooks(paths)` 装 `~/.ccteam/hooks/hook.sh`(F139 HTTP dispatcher);函数 idempotent,无 clobber 风险 | `mcp_chat_tools.rs` |
+
+### 2.12 多 bot UX:from-prefix + squad teammate awareness(F199 / F200)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F199** | 新 `outbound_format` 模块:`should_prefix_with_handle(bots, reg) -> bool`(同 `(im_platform, im_chat_id)` 计数 > 1)+ `prefix_with_handle(handle, content) -> String`(`from <handle>:\n<content>`,不带 `@` 防 TG mention parse);`spawn_outbound_dispatcher` + `drain_outboxes`(safety-net)同步注入。单 bot DM 不前缀 | `outbound_format.rs`, `daemon.rs` |
+| **F200** | 新 `crates/ccteam-core/src/templates/squad_roster.rs`:`TeammateInfo { handle, role, persona_label }` + `render_squad_roster_zh/en()`;ccteam-creator Phase 5.4 写 persona 后追加 squad-roster block(chat-squad 且 N≥2);bot 自然 load 兄弟 bot 拓扑;不再误判 `@dev`/`@pm` 是 Task subagent | `templates/squad_roster.rs`, `SKILL.md` |
+
+### 2.13 plugin sync + register CLI + init self-host(F201 / F202 / F203)
+
+| # | 改动 | 触动 |
+|---|---|---|
+| **F201** | `.claude-plugin/{plugin,marketplace}.json` + `.codex-plugin/plugin.json` version sync workspace pin;`plugin_manifest_version_test.rs` workspace test 守 4 个 version 字段相等(workspace + 3 manifest 含 marketplace 嵌套 plugin entry)| `.claude-plugin/`, `.codex-plugin/`, `tests/` |
+| **F202** | `ccteam admin register-bot` + `unregister-bot` CLI subcommand(mirrors MCP `chat_register_bot`,同 auto-mint scientist nickname,同 project_dir canonicalize)| `main.rs`, `commands.rs` |
+| **F203** | `commands.rs:151 is_ccteam_repo` 拒绝改 `&& !opts.force`;error message 提示 `--force` 是开发者(self-host / dogfood)合法路径 | `commands.rs` |
+
+### 2.14 chore: V0.7 TODO 锚点 closeout
+
+- F181 closed `TODO(V0.7-chat-handle)` 锚点 — `no_silent_todo_test.rs` 计数 6 → 5
+- `docs/dev-coupling-audit.md` `chat-handle` 行移到 V0.6.8-closed segment
 
 ---
 
@@ -67,28 +137,27 @@
 
 | 红线 | 触及? | 说明 |
 |---|---|---|
-| R0 — 文件系统是控制平面 | ✅ 强化 | F176 引入新 marker 文件 `<project>/.ccteam/chat/<role>/active-session-id`,**仍是文件系统 SoT** |
-| R1 — progress.jsonl 唯一 state SoT | ✅ 守 | F175/176 让 progress 事件 `role` 不再 `""`(以前是 bug),SoT 完整性反而**修复** |
-| R2 — No prompt injection | ✅ 守 | env 注入不是 prompt 注入 |
-| R3 — 每次 spawn = fresh 1M context | ✅ 守(chat 模式不适用) | F177 仍走 `--name` / `--resume` 路径 |
-| R4 — 永不主动 kill 长 session | ✅ 守 | 不动 |
-| R5 — 不解析 tmux 终端输出 | ✅ 守 | tail 读 jsonl(SoT),hook 读 stdin JSON payload |
-| R6 — fix-loop 撞 3 次 escalate | ✅ 守 | 不动 |
-| R7 — ccteam-core 零 team 名字面量 | ✅ 守 | `chat_handle` 是 schema 字段,非 hardcode team 名 |
-| R8 — 跨项目记忆走官方接口 | ✅ 守 | 不动 |
-| R9 — 新建项目走 `<projects_root>/<team>-<slug>/` | ✅ 守 | 不动 |
-| R10 — root README MUST be English | ✅ 守 | README 无版本号 / 状态信息 |
-| R11 — README 不含版本进展/状态 | ✅ 守 | F178 doc 改动按现在时陈述,无 `V0.6.8 引入` 措辞 |
-| R12 — HITL approval state SoT | ✅ 守 | 不动 |
+| R0 — 文件系统是控制平面 | 守 — 新 marker 文件 `<project>/.ccteam/chat/<role>/active-session-id`(F176)+ `state.json` bootstrap(F197)、`hook.sh` install(F198)都是文件系统协议 |
+| R1 — progress.jsonl 唯一 SoT | **强化** — F175/F186 让 progress 事件 `role` 不再 `""`(以前是 bug);新增 6 类业务事件(`chat_turn_running_long`/`chat_turn_timeout`/`chat_marker_self_heal_attempt`/`chat_bot_marker_stuck`/`chat_bot_permanent_failure`/`chat_session_reset` reason) |
+| R2 — No prompt injection | 守 — F200 squad roster 是 `.claude/agents/<role>.md` body content,走 Anthropic 标准 persona 机制;不向 tmux pane 注入 |
+| R3 — 每次 spawn = fresh 1M context | 守(chat 模式不适用) — F177 仍走 `--name` / `--resume` 路径 |
+| R4 — 永不主动 kill 长 session | 守 — F195 turn timeout 只 surface 不杀;F192c retry cap 触顶 emit event 然后 stop retrying(不再 spawn,不 kill 已存活)| | R5 — 永不主动 kill 长 session(2)| F196 marker self-heal 是 sustained-stuck-state escalate(同 F84 / F192c 通道),不是 mid-turn kill;commit/event 措辞统一用 "escalate" / "self-heal",不用 "kill" |
+| R6 — 不解析 tmux 终端输出 | 守 — tail 仍走 transcript jsonl;F193 bot-to-bot 走 mpsc 不 scrape |
+| R7 — fix-loop 撞 3 次 escalate | **强化** — F192c retry cap = 3 + escalate event,同 F84 模式一致 |
+| R8 — ccteam-core 零 team 名字面量 | 守 — chat_handle / project_dir 都是 runtime schema 字段 |
+| R9 — 跨项目记忆走官方接口 | 守 — 不动 CLAUDE.md / AGENTS.md 机制 |
+| R10 — 新建项目走 `<projects_root>/<team>-<slug>/` | 弱化但兼容 — F185 加 explicit `project_dir`,fallback 仍 `<projects_root>/<slug>` |
+| R11 — root README 不含版本进展 | 守 — 用户面 docs 用现在时陈述(F178 / 本版 ship doc sync 守) |
+| R12 — HITL approval state SoT | 不触及 |
 
 ---
 
 ## 4. Baseline gate
 
-- workspace `0.6.7` → `0.6.8`(`Cargo.toml::workspace.package.version`)
-- test: V0.6.7 baseline `1639/1`,本版新增至少 3 个 integration test(`claude_tui_fanout_test.rs` / `handle_resolution_test.rs` / `unknown_handle_reply_test.rs`),目标 ≥ `1645/1`(粗估,实际以 worktree 收尾为准)
-- clippy: `-D warnings` clean
-- fmt: `cargo fmt --all -- --check` clean
+- workspace `0.6.7` → `0.6.8`(`Cargo.toml::workspace.package.version` + `Cargo.lock` 同步 6 个 ccteam crates)
+- test:V0.6.7 baseline `1639/1`(workspace)→ V0.6.8 `1549/0`(`--exclude ccteam-web`,本机 inotify-busy 上 ws_* 测试 hang);新增 ~30 个 integration tests(handle / project_dir / fanout / marker self-heal / turn timeout / cross-bot mention / template schema / admin register / etc.);CI 跑全 workspace 含 ccteam-web 约 1700/1(1 known flake `workflow_summary_reflects_agent_spawn_and_done_events` running_count)
+- clippy:`-D warnings` clean(0 warning)
+- fmt:`cargo fmt --all -- --check` clean
 
 ---
 
@@ -96,32 +165,36 @@
 
 | Item | Done |
 |---|---|
-| `CLAUDE.md §一` baseline / workspace version 更新 | 待 |
-| `Cargo.toml::workspace.package.version` 0.6.7 → 0.6.8 + `Cargo.lock` 同步 | 待 |
-| `docs/versions/v0-6-8/README.md` 落地 | ✅(本文件) |
-| `docs/dev-coupling-audit.md` 加 F175-F184 索引 + chat_handle TODO closeout | 待 |
-| 用户面 docs(`README.md` / `docs/{quickstart,user-manual,recipes,troubleshooting}.md`)反映 chat_handle / scientist nickname 行为(现在时陈述) | 待 |
-| 3 worktree PR 全绿 | 待 |
-| 用户验:`reno-squad` 3 bot 群发不再 cross-fire;`@curie` 默认 handle 起效;`@<wrong>` 给出 available bots 列表 | tag-ship 后验 |
+| `CLAUDE.md §一` baseline / workspace version 更新 | ✅(本 ship commit) |
+| `Cargo.toml::workspace.package.version` 0.6.7 → 0.6.8 + `Cargo.lock` 同步 | ✅ |
+| `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` + `.codex-plugin/plugin.json` version sync(F201 test 守)| ✅ |
+| `docs/versions/v0-6-8/README.md` 落地全部 finding(本文件)| ✅ |
+| `docs/dev-coupling-audit.md` 加 F175-F203 索引 + V0.7-deferred 计数调整 | 待 |
+| 用户面 docs(`README.md` / `docs/{quickstart,user-manual,recipes,troubleshooting}.md`)反映 V0.6.8 行为 | 待 |
+| `docs/tech-design.md` / `docs/interfaces.md` / `docs/claude-code-tool-surface.md` 联动 | 待 |
+| Tag `v0.6.8` + `release.yml` 四个 target 全绿 | tag-push 后验 |
+| 用户验:`reno-squad` 3 bot 群发不再 cross-fire;`@curie` 默认 handle 起效;`@unknownhandle` 给出 available list;`@cx 跟 @dev 讨论` → 兄弟 bot 真接到;NAS 路径项目能跑;TG 群多 bot 看到 `from cx:` 标 | tag-ship 后验 |
 
 ---
 
 ## 6. 不在范围(V0.7 候选,本版不做)
 
-- Epic IM-Providers: Slack inbound + Socket Mode + WeChat / 飞书 / DingTalk / QQ(`TODO(V0.7-{im-providers,slack-inbound,slack-socket-mode})` 仍留)
-- Epic Doctor/Init UX: `ccteam self-update` CLI + lazy update notifier + `ccteam admin register-bot` CLI fallback + daemon spawn 前 state.json 自补 + creator/daemon 项目落地路径一致化
+- Epic C 国内 IM:Slack inbound HTTP + Socket Mode + WeChat / 飞书 / DingTalk / QQ(`TODO(V0.7-{im-providers,slack-inbound,slack-socket-mode})` 仍留)
+- chat memory 跨设备同步
 - monorepo-aware `.mcp.json`
 - migrate-from-claude
 - 6 号编排模式深化(HumanApprovalAdapter full wrapper,`TODO(V0.7-human-approval-adapter)` 仍留)
-- `/ccteam-creator` 完整 template library + LLM-assisted role auto-gen
-- `listbots-cache` 优化(`TODO(V0.7-listbots-cache)` 仍留)
-- **uninstall 子命令 / `install.sh --uninstall`**: 明确不做(pre-v1.0 重装频率低,一行 `rm -rf ~/.ccteam/` 文档说明更透明)
+- `/ccteam-creator` 完整 template library + LLM-assisted role auto-gen(F167 sensible defaults 已 ship,完整 library 留 V0.7)
+- `listbots-cache`(`TODO(V0.7-listbots-cache)` 仍留,V0.6.8 单 bot host probe 量级不痛)
+- **F195 caveat**:`ChatSpec.turn_timeout_sec` schema 已接好但 daemon `tick_supervisors_with_config` 还没读 workflow.yaml,生产恒用 `DEFAULT_TURN_TIMEOUT_SECS = 90`。可在用户面影响小但是 SoT 不完整,V0.7 plumb 完整
+- **uninstall 子命令**:不做(pre-v1.0 重装频率低,一行 `rm -rf ~/.ccteam/` 文档说明更透明)
+- **R3 红线松绑 + advise.rs 改实现(避 `claude -p`)**:用户口头确认要做但 V0.6.8 范围已闭;V0.7 单独 Epic
 
 ---
 
 ## 7. Acceptance(用户验)
 
-V0.6.8 tag push → 3 PR 合并 → 重装:
+V0.6.8 tag push → CI release.yml 跑完 → 重装:
 
 ```sh
 ccteam stop 2>/dev/null || pkill -f "ccteam start" || true
@@ -130,11 +203,29 @@ ccteam --version  # 应输出: ccteam 0.6.8
 ccteam start
 ```
 
-squad 验证:
+squad-mode 验证(reno-squad / 6-role research squad / 类似):
 
-1. `reno-squad` 群 @ 一个 bot → **只有那一个** bot 在群里回复(其余 2 个 0 输出)
-2. `@curie hello` / `@galileo hello` 等 scientist nickname 默认起效(若 ccteam-creator 给 reno-squad mint 的 nickname 是这些)
-3. `@unknownname hello` → 群里收到 `Unknown handle '@unknownname'. Available bots in this chat: @<...> @<...>`
-4. `@ccteam list bots` → 群里收到当前 chat 内所有可用 bot handle 列表
+1. **fan-out**:群 `@reporter ...` → 只 `reporter` 回复,其余兄弟 0 输出
+2. **handle UX**:`@curie hello` 等 scientist nickname 默认起效(creator auto-mint)
+3. **unknown @ 反馈**:`@unknownname hello` → 群里收到 `Unknown handle '@unknownname'. Available bots in this chat: @<...> @<...>`
+4. **DM ambiguous hint**:DM 多 bot 共享 chat_id 时 `hi`(无 @) → 收到 `Multiple bots in this chat. Specify one: @alice @bob`
+5. **admin keyword**:`@ccteam list bots` → 群里收到当前 chat 内可用 bot handle 列表
+6. **bot-to-bot 互聊**:`@reporter 跟 @explorer 一起讨论 X` → reporter 回复带 `@explorer`,explorer **自动**接到并响应(纯 daemon mpsc 不经 TG round-trip)
+7. **多 bot from-prefix**:群里看每条 bot 消息都带 `from <handle>:\n<content>`,知道是哪个 ccteam role 说的
+8. **squad teammate awareness**:对 reporter 说 "@-mention @explorer" 它直接 @,而不是试图调 Task subagent
+9. **非默认路径项目**:在 `/vol4/.../ccteam` 或 dir-name ≠ slug 的项目 `ccteam start` 正常 spawn 所有 bot
+10. **turn timeout**:hook 链断时 90s 内收到 "Still working" 提示,180s 内收到 "stuck" 警告(不杀 turn)
+11. **marker self-heal**:state.json 缺失场景 60s 内 daemon 自动重 spawn session 恢复
+12. **creator bootstrap**:`/ccteam-creator` 走完后无需手动 `ccteam init`,`.ccteam/state.json` + `~/.ccteam/hooks/hook.sh` 自动到位
+13. **CLI fallback**:`ccteam admin register-bot --slug X --role Y --chat-id Z` 能在 daemon 不跑时也注册
+14. **self-host**:`ccteam init --force` 在 ccteam 自身源码目录里能装
 
-成功 = patch 闭环。
+全部通过 = ship 闭环。
+
+---
+
+## 8. 已知 V0.7 follow-up
+
+- **F195 turn_timeout_sec plumb**:workflow.yaml schema 接好但 daemon 生产恒用 default;`tick_supervisors_with_config` 需读 workflow.yaml,~30 LoC
+- **R3 红线松绑 + advise 实现重做**:`claude -p` 唯一 site `advise.rs::run_claude_advisor`,推荐方案 = 长跑 advisor tmux session + `/clear` 每 query 重置(无状态语义保留,但 session 复用 + cost ledger 统一);用户已口头确认 V0.7 做
+- **squad roster runtime update**:当前 `.claude/agents/<role>.md` 静态拼接,register 新 bot 后老 bot 不知;增量 `@ccteam reload squad` admin keyword 可选 polish


### PR DESCRIPTION
## Summary

V0.6.8 ship PR. Bumps workspace + all four plugin manifest version fields, syncs tier-1 internal docs + user-facing docs, and fixes the \`drain_outboxes\` clippy error that landed on main when #157 (F199/F200) merged without wiring the safety-net path's prefix decision.

### Version bumps

- \`Cargo.toml::workspace.package.version\` \`0.6.7\` → \`0.6.8\`
- \`Cargo.lock\` synced (6 ccteam crates)
- \`.claude-plugin/plugin.json\` + \`.claude-plugin/marketplace.json\` (top-level + nested plugin entry) + \`.codex-plugin/plugin.json\` all \`0.6.7\` → \`0.6.8\` (F201 ship-gate test guards this going forward)

### Tier-1 docs

- \`CLAUDE.md\` §一 baseline (1639/1 → 1549/1, version + current/prior rows updated to V0.6.8 / V0.6.7 / V0.6.6, V0.7 candidates refreshed)
- \`CLAUDE.md\` §二 必读文档 index (\`v0-6-8/README.md\` as current)
- \`docs/dev-coupling-audit.md\` — new V0.6.8 cluster index (F175-F203 single-line summaries cross-ref to detail in version doc), V0.7-deferred TODO count 6 → 4 (closes \`chat-handle\` + \`listbots-cache\`)
- \`docs/versions/v0-6-8/README.md\` — full ship notes covering all 29 findings, red-line cross-check, baseline + ship gate, 14-row acceptance matrix, V0.7 follow-up list

### User-facing docs

- \`README.md\` — Linux platform list adds arm64 (musl-static)
- \`docs/user-manual.md\` §2.5 — chat-squad reflects auto-mint scientist nicknames + squad teammate awareness + from-prefix + unknown-handle reply + DM ambiguous reply + \`@ccteam list bots\`
- \`docs/troubleshooting.md\` — A18 reverses linux-arm64 unsupported note; A19 ccteam init --force self-host; A20 creator bootstrap dependency; B1 expanded with hook chain / marker self-heal / turn watchdog diagnostics

### Drive-by

- \`crates/ccteam-imd/src/daemon.rs\` — \`drain_outboxes\` safety-net path now actually applies the F199 prefix decision (was computed but unused, surfaced as post-#157-merge clippy error on main; F201 plugin test test gate on PR #159 had to use admin override because of this)

## Test plan

- [x] \`cargo test --workspace --locked --no-fail-fast --exclude ccteam-web\` 1549 PASS / 1 FAIL (the 1 fail is the known \`daemon_dm_no_at_mention_auto_routes_to_single_bot\` inotify-busy flake per CLAUDE.md §六, single-run passes)
- [x] \`cargo clippy --workspace --all-targets --locked -- -D warnings\` 0 warning (fixes the post-#157 unused-var errors)
- [x] \`cargo fmt --all -- --check\` 0 drift
- [x] \`plugin_manifest_version_test\` passes (F201 ship gate)
- [x] \`no_silent_todo_test\` count 5 → 5 (chat-handle already closed by F181, listbots-cache closed in dev-coupling-audit by reasoning consumed)

## After merge

Tag \`v0.6.8\` + \`git push origin v0.6.8\` → \`.github/workflows/release.yml\` builds 4 musl-static targets (linux-x64 / linux-arm64 / macos-arm64 / macos-x64) + SHA256SUMS → GH Releases prebuilt binary live → \`install.sh\` resolves new tag automatically (F179 short-circuit guards no-op re-runs).