### PR TITLE
feat(ccteam-im): native Lark/Feishu Channel provider + multi-provider…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "futures",
  "libc",
  "notify",
+ "prost",
  "regex",
  "reqwest",
  "serde",
@@ -1967,6 +1968,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,13 @@ async-trait = "0.1"
 # events() trait method.
 futures = { version = "0.3", default-features = false, features = ["std"] }
 
+# Lark/Feishu WebSocket long-connection frame codec (pbbp2.proto).
+# The `derive` feature is on by default and powers `#[derive(prost::Message)]`
+# on the hand-written `PbFrame` / `PbHeader` structs — no `prost-build`,
+# no codegen, no vendored `.proto`. Only consumed by ccteam-im behind the
+# `lark` feature.
+prost = "0.14"
+
 # V0.3 M5.0 — web UI (axum + askama). Pinned per `docs/versions/v0-3/prd.md`
 # §3.2.2; minor bumps in M5.x must update the table there.
 axum = "0.8"

--- a/crates/ccteam-im/Cargo.toml
+++ b/crates/ccteam-im/Cargo.toml
@@ -39,8 +39,14 @@ regex.workspace = true
 reqwest = { workspace = true, features = ["json", "multipart"] }
 # UNIX-only signalling for graceful supervisor SIGTERM (libc::kill).
 libc = "0.2"
-# Lightweight WebSocket Channel used for local/browser IM e2e validation.
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake"] }
+# Lightweight WebSocket Channel used for local/browser IM e2e validation,
+# plus the Lark/Feishu WSS long-connection. `rustls-tls-webpki-roots`
+# adds the rustls TLS provider so `connect_async("wss://…")` works against
+# real Feishu (matches the workspace `reqwest` rustls posture). Tests use
+# plain-TCP localhost peers, so the feature is a runtime-only requirement.
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
+# Lark/Feishu WS frame codec (pbbp2.proto) — used behind the `lark` feature.
+prost.workspace = true
 
 # V0.6.0 Wave 2 Option-C decision (docs/versions/v0-6-0/wave-2-decisions.md §3):
 # The Channel trait + slim TG/Slack/Discord providers live in-crate
@@ -53,10 +59,11 @@ tokio-tungstenite = { version = "0.24", default-features = false, features = ["c
 # URL needed for V0.6 host-probe scope).
 
 [features]
-# Each provider is a cargo feature; default = international "big three".
-# China-platform names (lark/dingtalk/qq/wechat) are placeholder feature
-# names — provider modules land in V0.7.
-default = ["telegram", "slack", "discord"]
+# Each provider is a cargo feature. `lark` (Feishu/Lark WS long-connection)
+# ships in `default` so the gate (`cargo test`/`clippy` without `--features`)
+# compiles + exercises the lark module and its tests. The remaining
+# China-platform names (dingtalk/qq/wechat) stay placeholder feature names.
+default = ["telegram", "slack", "discord", "lark"]
 telegram = []
 slack = []
 discord = []

--- a/crates/ccteam-im/src/acl.rs
+++ b/crates/ccteam-im/src/acl.rs
@@ -9,6 +9,7 @@
 //!   slack_user_ids: ["U0123ABC"]
 //!   discord_user_ids: ["..."]
 //!   ws_user_ids: ["alice"]
+//!   lark_user_ids: ["ou_..."]
 //! ```
 //!
 //! [`AclPolicy::allow`] returns `true` when (a) the platform block is
@@ -33,6 +34,9 @@ pub struct AclPolicy {
     /// Local WebSocket / browser web-chat user IDs. Empty = open.
     #[serde(default)]
     pub ws_user_ids: Vec<String>,
+    /// Lark/Feishu `open_id`s. Empty = open.
+    #[serde(default)]
+    pub lark_user_ids: Vec<String>,
 }
 
 impl AclPolicy {
@@ -43,6 +47,7 @@ impl AclPolicy {
             "slack" => &self.slack_user_ids,
             "discord" => &self.discord_user_ids,
             "ws" | "web" => &self.ws_user_ids,
+            "lark" => &self.lark_user_ids,
             // Unknown platform: deny by default (fail-closed).
             _ => return false,
         };
@@ -65,6 +70,17 @@ mod tests {
         assert!(p.allow("slack", "any"));
         assert!(p.allow("ws", "any"));
         assert!(p.allow("web", "any"));
+        assert!(p.allow("lark", "any"));
+    }
+
+    #[test]
+    fn lark_allowlist_enforced() {
+        let p = AclPolicy {
+            lark_user_ids: vec!["ou_x".into()],
+            ..Default::default()
+        };
+        assert!(p.allow("lark", "ou_x"));
+        assert!(!p.allow("lark", "ou_y"));
     }
 
     #[test]
@@ -88,10 +104,14 @@ mod tests {
         let p = AclPolicy {
             telegram_user_ids: vec!["alice-tg".into()],
             slack_user_ids: vec!["alice-slack".into()],
+            lark_user_ids: vec!["ou_alice".into()],
             ..Default::default()
         };
         // alice's TG id must not unlock the Slack channel.
         assert!(!p.allow("slack", "alice-tg"));
         assert!(p.allow("slack", "alice-slack"));
+        // …nor the Lark channel (open_id-space is isolated too).
+        assert!(!p.allow("lark", "alice-tg"));
+        assert!(p.allow("lark", "ou_alice"));
     }
 }

--- a/crates/ccteam-im/src/credentials.rs
+++ b/crates/ccteam-im/src/credentials.rs
@@ -6,7 +6,8 @@
 //! {
 //!   "telegram": { "bot_token": "...", "allowed_chat_ids": ["12345"] },
 //!   "slack":    { "bot_token": "xoxb-...", "signing_secret": "..." },
-//!   "discord":  { "bot_token": "...", "authorized_user_ids": ["..."] }
+//!   "discord":  { "bot_token": "...", "authorized_user_ids": ["..."] },
+//!   "lark":     { "app_id": "cli_...", "app_secret": "...", "allowed_user_ids": ["ou_..."] }
 //! }
 //! ```
 //!
@@ -32,6 +33,11 @@ pub struct Credentials {
     /// Discord bot credentials (REST messages API).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discord: Option<DiscordCreds>,
+    /// Lark/Feishu bot credentials (WebSocket long-connection +
+    /// `im/v1/messages`). No public URL / webhook port — the daemon
+    /// opens an outbound WSS long-connection (Path A).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lark: Option<LarkCreds>,
 }
 
 /// Telegram bot credentials.
@@ -69,6 +75,37 @@ pub struct DiscordCreds {
     /// the bound channel.
     #[serde(default)]
     pub authorized_user_ids: Vec<String>,
+}
+
+/// Lark/Feishu bot credentials.
+///
+/// The daemon uses the WebSocket long-connection receive path
+/// (`POST /callback/ws/endpoint` -> WSS frame loop): no public HTTPS
+/// endpoint, no `port`, no `verification_token` (those belong to the
+/// dropped webhook path). Outbound replies go via tenant-token
+/// `im/v1/messages`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LarkCreds {
+    /// App ID (`cli_...`) from the Lark/Feishu developer console.
+    pub app_id: String,
+    /// App secret (used to fetch the WS endpoint + tenant access token).
+    pub app_secret: String,
+    /// `open_id`s allowed to drive the bot. Empty = closed (deny all),
+    /// `"*"` = open — matches the channel-level `is_user_allowed`
+    /// semantics. NOTE: this is the opposite default of telegram's
+    /// empty=open; the daemon `AclPolicy` layer is independent and uses
+    /// empty=open (see `acl.rs`).
+    #[serde(default)]
+    pub allowed_user_ids: Vec<String>,
+    /// `true` -> Feishu (CN, open.feishu.cn); `false` -> Lark intl
+    /// (open.larksuite.com). Defaults true (CN-first, matches the
+    /// `china` feature intent).
+    #[serde(default = "default_use_feishu")]
+    pub use_feishu: bool,
+}
+
+fn default_use_feishu() -> bool {
+    true
 }
 
 /// Default credentials file path.
@@ -154,6 +191,7 @@ mod tests {
         assert!(creds.telegram.is_none());
         assert!(creds.slack.is_none());
         assert!(creds.discord.is_none());
+        assert!(creds.lark.is_none());
     }
 
     #[test]
@@ -170,6 +208,36 @@ mod tests {
         save(&path, &original).unwrap();
         let back = load(Some(&path)).unwrap();
         assert_eq!(back, original);
+    }
+
+    #[test]
+    fn round_trip_lark_only() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("c.json");
+        let original = Credentials {
+            lark: Some(LarkCreds {
+                app_id: "cli_app123".into(),
+                app_secret: "secret456".into(),
+                allowed_user_ids: vec!["ou_alice".into(), "ou_bob".into()],
+                use_feishu: false,
+            }),
+            ..Default::default()
+        };
+        save(&path, &original).unwrap();
+        let back = load(Some(&path)).unwrap();
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn lark_defaults_use_feishu() {
+        let json = r#"{"lark":{"app_id":"a","app_secret":"s"}}"#;
+        let creds: Credentials = serde_json::from_str(json).unwrap();
+        let lark = creds.lark.expect("lark block parsed");
+        assert!(lark.use_feishu, "use_feishu defaults to true (CN-first)");
+        assert!(
+            lark.allowed_user_ids.is_empty(),
+            "allowed_user_ids defaults empty (channel layer = closed)"
+        );
     }
 
     #[test]

--- a/crates/ccteam-im/src/daemon.rs
+++ b/crates/ccteam-im/src/daemon.rs
@@ -146,6 +146,7 @@ where
         has_telegram = creds.telegram.is_some(),
         has_slack = creds.slack.is_some(),
         has_discord = creds.discord.is_some(),
+        has_lark = creds.lark.is_some(),
         "ccteam-im daemon starting"
     );
 
@@ -292,44 +293,141 @@ where
 /// (backpressure, not silent drop).
 const INBOUND_BUF: usize = 64;
 
-/// V0.6.1 F132 — assemble the Channel set the daemon listens on.
+/// One row of the provider table [`build_channels`] walks. The builder
+/// inspects credentials + registered bots and yields the live [`Channel`]
+/// when its credential block is present, or `None` when unconfigured.
+/// Adding a provider is one row + one `build_*` fn — the loop never
+/// names a platform.
+///
+/// Builders are stateless free fns, so `fn`-pointers (not `Box<dyn Fn>`)
+/// keep the table a zero-alloc `const` that's `#[cfg]`-gateable per-row.
+type ChannelBuilder =
+    fn(&Credentials, &[BotRegistration]) -> Option<Arc<dyn Channel + Send + Sync>>;
+
+/// The platform-agnostic provider table. Each row pairs a channel key
+/// with its builder; `#[cfg]` on const-array elements drops a row when
+/// its feature is off. This is the single place a new IM provider is
+/// registered for the daemon.
+const CHANNEL_BUILDERS: &[(&str, ChannelBuilder)] = &[
+    #[cfg(feature = "telegram")]
+    ("telegram", build_telegram_channel),
+    #[cfg(feature = "slack")]
+    ("slack", build_slack_channel),
+    #[cfg(feature = "discord")]
+    ("discord", build_discord_channel),
+    #[cfg(feature = "lark")]
+    ("lark", build_lark_channel),
+];
+
+/// Assemble the Channel set the daemon listens on.
 ///
 /// Resolution order:
-/// 1. `args.channels_override` (tests inject `MockChannel`),
-/// 2. `creds.telegram` → build a [`TelegramChannel`] with the union of
-///    the user-configured allowlist + every registered telegram bot's
-///    `im_chat_id`,
-/// 3. (slack / discord wiring).
-///
-// TODO(V0.7-im-providers): construct `SlackChannel` / `DiscordChannel`
-//   here when `creds.slack` / `creds.discord` are set. Provider modules
-//   already exist (`transport/providers/{slack,discord}.rs`) but only
-//   telegram is exercised by the V0.6.x host probe.
-// Reason deferred: bundled with V0.7 Epic C (国内 IM enablement +
-//   Slack Socket Mode / inbound HTTP) so the daemon wiring, HMAC
-//   verification, and onboarding skill ship as one wave instead of
-//   trickling per-provider half-changes through V0.6.x patch releases.
-// Tracking: docs/versions/v0-6-6/prd.md §F168 (decision row #2) +
-//   docs/dev-coupling-audit.md V0.6.6 V0.7-deferred segment.
+/// 1. `args.channels_override` (tests inject `MockChannel`) — wins,
+/// 2. each [`CHANNEL_BUILDERS`] row whose credential block is present,
+/// 3. `args.extra_channels` (web-chat WS) — merged last.
 fn build_channels(args: &DaemonArgs, creds: &Credentials, bots: &[BotRegistration]) -> ChannelMap {
     if let Some(ch) = args.channels_override.clone() {
-        return ch;
+        return ch; // test MockChannel injection still wins, unchanged
     }
     let mut out: ChannelMap = HashMap::new();
-    if let Some(tg) = creds.telegram.as_ref() {
-        let mut allowed = tg.allowed_chat_ids.clone();
-        for b in bots.iter().filter(|b| b.im_platform == "telegram") {
-            allowed.push(b.im_chat_id.clone());
+    for (name, builder) in CHANNEL_BUILDERS {
+        if let Some(ch) = builder(creds, bots) {
+            out.insert((*name).to_string(), ch);
+            tracing::info!(channel = %name, "imd: provider channel built from credentials");
         }
-        allowed.sort();
-        allowed.dedup();
-        let ch = Arc::new(TelegramChannel::new(tg.bot_token.clone(), allowed));
-        out.insert("telegram".to_string(), ch as Arc<dyn Channel + Send + Sync>);
     }
     if let Some(extra) = args.extra_channels.clone() {
-        out.extend(extra);
+        out.extend(extra); // web-chat WS merge still last, unchanged
     }
     out
+}
+
+/// Telegram: union the user-configured chat-id allowlist with every
+/// registered telegram bot's `im_chat_id` (both live in `reply_target`
+/// chat-id space, so the union authorizes those chats). Verbatim move
+/// of the previous inline logic.
+#[cfg(feature = "telegram")]
+fn build_telegram_channel(
+    creds: &Credentials,
+    bots: &[BotRegistration],
+) -> Option<Arc<dyn Channel + Send + Sync>> {
+    let tg = creds.telegram.as_ref()?;
+    let mut allowed = tg.allowed_chat_ids.clone();
+    for b in bots.iter().filter(|b| b.im_platform == "telegram") {
+        allowed.push(b.im_chat_id.clone());
+    }
+    allowed.sort();
+    allowed.dedup();
+    Some(Arc::new(TelegramChannel::new(
+        tg.bot_token.clone(),
+        allowed,
+    )))
+}
+
+/// Slack: HTTP `chat.postMessage` + channel polling. Discharges the old
+/// `TODO(V0.7-im-providers)` — the row was dark only because no creds
+/// block existed, not because the provider was missing.
+#[cfg(feature = "slack")]
+fn build_slack_channel(
+    creds: &Credentials,
+    _bots: &[BotRegistration],
+) -> Option<Arc<dyn Channel + Send + Sync>> {
+    let slack = creds.slack.as_ref()?;
+    Some(Arc::new(
+        crate::transport::providers::slack::SlackChannel::new(
+            slack.bot_token.clone(),
+            slack.poll_channels.clone(),
+        ),
+    ))
+}
+
+/// Discord: REST messages API + per-channel polling. `DiscordCreds`
+/// carries no poll list (the bound channel is discovered at runtime), so
+/// the poll set starts empty; the user-id allowlist passes through.
+#[cfg(feature = "discord")]
+fn build_discord_channel(
+    creds: &Credentials,
+    _bots: &[BotRegistration],
+) -> Option<Arc<dyn Channel + Send + Sync>> {
+    let discord = creds.discord.as_ref()?;
+    Some(Arc::new(
+        crate::transport::providers::discord::DiscordChannel::new(
+            discord.bot_token.clone(),
+            Vec::new(),
+            discord.authorized_user_ids.clone(),
+        ),
+    ))
+}
+
+/// Lark/Feishu: WSS long-connection + `im/v1/messages`.
+///
+/// ALLOWLIST-UNION SUBTLETY: telegram unions registered bot `im_chat_id`s
+/// (chat-id space) into its chat-id allowlist, which authorizes those
+/// chats. Lark's [`LarkChannel::is_user_allowed`] checks the SENDER
+/// `open_id` (`ou_…`), but `im_chat_id` is a CHAT id (`oc_…`) — a
+/// different namespace — so this union is **parity-only**: it never
+/// authorizes anyone. Real auth comes from `LarkCreds.allowed_user_ids`.
+/// The union is kept so every provider's builder is shaped identically.
+#[cfg(feature = "lark")]
+fn build_lark_channel(
+    creds: &Credentials,
+    bots: &[BotRegistration],
+) -> Option<Arc<dyn Channel + Send + Sync>> {
+    let lark = creds.lark.as_ref()?;
+    let mut allowed = lark.allowed_user_ids.clone();
+    for b in bots.iter().filter(|b| b.im_platform == "lark") {
+        allowed.push(b.im_chat_id.clone());
+    }
+    allowed.sort();
+    allowed.dedup();
+    Some(Arc::new(
+        crate::transport::providers::lark::LarkChannel::new(
+            lark.app_id.clone(),
+            lark.app_secret.clone(),
+            allowed,
+            lark.use_feishu,
+        ),
+    ))
 }
 
 fn build_gateway(

--- a/crates/ccteam-im/src/transport/providers/lark.rs
+++ b/crates/ccteam-im/src/transport/providers/lark.rs
@@ -1,0 +1,958 @@
+//! Lark/Feishu channel — WebSocket long-connection (Path A) + `im/v1/messages`.
+//!
+//! Ported from `references/openhuman/src/openhuman/channels/providers/lark.rs`
+//! (the native WS implementation, NOT a CLI wrapper) with openhuman's
+//! `config` / `event_bus` couplings elided — ccteam-im has its own
+//! credentials + ACL + sanitize layers, so this provider is a plain
+//! `reqwest` + `tokio-tungstenite` client.
+//!
+//! **Path A only.** The daemon opens an outbound WSS long-connection
+//! (`POST /callback/ws/endpoint` -> `wss://…`); there is no public HTTPS
+//! endpoint and no webhook/axum receive path. Inbound is text + `post`
+//! rich-text; every other `message_type` is debug-logged and skipped
+//! (image ingest / outbound files are an explicit out-of-scope
+//! follow-up). Outbound replies go via tenant-token `im/v1/messages`.
+//!
+//! Two independent allowlist layers, by design (mirrors telegram's
+//! two-layer model). Both key on the sender **`open_id`** (`ou_…`): the WS
+//! loop sets [`ChannelMessage::sender`] to the user's `open_id` (not the
+//! chat id), so the daemon ACL compares like-for-like and turns.jsonl /
+//! logs record a user, matching telegram/discord/slack. Replies route via
+//! [`ChannelMessage::reply_target`] = the `chat_id`.
+//! - **provider layer** — the `allowed_users` `open_id` list enforced in
+//!   the WS loop via [`LarkChannel::is_user_allowed`]: empty = **deny
+//!   all** (fail-closed). An operator who leaves it empty gets a bot
+//!   that responds to no one.
+//! - **daemon layer** — `AclPolicy.lark_user_ids` (also `open_id`-keyed):
+//!   empty = open; a populated list enforces per-user.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
+use prost::Message as ProstMessage;
+use tokio::sync::RwLock;
+use tokio_tungstenite::tungstenite::Message as WsMsg;
+
+use crate::transport::{Channel, ChannelMessage, SendMessage};
+
+const FEISHU_BASE_URL: &str = "https://open.feishu.cn/open-apis";
+const FEISHU_WS_BASE_URL: &str = "https://open.feishu.cn";
+const LARK_BASE_URL: &str = "https://open.larksuite.com/open-apis";
+const LARK_WS_BASE_URL: &str = "https://open.larksuite.com";
+
+/// Conservative per-message ceiling in **UTF-16 code units**. Feishu's
+/// text-message hard cap is far larger (~30 kB of bytes), but we mirror
+/// telegram's headroom discipline so the outbound splitter is exercised
+/// uniformly. This is the *only* place the Lark length constant lives —
+/// the daemon reads it polymorphically via [`Channel::max_message_len`]
+/// and calls `split_for_channel`; no `"lark"`/number branch leaks up.
+const LARK_MAX_TEXT_UTF16: usize = 4000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Feishu WebSocket long-connection: pbbp2.proto frame codec
+//
+// Hand-written prost structs (no `.proto`, no `prost-build`, no codegen).
+// The non-contiguous tags are deliberate: fields 1-5 then payload at
+// tag=8 (6,7 map to real-pbbp2 fields openhuman doesn't model;
+// renumbering would break wire-compat with Feishu).
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone, PartialEq, prost::Message)]
+struct PbHeader {
+    #[prost(string, tag = "1")]
+    pub key: String,
+    #[prost(string, tag = "2")]
+    pub value: String,
+}
+
+/// Feishu WS frame (pbbp2.proto).
+/// `method=0` -> CONTROL (ping/pong)  `method=1` -> DATA (events)
+#[derive(Clone, PartialEq, prost::Message)]
+struct PbFrame {
+    #[prost(uint64, tag = "1")]
+    pub seq_id: u64,
+    #[prost(uint64, tag = "2")]
+    pub log_id: u64,
+    #[prost(int32, tag = "3")]
+    pub service: i32,
+    #[prost(int32, tag = "4")]
+    pub method: i32,
+    #[prost(message, repeated, tag = "5")]
+    pub headers: Vec<PbHeader>,
+    #[prost(bytes = "vec", optional, tag = "8")]
+    pub payload: Option<Vec<u8>>,
+}
+
+impl PbFrame {
+    fn header_value<'a>(&'a self, key: &str) -> &'a str {
+        self.headers
+            .iter()
+            .find(|h| h.key == key)
+            .map(|h| h.value.as_str())
+            .unwrap_or("")
+    }
+}
+
+/// Server-sent client config (parsed from pong payload).
+#[derive(Debug, serde::Deserialize, Default, Clone)]
+struct WsClientConfig {
+    #[serde(rename = "PingInterval")]
+    ping_interval: Option<u64>,
+}
+
+/// `POST /callback/ws/endpoint` response.
+#[derive(Debug, serde::Deserialize)]
+struct WsEndpointResp {
+    code: i32,
+    #[serde(default)]
+    msg: Option<String>,
+    #[serde(default)]
+    data: Option<WsEndpoint>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct WsEndpoint {
+    #[serde(rename = "URL")]
+    url: String,
+    #[serde(rename = "ClientConfig")]
+    client_config: Option<WsClientConfig>,
+}
+
+/// `LarkEvent` envelope (`method=1` / `type=event` payload).
+#[derive(Debug, serde::Deserialize)]
+struct LarkEvent {
+    header: LarkEventHeader,
+    event: serde_json::Value,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LarkEventHeader {
+    event_type: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    event_id: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct MsgReceivePayload {
+    sender: LarkSender,
+    message: LarkMessage,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LarkSender {
+    sender_id: LarkSenderId,
+    #[serde(default)]
+    sender_type: String,
+}
+
+#[derive(Debug, serde::Deserialize, Default)]
+struct LarkSenderId {
+    open_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LarkMessage {
+    /// Stable per-message id; always present on real events. Defaulted so
+    /// minimal unit fixtures need not carry it.
+    #[serde(default)]
+    message_id: String,
+    /// Conversation id (`oc_…`); always present on real events. Defaulted
+    /// for the same fixture-ergonomics reason.
+    #[serde(default)]
+    chat_id: String,
+    /// `"p2p"` | `"group"`; absent ⇒ treated as non-group (responds).
+    #[serde(default)]
+    chat_type: String,
+    message_type: String,
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    mentions: Vec<serde_json::Value>,
+    /// Lark send time in **milliseconds** (string). Absent in some
+    /// fixtures; the decode falls back to wall-clock then.
+    #[serde(default)]
+    create_time: String,
+}
+
+/// One inbound Lark message after decode + the group @-mention gate, but
+/// *before* the provider/daemon allowlists and dedup. The single source
+/// of truth for "how a `im.message.receive_v1` event becomes a
+/// [`ChannelMessage`]" — both the live WS loop ([`LarkChannel::listen_ws`])
+/// and the tested seam ([`LarkChannel::decode_event`]) flow through it, so
+/// the unit tests exercise the exact mapping production runs.
+struct DecodedMessage {
+    /// Sender user identity (`open_id`, `ou_…`). Becomes
+    /// [`ChannelMessage::sender`] — the daemon feeds this to the ACL, so
+    /// it must be the *user*, not the chat.
+    open_id: String,
+    /// Conversation id (`oc_…`). Becomes [`ChannelMessage::reply_target`].
+    chat_id: String,
+    /// Stable message id; becomes `lark-{message_id}`.
+    message_id: String,
+    /// Decoded, `@`-placeholder-stripped, trimmed body (never empty).
+    text: String,
+    /// Lark send time in seconds (from `create_time` ms, or wall-clock).
+    timestamp: u64,
+}
+
+/// Decode a single `im.message.receive_v1` event into a [`DecodedMessage`],
+/// applying every content/visibility rule the live WS loop applies *except*
+/// the allowlists and dedup (those need `&self` / shared state and stay at
+/// the call sites). Returns `None` to skip — bot/app sender, missing
+/// open_id, unsupported `message_type`, empty body, or a group message the
+/// bot wasn't @-mentioned in.
+fn decode_message_receive(recv: &MsgReceivePayload) -> Option<DecodedMessage> {
+    // Drop the bot's own (and other apps') messages.
+    if recv.sender.sender_type == "app" || recv.sender.sender_type == "bot" {
+        return None;
+    }
+
+    let open_id = recv.sender.sender_id.open_id.as_deref().unwrap_or("");
+    if open_id.is_empty() {
+        return None;
+    }
+
+    let msg = &recv.message;
+
+    // Decode the body by message type. Path A is text/`post`-only.
+    let text = match msg.message_type.as_str() {
+        "text" => {
+            let v = serde_json::from_str::<serde_json::Value>(&msg.content).ok()?;
+            v.get("text")
+                .and_then(|t| t.as_str())
+                .filter(|s| !s.is_empty())?
+                .to_string()
+        }
+        "post" => parse_post_content(&msg.content)?,
+        other => {
+            tracing::debug!("Lark: skipping unsupported message type '{other}'");
+            return None;
+        }
+    };
+
+    // Strip the `@_user_N` placeholders Feishu injects, then trim.
+    let text = strip_at_placeholders(&text).trim().to_string();
+    if text.is_empty() {
+        return None;
+    }
+
+    // Group chat: only respond when explicitly @-mentioned.
+    if msg.chat_type == "group" && !should_respond_in_group(&msg.mentions) {
+        return None;
+    }
+
+    let timestamp = msg
+        .create_time
+        .parse::<u64>()
+        .ok()
+        // Lark timestamps are in milliseconds.
+        .map(|ms| ms / 1000)
+        .unwrap_or_else(now_secs);
+
+    Some(DecodedMessage {
+        open_id: open_id.to_string(),
+        chat_id: msg.chat_id.clone(),
+        message_id: msg.message_id.clone(),
+        text,
+        timestamp,
+    })
+}
+
+impl DecodedMessage {
+    /// Build the daemon-facing [`ChannelMessage`].
+    ///
+    /// `sender` is the user `open_id` (so the daemon-layer
+    /// `AclPolicy.lark_user_ids` — documented as `open_id`s — compares
+    /// like-for-like, and turns.jsonl / handle-prefix / logs record a user,
+    /// matching telegram/discord/slack). `reply_target` is the `chat_id`, so
+    /// outbound replies still route to the conversation.
+    fn into_channel_message(self) -> ChannelMessage {
+        ChannelMessage {
+            id: format!("lark-{}", self.message_id),
+            sender: self.open_id,
+            reply_target: self.chat_id,
+            content: self.text,
+            channel: "lark".to_string(),
+            timestamp: self.timestamp,
+            thread_ts: None,
+            attachments: Vec::new(),
+        }
+    }
+}
+
+/// Wall-clock seconds since the Unix epoch (saturating).
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Heartbeat timeout for the WS connection — must be larger than
+/// `ping_interval` (default 120 s). If no binary frame (pong or event)
+/// arrives within this window, reconnect.
+const WS_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Returns true when the WebSocket frame indicates live traffic that
+/// should refresh the heartbeat watchdog.
+fn should_refresh_last_recv(msg: &WsMsg) -> bool {
+    matches!(msg, WsMsg::Binary(_) | WsMsg::Ping(_) | WsMsg::Pong(_))
+}
+
+/// Lark/Feishu channel (WS long-connection, Path A).
+pub struct LarkChannel {
+    app_id: String,
+    app_secret: String,
+    allowed_users: Vec<String>,
+    /// When true, use Feishu (CN) endpoints; when false, Lark (intl).
+    use_feishu: bool,
+    /// One reqwest client built once in [`LarkChannel::new`] and reused
+    /// at every call site (token fetch, ws-endpoint POST, send).
+    http: reqwest::Client,
+    /// Cached tenant access token.
+    tenant_token: Arc<RwLock<Option<String>>>,
+    /// Dedup set: WS `message_id`s seen in the last ~30 min to prevent
+    /// double-dispatch.
+    ws_seen_ids: Arc<RwLock<HashMap<String, Instant>>>,
+    name: String,
+}
+
+impl LarkChannel {
+    /// Build with the app credentials, the provider-level `open_id`
+    /// allowlist (empty = deny all; `"*"` = open), and the region flag.
+    pub fn new(
+        app_id: String,
+        app_secret: String,
+        allowed_users: Vec<String>,
+        use_feishu: bool,
+    ) -> Self {
+        Self {
+            app_id,
+            app_secret,
+            allowed_users,
+            use_feishu,
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("reqwest client"),
+            tenant_token: Arc::new(RwLock::new(None)),
+            ws_seen_ids: Arc::new(RwLock::new(HashMap::new())),
+            name: "lark".to_string(),
+        }
+    }
+
+    fn api_base(&self) -> &'static str {
+        if self.use_feishu {
+            FEISHU_BASE_URL
+        } else {
+            LARK_BASE_URL
+        }
+    }
+
+    fn ws_base(&self) -> &'static str {
+        if self.use_feishu {
+            FEISHU_WS_BASE_URL
+        } else {
+            LARK_WS_BASE_URL
+        }
+    }
+
+    fn tenant_access_token_url(&self) -> String {
+        format!("{}/auth/v3/tenant_access_token/internal", self.api_base())
+    }
+
+    fn send_message_url(&self) -> String {
+        format!("{}/im/v1/messages?receive_id_type=chat_id", self.api_base())
+    }
+
+    /// `POST /callback/ws/endpoint` -> (wss_url, client_config).
+    async fn get_ws_endpoint(&self) -> anyhow::Result<(String, WsClientConfig)> {
+        let resp = self
+            .http
+            .post(format!("{}/callback/ws/endpoint", self.ws_base()))
+            .header("locale", if self.use_feishu { "zh" } else { "en" })
+            .json(&serde_json::json!({
+                "AppID": self.app_id,
+                "AppSecret": self.app_secret,
+            }))
+            .send()
+            .await?
+            .json::<WsEndpointResp>()
+            .await?;
+        if resp.code != 0 {
+            anyhow::bail!(
+                "Lark WS endpoint failed: code={} msg={}",
+                resp.code,
+                resp.msg.as_deref().unwrap_or("(none)")
+            );
+        }
+        let ep = resp
+            .data
+            .ok_or_else(|| anyhow::anyhow!("Lark WS endpoint: empty data"))?;
+        Ok((ep.url, ep.client_config.unwrap_or_default()))
+    }
+
+    /// WS long-connection event loop. Returns `Ok(())` when the
+    /// connection closes; the [`Channel::listen`] wrapper reconnects.
+    ///
+    /// Ported from openhuman's native frame loop: fetch the endpoint,
+    /// `connect_async`, ping/pong heartbeat with a watchdog, ACK every
+    /// DATA frame within Feishu's 3 s window, reassemble fragments,
+    /// dedup by `message_id`, parse text/`post`, apply the provider-level
+    /// allowlist + group @-mention gate, then push a [`ChannelMessage`].
+    #[allow(clippy::too_many_lines)]
+    async fn listen_ws(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
+        let (wss_url, client_config) = self.get_ws_endpoint().await?;
+        let service_id = wss_url
+            .split('?')
+            .nth(1)
+            .and_then(|qs| {
+                qs.split('&')
+                    .find(|kv| kv.starts_with("service_id="))
+                    .and_then(|kv| kv.split('=').nth(1))
+                    .and_then(|v| v.parse::<i32>().ok())
+            })
+            .unwrap_or(0);
+        tracing::info!("Lark: connecting to {wss_url}");
+
+        let (ws_stream, _) = tokio_tungstenite::connect_async(&wss_url).await?;
+        let (mut write, mut read) = ws_stream.split();
+        tracing::info!("Lark: WS connected (service_id={service_id})");
+
+        let mut ping_secs = client_config.ping_interval.unwrap_or(120).max(10);
+        let mut hb_interval = tokio::time::interval(Duration::from_secs(ping_secs));
+        let mut timeout_check = tokio::time::interval(Duration::from_secs(10));
+        hb_interval.tick().await; // consume immediate tick
+
+        let mut seq: u64 = 0;
+        let mut last_recv = Instant::now();
+
+        // Send an initial ping immediately (like the official SDK) so the
+        // server starts responding with pongs and we can calibrate the
+        // ping interval.
+        seq = seq.wrapping_add(1);
+        let initial_ping = PbFrame {
+            seq_id: seq,
+            log_id: 0,
+            service: service_id,
+            method: 0,
+            headers: vec![PbHeader {
+                key: "type".into(),
+                value: "ping".into(),
+            }],
+            payload: None,
+        };
+        if write
+            .send(WsMsg::Binary(initial_ping.encode_to_vec()))
+            .await
+            .is_err()
+        {
+            anyhow::bail!("Lark: initial ping failed");
+        }
+        // message_id -> (fragment_slots, created_at) for multi-part reassembly.
+        type FragEntry = (Vec<Option<Vec<u8>>>, Instant);
+        let mut frag_cache: HashMap<String, FragEntry> = HashMap::new();
+
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = hb_interval.tick() => {
+                    seq = seq.wrapping_add(1);
+                    let ping = PbFrame {
+                        seq_id: seq, log_id: 0, service: service_id, method: 0,
+                        headers: vec![PbHeader { key: "type".into(), value: "ping".into() }],
+                        payload: None,
+                    };
+                    if write.send(WsMsg::Binary(ping.encode_to_vec())).await.is_err() {
+                        tracing::warn!("Lark: ping failed, reconnecting");
+                        break;
+                    }
+                    // GC stale fragments > 5 min.
+                    let cutoff = Instant::now()
+                        .checked_sub(Duration::from_secs(300))
+                        .unwrap_or_else(Instant::now);
+                    frag_cache.retain(|_, (_, ts)| *ts > cutoff);
+                }
+
+                _ = timeout_check.tick() => {
+                    if last_recv.elapsed() > WS_HEARTBEAT_TIMEOUT {
+                        tracing::warn!("Lark: heartbeat timeout, reconnecting");
+                        break;
+                    }
+                }
+
+                msg = read.next() => {
+                    let raw = match msg {
+                        Some(Ok(ws_msg)) => {
+                            if should_refresh_last_recv(&ws_msg) {
+                                last_recv = Instant::now();
+                            }
+                            match ws_msg {
+                                WsMsg::Binary(b) => b,
+                                WsMsg::Ping(d) => { let _ = write.send(WsMsg::Pong(d)).await; continue; }
+                                WsMsg::Pong(_) => continue,
+                                WsMsg::Close(_) => { tracing::info!("Lark: WS closed — reconnecting"); break; }
+                                _ => continue,
+                            }
+                        }
+                        None => { tracing::info!("Lark: WS closed — reconnecting"); break; }
+                        Some(Err(e)) => { tracing::error!("Lark: WS read error: {e}"); break; }
+                    };
+
+                    let frame = match PbFrame::decode(&raw[..]) {
+                        Ok(f) => f,
+                        Err(e) => { tracing::error!("Lark: proto decode: {e}"); continue; }
+                    };
+
+                    // CONTROL frame.
+                    if frame.method == 0 {
+                        if frame.header_value("type") == "pong" {
+                            if let Some(p) = &frame.payload {
+                                if let Ok(cfg) = serde_json::from_slice::<WsClientConfig>(p) {
+                                    if let Some(secs) = cfg.ping_interval {
+                                        let secs = secs.max(10);
+                                        if secs != ping_secs {
+                                            ping_secs = secs;
+                                            hb_interval = tokio::time::interval(Duration::from_secs(ping_secs));
+                                            tracing::info!("Lark: ping_interval -> {ping_secs}s");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
+                    // DATA frame.
+                    let msg_type = frame.header_value("type").to_string();
+                    let msg_id   = frame.header_value("message_id").to_string();
+                    let sum      = frame.header_value("sum").parse::<usize>().unwrap_or(1);
+                    let seq_num  = frame.header_value("seq").parse::<usize>().unwrap_or(0);
+
+                    // ACK immediately (Feishu requires within 3 s): echo the
+                    // frame back with a 200-ok payload and a biz_rt header.
+                    {
+                        let mut ack = frame.clone();
+                        ack.payload = Some(br#"{"code":200,"headers":{},"data":[]}"#.to_vec());
+                        ack.headers.push(PbHeader { key: "biz_rt".into(), value: "0".into() });
+                        let _ = write.send(WsMsg::Binary(ack.encode_to_vec())).await;
+                    }
+
+                    // Fragment reassembly.
+                    let sum = if sum == 0 { 1 } else { sum };
+                    let payload: Vec<u8> = if sum == 1 || msg_id.is_empty() || seq_num >= sum {
+                        frame.payload.clone().unwrap_or_default()
+                    } else {
+                        let entry = frag_cache.entry(msg_id.clone())
+                            .or_insert_with(|| (vec![None; sum], Instant::now()));
+                        if entry.0.len() != sum { *entry = (vec![None; sum], Instant::now()); }
+                        entry.0[seq_num] = frame.payload.clone();
+                        if entry.0.iter().all(|s| s.is_some()) {
+                            let full: Vec<u8> = entry.0.iter()
+                                .flat_map(|s| s.as_deref().unwrap_or(&[]))
+                                .copied().collect();
+                            frag_cache.remove(&msg_id);
+                            full
+                        } else { continue; }
+                    };
+
+                    if msg_type != "event" { continue; }
+
+                    // Decode through the single shared seam so this live path
+                    // and the unit tests run the *same* mapping (sender_type
+                    // filter, text/post extraction, @-placeholder strip, group
+                    // @-mention gate). ACL + dedup stay here — they need
+                    // `&self` state, not pure event data.
+                    let Some(decoded) = self.decode_event(&payload) else { continue };
+
+                    if !self.is_user_allowed(&decoded.open_id) {
+                        tracing::warn!("Lark WS: ignoring {} (not in allowed_users)", decoded.open_id);
+                        continue;
+                    }
+
+                    // Dedup. Scope the write guard so it is dropped BEFORE
+                    // the `tx.send(..).await` below (no guard held across an
+                    // await point).
+                    {
+                        let now = Instant::now();
+                        let mut seen = self.ws_seen_ids.write().await;
+                        seen.retain(|_, t| now.duration_since(*t) < Duration::from_secs(30 * 60));
+                        if seen.contains_key(&decoded.message_id) {
+                            tracing::debug!("Lark WS: dup {}", decoded.message_id);
+                            continue;
+                        }
+                        seen.insert(decoded.message_id.clone(), now);
+                    }
+
+                    let channel_msg = decoded.into_channel_message();
+                    tracing::debug!("Lark WS: message in {}", channel_msg.reply_target);
+                    if tx.send(channel_msg).await.is_err() { break; }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Check whether a user `open_id` is allowed (provider layer:
+    /// empty = deny all, `"*"` = open).
+    fn is_user_allowed(&self, open_id: &str) -> bool {
+        self.allowed_users.iter().any(|u| u == "*" || u == open_id)
+    }
+
+    /// Get or refresh the tenant access token (cached).
+    async fn get_tenant_access_token(&self) -> anyhow::Result<String> {
+        // Check cache first — scope the read guard out before any await.
+        {
+            let cached = self.tenant_token.read().await;
+            if let Some(ref token) = *cached {
+                return Ok(token.clone());
+            }
+        }
+
+        let url = self.tenant_access_token_url();
+        let body = serde_json::json!({
+            "app_id": self.app_id,
+            "app_secret": self.app_secret,
+        });
+
+        let resp = self.http.post(&url).json(&body).send().await?;
+        let data: serde_json::Value = resp.json().await?;
+
+        let code = data.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+        if code != 0 {
+            let msg = data
+                .get("msg")
+                .and_then(|m| m.as_str())
+                .unwrap_or("unknown error");
+            anyhow::bail!("Lark tenant_access_token failed: {msg}");
+        }
+
+        let token = data
+            .get("tenant_access_token")
+            .and_then(|t| t.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing tenant_access_token in response"))?
+            .to_string();
+
+        // Cache it — scope the write guard.
+        {
+            let mut cached = self.tenant_token.write().await;
+            *cached = Some(token.clone());
+        }
+
+        Ok(token)
+    }
+
+    /// Invalidate the cached token (called on a 401).
+    async fn invalidate_token(&self) {
+        let mut cached = self.tenant_token.write().await;
+        *cached = None;
+    }
+
+    /// Issue a tenant-token-authorized JSON request, transparently handling
+    /// the `tenant_access_token` ~2 h expiry: on a `401` it invalidates the
+    /// cache, re-fetches the token, and retries the request exactly once.
+    ///
+    /// The single token-retry path for every authorized call — `send` and
+    /// `edit_message` both route through it, so a long-running bot whose
+    /// outbound traffic is *only* progress edits still self-heals (the edit
+    /// path no longer fails permanently once the cached token ages out).
+    async fn send_json_with_token_retry(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: &serde_json::Value,
+    ) -> anyhow::Result<reqwest::Response> {
+        let build = |token: &str| {
+            self.http
+                .request(method.clone(), url)
+                .header("Authorization", format!("Bearer {token}"))
+                .header("Content-Type", "application/json; charset=utf-8")
+                .json(body)
+        };
+
+        let token = self.get_tenant_access_token().await?;
+        let resp = build(&token).send().await?;
+        if resp.status().as_u16() != 401 {
+            return Ok(resp);
+        }
+
+        // Token expired — invalidate, refresh, retry once.
+        self.invalidate_token().await;
+        let new_token = self.get_tenant_access_token().await?;
+        Ok(build(&new_token).send().await?)
+    }
+
+    /// Decode one `im.message.receive_v1` event into the [`ChannelMessage`]
+    /// the daemon receives, applying the provider-layer allowlist — i.e.
+    /// the exact `decode → map → ACL` the live WS loop runs, minus dedup
+    /// (which needs the shared `ws_seen_ids` mutable state). Returns `None`
+    /// for anything the loop would `continue` past: wrong event type, bot
+    /// sender, missing/disallowed `open_id`, unsupported `message_type`,
+    /// empty body, or an un-@-mentioned group message.
+    ///
+    /// This is the tested seam, and it shares [`decode_message_receive`] +
+    /// [`DecodedMessage::into_channel_message`] with [`Self::listen_ws`], so
+    /// the unit tests cover the same parser production runs (the two can no
+    /// longer drift). Takes a parsed `serde_json::Value` for test ergonomics;
+    /// the live loop hands it the WS frame's JSON bytes via
+    /// [`Self::decode_event`]. `#[cfg(test)]` because the live loop calls the
+    /// shared decode directly — this is purely the value-typed test entry.
+    #[cfg(test)]
+    fn decode_event_value(&self, payload: &serde_json::Value) -> Option<ChannelMessage> {
+        let event: LarkEvent = serde_json::from_value(payload.clone()).ok()?;
+        if event.header.event_type != "im.message.receive_v1" {
+            return None;
+        }
+        let recv: MsgReceivePayload = serde_json::from_value(event.event).ok()?;
+        let decoded = decode_message_receive(&recv)?;
+        if !self.is_user_allowed(&decoded.open_id) {
+            tracing::warn!(
+                "Lark: ignoring message from unauthorized user: {}",
+                decoded.open_id
+            );
+            return None;
+        }
+        Some(decoded.into_channel_message())
+    }
+
+    /// Decode a WS frame's event-JSON bytes into a [`DecodedMessage`]
+    /// (pre-ACL, pre-dedup). The live loop's entry into the shared parser.
+    fn decode_event(&self, payload: &[u8]) -> Option<DecodedMessage> {
+        let event: LarkEvent = match serde_json::from_slice(payload) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::error!("Lark: event JSON: {e}");
+                return None;
+            }
+        };
+        if event.header.event_type != "im.message.receive_v1" {
+            return None;
+        }
+        let recv: MsgReceivePayload = match serde_json::from_value(event.event) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!("Lark: payload parse: {e}");
+                return None;
+            }
+        };
+        decode_message_receive(&recv)
+    }
+}
+
+#[async_trait]
+impl Channel for LarkChannel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn send(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
+        let url = self.send_message_url();
+
+        // Feishu quirk: `content` is a STRING containing JSON, not a
+        // nested object.
+        let content = serde_json::json!({ "text": message.content }).to_string();
+        let body = serde_json::json!({
+            "receive_id": message.recipient,
+            "msg_type": "text",
+            "content": content,
+        });
+
+        let resp = self
+            .send_json_with_token_retry(reqwest::Method::POST, &url, &body)
+            .await?;
+        if !resp.status().is_success() {
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Lark send failed: {err}");
+        }
+
+        Ok(parse_sent_message_id(resp).await)
+    }
+
+    async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
+        // Reconnect loop lives INSIDE `listen` because the daemon
+        // supervisor never restarts a listener — it just logs when this
+        // returns. `tx.is_closed()` is the only graceful-stop signal
+        // (matches the trait contract: `Ok(())` solely when the sender
+        // is dropped); every other exit reconnects after a 5 s backoff.
+        loop {
+            if tx.is_closed() {
+                return Ok(());
+            }
+            if let Err(e) = self.listen_ws(tx.clone()).await {
+                tracing::warn!(error = %e, "lark: WS loop errored; reconnecting in 5s");
+            } else {
+                tracing::info!("lark: WS loop ended; reconnecting in 5s");
+            }
+            if tx.is_closed() {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        self.get_tenant_access_token().await.is_ok()
+    }
+
+    fn max_message_len(&self) -> Option<usize> {
+        Some(LARK_MAX_TEXT_UTF16)
+    }
+
+    async fn edit_message(
+        &self,
+        _recipient: &str,
+        message_id: &str,
+        content: &str,
+    ) -> anyhow::Result<Option<String>> {
+        // Lark addresses the edit by `message_id` in the URL path, not by
+        // recipient, so `recipient` is unused here.
+        let url = format!("{}/im/v1/messages/{message_id}", self.api_base());
+        // Same Feishu quirk as `send`: the inner value is stringified JSON.
+        let inner = serde_json::json!({ "text": content }).to_string();
+        let body = serde_json::json!({
+            "msg_type": "text",
+            "content": inner,
+        });
+        // Shared token-retry: a stale tenant token (~2 h) is invalidated +
+        // refreshed + retried once here too, so repeated progress edits
+        // don't fail permanently once the cache ages out.
+        let resp = self
+            .send_json_with_token_retry(reqwest::Method::PUT, &url, &body)
+            .await?;
+        if !resp.status().is_success() {
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Lark edit_message {message_id} failed: {err}");
+        }
+        // The message id is stable; echo it back for the daemon's status
+        // bookkeeping.
+        Ok(Some(message_id.to_string()))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WS helper functions (pure — unit-tested in lark_tests.rs)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parse the Feishu `im/v1/messages` success body for the new message id.
+/// Returns `Ok(None)` (NOT an error) when the id can't be parsed — the
+/// send already succeeded. Success shape:
+/// `{"code":0,"msg":"success","data":{"message_id":"om_xxx"}}`.
+async fn parse_sent_message_id(resp: reqwest::Response) -> Option<String> {
+    let v: serde_json::Value = resp.json().await.unwrap_or_default();
+    v.pointer("/data/message_id")
+        .and_then(|m| m.as_str())
+        .map(String::from)
+}
+
+/// Flatten a Feishu `post` rich-text message to plain text.
+///
+/// Returns `None` when the content cannot be parsed or yields no usable
+/// text, so callers can simply `continue` rather than forwarding a
+/// meaningless placeholder string to the agent.
+fn parse_post_content(content: &str) -> Option<String> {
+    let parsed = serde_json::from_str::<serde_json::Value>(content).ok()?;
+    let locale = parsed
+        .get("zh_cn")
+        .or_else(|| parsed.get("en_us"))
+        .or_else(|| {
+            parsed
+                .as_object()
+                .and_then(|m| m.values().find(|v| v.is_object()))
+        })?;
+
+    let mut text = String::new();
+
+    if let Some(title) = locale
+        .get("title")
+        .and_then(|t| t.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        text.push_str(title);
+        text.push_str("\n\n");
+    }
+
+    if let Some(paragraphs) = locale.get("content").and_then(|c| c.as_array()) {
+        for para in paragraphs {
+            if let Some(elements) = para.as_array() {
+                for el in elements {
+                    match el.get("tag").and_then(|t| t.as_str()).unwrap_or("") {
+                        "text" => {
+                            if let Some(t) = el.get("text").and_then(|t| t.as_str()) {
+                                text.push_str(t);
+                            }
+                        }
+                        "a" => {
+                            text.push_str(
+                                el.get("text")
+                                    .and_then(|t| t.as_str())
+                                    .filter(|s| !s.is_empty())
+                                    .or_else(|| el.get("href").and_then(|h| h.as_str()))
+                                    .unwrap_or(""),
+                            );
+                        }
+                        "at" => {
+                            let n = el
+                                .get("user_name")
+                                .and_then(|n| n.as_str())
+                                .or_else(|| el.get("user_id").and_then(|i| i.as_str()))
+                                .unwrap_or("user");
+                            text.push('@');
+                            text.push_str(n);
+                        }
+                        _ => {}
+                    }
+                }
+                text.push('\n');
+            }
+        }
+    }
+
+    let result = text.trim().to_string();
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Remove `@_user_N` placeholder tokens Feishu injects in group chats.
+fn strip_at_placeholders(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut chars = text.char_indices().peekable();
+    while let Some((_, ch)) = chars.next() {
+        if ch == '@' {
+            let rest: String = chars.clone().map(|(_, c)| c).collect();
+            if let Some(after) = rest.strip_prefix("_user_") {
+                let digit_count = after.chars().take_while(|c| c.is_ascii_digit()).count();
+                if digit_count == 0 {
+                    result.push(ch);
+                    continue;
+                }
+                let skip = "_user_".len() + digit_count;
+                for _ in 0..skip {
+                    chars.next();
+                }
+                if chars.peek().map(|(_, c)| *c == ' ').unwrap_or(false) {
+                    chars.next();
+                }
+                continue;
+            }
+        }
+        result.push(ch);
+    }
+    result
+}
+
+/// In group chats, only respond when the bot is explicitly @-mentioned.
+fn should_respond_in_group(mentions: &[serde_json::Value]) -> bool {
+    !mentions.is_empty()
+}
+
+#[cfg(test)]
+#[path = "lark_tests.rs"]
+mod tests;

--- a/crates/ccteam-im/src/transport/providers/lark_tests.rs
+++ b/crates/ccteam-im/src/transport/providers/lark_tests.rs
@@ -1,0 +1,725 @@
+//! Pure-parser, codec, and URL-builder tests for the Lark/Feishu
+//! channel. Adapted from
+//! `references/openhuman/src/openhuman/channels/providers/lark_tests.rs`:
+//! the `LarkConfig`/`LarkReceiveMode` serde tests are dropped (those
+//! types don't exist in ccteam — region behavior is covered by the
+//! URL-builder test instead), the 4-arg ctor replaces openhuman's
+//! 5-arg one, and the WS frame literals are rewritten for tungstenite
+//! 0.24 (`Vec<u8>`, no `.into()`).
+//!
+//! Zero network / fs / env. The inbound decode is covered against the
+//! *production* parser, not a parallel copy: `decode_event` is exactly
+//! what `listen_ws` runs on each reassembled DATA-frame payload, and
+//! `decode_event_value` shares `decode_message_receive` +
+//! `into_channel_message` with it — so feeding event JSON/bytes through
+//! either here exercises the same decode→map (sender open_id, text/`post`,
+//! @-placeholder strip, group @-mention gate) the live loop runs. The
+//! wire framing is proven by the `pbbp2_*` round-trips. The only
+//! uncovered seam is the socket plumbing of `listen_ws` itself (connect /
+//! ACK / heartbeat / fragment reassembly / dedup); driving that would
+//! need a `listen_ws_at(url)` seam + a scripted localhost peer, out of
+//! Path-A parity scope.
+
+use super::*;
+
+fn make_channel() -> LarkChannel {
+    LarkChannel::new(
+        "cli_test_app_id".into(),
+        "test_app_secret".into(),
+        vec!["ou_testuser123".into()],
+        true,
+    )
+}
+
+// ── test-only helpers (inlined from openhuman's `test_support`) ─────────────
+
+/// Deserialize a raw `POST /callback/ws/endpoint` reply and extract
+/// `(url, ping_interval)`, mirroring the parsing inside `get_ws_endpoint`
+/// without a socket.
+fn endpoint_response(raw: &str) -> anyhow::Result<(String, Option<u64>)> {
+    let resp = serde_json::from_str::<WsEndpointResp>(raw)?;
+    if resp.code != 0 {
+        anyhow::bail!(
+            "Lark WS endpoint failed: code={} msg={}",
+            resp.code,
+            resp.msg.as_deref().unwrap_or("(none)")
+        );
+    }
+    let ep = resp
+        .data
+        .ok_or_else(|| anyhow::anyhow!("Lark WS endpoint: empty data"))?;
+    Ok((ep.url, ep.client_config.and_then(|cfg| cfg.ping_interval)))
+}
+
+/// Parse the `service_id` query param from a wss URL (default 0 on a
+/// malformed / absent query), mirroring `listen_ws`.
+fn parse_service_id(wss_url: &str) -> i32 {
+    wss_url
+        .split('?')
+        .nth(1)
+        .and_then(|qs| {
+            qs.split('&')
+                .find(|kv| kv.starts_with("service_id="))
+                .and_then(|kv| kv.split('=').nth(1))
+                .and_then(|v| v.parse::<i32>().ok())
+        })
+        .unwrap_or(0)
+}
+
+// ── channel basics ─────────────────────────────────────────────
+
+#[test]
+fn lark_channel_name() {
+    let ch = make_channel();
+    assert_eq!(ch.name(), "lark");
+}
+
+#[test]
+fn lark_new_stores_fields_and_allowlist() {
+    let ch = LarkChannel::new(
+        "app_id".into(),
+        "secret".into(),
+        vec!["u1".into(), "u2".into()],
+        true,
+    );
+    assert_eq!(ch.app_id, "app_id");
+    assert_eq!(ch.allowed_users.len(), 2);
+    assert!(ch.use_feishu);
+}
+
+// ── is_user_allowed ────────────────────────────────────────────
+
+#[test]
+fn lark_user_allowed_exact() {
+    let ch = make_channel();
+    assert!(ch.is_user_allowed("ou_testuser123"));
+    assert!(!ch.is_user_allowed("ou_other"));
+}
+
+#[test]
+fn lark_user_allowed_wildcard() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    assert!(ch.is_user_allowed("ou_anyone"));
+}
+
+#[test]
+fn lark_user_denied_empty() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec![], true);
+    assert!(!ch.is_user_allowed("ou_anyone"));
+}
+
+#[test]
+fn lark_is_user_allowed_wildcard_allows_everyone() {
+    let ch = LarkChannel::new("a".into(), "s".into(), vec!["*".into()], true);
+    assert!(ch.is_user_allowed("anyone"));
+}
+
+#[test]
+fn lark_is_user_allowed_empty_allowlist_blocks_everyone() {
+    // Empty allowlist matches nothing — explicit guard against the
+    // "accidentally allowing all users" bug.
+    let ch = LarkChannel::new("a".into(), "s".into(), vec![], true);
+    assert!(!ch.is_user_allowed("anyone"));
+}
+
+#[test]
+fn lark_is_user_allowed_respects_allowlist() {
+    let ch = LarkChannel::new("a".into(), "s".into(), vec!["u1".into()], true);
+    assert!(ch.is_user_allowed("u1"));
+    assert!(!ch.is_user_allowed("u2"));
+}
+
+// ── heartbeat watchdog ─────────────────────────────────────────
+
+#[test]
+fn should_refresh_last_recv_true_for_binary_ping_pong() {
+    assert!(should_refresh_last_recv(&WsMsg::Binary(vec![1, 2, 3])));
+    assert!(should_refresh_last_recv(&WsMsg::Ping(vec![])));
+    assert!(should_refresh_last_recv(&WsMsg::Pong(vec![])));
+}
+
+#[test]
+fn should_refresh_last_recv_false_for_text_and_close() {
+    assert!(!should_refresh_last_recv(&WsMsg::Text("x".to_string())));
+    assert!(!should_refresh_last_recv(&WsMsg::Close(None)));
+}
+
+// ── pbbp2 codec round-trip (proves the hand-ported wire format) ─
+
+#[test]
+fn pbbp2_frame_roundtrip() {
+    let frame = PbFrame {
+        seq_id: 7,
+        log_id: 0,
+        service: 7,
+        method: 1,
+        headers: vec![PbHeader {
+            key: "type".into(),
+            value: "event".into(),
+        }],
+        payload: Some(br#"{"ok":true}"#.to_vec()),
+    };
+    let raw = frame.encode_to_vec();
+    let decoded = PbFrame::decode(&raw[..]).expect("decode");
+    assert_eq!(decoded.seq_id, 7);
+    assert_eq!(decoded.method, 1);
+    assert_eq!(decoded.header_value("type"), "event");
+    assert_eq!(decoded.payload.as_deref(), Some(&br#"{"ok":true}"#[..]));
+}
+
+#[test]
+fn pbbp2_control_frame_roundtrip() {
+    // CONTROL discriminator (method=0, pong) — the other branch.
+    let frame = PbFrame {
+        seq_id: 1,
+        log_id: 0,
+        service: 0,
+        method: 0,
+        headers: vec![PbHeader {
+            key: "type".into(),
+            value: "pong".into(),
+        }],
+        payload: None,
+    };
+    let raw = frame.encode_to_vec();
+    let decoded = PbFrame::decode(&raw[..]).expect("decode");
+    assert_eq!(decoded.method, 0);
+    assert_eq!(decoded.header_value("type"), "pong");
+    assert!(decoded.payload.is_none());
+}
+
+// ── WS-endpoint reply parse + service_id query parse ───────────
+
+#[test]
+fn endpoint_response_extracts_url_and_ping() {
+    let raw =
+        r#"{"code":0,"data":{"URL":"wss://x?service_id=42","ClientConfig":{"PingInterval":11}}}"#;
+    let (url, ping) = endpoint_response(raw).expect("parsed");
+    assert_eq!(url, "wss://x?service_id=42");
+    assert_eq!(ping, Some(11));
+}
+
+#[test]
+fn endpoint_response_errors_on_nonzero_code() {
+    let raw = r#"{"code":1901,"msg":"bad app"}"#;
+    let err = endpoint_response(raw).expect_err("should error");
+    assert!(
+        err.to_string().contains("1901"),
+        "error should carry the code, got: {err}"
+    );
+}
+
+#[test]
+fn service_id_defaults_zero_on_malformed_query() {
+    assert_eq!(parse_service_id("wss://x?service_id=42"), 42);
+    assert_eq!(parse_service_id("wss://x"), 0);
+    assert_eq!(parse_service_id("wss://x?foo=bar"), 0);
+    assert_eq!(parse_service_id("wss://x?service_id=notanint"), 0);
+}
+
+// ── region URL builders (Feishu <-> Lark switch) ───────────────
+
+#[test]
+fn region_urls_switch_on_use_feishu() {
+    let lark = LarkChannel::new("a".into(), "s".into(), vec![], false);
+    assert!(
+        lark.tenant_access_token_url()
+            .contains("open.larksuite.com/open-apis/auth"),
+        "intl token url, got: {}",
+        lark.tenant_access_token_url()
+    );
+    assert!(
+        lark.send_message_url()
+            .ends_with("/im/v1/messages?receive_id_type=chat_id"),
+        "send url shape, got: {}",
+        lark.send_message_url()
+    );
+    assert!(lark.send_message_url().contains("open.larksuite.com"));
+
+    let feishu = LarkChannel::new("a".into(), "s".into(), vec![], true);
+    assert!(feishu.tenant_access_token_url().contains("open.feishu.cn"));
+    assert!(feishu.send_message_url().contains("open.feishu.cn"));
+}
+
+// ── decode_event_value (the tested seam — same parser the WS loop runs) ─
+//
+// These drive `decode_event_value`, which shares `decode_message_receive`
+// + `into_channel_message` with the live `listen_ws` path, so they exercise
+// the exact decode→map→ACL production runs. The byte-level WS entry
+// (`decode_event` + the frame codec) is covered by `ws_*` below.
+
+#[test]
+fn lark_decode_non_event_payload() {
+    let ch = make_channel();
+    let payload = serde_json::json!({
+        "challenge": "abc123",
+        "token": "test_verification_token",
+        "type": "url_verification"
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_valid_text_message() {
+    let ch = make_channel();
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_testuser123" } },
+            "message": {
+                "message_id": "om_abc",
+                "message_type": "text",
+                "content": "{\"text\":\"Hello OpenHuman!\"}",
+                "chat_id": "oc_chat123",
+                "create_time": "1699999999000"
+            }
+        }
+    });
+
+    let msg = ch.decode_event_value(&payload).expect("decoded");
+    assert_eq!(msg.content, "Hello OpenHuman!");
+    // sender = the user open_id (so the daemon ACL keys on a user, not a
+    // chat); reply_target = the chat id (so replies still route).
+    assert_eq!(msg.sender, "ou_testuser123");
+    assert_eq!(msg.reply_target, "oc_chat123");
+    assert_eq!(msg.id, "lark-om_abc");
+    assert_eq!(msg.channel, "lark");
+    assert_eq!(msg.timestamp, 1_699_999_999);
+    assert!(msg.attachments.is_empty());
+}
+
+#[test]
+fn lark_decode_sender_is_open_id_not_chat_id() {
+    // The core ACL fix: a populated daemon-layer `lark_user_ids` (open_id
+    // space, per acl.rs) can only ever match if the channel hands the
+    // daemon the sender open_id — NOT the oc_ chat id. Guard it directly.
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_alice" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": "{\"text\":\"hi\"}",
+                "chat_id": "oc_room",
+                "create_time": "1000"
+            }
+        }
+    });
+    let msg = ch.decode_event_value(&payload).expect("decoded");
+    assert_eq!(msg.sender, "ou_alice", "sender must be the user open_id");
+    assert_ne!(
+        msg.sender, "oc_room",
+        "sender must NOT collapse into the chat id"
+    );
+    assert_eq!(msg.reply_target, "oc_room");
+}
+
+#[test]
+fn lark_decode_unauthorized_user() {
+    let ch = make_channel();
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_unauthorized" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": "{\"text\":\"spam\"}",
+                "chat_id": "oc_chat",
+                "create_time": "1000"
+            }
+        }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_skips_app_and_bot_senders() {
+    // The bot's own echoes (sender_type app/bot) must never loop back in,
+    // even with a wildcard allowlist.
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    for sender_type in ["app", "bot"] {
+        let payload = serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1" },
+            "event": {
+                "sender": {
+                    "sender_id": { "open_id": "ou_user" },
+                    "sender_type": sender_type
+                },
+                "message": {
+                    "message_id": "om_1",
+                    "message_type": "text",
+                    "content": "{\"text\":\"echo\"}",
+                    "chat_id": "oc_chat",
+                    "create_time": "1000"
+                }
+            }
+        });
+        assert!(
+            ch.decode_event_value(&payload).is_none(),
+            "sender_type={sender_type} must be dropped"
+        );
+    }
+}
+
+#[test]
+fn lark_decode_group_requires_at_mention() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let base = |mentions: serde_json::Value| {
+        serde_json::json!({
+            "header": { "event_type": "im.message.receive_v1" },
+            "event": {
+                "sender": { "sender_id": { "open_id": "ou_user" } },
+                "message": {
+                    "message_id": "om_grp",
+                    "message_type": "text",
+                    "content": "{\"text\":\"hi team\"}",
+                    "chat_id": "oc_group",
+                    "chat_type": "group",
+                    "mentions": mentions,
+                    "create_time": "1000"
+                }
+            }
+        })
+    };
+    // No @-mention in a group → dropped.
+    assert!(ch
+        .decode_event_value(&base(serde_json::json!([])))
+        .is_none());
+    // @-mentioned → delivered.
+    let msg = ch
+        .decode_event_value(&base(serde_json::json!([{"key": "@_user_1"}])))
+        .expect("mentioned group message delivered");
+    assert_eq!(msg.reply_target, "oc_group");
+}
+
+#[test]
+fn lark_decode_non_text_message_skipped() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_user" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "image",
+                "content": "{}",
+                "chat_id": "oc_chat"
+            }
+        }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_empty_text_skipped() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_user" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": "{\"text\":\"\"}",
+                "chat_id": "oc_chat"
+            }
+        }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_wrong_event_type() {
+    let ch = make_channel();
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.chat.disbanded_v1" },
+        "event": {}
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_missing_sender() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": "{\"text\":\"hello\"}",
+                "chat_id": "oc_chat"
+            }
+        }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_unicode_message() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_user" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": "{\"text\":\"Hello world 🌍\"}",
+                "chat_id": "oc_chat",
+                "create_time": "1000"
+            }
+        }
+    });
+    let msg = ch.decode_event_value(&payload).expect("decoded");
+    assert_eq!(msg.content, "Hello world 🌍");
+}
+
+#[test]
+fn lark_decode_missing_event() {
+    let ch = make_channel();
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_invalid_content_json() {
+    let ch = LarkChannel::new("id".into(), "secret".into(), vec!["*".into()], true);
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_user" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": "not valid json",
+                "chat_id": "oc_chat"
+            }
+        }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_empty_object_returns_none() {
+    let ch = make_channel();
+    assert!(ch.decode_event_value(&serde_json::json!({})).is_none());
+}
+
+#[test]
+fn lark_decode_empty_sender_returns_none() {
+    let ch = make_channel();
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "" } },
+            "message": {
+                "message_id": "om_1",
+                "message_type": "text",
+                "content": r#"{"text":"hi"}"#,
+                "chat_id": "oc_chat",
+                "create_time": "1700000000000"
+            }
+        }
+    });
+    assert!(ch.decode_event_value(&payload).is_none());
+}
+
+#[test]
+fn lark_decode_post_type_extracts_readable_text() {
+    let ch = make_channel();
+    let post_content = serde_json::json!({
+        "zh_cn": {
+            "title": "Title",
+            "content": [[{"tag":"text","text":"Body"}]]
+        }
+    })
+    .to_string();
+    let payload = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_testuser123" } },
+            "message": {
+                "message_id": "om_post",
+                "message_type": "post",
+                "content": post_content,
+                "create_time": "1700000000000",
+                "chat_id": "oc_chat_xyz"
+            }
+        }
+    });
+    let msg = ch.decode_event_value(&payload).expect("decoded");
+    assert!(msg.content.contains("Title"));
+    assert_eq!(msg.sender, "ou_testuser123");
+    assert_eq!(msg.reply_target, "oc_chat_xyz");
+}
+
+// ── decode_event (the live WS byte path: frame JSON → DecodedMessage) ───
+//
+// `decode_event` is exactly what `listen_ws` calls on each DATA frame's
+// reassembled payload, so feeding it the bytes a real `im.message.receive_v1`
+// frame carries proves the production decode end-to-end (the ACL + dedup
+// that wrap it at the call site are covered by `decode_event_value` + the
+// AclPolicy tests).
+
+#[test]
+fn lark_decode_event_bytes_maps_text_message() {
+    let ch = make_channel();
+    let event = serde_json::json!({
+        "header": { "event_type": "im.message.receive_v1", "event_id": "evt_1" },
+        "event": {
+            "sender": { "sender_id": { "open_id": "ou_testuser123" } },
+            "message": {
+                "message_id": "om_bytes",
+                "message_type": "text",
+                "content": "{\"text\":\"from the wire @_user_1\"}",
+                "chat_id": "oc_wire",
+                "create_time": "1699999999000"
+            }
+        }
+    });
+    let bytes = serde_json::to_vec(&event).expect("serialize event");
+    let decoded = ch.decode_event(&bytes).expect("decoded from bytes");
+    assert_eq!(decoded.open_id, "ou_testuser123");
+    assert_eq!(decoded.chat_id, "oc_wire");
+    assert_eq!(decoded.message_id, "om_bytes");
+    // @-placeholder stripped + trimmed, identical to the seam path.
+    assert_eq!(decoded.text, "from the wire");
+    let msg = decoded.into_channel_message();
+    assert_eq!(msg.id, "lark-om_bytes");
+    assert_eq!(msg.sender, "ou_testuser123");
+    assert_eq!(msg.reply_target, "oc_wire");
+}
+
+#[test]
+fn lark_decode_event_bytes_rejects_wrong_event_type() {
+    let ch = make_channel();
+    let event = serde_json::json!({
+        "header": { "event_type": "im.chat.disbanded_v1", "event_id": "evt_2" },
+        "event": {}
+    });
+    let bytes = serde_json::to_vec(&event).expect("serialize");
+    assert!(ch.decode_event(&bytes).is_none());
+}
+
+#[test]
+fn lark_decode_event_bytes_rejects_garbage() {
+    let ch = make_channel();
+    assert!(ch.decode_event(b"not json at all").is_none());
+}
+
+// ── parse_post_content ─────────────────────────────────────────
+
+#[test]
+fn parse_post_content_returns_zh_cn_locale_content() {
+    let post = serde_json::json!({
+        "zh_cn": {
+            "title": "标题",
+            "content": [[{"tag": "text", "text": "你好"}]]
+        }
+    })
+    .to_string();
+    let out = parse_post_content(&post).expect("parsed");
+    assert!(out.contains("标题"));
+    assert!(out.contains("你好"));
+}
+
+#[test]
+fn parse_post_content_falls_back_to_en_us_when_zh_cn_missing() {
+    let post = serde_json::json!({
+        "en_us": {
+            "title": "Hello",
+            "content": [[{"tag": "text", "text": "world"}]]
+        }
+    })
+    .to_string();
+    let out = parse_post_content(&post).expect("parsed");
+    assert!(out.contains("Hello"));
+    assert!(out.contains("world"));
+}
+
+#[test]
+fn parse_post_content_returns_none_for_invalid_json() {
+    assert!(parse_post_content("not json").is_none());
+}
+
+#[test]
+fn parse_post_content_handles_links_and_mentions() {
+    let post = serde_json::json!({
+        "zh_cn": {
+            "title": "T",
+            "content": [[
+                {"tag": "text", "text": "pre "},
+                {"tag": "a", "text": "link", "href": "https://x"},
+                {"tag": "at", "user_name": "alice"}
+            ]]
+        }
+    })
+    .to_string();
+    let out = parse_post_content(&post).expect("parsed");
+    assert!(out.contains("link"));
+    assert!(out.contains("@alice"));
+}
+
+#[test]
+fn parse_post_content_falls_back_to_href_when_anchor_text_missing() {
+    // Anchor without `text` must surface the `href` — otherwise the
+    // link is invisible in the rendered message.
+    let post = serde_json::json!({
+        "zh_cn": {
+            "title": "T",
+            "content": [[
+                {"tag": "text", "text": "see "},
+                {"tag": "a", "href": "https://example.com/no-text"}
+            ]]
+        }
+    })
+    .to_string();
+    let out = parse_post_content(&post).expect("parsed");
+    assert!(
+        out.contains("https://example.com/no-text"),
+        "href fallback should surface when anchor has no text, got: {out}"
+    );
+}
+
+#[test]
+fn parse_post_content_returns_none_when_all_sections_empty() {
+    let post = serde_json::json!({ "zh_cn": { "title": "" } }).to_string();
+    assert!(parse_post_content(&post).is_none());
+}
+
+// ── strip_at_placeholders ──────────────────────────────────────
+
+#[test]
+fn strip_at_placeholders_removes_user_tokens() {
+    assert_eq!(strip_at_placeholders("hello @_user_1 world"), "hello world");
+    assert_eq!(
+        strip_at_placeholders("@_user_42 message here"),
+        "message here"
+    );
+}
+
+#[test]
+fn strip_at_placeholders_preserves_real_at_mentions() {
+    assert_eq!(strip_at_placeholders("hello @alice"), "hello @alice");
+}
+
+#[test]
+fn strip_at_placeholders_handles_multiple_placeholders() {
+    assert_eq!(strip_at_placeholders("@_user_1 hi @_user_2 bye"), "hi bye");
+}
+
+// ── should_respond_in_group ────────────────────────────────────
+
+#[test]
+fn should_respond_in_group_requires_nonempty_mentions() {
+    assert!(!should_respond_in_group(&[]));
+    assert!(should_respond_in_group(&[
+        serde_json::json!({"key": "val"})
+    ]));
+}

--- a/crates/ccteam-im/src/transport/providers/mod.rs
+++ b/crates/ccteam-im/src/transport/providers/mod.rs
@@ -15,3 +15,6 @@ pub mod slack;
 
 #[cfg(feature = "discord")]
 pub mod discord;
+
+#[cfg(feature = "lark")]
+pub mod lark;

--- a/crates/ccteam-im/tests/credentials_test.rs
+++ b/crates/ccteam-im/tests/credentials_test.rs
@@ -1,6 +1,6 @@
 //! Credentials reader integration tests.
 
-use ccteam_im::credentials::{load, save, Credentials, SlackCreds, TelegramCreds};
+use ccteam_im::credentials::{load, save, Credentials, LarkCreds, SlackCreds, TelegramCreds};
 use tempfile::TempDir;
 
 #[test]
@@ -11,6 +11,7 @@ fn missing_file_returns_default() {
     assert!(c.telegram.is_none());
     assert!(c.slack.is_none());
     assert!(c.discord.is_none());
+    assert!(c.lark.is_none());
 }
 
 #[test]
@@ -28,6 +29,12 @@ fn round_trip_all_platforms() {
             poll_channels: vec!["C123".into()],
         }),
         discord: None,
+        lark: Some(LarkCreds {
+            app_id: "cli_x".into(),
+            app_secret: "sek".into(),
+            allowed_user_ids: vec!["ou_a".into()],
+            use_feishu: true,
+        }),
     };
     save(&path, &original).unwrap();
     let back = load(Some(&path)).unwrap();


### PR DESCRIPTION
… build_channels

Add Lark/Feishu as a second IM channel via a native Rust provider ported from openhuman's lark.rs (Path A): WebSocket long-connection with a self-contained pbbp2 prost codec (no public endpoint), im/v1/messages send, and edit_message with tenant-token invalidate+refresh+retry.

Generalize build_channels into a per-provider builder table so telegram/slack/discord/lark wire in uniformly — the previous telegram-only construction is gone and slack/discord are now actually wired. Add LarkCreds + the lark_user_ids ACL key (open_id-keyed), gated behind the `lark` default feature.

ccteam-im: 341 passed / 0 failed; clippy 0 warnings; fmt clean; cargo build --workspace clean.