### PR TITLE
fix(im+harness): project-list ACL leak + eviction correctness + /sessions display cleanup + default-model leak

### DIFF
--- a/crates/ccteam-harness/src/execution/claude_stream_json/mod.rs
+++ b/crates/ccteam-harness/src/execution/claude_stream_json/mod.rs
@@ -726,6 +726,17 @@ fn read_status_file(project_dir: &Path, sid: &str) -> Option<ThreadStatus> {
     serde_json::from_str(&body).ok()
 }
 
+/// Whether `m` is claude's OWN model-picker placeholder (`SystemMsg::
+/// from_initialize`'s `models[0].value`, typically the literal string
+/// `"default"` — labeled "Default"/"recommended" in the picker) rather than a
+/// concrete, resolvable model id. ccteam cannot know which real model that
+/// resolves to without a live turn, so this must never reach `--model` or be
+/// displayed as if it were a resolved name — see the status seed in
+/// [`ClaudeStreamJsonAdapter::start_thread`] and the filter below.
+fn is_model_placeholder(m: &str) -> bool {
+    m.trim().eq_ignore_ascii_case("default")
+}
+
 /// The last-known model for a session, from its persisted `status.json` (the
 /// status tap records every `/model` switch + the API model). The gateway uses
 /// this so a daemon-restart resume re-spawns at the model the user actually set
@@ -736,10 +747,13 @@ pub fn persisted_session_model(project_dir: &Path, sid: &str) -> Option<String> 
     read_status_file(project_dir, sid)
         .and_then(|s| s.model)
         // Real model ids never contain `<`/`>`; reject a placeholder like
-        // `<synthetic>` (legacy / never-resolved) so it can't reach `--model`.
+        // `<synthetic>` (legacy / never-resolved), and reject claude's own
+        // unresolved "default" picker label (defense-in-depth — the status
+        // seed already withholds it, but `--model default` would be a
+        // meaningless, ambiguous request if one ever slipped through).
         .filter(|m| {
             let m = m.trim();
-            !m.is_empty() && !m.contains('<') && !m.contains('>')
+            !m.is_empty() && !m.contains('<') && !m.contains('>') && !is_model_placeholder(m)
         })
 }
 
@@ -1161,9 +1175,18 @@ impl HarnessAdapter for ClaudeStreamJsonAdapter {
         };
         // Seed the live status with the `initialize` model (context unknown
         // until the first turn's `usage` lands). The status tap below keeps it
-        // current; thread_status reads it.
+        // current; thread_status reads it. `models[0].value` is often the
+        // literal string `"default"` — claude's OWN picker-menu placeholder
+        // (`SystemMsg::from_initialize`: "Default" / "recommended"), not a
+        // concrete resolved model id; ccteam genuinely does not know which
+        // model that resolves to until a real turn runs. Surfacing "default"
+        // verbatim in /sessions or /status would read as a real (wrong) model
+        // name, so withhold it here (`None` = "not yet known", the SAME
+        // convention every other not-yet-reported field already uses) —
+        // `spawn_status_tap`'s `preserve_1m_tag` below overwrites it with the
+        // REAL API-reported model as soon as the first assistant message lands.
         let status = Arc::new(StdMutex::new(ThreadStatus {
-            model: init.model.clone(),
+            model: init.model.clone().filter(|m| !is_model_placeholder(m)),
             context: None,
             // Effort is unknown until the first turn — the status tap reads the
             // vendor's runtime-resolved level via `get_settings`.
@@ -1742,11 +1765,63 @@ impl HarnessAdapter for ClaudeStreamJsonAdapter {
 mod effort_tests {
     use super::protocol::SystemMsg;
     use super::{
-        claude_model_options, normalize_effort, parse_latest_goal_status, preserve_1m_tag,
-        reflect_task_event, set_effort_level, split_model_effort, task_outlives_turn,
-        ClaudeModelOption, EFFORT_LEVELS,
+        claude_model_options, is_model_placeholder, normalize_effort, parse_latest_goal_status,
+        persisted_session_model, preserve_1m_tag, reflect_task_event, set_effort_level,
+        split_model_effort, task_outlives_turn, write_status_file, ClaudeModelOption,
+        EFFORT_LEVELS,
     };
+    use crate::ThreadStatus;
     use std::sync::Mutex;
+
+    /// `"default"` (claude's own picker-menu label, any case/whitespace) is a
+    /// placeholder, not a real model id; every other string — including a
+    /// concrete id that merely CONTAINS "default" as a substring — is not.
+    #[test]
+    fn is_model_placeholder_matches_only_the_bare_default_label() {
+        assert!(is_model_placeholder("default"));
+        assert!(is_model_placeholder("Default"));
+        assert!(is_model_placeholder("  default  "));
+        assert!(!is_model_placeholder("claude-opus-4-8[1m]"));
+        assert!(!is_model_placeholder("default-ish"));
+        assert!(!is_model_placeholder(""));
+    }
+
+    /// THE FIX — `persisted_session_model` must never resolve to claude's own
+    /// unresolved "default" placeholder (defense-in-depth for the spawn-time
+    /// seed filter): a `status.json` snapshot recording it reads back as
+    /// `None`, exactly like the existing `<synthetic>` placeholder guard, so
+    /// neither can reach a real `--model` respawn request.
+    #[test]
+    fn persisted_session_model_rejects_the_default_placeholder() {
+        let dir = tempfile::tempdir().unwrap();
+        write_status_file(
+            dir.path(),
+            "s1",
+            &ThreadStatus {
+                model: Some("default".to_string()),
+                context: None,
+                effort: None,
+                goal: None,
+            },
+        );
+        assert_eq!(persisted_session_model(dir.path(), "s1"), None);
+
+        // A concrete id round-trips normally.
+        write_status_file(
+            dir.path(),
+            "s2",
+            &ThreadStatus {
+                model: Some("claude-opus-4-8[1m]".to_string()),
+                context: None,
+                effort: None,
+                goal: None,
+            },
+        );
+        assert_eq!(
+            persisted_session_model(dir.path(), "s2"),
+            Some("claude-opus-4-8[1m]".to_string())
+        );
+    }
 
     /// Build a `system:task_*` line with the given subtype + task id.
     fn task_sys(subtype: &str, task_id: &str) -> SystemMsg {

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -5726,11 +5726,6 @@ impl Gateway {
             };
             return Self::append_history_section(head, &history);
         }
-        let activity_by_sid = if is_web {
-            std::collections::HashMap::new()
-        } else {
-            self.session_activity_snapshot(&visible)
-        };
         // Render each visible session's row (async `thread_status`) once,
         // keyed by sid for the IM tree; web keeps the flat bare-row feed.
         let mut web_rows: Vec<String> = Vec::with_capacity(visible.len());
@@ -5757,16 +5752,12 @@ impl Gateway {
                 web_rows.push(row);
                 continue;
             }
-            let vendor_tag = format!("[{}]", vendor_str(s.vendor));
-            let activity = activity_by_sid
-                .get(&s.id)
-                .map(String::as_str)
-                .unwrap_or("idle");
-            row = format!("{vendor_tag:<10} {} · {row}", activity_marker(activity));
+            // The row already starts with `s.id` (the `base` built above) — no
+            // leading vendor tag or activity dot: the tree is a terse
+            // `sid:project:vendor:role` identifier line now, scannable by sid.
+            // (Activity/state lives on `/status`; the session TITLE lives on
+            // the switch button label — see `session_switch_options`.)
             // v0.9.0 W2 (F2) — annotate the IM row with a non-local host.
-            // (The session title is deliberately NOT on the text row anymore —
-            // it lives on the switch button label instead; see
-            // `session_switch_options`.)
             if !s.host.is_empty() && s.host != "local" {
                 row.push_str(&format!(" @{}", s.host));
             }
@@ -8855,7 +8846,7 @@ const TELEGRAM_CALLBACK_MAX: usize = 64;
 /// Max display columns a session title may occupy inside a `/sessions` switch
 /// button label. A longer title is clipped with `…` so one verbose title can't
 /// widen every button — the left-align padding aligns all labels to the widest.
-const SESSION_BUTTON_TITLE_MAX_COLS: usize = 24;
+const SESSION_BUTTON_TITLE_MAX_COLS: usize = 32;
 
 /// Clip `s` to at most `max_cols` DISPLAY columns, appending `…` on overflow.
 /// Column-based (not char count) so a CJK double-width title clips at a stable
@@ -8880,20 +8871,34 @@ fn truncate_cols(s: &str, max_cols: usize) -> String {
     out
 }
 
-/// Right-pad every picker label to the set's widest row so Telegram's
+/// Floor for [`left_align_option_labels`]'s pad target: Telegram renders every
+/// option as its OWN full-width single-button row (one button per
+/// `inline_keyboard` row — see `TelegramChannel::send`), so its text is
+/// centered within the FULL row width, not a column sized to the option set.
+/// Padding rows to only the OBSERVED max-in-set (e.g. all bare sids like
+/// "s1"/"s2"/"s28") still centers a short block deep in a wide row — visually
+/// indistinguishable from plain centering. Padding every label out to at
+/// least this many columns pushes that block toward the row's left edge on a
+/// typical phone-width chat. Approximate by nature: the bot API exposes no
+/// client viewport, so this can undershoot (desktop) or overshoot slightly.
+const PICKER_LABEL_MIN_PAD_COLS: usize = 30;
+
+/// Right-pad every picker label to at least the widest row in the SET, or
+/// [`PICKER_LABEL_MIN_PAD_COLS`], whichever is larger — so Telegram's
 /// centre-aligned button text reads as a LEFT-aligned list (owner req,
-/// tg-6955). Telegram strips ordinary trailing whitespace from button
-/// labels, so the pad is U+2800 BRAILLE PATTERN BLANK — renders blank,
-/// survives the trim, ~1 cell wide.
+/// tg-6955) even when every option in the set is short. Telegram strips
+/// ordinary trailing whitespace from button labels, so the pad is U+2800
+/// BRAILLE PATTERN BLANK — renders blank, survives the trim, ~1 cell wide.
 fn left_align_option_labels(options: &mut [MessageOption]) {
     use unicode_width::UnicodeWidthStr;
-    let max = options
+    let observed_max = options
         .iter()
         .map(|o| o.label.as_str().width())
         .max()
         .unwrap_or(0);
+    let target = observed_max.max(PICKER_LABEL_MIN_PAD_COLS);
     for o in options.iter_mut() {
-        for _ in 0..max.saturating_sub(o.label.as_str().width()) {
+        for _ in 0..target.saturating_sub(o.label.as_str().width()) {
             o.label.push('\u{2800}');
         }
     }
@@ -12962,8 +12967,12 @@ mod tests {
         );
     }
 
+    /// `/sessions` text rows START with the sid and carry NO activity dot
+    /// (🟢/🟡/🟠/🔴/⚪) or leading `[vendor]` tag — those lived on the text row
+    /// pre-cleanup; activity now lives only on `/status`, and the vendor is
+    /// still readable from the `:{vendor}:` colon field.
     #[tokio::test]
-    async fn gateway_sessions_rows_show_activity_marker() {
+    async fn gateway_sessions_text_rows_start_with_sid_and_have_no_activity_dot() {
         let fake = Arc::new(FakeAdapter::new(AgentVendor::Claude));
         let proj = tempfile::TempDir::new().unwrap();
         let mut gateway = Gateway::new(fake, "alpha", proj.path());
@@ -12976,10 +12985,17 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
+        let row = listing[0].split('\n').nth(1).expect("a session row");
         assert!(
-            listing[0].contains("[claude]   🟢 idle · s1:alpha:Claude:reviewer"),
-            "activity marker belongs in the information-rich text row: {listing:?}"
+            row.starts_with("s1:alpha:Claude:reviewer"),
+            "row starts with the sid: {row:?}"
         );
+        for marker in ["🟢", "🟡", "🟠", "🔴", "⚪", "[claude]"] {
+            assert!(
+                !listing[0].contains(marker),
+                "no activity dot / vendor tag on the text row: {listing:?}"
+            );
+        }
     }
 
     /// Picker-label padding equalizes display width across an option set.
@@ -13108,10 +13124,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            bare,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
-        );
+        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]);
 
         // Now report a model + usage → suffix appears, rendered the same
         // way Codex /status renders (shared helper).
@@ -13131,7 +13144,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
+            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
         );
 
         // A non-[1m] model renders against the 200k baseline.
@@ -13151,12 +13164,15 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
+            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
         );
     }
 
+    /// Every vendor's row carries its vendor in the `:{vendor}:` colon field
+    /// (no separate `[vendor]` tag anymore — that prefix was dropped so the
+    /// row starts with the sid).
     #[tokio::test]
-    async fn gateway_sessions_im_rows_prefix_all_vendor_tags() {
+    async fn gateway_sessions_im_rows_carry_every_vendor_in_the_colon_field() {
         let factory: Arc<
             dyn Fn(AgentVendor, SessionProtocol) -> Arc<dyn HarnessAdapter + Send + Sync>
                 + Send
@@ -13177,8 +13193,8 @@ mod tests {
             .into_iter()
             .next()
             .unwrap();
-        for vendor in ["claude", "codex", "grok", "opencode", "kimi"] {
-            assert!(listing.contains(&format!("[{vendor}] ")), "{listing}");
+        for vendor in ["Claude", "Codex", "Grok", "Opencode", "Kimi"] {
+            assert!(listing.contains(&format!(":{vendor}:")), "{listing}");
         }
     }
 
@@ -13212,7 +13228,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             before,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s2:alpha:Claude:qa\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns2:alpha:Claude:qa\ns1:alpha:Claude:reviewer"]
         );
 
         // Tag s1 (the OLDER session) with an outstanding approval.
@@ -13232,7 +13248,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             after,
-            vec!["📁 当前项目: alpha\n⏳ [claude]   🟢 idle · s1:alpha:Claude:reviewer\n[claude]   🟢 idle · s2:alpha:Claude:qa"],
+            vec!["📁 当前项目: alpha\n⏳ s1:alpha:Claude:reviewer\ns2:alpha:Claude:qa"],
             "s1 pinned to the top + ⏳-marked despite being less recent"
         );
     }
@@ -14479,7 +14495,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             owner_sees,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]
         );
         let owner_uses = gateway
             .handle_text("mock", "chat-1", "alice", "/use s1")
@@ -14521,10 +14537,7 @@ mod tests {
             "/sessions",
         )
         .await;
-        assert_eq!(
-            seen,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
-        );
+        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]);
         let used = gateway
             .handle_text("telegram", "339498819", "rob", "/use s1")
             .await
@@ -14699,7 +14712,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\n[claude]   🟢 idle · s2:beta:Claude:reviewer\n[codex]    🟢 idle · s1:beta:Codex:api"]
+            vec!["📁 当前项目: beta\ns2:beta:Claude:reviewer\ns1:beta:Codex:api"]
         );
 
         let use_first = gateway
@@ -14773,7 +14786,7 @@ mod tests {
         assert_eq!(
             sessions,
             vec![
-                "📁 当前项目: beta\n[claude]   🟢 idle · s4:beta:Claude:qa\n[codex]    🟢 idle · s3:beta:Codex:api\n[codex]    🟢 idle · s2:alpha:Codex:docs\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"
+                "📁 当前项目: beta\ns4:beta:Claude:qa\ns3:beta:Codex:api\ns2:alpha:Codex:docs\ns1:alpha:Claude:reviewer"
             ]
         );
         let projects = gateway
@@ -15196,7 +15209,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\n[claude]   🟢 idle · s2:beta:Claude:reviewer\n[claude]   🟢 idle · s1:beta:Claude:reviewer"]
+            vec!["📁 当前项目: beta\ns2:beta:Claude:reviewer\ns1:beta:Claude:reviewer"]
         );
 
         assert_eq!(
@@ -15268,10 +15281,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            sessions,
-            vec!["📁 当前项目: beta\n[claude]   🟢 idle · s1:beta:Claude:reviewer"]
-        );
+        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1:beta:Claude:reviewer"]);
 
         assert_eq!(
             restored
@@ -15734,10 +15744,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            before,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
-        );
+        assert_eq!(before, vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]);
 
         // /cd to beta, where no session exists yet, clears the active session.
         let cd = gateway
@@ -15771,7 +15778,7 @@ mod tests {
         // (`s2:beta:Claude:`).
         assert_eq!(
             after,
-            vec!["📁 当前项目: beta\n[claude]   🟢 idle · s2:beta:Claude:\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: beta\ns2:beta:Claude:\ns1:alpha:Claude:reviewer"]
         );
     }
 
@@ -16129,7 +16136,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             listing,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]
         );
 
         // `/use s1` still resolves the same (now-reviewer) session.
@@ -16200,10 +16207,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            listing,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto"]
-        );
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:Claude:cto"]);
         // And a follow-up turn still routes to the SAME live `cto` pane.
         let still_cto = gateway
             .handle_text("mock", "chat-1", "alice", "still here?")
@@ -16304,10 +16308,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            listing,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto"]
-        );
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:Claude:cto"]);
         // …and the rename SURFACES on the picker button.
         let chat = ChatKey::new("mock", "chat-1", "alice");
         let s1_button = |g: &Gateway| {
@@ -16330,10 +16331,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            listing2,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto"]
-        );
+        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1:alpha:Claude:cto"]);
         assert_eq!(
             s1_button(&gateway).as_deref(),
             Some("✓ s1 「my custom title」"),
@@ -17449,8 +17447,8 @@ mod tests {
             .render_sessions(&ChatKey::new("mock", "chat-1", "alice"), true)
             .await;
         // Parent row precedes the indented child row.
-        let pline = format!("[claude]   🟢 idle · {parent}:alpha:Claude:");
-        let cline = format!("└─ [claude]   🟢 idle · {child}:alpha:Claude:");
+        let pline = format!("{parent}:alpha:Claude:");
+        let cline = format!("└─ {child}:alpha:Claude:");
         let pi = out
             .find(&pline)
             .unwrap_or_else(|| panic!("parent row: {out}"));

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -13851,6 +13851,90 @@ mod tests {
         }
     }
 
+    /// IM `/projects` + `/cd` end-to-end — proves the owner ACL is WIRED at the
+    /// command surface, not just correct as a predicate: a tenant's `/projects`
+    /// lists only its OWN project, and it cannot `/cd` into — then spawn sessions
+    /// in — the admin's project by typing the slug. Seeds real owned
+    /// `state.json`s read through `collect_projects` (the SAME source the web
+    /// list reads), so a future refactor that keeps `chat_can_see_project_owner`
+    /// but stops `visible_project_slugs` / `change_project` from calling it would
+    /// still fail here — the gap the pure-predicate test above can't catch.
+    #[tokio::test]
+    async fn im_project_list_and_cd_hide_other_owners_projects() {
+        fn seed(paths: &ccteam_core::CcteamPaths, slug: &str, owner: Option<&str>) {
+            let dir = paths.projects_root.join(slug);
+            std::fs::create_dir_all(dir.join(".ccteam")).unwrap();
+            let mut state = ccteam_core::ProjectState::initial(slug.to_string());
+            state.owner = owner.map(str::to_string);
+            state
+                .save(&ccteam_core::CcteamPaths::project_state_in(&dir))
+                .unwrap();
+            ccteam_core::config::upsert_project(
+                &paths.root,
+                ccteam_core::ProjectEntry {
+                    slug: slug.to_string(),
+                    path: dir,
+                    host: ccteam_core::LOCAL_HOST.to_string(),
+                    remote_slug: None,
+                    remote_path: None,
+                    team: "dev".to_string(),
+                    installed_at: chrono::Utc::now(),
+                },
+            )
+            .unwrap();
+        }
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = ccteam_core::CcteamPaths {
+            root: tmp.path().join(".ccteam"),
+            projects_root: tmp.path().join("projects"),
+        };
+        std::fs::create_dir_all(&paths.root).unwrap();
+        seed(&paths, "tenant-proj", Some("user:ualice"));
+        seed(&paths, "admin-proj", Some("user:web-api"));
+        seed(&paths, "cli-proj", None); // legacy, unowned
+
+        let fake = Arc::new(FakeAdapter::default());
+        let mut gateway = Gateway::new(fake, "seed", tmp.path().join("seed"));
+        gateway.enable_project_creation(paths);
+
+        let tenant = ChatKey::new("telegram@ualice", "111", "alice");
+        let admin = ChatKey::new("telegram", "339", "rob");
+
+        // THE BUG: the tenant's `/projects` lists ONLY its own project.
+        assert_eq!(
+            gateway.visible_project_slugs(&tenant),
+            vec!["tenant-proj".to_string()],
+            "a tenant's /projects must not include the admin's or legacy projects"
+        );
+        // The operator sees the admin + legacy projects, not the tenant's private.
+        let admin_visible = gateway.visible_project_slugs(&admin);
+        assert!(
+            admin_visible.contains(&"admin-proj".to_string())
+                && admin_visible.contains(&"cli-proj".to_string()),
+            "operator sees its own + legacy, got {admin_visible:?}"
+        );
+        assert!(
+            !admin_visible.contains(&"tenant-proj".to_string()),
+            "operator must not peek into a tenant's project, got {admin_visible:?}"
+        );
+
+        // Addressing is gated too: the tenant can't `/cd` into the admin's
+        // project by typing the slug — it reads identically to a nonexistent one
+        // ("unknown project"), leaking no existence — but CAN `/cd` into its own.
+        let err = gateway
+            .change_project(&tenant, "admin-proj")
+            .expect_err("tenant must not /cd into the admin's project");
+        assert!(
+            err.to_string().contains("unknown project"),
+            "expected an unknown-project error, got {err}"
+        );
+        assert!(
+            gateway.change_project(&tenant, "tenant-proj").is_ok(),
+            "a tenant must be able to /cd into its OWN project"
+        );
+    }
+
     /// v0.8.21 cold-resume ACL (web path) — `resume_stopped_session` resolves a
     /// sid across ALL registered projects (`find_meta_for_sid`), so the web
     /// caller's authorised slug MUST bind the resolved project. Without the

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -2745,13 +2745,13 @@ impl Gateway {
         let mut options: Vec<MessageOption> = visible
             .into_iter()
             .map(|s| {
-                // Label = `sid vendor 「title」` (✓ prefixes the current
-                // session), arranged sid → vendor → title. The terse text tree
-                // keeps the full `sid:project:vendor:role` line; the button
-                // carries the human name. A long title is clipped to
-                // `SESSION_BUTTON_TITLE_MAX_COLS` display cols so one verbose
-                // title can't widen every button (the left-align padding below
-                // pads all labels to the widest). Callback `data` is unchanged.
+                // Label = `sid vendor (title)` (✓ prefixes the current
+                // session), arranged sid → vendor → title — same `sid vendor`
+                // opening as the text rows. The button carries the human name;
+                // a long title is clipped to `SESSION_BUTTON_TITLE_MAX_COLS`
+                // display cols so one verbose title can't widen every button
+                // (the left-align padding below pads all labels to the widest).
+                // Callback `data` is unchanged.
                 let marker = if Some(&s.id) == current_sid.as_ref() {
                     "✓ "
                 } else {
@@ -2760,7 +2760,7 @@ impl Gateway {
                 let mut label = format!("{marker}{} {}", s.id, vendor_str(s.vendor));
                 if let Some(title) = self.session_title(s) {
                     label.push_str(&format!(
-                        " 「{}」",
+                        " ({})",
                         truncate_cols(&title, SESSION_BUTTON_TITLE_MAX_COLS)
                     ));
                 }
@@ -5727,35 +5727,35 @@ impl Gateway {
         for s in &visible {
             // P3 — model + ctx from the owning adapter's `thread_status`.
             // Statusless adapters (bg / default) report `ThreadStatus::default()`
-            // → `status_suffix() == None` → no ` — suffix`. Per-session failures
-            // degrade to the bare row (never break the listing).
-            let suffix = match s.adapter.thread_status(&s.thread).await {
-                Ok(status) => status.status_suffix(),
-                Err(_) => None,
-            };
-            // Web rows stay the machine-parsed `sid:project:vendor:role` feed
-            // (`parse_sessions_reply` splits on exactly 4 colon fields and must
-            // not see extra content appended).
+            // (no model / no context). Per-session failures degrade to the bare
+            // row (never break the listing).
+            let status = (s.adapter.thread_status(&s.thread).await).ok();
+            // Web rows stay the machine-parsed `sid:project:vendor:role` feed +
+            // the full, shared `status_suffix()` (matches Codex /status;
+            // `parse_sessions_reply` splits on exactly 4 colon fields).
             if is_web {
                 let base = format!("{}:{}:{}:{}", s.id, s.project, vendor_str(s.vendor), s.role);
-                web_rows.push(match &suffix {
+                web_rows.push(match status.as_ref().and_then(|st| st.status_suffix()) {
                     Some(sfx) => format!("{base} — {sfx}"),
                     None => base,
                 });
                 continue;
             }
-            // IM row LEADS with `sid vendor` — the SAME opening as the switch
-            // button (`session_switch_options`: `sid vendor 「title」`) — so the
-            // text tree and the buttons line up. Then `· project`, `· role`
-            // (role omitted when empty), the optional model/ctx suffix, and a
-            // non-local host. No vendor tag or activity dot (activity → /status;
-            // title → the button).
-            let mut row = format!("{} {} · {}", s.id, vendor_str(s.vendor), s.project);
-            if !s.role.is_empty() {
-                row.push_str(&format!(" · {}", s.role));
-            }
-            if let Some(sfx) = &suffix {
-                row.push_str(&format!(" — {sfx}"));
+            // IM row: COMPACT, single-line, `.`-joined with no padding. Leads
+            // with `sid vendor` (the SAME opening as the switch button —
+            // `session_switch_options`: `sid vendor (title)`), then `.project`
+            // and — when the adapter reports them — `.model` and `.<pct>%`
+            // context. Deliberately terse: NO role, NO `ctx` label, NO absolute
+            // token counts (all on /status); the title lives on the button; the
+            // vendor tag + activity dot are gone.
+            let mut row = format!("{} {}.{}", s.id, vendor_str(s.vendor), s.project);
+            if let Some(st) = &status {
+                if let Some(m) = st.model.as_deref().filter(|m| !m.is_empty()) {
+                    row.push_str(&format!(".{m}"));
+                }
+                if let Some(ctx) = st.context.as_ref().filter(|c| c.window_tokens > 0) {
+                    row.push_str(&format!(".{:.0}%", ctx.pct()));
+                }
             }
             // v0.9.0 W2 (F2) — annotate the IM row with a non-local host.
             if !s.host.is_empty() && s.host != "local" {
@@ -12791,14 +12791,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mock.len(), 1);
-        assert!(
-            mock[0].contains("s2 claude · alpha · reviewer"),
-            "{}",
-            mock[0]
-        );
+        assert!(mock[0].contains("s2 claude.alpha"), "{}", mock[0]);
     }
 
-    /// Picker buttons are `sid vendor 「title」` (sid → vendor → title), a `✓`
+    /// Picker buttons are `sid vendor (title)` (sid → vendor → title), a `✓`
     /// marking the current session. The ROLE is NOT on the button (it stays on
     /// the information-rich text rows). Tail-padding stays visual-only so
     /// Telegram left-aligns the variable-width labels.
@@ -12809,7 +12805,7 @@ mod tests {
         let proj = tempfile::TempDir::new().unwrap();
         let mut gateway = Gateway::new(fake, "alpha", proj.path());
         // One roleless untitled session + one titled session: the untitled
-        // button is `sid vendor`, the titled one appends its 「title」.
+        // button is `sid vendor`, the titled one appends its (title).
         gateway
             .handle_text("telegram", "chat-1", "alice", "/new claude")
             .await
@@ -12826,10 +12822,10 @@ mod tests {
         let s2 = opts.iter().find(|o| o.id == "s2").unwrap();
         let s1_text = s1.label.trim_end_matches('\u{2800}');
         let s2_text = s2.label.trim_end_matches('\u{2800}');
-        // Untitled → `sid vendor`; titled + current → `✓ sid vendor 「title」`.
+        // Untitled → `sid vendor`; titled + current → `✓ sid vendor (title)`.
         // Vendor is lowercase (`vendor_str`).
         assert_eq!(s1_text, "s1 claude");
-        assert_eq!(s2_text, "✓ s2 claude 「A long review title」");
+        assert_eq!(s2_text, "✓ s2 claude (A long review title)");
         for label in [s1_text, s2_text] {
             assert!(
                 !label.contains("reviewer"),
@@ -12867,8 +12863,8 @@ mod tests {
         let opts = gateway.session_switch_options(&chat, false);
         let label = opts[0].label.trim_end_matches('\u{2800}');
         let title = label
-            .split_once('「')
-            .and_then(|(_, rest)| rest.strip_suffix('」'))
+            .split_once('(')
+            .and_then(|(_, rest)| rest.strip_suffix(')'))
             .expect("titled button label");
         assert!(
             title.ends_with('…'),
@@ -12904,7 +12900,7 @@ mod tests {
             .unwrap();
         let row = listing[0].split('\n').nth(1).expect("a session row");
         assert!(
-            row.starts_with("s1 claude · alpha · reviewer"),
+            row.starts_with("s1 claude.alpha"),
             "row starts with the sid: {row:?}"
         );
         for marker in ["🟢", "🟡", "🟠", "🔴", "⚪", "[claude]"] {
@@ -13041,10 +13037,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            bare,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
-        );
+        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
 
         // Now report a model + usage → suffix appears, rendered the same
         // way Codex /status renders (shared helper).
@@ -13064,7 +13057,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
+            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-opus-4-8[1m].19%"]
         );
 
         // A non-[1m] model renders against the 200k baseline.
@@ -13084,7 +13077,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
+            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-sonnet-4-5.94%"]
         );
     }
 
@@ -13113,7 +13106,7 @@ mod tests {
             .next()
             .unwrap();
         for vendor in ["claude", "codex", "grok", "opencode", "kimi"] {
-            assert!(listing.contains(&format!(" {vendor} · ")), "{listing}");
+            assert!(listing.contains(&format!(" {vendor}.")), "{listing}");
         }
     }
 
@@ -13147,7 +13140,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             before,
-            vec!["📁 当前项目: alpha\ns2 claude · alpha · qa\ns1 claude · alpha · reviewer"]
+            vec!["📁 当前项目: alpha\ns2 claude.alpha\ns1 claude.alpha"]
         );
 
         // Tag s1 (the OLDER session) with an outstanding approval.
@@ -13167,7 +13160,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             after,
-            vec!["📁 当前项目: alpha\n⏳ s1 claude · alpha · reviewer\ns2 claude · alpha · qa"],
+            vec!["📁 当前项目: alpha\n⏳ s1 claude.alpha\ns2 claude.alpha"],
             "s1 pinned to the top + ⏳-marked despite being less recent"
         );
     }
@@ -14333,10 +14326,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            owner_sees,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
-        );
+        assert_eq!(owner_sees, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
         let owner_uses = gateway
             .handle_text("mock", "chat-1", "alice", "/use s1")
             .await
@@ -14377,10 +14367,7 @@ mod tests {
             "/sessions",
         )
         .await;
-        assert_eq!(
-            seen,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
-        );
+        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
         let used = gateway
             .handle_text("telegram", "339498819", "rob", "/use s1")
             .await
@@ -14555,7 +14542,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\ns2 claude · beta · reviewer\ns1 codex · beta · api"]
+            vec!["📁 当前项目: beta\ns2 claude.beta\ns1 codex.beta"]
         );
 
         let use_first = gateway
@@ -14629,7 +14616,7 @@ mod tests {
         assert_eq!(
             sessions,
             vec![
-                "📁 当前项目: beta\ns4 claude · beta · qa\ns3 codex · beta · api\ns2 codex · alpha · docs\ns1 claude · alpha · reviewer"
+                "📁 当前项目: beta\ns4 claude.beta\ns3 codex.beta\ns2 codex.alpha\ns1 claude.alpha"
             ]
         );
         let projects = gateway
@@ -15052,7 +15039,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\ns2 claude · beta · reviewer\ns1 claude · beta · reviewer"]
+            vec!["📁 当前项目: beta\ns2 claude.beta\ns1 claude.beta"]
         );
 
         assert_eq!(
@@ -15124,10 +15111,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            sessions,
-            vec!["📁 当前项目: beta\ns1 claude · beta · reviewer"]
-        );
+        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1 claude.beta"]);
 
         assert_eq!(
             restored
@@ -15590,10 +15574,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            before,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
-        );
+        assert_eq!(before, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
 
         // /cd to beta, where no session exists yet, clears the active session.
         let cd = gateway
@@ -15624,10 +15605,10 @@ mod tests {
         // now rides the switch BUTTON, not the text row (see
         // `session_switch_options`); s1 never sent a plain message, so it is
         // untitled either way. s2 is roleless → empty role field
-        // (`s2 claude · beta`).
+        // (`s2 claude.beta`).
         assert_eq!(
             after,
-            vec!["📁 当前项目: beta\ns2 claude · beta\ns1 claude · alpha · reviewer"]
+            vec!["📁 当前项目: beta\ns2 claude.beta\ns1 claude.alpha"]
         );
     }
 
@@ -15858,9 +15839,7 @@ mod tests {
         )
         .await;
         assert!(
-            owner_sees
-                .iter()
-                .any(|r| r.contains("s1 claude · alpha · assistant")),
+            owner_sees.iter().any(|r| r.contains("s1 claude.alpha")),
             "owner should see its own session: {owner_sees:?}"
         );
         let owner_uses = gateway
@@ -15983,10 +15962,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            listing,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
-        );
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
 
         // `/use s1` still resolves the same (now-reviewer) session.
         let used = gateway
@@ -16056,7 +16032,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude · alpha · cto"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
         // And a follow-up turn still routes to the SAME live `cto` pane.
         let still_cto = gateway
             .handle_text("mock", "chat-1", "alice", "still here?")
@@ -16157,7 +16133,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude · alpha · cto"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
         // …and the rename SURFACES on the picker button.
         let chat = ChatKey::new("mock", "chat-1", "alice");
         let s1_button = |g: &Gateway| {
@@ -16168,7 +16144,7 @@ mod tests {
         };
         assert_eq!(
             s1_button(&gateway).as_deref(),
-            Some("✓ s1 claude 「my custom title」")
+            Some("✓ s1 claude (my custom title)")
         );
 
         // A later plain message must NOT clobber the rename via auto-title.
@@ -16180,13 +16156,10 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            listing2,
-            vec!["📁 当前项目: alpha\ns1 claude · alpha · cto"]
-        );
+        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
         assert_eq!(
             s1_button(&gateway).as_deref(),
-            Some("✓ s1 claude 「my custom title」"),
+            Some("✓ s1 claude (my custom title)"),
             "an explicit /rename must survive a later message (sticky user title)"
         );
     }
@@ -17299,8 +17272,8 @@ mod tests {
             .render_sessions(&ChatKey::new("mock", "chat-1", "alice"), true)
             .await;
         // Parent row precedes the indented child row (roleless → `sid claude · alpha`).
-        let pline = format!("{parent} claude · alpha");
-        let cline = format!("└─ {child} claude · alpha");
+        let pline = format!("{parent} claude.alpha");
+        let cline = format!("└─ {child} claude.alpha");
         let pi = out
             .find(&pline)
             .unwrap_or_else(|| panic!("parent row: {out}"));

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -17,7 +17,7 @@ use ccteam_core::projects::{bootstrap_project_at_dir, validate_slug_format};
 use ccteam_core::{CcteamPaths, HotConfig, RoleDetail};
 use ccteam_harness::{
     apply_title, atomic_write_durable, chat_session_name, discover_external_claude_sessions,
-    list_session_metas, parse_chat_session_name, read_session_meta, truncate_title,
+    format_tokens, list_session_metas, parse_chat_session_name, read_session_meta, truncate_title,
     write_session_meta, AccountUsage, AgentSpecBrief, AgentVendor, ChoicePrompt, ChoiceSelection,
     Directive, DirectiveOutcome, ExternalClaudeSession, HarnessAdapter, HarnessError,
     PermissionMode, ProcessBackend, RunningTask, SessionMeta, SessionOrigin, SessionProtocol,
@@ -5744,17 +5744,26 @@ impl Gateway {
             // IM row: COMPACT, single-line, `.`-joined with no padding. Leads
             // with `sid vendor` (the SAME opening as the switch button —
             // `session_switch_options`: `sid vendor (title)`), then `.project`
-            // and — when the adapter reports them — `.model` and `.<pct>%`
-            // context. Deliberately terse: NO role, NO `ctx` label, NO absolute
-            // token counts (all on /status); the title lives on the button; the
-            // vendor tag + activity dot are gone.
+            // and — when the adapter reports them — `.model`, `.effort`, and
+            // `.used/window(pct%)` context (absolute counts via the same
+            // `format_tokens` humanizer `ContextUsage::render` uses). NO role,
+            // NO `ctx` label (all on /status); the title lives on the button;
+            // the vendor tag + activity dot are gone.
             let mut row = format!("{} {}.{}", s.id, vendor_str(s.vendor), s.project);
             if let Some(st) = &status {
                 if let Some(m) = st.model.as_deref().filter(|m| !m.is_empty()) {
                     row.push_str(&format!(".{m}"));
                 }
+                if let Some(e) = st.effort.as_deref().filter(|e| !e.is_empty()) {
+                    row.push_str(&format!(".{e}"));
+                }
                 if let Some(ctx) = st.context.as_ref().filter(|c| c.window_tokens > 0) {
-                    row.push_str(&format!(".{:.0}%", ctx.pct()));
+                    row.push_str(&format!(
+                        ".{}/{}({:.0}%)",
+                        format_tokens(ctx.used_tokens),
+                        format_tokens(ctx.window_tokens),
+                        ctx.pct()
+                    ));
                 }
             }
             // v0.9.0 W2 (F2) — annotate the IM row with a non-local host.
@@ -13039,15 +13048,15 @@ mod tests {
             .unwrap();
         assert_eq!(bare, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
 
-        // Now report a model + usage → suffix appears, rendered the same
-        // way Codex /status renders (shared helper).
+        // Now report a model + effort + usage → suffix appears with absolute
+        // counts (`format_tokens`) alongside the percent.
         fake.set_status(ThreadStatus {
             model: Some("claude-opus-4-8[1m]".into()),
             context: Some(ContextUsage {
                 used_tokens: 188_000,
                 window_tokens: 1_000_000,
             }),
-            effort: None,
+            effort: Some("max".into()),
             goal: None,
         })
         .await;
@@ -13057,10 +13066,10 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-opus-4-8[1m].19%"]
+            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-opus-4-8[1m].max.188k/1M(19%)"]
         );
 
-        // A non-[1m] model renders against the 200k baseline.
+        // A non-[1m] model, no effort, renders against the 200k baseline.
         fake.set_status(ThreadStatus {
             model: Some("claude-sonnet-4-5".into()),
             context: Some(ContextUsage {
@@ -13077,7 +13086,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-sonnet-4-5.94%"]
+            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-sonnet-4-5.188k/200k(94%)"]
         );
     }
 

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -2735,18 +2735,19 @@ impl Gateway {
         let mut options: Vec<MessageOption> = visible
             .into_iter()
             .map(|s| {
-                // Label = sid (✓ marks the current session) + the session's
-                // title, moved here off the text rows: the terse tree keeps the
-                // machine-ish `sid:project:vendor:role` line, the button carries
-                // the human name. A long title is clipped to
+                // Label = `sid vendor 「title」` (✓ prefixes the current
+                // session), arranged sid → vendor → title. The terse text tree
+                // keeps the full `sid:project:vendor:role` line; the button
+                // carries the human name. A long title is clipped to
                 // `SESSION_BUTTON_TITLE_MAX_COLS` display cols so one verbose
                 // title can't widen every button (the left-align padding below
                 // pads all labels to the widest). Callback `data` is unchanged.
-                let mut label = if Some(&s.id) == current_sid.as_ref() {
-                    format!("✓ {}", s.id)
+                let marker = if Some(&s.id) == current_sid.as_ref() {
+                    "✓ "
                 } else {
-                    s.id.clone()
+                    ""
                 };
+                let mut label = format!("{marker}{} {}", s.id, vendor_str(s.vendor));
                 if let Some(title) = self.session_title(s) {
                     label.push_str(&format!(
                         " 「{}」",
@@ -5737,7 +5738,7 @@ impl Gateway {
             // `ThreadStatus::default()` → `status_suffix() == None` → the
             // legacy `id:project:vendor:role` row is unchanged. Per-session
             // failures degrade to the bare row (never break the listing).
-            let base = format!("{}:{}:{:?}:{}", s.id, s.project, s.vendor, s.role);
+            let base = format!("{}:{}:{}:{}", s.id, s.project, vendor_str(s.vendor), s.role);
             let suffix = match s.adapter.thread_status(&s.thread).await {
                 Ok(status) => status.status_suffix(),
                 Err(_) => None,
@@ -5969,10 +5970,10 @@ impl Gateway {
                     .map(|t| format!(" 「{t}」"))
                     .unwrap_or_default();
                 format!(
-                    "{}:{}:{:?}:{role}{title_suffix} — {} → /use {}",
+                    "{}:{}:{}:{role}{title_suffix} — {} → /use {}",
                     m.sid,
                     m.slug,
-                    m.vendor,
+                    vendor_str(m.vendor),
                     relative_time_zh(&m.last_active),
                     m.sid
                 )
@@ -6105,11 +6106,11 @@ impl Gateway {
         // the two surfaces read identically.
         let title = self.session_title(s);
         let mut out = format!(
-            "🧭 {}\n📍 当前会话 {} · {} · {:?} · {role} · {state} {detail}",
+            "🧭 {}\n📍 当前会话 {} · {} · {} · {role} · {state} {detail}",
             context_echo_line(&s.project, &s.id, &s.role, title.as_deref()),
             s.id,
             s.project,
-            s.vendor
+            vendor_str(s.vendor)
         );
 
         // Project working-tree PATH — disambiguates an auto-appended slug
@@ -6297,7 +6298,7 @@ impl Gateway {
         let mut lines: Vec<String> = self
             .sessions
             .values()
-            .map(|s| format!("{}:{}:{:?}:{}", s.id, s.project, s.vendor, s.role))
+            .map(|s| format!("{}:{}:{}:{}", s.id, s.project, vendor_str(s.vendor), s.role))
             .collect();
         lines.sort();
         for orphan in &inventory.orphans {
@@ -12875,21 +12876,21 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mock.len(), 1);
-        assert!(mock[0].contains("s2:alpha:Claude:reviewer"), "{}", mock[0]);
+        assert!(mock[0].contains("s2:alpha:claude:reviewer"), "{}", mock[0]);
     }
 
-    /// Picker buttons carry the sid + the session's TITLE (moved here off the
-    /// text rows), a `✓` marking the current session — but NOT the vendor/role,
-    /// which stay on the information-rich text rows. Tail-padding stays
-    /// visual-only so Telegram left-aligns the variable-width labels.
+    /// Picker buttons are `sid vendor 「title」` (sid → vendor → title), a `✓`
+    /// marking the current session. The ROLE is NOT on the button (it stays on
+    /// the information-rich text rows). Tail-padding stays visual-only so
+    /// Telegram left-aligns the variable-width labels.
     #[tokio::test]
-    async fn session_picker_labels_carry_sid_and_title() {
+    async fn session_picker_labels_carry_sid_vendor_and_title() {
         use unicode_width::UnicodeWidthStr;
         let fake = Arc::new(FakeAdapter::new(AgentVendor::Claude));
         let proj = tempfile::TempDir::new().unwrap();
         let mut gateway = Gateway::new(fake, "alpha", proj.path());
         // One roleless untitled session + one titled session: the untitled
-        // button is a bare sid, the titled one appends its 「title」.
+        // button is `sid vendor`, the titled one appends its 「title」.
         gateway
             .handle_text("telegram", "chat-1", "alice", "/new claude")
             .await
@@ -12906,14 +12907,11 @@ mod tests {
         let s2 = opts.iter().find(|o| o.id == "s2").unwrap();
         let s1_text = s1.label.trim_end_matches('\u{2800}');
         let s2_text = s2.label.trim_end_matches('\u{2800}');
-        // Untitled → bare sid; titled + current → `✓ sid 「title」`.
-        assert_eq!(s1_text, "s1");
-        assert_eq!(s2_text, "✓ s2 「A long review title」");
+        // Untitled → `sid vendor`; titled + current → `✓ sid vendor 「title」`.
+        // Vendor is lowercase (`vendor_str`).
+        assert_eq!(s1_text, "s1 claude");
+        assert_eq!(s2_text, "✓ s2 claude 「A long review title」");
         for label in [s1_text, s2_text] {
-            assert!(
-                !label.contains("claude"),
-                "no vendor on the button: {label:?}"
-            );
             assert!(
                 !label.contains("reviewer"),
                 "no role on the button: {label:?}"
@@ -12987,7 +12985,7 @@ mod tests {
             .unwrap();
         let row = listing[0].split('\n').nth(1).expect("a session row");
         assert!(
-            row.starts_with("s1:alpha:Claude:reviewer"),
+            row.starts_with("s1:alpha:claude:reviewer"),
             "row starts with the sid: {row:?}"
         );
         for marker in ["🟢", "🟡", "🟠", "🔴", "⚪", "[claude]"] {
@@ -13124,7 +13122,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]);
+        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]);
 
         // Now report a model + usage → suffix appears, rendered the same
         // way Codex /status renders (shared helper).
@@ -13144,7 +13142,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
+            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
         );
 
         // A non-[1m] model renders against the 200k baseline.
@@ -13164,7 +13162,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
+            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
         );
     }
 
@@ -13193,7 +13191,7 @@ mod tests {
             .into_iter()
             .next()
             .unwrap();
-        for vendor in ["Claude", "Codex", "Grok", "Opencode", "Kimi"] {
+        for vendor in ["claude", "codex", "grok", "opencode", "kimi"] {
             assert!(listing.contains(&format!(":{vendor}:")), "{listing}");
         }
     }
@@ -13228,7 +13226,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             before,
-            vec!["📁 当前项目: alpha\ns2:alpha:Claude:qa\ns1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns2:alpha:claude:qa\ns1:alpha:claude:reviewer"]
         );
 
         // Tag s1 (the OLDER session) with an outstanding approval.
@@ -13248,7 +13246,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             after,
-            vec!["📁 当前项目: alpha\n⏳ s1:alpha:Claude:reviewer\ns2:alpha:Claude:qa"],
+            vec!["📁 当前项目: alpha\n⏳ s1:alpha:claude:reviewer\ns2:alpha:claude:qa"],
             "s1 pinned to the top + ⏳-marked despite being less recent"
         );
     }
@@ -13291,7 +13289,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             web_view,
-            vec!["s2:alpha:Claude:qa\ns1:alpha:Claude:reviewer"]
+            vec!["s2:alpha:claude:qa\ns1:alpha:claude:reviewer"]
         );
     }
 
@@ -13332,7 +13330,7 @@ mod tests {
         // /status = the CURRENT session deep view (📍 当前会话), NOT the fleet
         // list. The fake adapter's handle carries no `vendor_uuid` → `resume —`.
         assert!(
-            idle[0].contains("📍 当前会话 s1 · alpha · Claude · reviewer · 🟢 idle"),
+            idle[0].contains("📍 当前会话 s1 · alpha · claude · reviewer · 🟢 idle"),
             "current-session header: {idle:?}"
         );
         assert!(
@@ -13360,7 +13358,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            working[0].contains("📍 当前会话 s1 · alpha · Claude · reviewer · 🔵 working "),
+            working[0].contains("📍 当前会话 s1 · alpha · claude · reviewer · 🔵 working "),
             "working state: {working:?}"
         );
         assert!(
@@ -13386,7 +13384,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            stuck[0].contains("📍 当前会话 s1 · alpha · Claude · reviewer · 🔴 STUCK "),
+            stuck[0].contains("📍 当前会话 s1 · alpha · claude · reviewer · 🔴 STUCK "),
             "stuck state: {stuck:?}"
         );
         assert!(stuck[0].contains("silent"), "silent duration: {stuck:?}");
@@ -13459,7 +13457,7 @@ mod tests {
         assert_eq!(
             out,
             vec![format!(
-                "🧭 → alpha/s1 (reviewer)\n📍 当前会话 s1 · alpha · Claude · reviewer · 🟢 idle\n   📁 {}\n   — · — · ctx — · resume —\n   ↓ 所有 1 个项目 → /projects",
+                "🧭 → alpha/s1 (reviewer)\n📍 当前会话 s1 · alpha · claude · reviewer · 🟢 idle\n   📁 {}\n   — · — · ctx — · resume —\n   ↓ 所有 1 个项目 → /projects",
                 proj.path().display()
             )]
         );
@@ -13482,7 +13480,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            out[0].contains("📍 当前会话 s1 · alpha · Claude · — · 🟢 idle"),
+            out[0].contains("📍 当前会话 s1 · alpha · claude · — · 🟢 idle"),
             "roleless → role shows —, vendor still shown: {out:?}"
         );
         assert!(
@@ -13646,7 +13644,7 @@ mod tests {
             .unwrap();
         assert_eq!(owner.len(), 1);
         assert!(
-            owner[0].contains("📍 当前会话 s1 · alpha · Claude · reviewer · 🟢 idle"),
+            owner[0].contains("📍 当前会话 s1 · alpha · claude · reviewer · 🟢 idle"),
             "got: {owner:?}"
         );
     }
@@ -13680,7 +13678,7 @@ mod tests {
             "the real --resume uuid must show in the deep view: {out:?}"
         );
         assert!(
-            out[0].contains("📍 当前会话 s1 · alpha · Claude · reviewer · 🟢 idle"),
+            out[0].contains("📍 当前会话 s1 · alpha · claude · reviewer · 🟢 idle"),
             "got: {out:?}"
         );
     }
@@ -14437,7 +14435,7 @@ mod tests {
             "history section present: {owner_view:?}"
         );
         assert!(
-            owner_view[0].contains("s1:alpha:Claude:reviewer") && owner_view[0].contains("/use s1"),
+            owner_view[0].contains("s1:alpha:claude:reviewer") && owner_view[0].contains("/use s1"),
             "s1 row carries a /use resume hint: {owner_view:?}"
         );
 
@@ -14495,7 +14493,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             owner_sees,
-            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]
         );
         let owner_uses = gateway
             .handle_text("mock", "chat-1", "alice", "/use s1")
@@ -14537,7 +14535,7 @@ mod tests {
             "/sessions",
         )
         .await;
-        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]);
+        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]);
         let used = gateway
             .handle_text("telegram", "339498819", "rob", "/use s1")
             .await
@@ -14712,7 +14710,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\ns2:beta:Claude:reviewer\ns1:beta:Codex:api"]
+            vec!["📁 当前项目: beta\ns2:beta:claude:reviewer\ns1:beta:codex:api"]
         );
 
         let use_first = gateway
@@ -14786,7 +14784,7 @@ mod tests {
         assert_eq!(
             sessions,
             vec![
-                "📁 当前项目: beta\ns4:beta:Claude:qa\ns3:beta:Codex:api\ns2:alpha:Codex:docs\ns1:alpha:Claude:reviewer"
+                "📁 当前项目: beta\ns4:beta:claude:qa\ns3:beta:codex:api\ns2:alpha:codex:docs\ns1:alpha:claude:reviewer"
             ]
         );
         let projects = gateway
@@ -15209,7 +15207,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\ns2:beta:Claude:reviewer\ns1:beta:Claude:reviewer"]
+            vec!["📁 当前项目: beta\ns2:beta:claude:reviewer\ns1:beta:claude:reviewer"]
         );
 
         assert_eq!(
@@ -15281,7 +15279,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1:beta:Claude:reviewer"]);
+        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1:beta:claude:reviewer"]);
 
         assert_eq!(
             restored
@@ -15744,7 +15742,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(before, vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]);
+        assert_eq!(before, vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]);
 
         // /cd to beta, where no session exists yet, clears the active session.
         let cd = gateway
@@ -15775,10 +15773,10 @@ mod tests {
         // now rides the switch BUTTON, not the text row (see
         // `session_switch_options`); s1 never sent a plain message, so it is
         // untitled either way. s2 is roleless → empty role field
-        // (`s2:beta:Claude:`).
+        // (`s2:beta:claude:`).
         assert_eq!(
             after,
-            vec!["📁 当前项目: beta\ns2:beta:Claude:\ns1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: beta\ns2:beta:claude:\ns1:alpha:claude:reviewer"]
         );
     }
 
@@ -15901,7 +15899,7 @@ mod tests {
         let live = ccteam_harness::list_chat_sessions(&backend).await.unwrap();
         let rendered = gateway.render_all_sessions(&live);
         assert!(
-            rendered.contains("s1:alpha:Claude:lead"),
+            rendered.contains("s1:alpha:claude:lead"),
             "rendered: {rendered}"
         );
         // v0.8.8 F1 — the orphan render labels the trailing segment as the sid
@@ -16011,7 +16009,7 @@ mod tests {
         assert!(
             owner_sees
                 .iter()
-                .any(|r| r.contains("s1:alpha:Claude:assistant")),
+                .any(|r| r.contains("s1:alpha:claude:assistant")),
             "owner should see its own session: {owner_sees:?}"
         );
         let owner_uses = gateway
@@ -16136,7 +16134,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             listing,
-            vec!["📁 当前项目: alpha\ns1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]
         );
 
         // `/use s1` still resolves the same (now-reviewer) session.
@@ -16207,7 +16205,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:Claude:cto"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:claude:cto"]);
         // And a follow-up turn still routes to the SAME live `cto` pane.
         let still_cto = gateway
             .handle_text("mock", "chat-1", "alice", "still here?")
@@ -16308,7 +16306,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:Claude:cto"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:claude:cto"]);
         // …and the rename SURFACES on the picker button.
         let chat = ChatKey::new("mock", "chat-1", "alice");
         let s1_button = |g: &Gateway| {
@@ -16319,7 +16317,7 @@ mod tests {
         };
         assert_eq!(
             s1_button(&gateway).as_deref(),
-            Some("✓ s1 「my custom title」")
+            Some("✓ s1 claude 「my custom title」")
         );
 
         // A later plain message must NOT clobber the rename via auto-title.
@@ -16331,10 +16329,10 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1:alpha:Claude:cto"]);
+        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1:alpha:claude:cto"]);
         assert_eq!(
             s1_button(&gateway).as_deref(),
-            Some("✓ s1 「my custom title」"),
+            Some("✓ s1 claude 「my custom title」"),
             "an explicit /rename must survive a later message (sticky user title)"
         );
     }
@@ -17447,8 +17445,8 @@ mod tests {
             .render_sessions(&ChatKey::new("mock", "chat-1", "alice"), true)
             .await;
         // Parent row precedes the indented child row.
-        let pline = format!("{parent}:alpha:Claude:");
-        let cline = format!("└─ {child}:alpha:Claude:");
+        let pline = format!("{parent}:alpha:claude:");
+        let cline = format!("└─ {child}:alpha:claude:");
         let pi = out
             .find(&pline)
             .unwrap_or_else(|| panic!("parent row: {out}"));

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -191,21 +191,35 @@ struct GatewaySession {
     delegation_depth: u32,
 }
 
-/// Snapshot used by the pure live-capacity eviction selector. `None`
-/// `last_event_at` is deliberately treated as newest: a just-spawned session
-/// has not emitted an event yet and must not look older than every timestamped
-/// session.
+/// Snapshot used by the pure live-capacity eviction selector.
+///
+/// `last_active` is the PERSISTED `meta.json.last_active` (RFC3339,
+/// lexically sortable), refreshed on every completed turn by
+/// `refresh_session_activity_meta` — deliberately NOT the in-process
+/// `GatewaySession::last_event_at` (`Instant`), which resets to `None` every
+/// time a session is (re)constructed in memory (daemon restart, cold `/use`
+/// resume). Under the old `Instant`-based ranking, `None` was treated as
+/// "newest" (a reasonable default for a session that TRULY just spawned), but
+/// a rebuilt/restored session also starts at `None` despite having a real,
+/// possibly ancient, history — making a long-dormant-but-still-live session
+/// permanently eviction-immune (it always looked "freshest") while genuinely
+/// recently-used sessions got evicted around it. `last_active` fixes this: it
+/// is accurate across restarts/rebuilds because it lives on disk, not in the
+/// process. Empty (unreadable/never-written meta) sorts FIRST — a fail-safe
+/// toward evictable, not toward immunity.
 #[derive(Debug, Clone)]
 struct LiveCapacityCandidate {
     sid: String,
     idle: bool,
-    last_event_at: Option<Instant>,
+    last_active: String,
     waiting_approval: bool,
 }
 
 /// Select the least-recently-active eligible live session. Idle sessions are
 /// always preferred; busy sessions are considered only when no idle candidate
-/// remains. Sids and HITL waiters are excluded before ordering.
+/// remains. Among ties, an older (lexically smaller) `last_active` wins; a sid
+/// compare is the final deterministic tiebreak. Sids and HITL waiters are
+/// excluded before ordering.
 fn select_live_capacity_eviction(
     candidates: &[LiveCapacityCandidate],
     excluded: &HashSet<String>,
@@ -216,12 +230,8 @@ fn select_live_capacity_eviction(
         .min_by(|a, b| {
             b.idle
                 .cmp(&a.idle)
-                .then_with(|| match (a.last_event_at, b.last_event_at) {
-                    (Some(a), Some(b)) => a.cmp(&b),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.sid.cmp(&b.sid),
-                })
+                .then_with(|| a.last_active.cmp(&b.last_active))
+                .then_with(|| a.sid.cmp(&b.sid))
         })
         .map(|candidate| candidate.sid.clone())
 }
@@ -6921,7 +6931,7 @@ impl Gateway {
                             .lock()
                             .map(|started| started.is_none())
                             .unwrap_or(false),
-                        last_event_at: session.last_event_at.lock().ok().and_then(|last| *last),
+                        last_active: self.session_last_active(session),
                         waiting_approval: pending.pending_for_sid(&session.id).is_some(),
                     })
                     .collect::<Vec<_>>()
@@ -9058,34 +9068,40 @@ mod tests {
         })
     }
 
-    fn capacity_candidate(
-        sid: &str,
-        idle: bool,
-        last_event_at: Option<Instant>,
-    ) -> LiveCapacityCandidate {
+    fn capacity_candidate(sid: &str, idle: bool, last_active: &str) -> LiveCapacityCandidate {
         LiveCapacityCandidate {
             sid: sid.to_string(),
             idle,
-            last_event_at,
+            last_active: last_active.to_string(),
             waiting_approval: false,
         }
     }
 
+    /// RFC3339 timestamp `secs_ago` seconds in the past — matches
+    /// `meta.json.last_active`'s format, which sorts correctly as a plain
+    /// string (the property `select_live_capacity_eviction` relies on).
+    fn capacity_ts(secs_ago: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(secs_ago)).to_rfc3339()
+    }
+
     #[test]
-    fn capacity_eviction_prefers_idle_oldest_and_none_is_newest() {
-        let now = Instant::now();
+    fn capacity_eviction_prefers_idle_over_busy_even_if_more_recently_active() {
         let candidates = vec![
-            capacity_candidate("idle-new", true, None),
-            capacity_candidate(
-                "idle-old",
-                true,
-                Some(now - std::time::Duration::from_secs(20)),
-            ),
-            capacity_candidate(
-                "busy-older",
-                false,
-                Some(now - std::time::Duration::from_secs(100)),
-            ),
+            capacity_candidate("idle-recent", true, &capacity_ts(1)),
+            capacity_candidate("busy-older", false, &capacity_ts(100)),
+        ];
+        assert_eq!(
+            select_live_capacity_eviction(&candidates, &HashSet::new()).as_deref(),
+            Some("idle-recent"),
+            "idle is preferred for eviction even over a busier-but-older session"
+        );
+    }
+
+    #[test]
+    fn capacity_eviction_prefers_oldest_last_active_among_idle() {
+        let candidates = vec![
+            capacity_candidate("idle-new", true, &capacity_ts(5)),
+            capacity_candidate("idle-old", true, &capacity_ts(20)),
         ];
         assert_eq!(
             select_live_capacity_eviction(&candidates, &HashSet::new()).as_deref(),
@@ -9093,20 +9109,36 @@ mod tests {
         );
     }
 
+    /// THE BUG FIX — a candidate with no readable `last_active` (empty: no
+    /// meta, or a meta that never completed a turn) must be treated as the
+    /// OLDEST (most evictable), never the newest. The prior `Instant`-based
+    /// design treated its "no signal yet" case (`None`) as newest — correct
+    /// for a session that TRULY just spawned, but also hit by every
+    /// REBUILT/RESTORED session (daemon restart, cold `/use` resume), whose
+    /// in-process clock resets to `None` regardless of how stale its real
+    /// history was. That made a long-dormant-but-still-live session
+    /// PERMANENTLY eviction-immune while genuinely-recent sessions were
+    /// evicted around it. Reading `last_active` from disk (refreshed on every
+    /// completed turn, survives restarts) fixes the common case; this test
+    /// locks the remaining fallback to fail toward evictable, not immunity.
+    #[test]
+    fn capacity_eviction_treats_missing_last_active_as_oldest_not_newest() {
+        let candidates = vec![
+            capacity_candidate("has-recent-real-activity", true, &capacity_ts(10)),
+            capacity_candidate("no-meta-signal", true, ""),
+        ];
+        assert_eq!(
+            select_live_capacity_eviction(&candidates, &HashSet::new()).as_deref(),
+            Some("no-meta-signal"),
+            "a blank/unreadable last_active must be evicted BEFORE a session with real recent activity"
+        );
+    }
+
     #[test]
     fn capacity_eviction_falls_back_to_busy_oldest() {
-        let now = Instant::now();
         let candidates = vec![
-            capacity_candidate(
-                "busy-new",
-                false,
-                Some(now - std::time::Duration::from_secs(2)),
-            ),
-            capacity_candidate(
-                "busy-old",
-                false,
-                Some(now - std::time::Duration::from_secs(30)),
-            ),
+            capacity_candidate("busy-new", false, &capacity_ts(2)),
+            capacity_candidate("busy-old", false, &capacity_ts(30)),
         ];
         assert_eq!(
             select_live_capacity_eviction(&candidates, &HashSet::new()).as_deref(),
@@ -9116,25 +9148,12 @@ mod tests {
 
     #[test]
     fn capacity_eviction_respects_sid_and_hitl_exclusions() {
-        let now = Instant::now();
-        let mut waiting = capacity_candidate(
-            "waiting",
-            true,
-            Some(now - std::time::Duration::from_secs(60)),
-        );
+        let mut waiting = capacity_candidate("waiting", true, &capacity_ts(60));
         waiting.waiting_approval = true;
         let candidates = vec![
             waiting,
-            capacity_candidate(
-                "parent",
-                true,
-                Some(now - std::time::Duration::from_secs(40)),
-            ),
-            capacity_candidate(
-                "eligible",
-                true,
-                Some(now - std::time::Duration::from_secs(10)),
-            ),
+            capacity_candidate("parent", true, &capacity_ts(40)),
+            capacity_candidate("eligible", true, &capacity_ts(10)),
         ];
         let excluded = HashSet::from(["parent".to_string()]);
         assert_eq!(
@@ -9146,8 +9165,8 @@ mod tests {
     #[test]
     fn capacity_eviction_returns_none_when_all_candidates_are_excluded() {
         let candidates = vec![
-            capacity_candidate("s1", true, Some(Instant::now())),
-            capacity_candidate("s2", false, None),
+            capacity_candidate("s1", true, &capacity_ts(0)),
+            capacity_candidate("s2", false, ""),
         ];
         let excluded = HashSet::from(["s1".to_string(), "s2".to_string()]);
         assert_eq!(select_live_capacity_eviction(&candidates, &excluded), None);
@@ -9186,11 +9205,15 @@ mod tests {
             vec!["s3".to_string(), second.clone(), first.clone()]
         );
         gateway.sessions.get_mut(&second).unwrap().parent_sid = None;
-        let now = Instant::now();
-        *gateway.sessions[&first].last_event_at.lock().unwrap() =
-            Some(now - std::time::Duration::from_secs(30));
-        *gateway.sessions[&second].last_event_at.lock().unwrap() =
-            Some(now - std::time::Duration::from_secs(5));
+        // Eviction ranks on the PERSISTED `meta.json.last_active` (not an
+        // in-process clock — see `LiveCapacityCandidate`), so seed it on disk:
+        // `first` older, `second` more recent.
+        for (sid, secs_ago) in [(&first, 30i64), (&second, 5)] {
+            let mut meta = read_session_meta(tmp.path(), sid).unwrap();
+            meta.last_active =
+                (chrono::Utc::now() - chrono::Duration::seconds(secs_ago)).to_rfc3339();
+            write_session_meta(tmp.path(), &meta).unwrap();
+        }
 
         let mut events = gateway.subscribe_events();
         let third = gateway

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -2735,14 +2735,24 @@ impl Gateway {
         let mut options: Vec<MessageOption> = visible
             .into_iter()
             .map(|s| {
-                // The text rows already carry vendor / role / model / title.
-                // Buttons are action-only: sid, plus a marker for the current
-                // session. Their callback payload remains unchanged.
-                let label = if Some(&s.id) == current_sid.as_ref() {
+                // Label = sid (✓ marks the current session) + the session's
+                // title, moved here off the text rows: the terse tree keeps the
+                // machine-ish `sid:project:vendor:role` line, the button carries
+                // the human name. A long title is clipped to
+                // `SESSION_BUTTON_TITLE_MAX_COLS` display cols so one verbose
+                // title can't widen every button (the left-align padding below
+                // pads all labels to the widest). Callback `data` is unchanged.
+                let mut label = if Some(&s.id) == current_sid.as_ref() {
                     format!("✓ {}", s.id)
                 } else {
                     s.id.clone()
                 };
+                if let Some(title) = self.session_title(s) {
+                    label.push_str(&format!(
+                        " 「{}」",
+                        truncate_cols(&title, SESSION_BUTTON_TITLE_MAX_COLS)
+                    ));
+                }
                 MessageOption {
                     data: format!("nav:use:{}", s.id),
                     label,
@@ -5753,13 +5763,12 @@ impl Gateway {
                 .map(String::as_str)
                 .unwrap_or("idle");
             row = format!("{vendor_tag:<10} {} · {row}", activity_marker(activity));
-            // v0.9.0 W2 (F2) — annotate the IM row with a non-local host…
+            // v0.9.0 W2 (F2) — annotate the IM row with a non-local host.
+            // (The session title is deliberately NOT on the text row anymore —
+            // it lives on the switch button label instead; see
+            // `session_switch_options`.)
             if !s.host.is_empty() && s.host != "local" {
                 row.push_str(&format!(" @{}", s.host));
-            }
-            // v0.8.22 P1 — …and the session's title when it has one.
-            if let Some(title) = self.session_title(s) {
-                row.push_str(&format!(" 「{title}」"));
             }
             // v0.8.23 review item 9 — ⏳ marks a session pinned to the top for
             // an outstanding HITL approval. Prefixed last so it stays the
@@ -8842,6 +8851,34 @@ fn pending_key(chat: &ChatKey, session_id: &str) -> String {
 /// button whose payload would exceed it; slugs/sids are short, so this only
 /// guards a pathological slug and never the common case.
 const TELEGRAM_CALLBACK_MAX: usize = 64;
+
+/// Max display columns a session title may occupy inside a `/sessions` switch
+/// button label. A longer title is clipped with `…` so one verbose title can't
+/// widen every button — the left-align padding aligns all labels to the widest.
+const SESSION_BUTTON_TITLE_MAX_COLS: usize = 24;
+
+/// Clip `s` to at most `max_cols` DISPLAY columns, appending `…` on overflow.
+/// Column-based (not char count) so a CJK double-width title clips at a stable
+/// visual width; the ellipsis reserves one column.
+fn truncate_cols(s: &str, max_cols: usize) -> String {
+    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+    if s.width() <= max_cols {
+        return s.to_string();
+    }
+    let budget = max_cols.saturating_sub(1);
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in s.chars() {
+        let w = ch.width().unwrap_or(0);
+        if used + w > budget {
+            break;
+        }
+        out.push(ch);
+        used += w;
+    }
+    out.push('…');
+    out
+}
 
 /// Right-pad every picker label to the set's widest row so Telegram's
 /// centre-aligned button text reads as a LEFT-aligned list (owner req,
@@ -12836,17 +12873,18 @@ mod tests {
         assert!(mock[0].contains("s2:alpha:Claude:reviewer"), "{}", mock[0]);
     }
 
-    /// `/sessions` text owns the session information; picker buttons are a
-    /// complementary action surface with only the sid and a current marker.
-    /// Tail-padding remains visual-only so Telegram left-aligns the labels.
+    /// Picker buttons carry the sid + the session's TITLE (moved here off the
+    /// text rows), a `✓` marking the current session — but NOT the vendor/role,
+    /// which stay on the information-rich text rows. Tail-padding stays
+    /// visual-only so Telegram left-aligns the variable-width labels.
     #[tokio::test]
-    async fn session_picker_labels_are_compact_actions() {
+    async fn session_picker_labels_carry_sid_and_title() {
         use unicode_width::UnicodeWidthStr;
         let fake = Arc::new(FakeAdapter::new(AgentVendor::Claude));
         let proj = tempfile::TempDir::new().unwrap();
         let mut gateway = Gateway::new(fake, "alpha", proj.path());
-        // One roleless session + one named/title-bearing session. Neither
-        // button should repeat the facets/title carried by the text rows.
+        // One roleless untitled session + one titled session: the untitled
+        // button is a bare sid, the titled one appends its 「title」.
         gateway
             .handle_text("telegram", "chat-1", "alice", "/new claude")
             .await
@@ -12863,20 +12901,17 @@ mod tests {
         let s2 = opts.iter().find(|o| o.id == "s2").unwrap();
         let s1_text = s1.label.trim_end_matches('\u{2800}');
         let s2_text = s2.label.trim_end_matches('\u{2800}');
+        // Untitled → bare sid; titled + current → `✓ sid 「title」`.
         assert_eq!(s1_text, "s1");
-        assert_eq!(s2_text, "✓ s2");
+        assert_eq!(s2_text, "✓ s2 「A long review title」");
         for label in [s1_text, s2_text] {
             assert!(
                 !label.contains("claude"),
-                "no vendor duplication: {label:?}"
+                "no vendor on the button: {label:?}"
             );
             assert!(
                 !label.contains("reviewer"),
-                "no role duplication: {label:?}"
-            );
-            assert!(
-                !label.contains("review title"),
-                "no title duplication: {label:?}"
+                "no role on the button: {label:?}"
             );
         }
         // Both labels padded to the same display width, with braille blanks.
@@ -12889,6 +12924,41 @@ mod tests {
             s1.label.ends_with('\u{2800}'),
             "shorter row is tail-padded: {:?}",
             s1.label
+        );
+    }
+
+    /// A verbose title is clipped to `SESSION_BUTTON_TITLE_MAX_COLS` display
+    /// columns (ellipsis included) so one long title can't widen every button.
+    #[tokio::test]
+    async fn session_picker_title_is_width_capped() {
+        use unicode_width::UnicodeWidthStr;
+        let fake = Arc::new(FakeAdapter::new(AgentVendor::Claude));
+        let proj = tempfile::TempDir::new().unwrap();
+        let mut gateway = Gateway::new(fake, "alpha", proj.path());
+        gateway
+            .handle_text("telegram", "chat-1", "alice", "/new claude")
+            .await
+            .unwrap();
+        let long = "A really really long session title that keeps going";
+        gateway.rename_session("s1", long).unwrap();
+        let chat = ChatKey::new("telegram", "chat-1", "alice");
+        let opts = gateway.session_switch_options(&chat, false);
+        let label = opts[0].label.trim_end_matches('\u{2800}');
+        let title = label
+            .split_once('「')
+            .and_then(|(_, rest)| rest.strip_suffix('」'))
+            .expect("titled button label");
+        assert!(
+            title.ends_with('…'),
+            "clipped title ends with an ellipsis: {title:?}"
+        );
+        assert!(
+            title.width() <= SESSION_BUTTON_TITLE_MAX_COLS,
+            "within cap: {title:?}"
+        );
+        assert!(
+            long.starts_with(title.trim_end_matches('…')),
+            "prefix of the real title"
         );
     }
 
@@ -15694,14 +15764,14 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions all")
             .await
             .unwrap();
-        // v0.8.22 P1 — s2's first plain message ("where am i") auto-titles it
-        // (rule-based truncation, no LLM); s1 never sent a plain message
-        // (only the `/new` directive), so it stays untitled/bare.
-        // v0.9.0 neutralization — s2 is roleless, so its `/sessions` row has an
-        // empty role field (`s2:beta:Claude:` + title).
+        // s2's first plain message ("where am i") auto-titles it, but the title
+        // now rides the switch BUTTON, not the text row (see
+        // `session_switch_options`); s1 never sent a plain message, so it is
+        // untitled either way. s2 is roleless → empty role field
+        // (`s2:beta:Claude:`).
         assert_eq!(
             after,
-            vec!["📁 当前项目: beta\n[claude]   🟢 idle · s2:beta:Claude: 「where am i」\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
+            vec!["📁 当前项目: beta\n[claude]   🟢 idle · s2:beta:Claude:\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
         );
     }
 
@@ -16051,16 +16121,15 @@ mod tests {
         assert_eq!(after, vec!["alpha-reviewer-s1 echo: still here?"]);
 
         // The session list shows the new role bound to the same sid (no s2).
-        // v0.8.22 P1 — s1's first plain message ("hi") auto-titled it; the
-        // title is sid-scoped (not role-scoped), so it survives the `/role`
-        // re-spawn untouched.
+        // (The auto-title from "hi" is sid-scoped and survives the `/role`
+        // re-spawn, but now rides the switch button, not this text row.)
         let listing = gateway
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
         assert_eq!(
             listing,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer 「hi」"]
+            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:reviewer"]
         );
 
         // `/use s1` still resolves the same (now-reviewer) session.
@@ -16125,15 +16194,15 @@ mod tests {
             "a bad /role must not re-spawn (no teardown of the live pane)"
         );
 
-        // The session is still resolvable, still s1, still `cto`.
-        // v0.8.22 P1 — carries the title auto-set from its earlier "hi".
+        // The session is still resolvable, still s1, still `cto`. (The title
+        // auto-set from "hi" now rides the switch button, not this text row.)
         let listing = gateway
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
         assert_eq!(
             listing,
-            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto 「hi」"]
+            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto"]
         );
         // And a follow-up turn still routes to the SAME live `cto` pane.
         let still_cto = gateway
@@ -16230,16 +16299,26 @@ mod tests {
             vec!["已重命名 s1 → my custom title\n↓ 本项目会话 → /sessions"]
         );
 
-        // /sessions shows the rename.
+        // The title moved off the /sessions text row onto the switch button.
         let listing = gateway
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
         assert_eq!(
             listing,
-            vec![
-                "📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto 「my custom title」"
-            ]
+            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto"]
+        );
+        // …and the rename SURFACES on the picker button.
+        let chat = ChatKey::new("mock", "chat-1", "alice");
+        let s1_button = |g: &Gateway| {
+            g.session_switch_options(&chat, false)
+                .into_iter()
+                .find(|o| o.id == "s1")
+                .map(|o| o.label.trim_end_matches('\u{2800}').to_string())
+        };
+        assert_eq!(
+            s1_button(&gateway).as_deref(),
+            Some("✓ s1 「my custom title」")
         );
 
         // A later plain message must NOT clobber the rename via auto-title.
@@ -16253,9 +16332,11 @@ mod tests {
             .unwrap();
         assert_eq!(
             listing2,
-            vec![
-                "📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto 「my custom title」"
-            ],
+            vec!["📁 当前项目: alpha\n[claude]   🟢 idle · s1:alpha:Claude:cto"]
+        );
+        assert_eq!(
+            s1_button(&gateway).as_deref(),
+            Some("✓ s1 「my custom title」"),
             "an explicit /rename must survive a later message (sticky user title)"
         );
     }

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -5656,10 +5656,11 @@ impl Gateway {
         // Web has its own GUI chrome (project picker, session list, Status page)
         // AND the chat bridge parses this reply into a structured frame, so the
         // web reply MUST stay the bare `id:project:vendor:role` rows (no banner /
-        // scoping / footer / history section — those would break
-        // `parse_sessions_reply`). The IM text surface, which has no chrome,
-        // instead gets a current-project banner + project scoping + an
-        // `/sessions all` footer + a "最近结束" history section (v0.8.22 P0-4).
+        // scoping / footer — those would break `parse_sessions_reply`). The IM
+        // text surface, which has no chrome, instead gets a current-project
+        // banner + project scoping + an `/sessions all` footer, and rows in the
+        // human-facing `sid vendor · project · role` shape (leading `sid vendor`
+        // mirrors the switch buttons).
         let is_web = chat.channel == "web";
         // Default scope = the chat's CURRENT project; `all` (and web) lists the
         // full fleet. `elsewhere` counts accessible sessions in OTHER projects so
@@ -5707,35 +5708,16 @@ impl Gateway {
         if !waiting_sids.is_empty() {
             visible.sort_by_key(|s| !waiting_sids.contains(&s.id));
         }
-        // v0.8.22 P0-4 — up to 5 most-recently-ended sessions this chat can
-        // see (same visibility rule as the live list), scoped like the live
-        // list (current project unless `all`). Reuses the existing on-disk
-        // `meta.json` scan (`list_history_sessions`) — no new store. IM-only:
-        // every web return below happens before this is rendered, so
-        // `parse_sessions_reply` still only ever sees live
-        // `id:project:vendor:role` rows.
-        let history = if is_web {
-            Vec::new()
-        } else {
-            let slugs: Vec<String> = if all {
-                self.projects.keys().cloned().collect()
-            } else {
-                vec![cur.clone()]
-            };
-            self.recent_ended_sessions(chat, &slugs, 5)
-        };
         if visible.is_empty() {
             if is_web {
                 return "no sessions".to_string();
             }
-            let head = if elsewhere > 0 {
-                format!(
+            if elsewhere > 0 {
+                return format!(
                     "📁 当前项目: {cur}\n本项目暂无会话 —— ↓ 其他项目还有 {elsewhere} 个 → /sessions all"
-                )
-            } else {
-                format!("📁 当前项目: {cur}\n暂无会话 —— /new 开一个")
-            };
-            return Self::append_history_section(head, &history);
+                );
+            }
+            return format!("📁 当前项目: {cur}\n暂无会话 —— /new 开一个");
         }
         // Render each visible session's row (async `thread_status`) once,
         // keyed by sid for the IM tree; web keeps the flat bare-row feed.
@@ -5743,31 +5725,38 @@ impl Gateway {
         let mut rendered: std::collections::HashMap<String, String> =
             std::collections::HashMap::with_capacity(visible.len());
         for s in &visible {
-            // P3 — append model + ctx from the owning adapter's
-            // `thread_status`. Statusless adapters (bg / default) report
-            // `ThreadStatus::default()` → `status_suffix() == None` → the
-            // legacy `id:project:vendor:role` row is unchanged. Per-session
-            // failures degrade to the bare row (never break the listing).
-            let base = format!("{}:{}:{}:{}", s.id, s.project, vendor_str(s.vendor), s.role);
+            // P3 — model + ctx from the owning adapter's `thread_status`.
+            // Statusless adapters (bg / default) report `ThreadStatus::default()`
+            // → `status_suffix() == None` → no ` — suffix`. Per-session failures
+            // degrade to the bare row (never break the listing).
             let suffix = match s.adapter.thread_status(&s.thread).await {
                 Ok(status) => status.status_suffix(),
                 Err(_) => None,
             };
-            let mut row = match suffix {
-                Some(sfx) => format!("{base} — {sfx}"),
-                None => base,
-            };
-            // Web rows stay untouched (`parse_sessions_reply` splits on exactly
-            // 4 colon fields and must not see extra content appended).
+            // Web rows stay the machine-parsed `sid:project:vendor:role` feed
+            // (`parse_sessions_reply` splits on exactly 4 colon fields and must
+            // not see extra content appended).
             if is_web {
-                web_rows.push(row);
+                let base = format!("{}:{}:{}:{}", s.id, s.project, vendor_str(s.vendor), s.role);
+                web_rows.push(match &suffix {
+                    Some(sfx) => format!("{base} — {sfx}"),
+                    None => base,
+                });
                 continue;
             }
-            // The row already starts with `s.id` (the `base` built above) — no
-            // leading vendor tag or activity dot: the tree is a terse
-            // `sid:project:vendor:role` identifier line now, scannable by sid.
-            // (Activity/state lives on `/status`; the session TITLE lives on
-            // the switch button label — see `session_switch_options`.)
+            // IM row LEADS with `sid vendor` — the SAME opening as the switch
+            // button (`session_switch_options`: `sid vendor 「title」`) — so the
+            // text tree and the buttons line up. Then `· project`, `· role`
+            // (role omitted when empty), the optional model/ctx suffix, and a
+            // non-local host. No vendor tag or activity dot (activity → /status;
+            // title → the button).
+            let mut row = format!("{} {} · {}", s.id, vendor_str(s.vendor), s.project);
+            if !s.role.is_empty() {
+                row.push_str(&format!(" · {}", s.role));
+            }
+            if let Some(sfx) = &suffix {
+                row.push_str(&format!(" — {sfx}"));
+            }
             // v0.9.0 W2 (F2) — annotate the IM row with a non-local host.
             if !s.host.is_empty() && s.host != "local" {
                 row.push_str(&format!(" @{}", s.host));
@@ -5850,7 +5839,7 @@ impl Gateway {
                 "\n↓ 其他项目还有 {elsewhere} 个会话 → /sessions all"
             ));
         }
-        Self::append_history_section(out, &history)
+        out
     }
 
     /// Best-effort `last_active` (RFC3339) for a LIVE session, read from its
@@ -5932,64 +5921,6 @@ impl Gateway {
                 (session.id.clone(), activity.to_string())
             })
             .collect()
-    }
-
-    /// Up to `limit` most-recently-ended sessions across `slugs` that `chat`
-    /// may see (same rule as the live list: own sessions + the shared `user:`
-    /// pool for the admin/web querier). Draws from on-disk `meta.json` via
-    /// [`Gateway::list_history_sessions`] (already excludes anything still in
-    /// the live map) — no new store, no new persistence.
-    fn recent_ended_sessions(
-        &self,
-        chat: &ChatKey,
-        slugs: &[String],
-        limit: usize,
-    ) -> Vec<SessionMeta> {
-        let mut metas: Vec<SessionMeta> = slugs
-            .iter()
-            .flat_map(|slug| self.list_history_sessions(slug))
-            .filter(|m| Self::owner_identity_visible(chat, &m.owner))
-            .collect();
-        metas.sort_by(|a, b| {
-            b.last_active
-                .cmp(&a.last_active)
-                .then_with(|| session_index(&b.sid).cmp(&session_index(&a.sid)))
-        });
-        metas.truncate(limit);
-        metas
-    }
-
-    /// Append the "最近结束" section (when non-empty) to an IM `/sessions`
-    /// reply. Each row carries `sid:project:vendor:role`, a relative
-    /// `last_active` time, and a `/use <sid>` resume hint — the cold-resume
-    /// path already exists (see `/use` handling); this just gives it a
-    /// visible entry point.
-    fn append_history_section(head: String, history: &[SessionMeta]) -> String {
-        if history.is_empty() {
-            return head;
-        }
-        let rows: Vec<String> = history
-            .iter()
-            .map(|m| {
-                let role = if m.role.is_empty() { "—" } else { &m.role };
-                // v0.8.22 P1 — show the session's title when it has one
-                // (fallback: the existing bare role/sid row, unchanged).
-                let title_suffix = m
-                    .title
-                    .as_deref()
-                    .map(|t| format!(" 「{t}」"))
-                    .unwrap_or_default();
-                format!(
-                    "{}:{}:{}:{role}{title_suffix} — {} → /use {}",
-                    m.sid,
-                    m.slug,
-                    vendor_str(m.vendor),
-                    relative_time_zh(&m.last_active),
-                    m.sid
-                )
-            })
-            .collect();
-        format!("{head}\n\n📜 最近结束:\n{}", rows.join("\n"))
     }
 
     /// v0.8.19 — PULL-only fleet-health view for `/status`. One line per
@@ -8745,45 +8676,6 @@ fn humanize_dur(d: std::time::Duration) -> String {
     } else {
         format!("{s}s")
     }
-}
-
-/// v0.8.22 P0-4 — Chinese relative-time phrase for an RFC3339 timestamp,
-/// matching the surrounding hardcoded-Chinese IM copy ("3分钟前"/"昨天"/
-/// "3天前"). Unparseable/empty input renders as `"—"` rather than panicking a
-/// `/sessions` reply (a missing `meta.json` read is already handled upstream
-/// by [`Gateway::session_last_active`] / [`Gateway::recent_ended_sessions`]).
-fn relative_time_zh(rfc3339: &str) -> String {
-    let Ok(dt) = chrono::DateTime::parse_from_rfc3339(rfc3339) else {
-        return "—".to_string();
-    };
-    let now = chrono::Utc::now();
-    let secs = now
-        .signed_duration_since(dt.with_timezone(&chrono::Utc))
-        .num_seconds()
-        .max(0);
-    if secs < 60 {
-        return "刚刚".to_string();
-    }
-    let mins = secs / 60;
-    if mins < 60 {
-        return format!("{mins}分钟前");
-    }
-    let hours = mins / 60;
-    if hours < 24 {
-        return format!("{hours}小时前");
-    }
-    let days = hours / 24;
-    if days == 1 {
-        return "昨天".to_string();
-    }
-    if days < 7 {
-        return format!("{days}天前");
-    }
-    let weeks = days / 7;
-    if weeks < 5 {
-        return format!("{weeks}周前");
-    }
-    dt.format("%Y-%m-%d").to_string()
 }
 
 /// The vendor `--resume` id (Anthropic session UUID) carried by a stream-json
@@ -12899,7 +12791,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mock.len(), 1);
-        assert!(mock[0].contains("s2:alpha:claude:reviewer"), "{}", mock[0]);
+        assert!(
+            mock[0].contains("s2 claude · alpha · reviewer"),
+            "{}",
+            mock[0]
+        );
     }
 
     /// Picker buttons are `sid vendor 「title」` (sid → vendor → title), a `✓`
@@ -13008,7 +12904,7 @@ mod tests {
             .unwrap();
         let row = listing[0].split('\n').nth(1).expect("a session row");
         assert!(
-            row.starts_with("s1:alpha:claude:reviewer"),
+            row.starts_with("s1 claude · alpha · reviewer"),
             "row starts with the sid: {row:?}"
         );
         for marker in ["🟢", "🟡", "🟠", "🔴", "⚪", "[claude]"] {
@@ -13145,7 +13041,10 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]);
+        assert_eq!(
+            bare,
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
+        );
 
         // Now report a model + usage → suffix appears, rendered the same
         // way Codex /status renders (shared helper).
@@ -13165,7 +13064,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer — claude-opus-4-8[1m] · ctx 188k / 1M (19%)"]
         );
 
         // A non-[1m] model renders against the 200k baseline.
@@ -13185,15 +13084,14 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer — claude-sonnet-4-5 · ctx 188k / 200k (94%)"]
         );
     }
 
-    /// Every vendor's row carries its vendor in the `:{vendor}:` colon field
-    /// (no separate `[vendor]` tag anymore — that prefix was dropped so the
-    /// row starts with the sid).
+    /// Every vendor's IM row carries its lowercase vendor right after the sid
+    /// (`sid vendor · …`, the same opening as the switch button).
     #[tokio::test]
-    async fn gateway_sessions_im_rows_carry_every_vendor_in_the_colon_field() {
+    async fn gateway_sessions_im_rows_lead_with_sid_then_vendor() {
         let factory: Arc<
             dyn Fn(AgentVendor, SessionProtocol) -> Arc<dyn HarnessAdapter + Send + Sync>
                 + Send
@@ -13215,7 +13113,7 @@ mod tests {
             .next()
             .unwrap();
         for vendor in ["claude", "codex", "grok", "opencode", "kimi"] {
-            assert!(listing.contains(&format!(":{vendor}:")), "{listing}");
+            assert!(listing.contains(&format!(" {vendor} · ")), "{listing}");
         }
     }
 
@@ -13249,7 +13147,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             before,
-            vec!["📁 当前项目: alpha\ns2:alpha:claude:qa\ns1:alpha:claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns2 claude · alpha · qa\ns1 claude · alpha · reviewer"]
         );
 
         // Tag s1 (the OLDER session) with an outstanding approval.
@@ -13269,7 +13167,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             after,
-            vec!["📁 当前项目: alpha\n⏳ s1:alpha:claude:reviewer\ns2:alpha:claude:qa"],
+            vec!["📁 当前项目: alpha\n⏳ s1 claude · alpha · reviewer\ns2 claude · alpha · qa"],
             "s1 pinned to the top + ⏳-marked despite being less recent"
         );
     }
@@ -13742,30 +13640,6 @@ mod tests {
         assert_eq!(humanize_dur(Duration::from_secs(7200)), "2h");
         // Sub-second rounds down to 0s (never panics / never blank).
         assert_eq!(humanize_dur(Duration::from_millis(400)), "0s");
-    }
-
-    /// v0.8.22 P0-4 — `relative_time_zh` phrase boundaries: seconds → 刚刚,
-    /// minutes/hours/days-per-unit thresholds, the "yesterday" special case,
-    /// the ≥5-week fallback to an absolute date, and the unparsable/empty
-    /// input fallback (never panics a `/sessions` reply).
-    #[test]
-    fn relative_time_zh_covers_all_bands() {
-        let ts =
-            |secs_ago: i64| (chrono::Utc::now() - chrono::Duration::seconds(secs_ago)).to_rfc3339();
-        assert_eq!(relative_time_zh(""), "—");
-        assert_eq!(relative_time_zh("not-a-timestamp"), "—");
-        assert_eq!(relative_time_zh(&ts(10)), "刚刚");
-        assert_eq!(relative_time_zh(&ts(5 * 60)), "5分钟前");
-        assert_eq!(relative_time_zh(&ts(3 * 3600)), "3小时前");
-        assert_eq!(relative_time_zh(&ts(24 * 3600)), "昨天");
-        assert_eq!(relative_time_zh(&ts(3 * 24 * 3600)), "3天前");
-        assert_eq!(relative_time_zh(&ts(14 * 24 * 3600)), "2周前");
-        // ≥5 weeks falls back to an absolute `YYYY-MM-DD` date.
-        let old = chrono::Utc::now() - chrono::Duration::days(40);
-        assert_eq!(
-            relative_time_zh(&old.to_rfc3339()),
-            old.format("%Y-%m-%d").to_string()
-        );
     }
 
     /// v0.8.18 柱2 (multi-user soft-partition 档0) — own-only isolation: a
@@ -14419,61 +14293,6 @@ mod tests {
         );
     }
 
-    /// v0.8.22 P0-4 — `/sessions` grows a "📜 最近结束" section listing
-    /// recently-ended sessions with a `/use <sid>` resume hint, giving the
-    /// existing cold-resume path (exercised above) a visible entry point.
-    /// Own-only ACL applies to the history section too: a chat that doesn't
-    /// own the stopped session must not see it listed as "最近结束".
-    #[tokio::test]
-    async fn im_sessions_lists_recently_ended_with_use_hint_own_only() {
-        let proj = tempfile::TempDir::new().unwrap();
-        let agents = proj.path().join(".claude").join("agents");
-        std::fs::create_dir_all(&agents).unwrap();
-        std::fs::write(
-            agents.join("reviewer.md"),
-            "---\nname: reviewer\n---\nbody\n",
-        )
-        .unwrap();
-
-        let fake = Arc::new(FakeAdapter::new(AgentVendor::Claude));
-        let mut gateway = Gateway::new(fake.clone(), "alpha", proj.path());
-
-        gateway
-            .handle_text("mock", "chat-1", "alice", "/new claude reviewer")
-            .await
-            .unwrap();
-        gateway
-            .handle_text("mock", "chat-1", "alice", "/stop s1")
-            .await
-            .unwrap();
-
-        // The owner sees s1 under "最近结束" with a `/use s1` resume hint.
-        let owner_view = gateway
-            .handle_text("mock", "chat-1", "alice", "/sessions")
-            .await
-            .unwrap();
-        assert_eq!(owner_view.len(), 1);
-        assert!(
-            owner_view[0].contains("📜 最近结束:"),
-            "history section present: {owner_view:?}"
-        );
-        assert!(
-            owner_view[0].contains("s1:alpha:claude:reviewer") && owner_view[0].contains("/use s1"),
-            "s1 row carries a /use resume hint: {owner_view:?}"
-        );
-
-        // A different chat's `/sessions` must NOT list it — own-only ACL
-        // covers the history section exactly like the live list.
-        let other_view = gateway
-            .handle_text("mock", "chat-2", "bob", "/sessions")
-            .await
-            .unwrap();
-        assert!(
-            !other_view[0].contains("最近结束") && !other_view[0].contains("s1"),
-            "a non-owner must not see the ended s1 in history: {other_view:?}"
-        );
-    }
-
     #[tokio::test]
     async fn gateway_sessions_are_own_only_across_chats() {
         let fake = Arc::new(FakeAdapter::new(AgentVendor::Claude));
@@ -14516,7 +14335,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             owner_sees,
-            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
         );
         let owner_uses = gateway
             .handle_text("mock", "chat-1", "alice", "/use s1")
@@ -14558,7 +14377,10 @@ mod tests {
             "/sessions",
         )
         .await;
-        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]);
+        assert_eq!(
+            seen,
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
+        );
         let used = gateway
             .handle_text("telegram", "339498819", "rob", "/use s1")
             .await
@@ -14733,7 +14555,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\ns2:beta:claude:reviewer\ns1:beta:codex:api"]
+            vec!["📁 当前项目: beta\ns2 claude · beta · reviewer\ns1 codex · beta · api"]
         );
 
         let use_first = gateway
@@ -14807,7 +14629,7 @@ mod tests {
         assert_eq!(
             sessions,
             vec![
-                "📁 当前项目: beta\ns4:beta:claude:qa\ns3:beta:codex:api\ns2:alpha:codex:docs\ns1:alpha:claude:reviewer"
+                "📁 当前项目: beta\ns4 claude · beta · qa\ns3 codex · beta · api\ns2 codex · alpha · docs\ns1 claude · alpha · reviewer"
             ]
         );
         let projects = gateway
@@ -15230,7 +15052,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec!["📁 当前项目: beta\ns2:beta:claude:reviewer\ns1:beta:claude:reviewer"]
+            vec!["📁 当前项目: beta\ns2 claude · beta · reviewer\ns1 claude · beta · reviewer"]
         );
 
         assert_eq!(
@@ -15302,7 +15124,10 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1:beta:claude:reviewer"]);
+        assert_eq!(
+            sessions,
+            vec!["📁 当前项目: beta\ns1 claude · beta · reviewer"]
+        );
 
         assert_eq!(
             restored
@@ -15765,7 +15590,10 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(before, vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]);
+        assert_eq!(
+            before,
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
+        );
 
         // /cd to beta, where no session exists yet, clears the active session.
         let cd = gateway
@@ -15796,10 +15624,10 @@ mod tests {
         // now rides the switch BUTTON, not the text row (see
         // `session_switch_options`); s1 never sent a plain message, so it is
         // untitled either way. s2 is roleless → empty role field
-        // (`s2:beta:claude:`).
+        // (`s2 claude · beta`).
         assert_eq!(
             after,
-            vec!["📁 当前项目: beta\ns2:beta:claude:\ns1:alpha:claude:reviewer"]
+            vec!["📁 当前项目: beta\ns2 claude · beta\ns1 claude · alpha · reviewer"]
         );
     }
 
@@ -16032,7 +15860,7 @@ mod tests {
         assert!(
             owner_sees
                 .iter()
-                .any(|r| r.contains("s1:alpha:claude:assistant")),
+                .any(|r| r.contains("s1 claude · alpha · assistant")),
             "owner should see its own session: {owner_sees:?}"
         );
         let owner_uses = gateway
@@ -16157,7 +15985,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             listing,
-            vec!["📁 当前项目: alpha\ns1:alpha:claude:reviewer"]
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · reviewer"]
         );
 
         // `/use s1` still resolves the same (now-reviewer) session.
@@ -16228,7 +16056,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:claude:cto"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude · alpha · cto"]);
         // And a follow-up turn still routes to the SAME live `cto` pane.
         let still_cto = gateway
             .handle_text("mock", "chat-1", "alice", "still here?")
@@ -16329,7 +16157,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1:alpha:claude:cto"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude · alpha · cto"]);
         // …and the rename SURFACES on the picker button.
         let chat = ChatKey::new("mock", "chat-1", "alice");
         let s1_button = |g: &Gateway| {
@@ -16352,7 +16180,10 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1:alpha:claude:cto"]);
+        assert_eq!(
+            listing2,
+            vec!["📁 当前项目: alpha\ns1 claude · alpha · cto"]
+        );
         assert_eq!(
             s1_button(&gateway).as_deref(),
             Some("✓ s1 claude 「my custom title」"),
@@ -17467,9 +17298,9 @@ mod tests {
         let out = gw
             .render_sessions(&ChatKey::new("mock", "chat-1", "alice"), true)
             .await;
-        // Parent row precedes the indented child row.
-        let pline = format!("{parent}:alpha:claude:");
-        let cline = format!("└─ {child}:alpha:claude:");
+        // Parent row precedes the indented child row (roleless → `sid claude · alpha`).
+        let pline = format!("{parent} claude · alpha");
+        let cline = format!("└─ {child} claude · alpha");
         let pi = out
             .find(&pline)
             .unwrap_or_else(|| panic!("parent row: {out}"));

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -5658,9 +5658,10 @@ impl Gateway {
         // web reply MUST stay the bare `id:project:vendor:role` rows (no banner /
         // scoping / footer — those would break `parse_sessions_reply`). The IM
         // text surface, which has no chrome, instead gets a current-project
-        // banner + project scoping + an `/sessions all` footer, and rows in the
-        // human-facing `sid vendor · project · role` shape (leading `sid vendor`
-        // mirrors the switch buttons).
+        // banner + project scoping + an `/sessions all` footer, and compact
+        // `sid vendor[.model][.effort][.window(pct%)]` rows (leading
+        // `sid vendor` mirrors the switch buttons; no project slug per row —
+        // the banner names it).
         let is_web = chat.channel == "web";
         // Default scope = the chat's CURRENT project; `all` (and web) lists the
         // full fleet. `elsewhere` counts accessible sessions in OTHER projects so
@@ -5743,13 +5744,16 @@ impl Gateway {
             }
             // IM row: COMPACT, single-line, `.`-joined with no padding. Leads
             // with `sid vendor` (the SAME opening as the switch button —
-            // `session_switch_options`: `sid vendor (title)`), then `.project`
-            // and — when the adapter reports them — `.model`, `.effort`, and
-            // `.used/window(pct%)` context (absolute counts via the same
-            // `format_tokens` humanizer `ContextUsage::render` uses). NO role,
-            // NO `ctx` label (all on /status); the title lives on the button;
-            // the vendor tag + activity dot are gone.
-            let mut row = format!("{} {}.{}", s.id, vendor_str(s.vendor), s.project);
+            // `session_switch_options`: `sid vendor (title)`), then — when the
+            // adapter reports them — `.model`, `.effort`, and `.window(pct%)`
+            // context: the TOTAL window (absolute, via the same
+            // `format_tokens` humanizer `ContextUsage::render` uses) + the
+            // used percentage, but NOT the absolute used count. NO project
+            // slug (the `📁 当前项目:` header already names it; `/sessions all`
+            // spans projects without a per-row slug), NO role, NO `ctx` label
+            // (all on /status); the title lives on the button; the vendor tag
+            // + activity dot are gone.
+            let mut row = format!("{} {}", s.id, vendor_str(s.vendor));
             if let Some(st) = &status {
                 if let Some(m) = st.model.as_deref().filter(|m| !m.is_empty()) {
                     row.push_str(&format!(".{m}"));
@@ -5759,8 +5763,7 @@ impl Gateway {
                 }
                 if let Some(ctx) = st.context.as_ref().filter(|c| c.window_tokens > 0) {
                     row.push_str(&format!(
-                        ".{}/{}({:.0}%)",
-                        format_tokens(ctx.used_tokens),
+                        ".{}({:.0}%)",
                         format_tokens(ctx.window_tokens),
                         ctx.pct()
                     ));
@@ -12800,7 +12803,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mock.len(), 1);
-        assert!(mock[0].contains("s2 claude.alpha"), "{}", mock[0]);
+        assert!(mock[0].contains("s2 claude"), "{}", mock[0]);
     }
 
     /// Picker buttons are `sid vendor (title)` (sid → vendor → title), a `✓`
@@ -12909,7 +12912,7 @@ mod tests {
             .unwrap();
         let row = listing[0].split('\n').nth(1).expect("a session row");
         assert!(
-            row.starts_with("s1 claude.alpha"),
+            row.starts_with("s1 claude"),
             "row starts with the sid: {row:?}"
         );
         for marker in ["🟢", "🟡", "🟠", "🔴", "⚪", "[claude]"] {
@@ -13046,10 +13049,11 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(bare, vec!["📁 当前项目: alpha\ns1 claude"]);
 
-        // Now report a model + effort + usage → suffix appears with absolute
-        // counts (`format_tokens`) alongside the percent.
+        // Now report a model + effort + usage → suffix appears with the
+        // TOTAL window (absolute, via `format_tokens`) + percent — no project
+        // slug, no absolute USED count.
         fake.set_status(ThreadStatus {
             model: Some("claude-opus-4-8[1m]".into()),
             context: Some(ContextUsage {
@@ -13066,7 +13070,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-opus-4-8[1m].max.188k/1M(19%)"]
+            vec!["📁 当前项目: alpha\ns1 claude.claude-opus-4-8[1m].max.1M(19%)"]
         );
 
         // A non-[1m] model, no effort, renders against the 200k baseline.
@@ -13086,7 +13090,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\ns1 claude.alpha.claude-sonnet-4-5.188k/200k(94%)"]
+            vec!["📁 当前项目: alpha\ns1 claude.claude-sonnet-4-5.200k(94%)"]
         );
     }
 
@@ -13115,7 +13119,7 @@ mod tests {
             .next()
             .unwrap();
         for vendor in ["claude", "codex", "grok", "opencode", "kimi"] {
-            assert!(listing.contains(&format!(" {vendor}.")), "{listing}");
+            assert!(listing.contains(&format!(" {vendor}")), "{listing}");
         }
     }
 
@@ -13147,10 +13151,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            before,
-            vec!["📁 当前项目: alpha\ns2 claude.alpha\ns1 claude.alpha"]
-        );
+        assert_eq!(before, vec!["📁 当前项目: alpha\ns2 claude\ns1 claude"]);
 
         // Tag s1 (the OLDER session) with an outstanding approval.
         let token = "pwaitpin001";
@@ -13169,7 +13170,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             after,
-            vec!["📁 当前项目: alpha\n⏳ s1 claude.alpha\ns2 claude.alpha"],
+            vec!["📁 当前项目: alpha\n⏳ s1 claude\ns2 claude"],
             "s1 pinned to the top + ⏳-marked despite being less recent"
         );
     }
@@ -14335,7 +14336,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(owner_sees, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(owner_sees, vec!["📁 当前项目: alpha\ns1 claude"]);
         let owner_uses = gateway
             .handle_text("mock", "chat-1", "alice", "/use s1")
             .await
@@ -14376,7 +14377,7 @@ mod tests {
             "/sessions",
         )
         .await;
-        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(seen, vec!["📁 当前项目: alpha\ns1 claude"]);
         let used = gateway
             .handle_text("telegram", "339498819", "rob", "/use s1")
             .await
@@ -14549,10 +14550,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            sessions,
-            vec!["📁 当前项目: beta\ns2 claude.beta\ns1 codex.beta"]
-        );
+        assert_eq!(sessions, vec!["📁 当前项目: beta\ns2 claude\ns1 codex"]);
 
         let use_first = gateway
             .handle_text("mock", "chat-1", "alice", "/use s1")
@@ -14624,9 +14622,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             sessions,
-            vec![
-                "📁 当前项目: beta\ns4 claude.beta\ns3 codex.beta\ns2 codex.alpha\ns1 claude.alpha"
-            ]
+            vec!["📁 当前项目: beta\ns4 claude\ns3 codex\ns2 codex\ns1 claude"]
         );
         let projects = gateway
             .handle_text("mock", "chat-1", "alice", "/projects")
@@ -15046,10 +15042,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(
-            sessions,
-            vec!["📁 当前项目: beta\ns2 claude.beta\ns1 claude.beta"]
-        );
+        assert_eq!(sessions, vec!["📁 当前项目: beta\ns2 claude\ns1 claude"]);
 
         assert_eq!(
             restored
@@ -15120,7 +15113,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1 claude.beta"]);
+        assert_eq!(sessions, vec!["📁 当前项目: beta\ns1 claude"]);
 
         assert_eq!(
             restored
@@ -15583,7 +15576,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(before, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(before, vec!["📁 当前项目: alpha\ns1 claude"]);
 
         // /cd to beta, where no session exists yet, clears the active session.
         let cd = gateway
@@ -15615,10 +15608,7 @@ mod tests {
         // `session_switch_options`); s1 never sent a plain message, so it is
         // untitled either way. s2 is roleless → empty role field
         // (`s2 claude.beta`).
-        assert_eq!(
-            after,
-            vec!["📁 当前项目: beta\ns2 claude.beta\ns1 claude.alpha"]
-        );
+        assert_eq!(after, vec!["📁 当前项目: beta\ns2 claude\ns1 claude"]);
     }
 
     #[tokio::test]
@@ -15848,7 +15838,7 @@ mod tests {
         )
         .await;
         assert!(
-            owner_sees.iter().any(|r| r.contains("s1 claude.alpha")),
+            owner_sees.iter().any(|r| r.contains("s1 claude")),
             "owner should see its own session: {owner_sees:?}"
         );
         let owner_uses = gateway
@@ -15971,7 +15961,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude"]);
 
         // `/use s1` still resolves the same (now-reviewer) session.
         let used = gateway
@@ -16041,7 +16031,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude"]);
         // And a follow-up turn still routes to the SAME live `cto` pane.
         let still_cto = gateway
             .handle_text("mock", "chat-1", "alice", "still here?")
@@ -16142,7 +16132,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(listing, vec!["📁 当前项目: alpha\ns1 claude"]);
         // …and the rename SURFACES on the picker button.
         let chat = ChatKey::new("mock", "chat-1", "alice");
         let s1_button = |g: &Gateway| {
@@ -16165,7 +16155,7 @@ mod tests {
             .handle_text("mock", "chat-1", "alice", "/sessions")
             .await
             .unwrap();
-        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1 claude.alpha"]);
+        assert_eq!(listing2, vec!["📁 当前项目: alpha\ns1 claude"]);
         assert_eq!(
             s1_button(&gateway).as_deref(),
             Some("✓ s1 claude (my custom title)"),
@@ -17280,9 +17270,9 @@ mod tests {
         let out = gw
             .render_sessions(&ChatKey::new("mock", "chat-1", "alice"), true)
             .await;
-        // Parent row precedes the indented child row (roleless → `sid claude · alpha`).
-        let pline = format!("{parent} claude.alpha");
-        let cline = format!("└─ {child} claude.alpha");
+        // Parent row precedes the indented child row (roleless → `sid claude`).
+        let pline = format!("{parent} claude");
+        let cline = format!("└─ {child} claude");
         let pi = out
             .find(&pline)
             .unwrap_or_else(|| panic!("parent row: {out}"));

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -5756,7 +5756,10 @@ impl Gateway {
             let mut row = format!("{} {}", s.id, vendor_str(s.vendor));
             if let Some(st) = &status {
                 if let Some(m) = st.model.as_deref().filter(|m| !m.is_empty()) {
-                    row.push_str(&format!(".{m}"));
+                    row.push_str(&format!(
+                        ".{}",
+                        strip_vendor_prefix(vendor_str(s.vendor), m)
+                    ));
                 }
                 if let Some(e) = st.effort.as_deref().filter(|e| !e.is_empty()) {
                     row.push_str(&format!(".{e}"));
@@ -7834,6 +7837,33 @@ fn vendor_str(v: AgentVendor) -> &'static str {
         AgentVendor::Grok => "grok",
         AgentVendor::Opencode => "opencode",
         AgentVendor::Kimi => "kimi",
+    }
+}
+
+/// Model ids commonly repeat the vendor name as their own prefix
+/// (`claude-opus-4-8`, `grok-4.5`) — since the compact `/sessions` row
+/// ALREADY leads with the vendor (`sid vendor.model…`), showing the model
+/// verbatim reads redundant: `claude.claude-opus-4-8[1m]`. This strips a
+/// leading `{vendor}` + separator (`-`/`_`/`.`/`/`) for DISPLAY ONLY —
+/// `claude.opus-4-8[1m]` — never touching the real model id used for
+/// `--model` respawns / cost accounting / persistence. A false-positive
+/// partial-word match (no separator boundary) or a match that would leave
+/// nothing after stripping returns `model` unchanged.
+fn strip_vendor_prefix<'a>(vendor: &str, model: &'a str) -> &'a str {
+    let lower = model.to_ascii_lowercase();
+    let Some(rest) = lower.strip_prefix(vendor) else {
+        return model;
+    };
+    let sep_len = match rest.as_bytes().first() {
+        None => 0,
+        Some(b'-' | b'_' | b'.' | b'/') => 1,
+        Some(_) => return model,
+    };
+    let stripped = &model[vendor.len() + sep_len..];
+    if stripped.is_empty() {
+        model
+    } else {
+        stripped
     }
 }
 
@@ -13027,6 +13057,35 @@ mod tests {
         assert_eq!(replies, vec!["invalid selection"]);
     }
 
+    /// `strip_vendor_prefix` drops a leading `{vendor}` + separator from a
+    /// model id that repeats it (`claude-opus-4-8` → `opus-4-8`), so the
+    /// compact `/sessions` row (`sid vendor.model…`) doesn't read redundant
+    /// (`claude.claude-opus-4-8`). A model that does NOT start with the
+    /// vendor (codex's `gpt-5`), a partial-word false-positive (no separator
+    /// boundary), and a match that would leave nothing after stripping all
+    /// pass through unchanged — case-insensitive on the match, but the
+    /// RETURNED text preserves the model's original casing/content.
+    #[test]
+    fn strip_vendor_prefix_drops_only_a_real_separator_bounded_match() {
+        assert_eq!(
+            strip_vendor_prefix("claude", "claude-opus-4-8[1m]"),
+            "opus-4-8[1m]"
+        );
+        assert_eq!(strip_vendor_prefix("grok", "grok-4.5"), "4.5");
+        assert_eq!(strip_vendor_prefix("claude", "Claude-Opus"), "Opus");
+        // codex's models (gpt-*) never repeat "codex" — unchanged.
+        assert_eq!(
+            strip_vendor_prefix("codex", "gpt-5.5-codex"),
+            "gpt-5.5-codex"
+        );
+        // "claudexyz" is a partial-word match, not "claude" + a real
+        // separator — must NOT strip.
+        assert_eq!(strip_vendor_prefix("claude", "claudexyz"), "claudexyz");
+        // Stripping down to nothing falls back to the original.
+        assert_eq!(strip_vendor_prefix("claude", "claude"), "claude");
+        assert_eq!(strip_vendor_prefix("claude", "claude-"), "claude-");
+    }
+
     /// P3 — `/sessions` appends each session's model + ctx from
     /// `thread_status`. With a `[1m]` model the window is 1M; with no
     /// status reported the legacy `id:project:vendor:role` row is unchanged.
@@ -13070,7 +13129,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             with_status,
-            vec!["📁 当前项目: alpha\ns1 claude.claude-opus-4-8[1m].max.1M(19%)"]
+            vec!["📁 当前项目: alpha\ns1 claude.opus-4-8[1m].max.1M(19%)"]
         );
 
         // A non-[1m] model, no effort, renders against the 200k baseline.
@@ -13090,7 +13149,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             baseline,
-            vec!["📁 当前项目: alpha\ns1 claude.claude-sonnet-4-5.200k(94%)"]
+            vec!["📁 当前项目: alpha\ns1 claude.sonnet-4-5.200k(94%)"]
         );
     }
 

--- a/crates/ccteam-im/src/gateway.rs
+++ b/crates/ccteam-im/src/gateway.rs
@@ -2510,7 +2510,7 @@ impl Gateway {
                     );
                     Ok(None)
                 } else {
-                    Ok(Some(self.render_projects()))
+                    Ok(Some(self.render_projects(chat)))
                 }
             }
             "/help" => Ok(Some(format!(
@@ -2532,7 +2532,12 @@ impl Gateway {
     /// clear the active session so the next message spawns one there.
     fn change_project(&mut self, chat: &ChatKey, project: &str) -> Result<String> {
         self.ensure_project_loaded(project);
-        if !self.projects.contains_key(project) {
+        // Existence AND ownership in one gate (same policy as the picker /
+        // `/projects` / web REST): a chat may `/cd` only into a project it can
+        // SEE, so a tenant can't switch into — and then spawn sessions in — the
+        // admin's project by typing its slug. A hidden or nonexistent slug reads
+        // identically ("unknown project"), disclosing nothing.
+        if !self.can_see_project(chat, project) {
             return Err(anyhow!("unknown project: {project}"));
         }
         self.current_project
@@ -2633,17 +2638,49 @@ impl Gateway {
         crate::transport::platform_of(channel) == "telegram"
     }
 
-    /// Project slugs for `/projects` + the picker — the SAME source web and
-    /// `ccteam status` use (`collect_projects`: config.yaml filtered to on-disk
-    /// `state.json`), falling back to the in-memory routing cache when
-    /// `project_paths` isn't wired (unit tests without `enable_project_creation`).
-    fn project_slugs(&self) -> Vec<String> {
+    /// Project slugs `chat` may SEE — backs `/projects`, the `/cd` picker, and
+    /// the `/status` project count. Same source web and `ccteam status` use
+    /// (`collect_projects`: config.yaml filtered to on-disk `state.json`),
+    /// filtered through the SAME ownership policy the web REST project list
+    /// applies (`build_projects` → `Identity::can_see_owner`): a tenant sees only
+    /// its own `user:<id>` projects, the operator/admin sees every non-tenant
+    /// project. This is the IM twin of `build_projects`, so IM and web never
+    /// diverge on who sees which project (the multi-user isolation contract).
+    ///
+    /// Falls back to the UNFILTERED in-memory routing cache only when
+    /// `project_paths` isn't wired (unit tests without `enable_project_creation`),
+    /// where no persisted owner is available; production always has the paths.
+    fn visible_project_slugs(&self, chat: &ChatKey) -> Vec<String> {
         if let Some(paths) = &self.project_paths {
             if let Ok(summaries) = ccteam_core::collect_projects(paths) {
-                return summaries.iter().map(|s| s.state.slug.clone()).collect();
+                return summaries
+                    .iter()
+                    .filter(|s| Self::chat_can_see_project_owner(chat, s.state.owner.as_deref()))
+                    .map(|s| s.state.slug.clone())
+                    .collect();
             }
         }
         self.projects.keys().cloned().collect()
+    }
+
+    /// Whether `chat` may see/address the project `slug` — existence AND
+    /// ownership, the gate behind `/cd <slug>`. Existence via the in-memory
+    /// registry (as before); ownership via the SAME core policy as the picker /
+    /// web REST, so a tenant can't `/cd` into the admin's project by typing its
+    /// slug (visibility alone isn't enough — addressing must be gated too).
+    fn can_see_project(&self, chat: &ChatKey, slug: &str) -> bool {
+        self.projects.contains_key(slug)
+            && Self::chat_can_see_project_owner(chat, self.project_owner(slug).as_deref())
+    }
+
+    /// The persisted `ProjectState.owner` of `slug` (`None` when unset or the
+    /// state can't be read — treated as unowned: operator-visible, tenant-hidden,
+    /// a fail-safe that matches the web ACL).
+    fn project_owner(&self, slug: &str) -> Option<String> {
+        self.project_paths
+            .as_ref()
+            .and_then(|paths| ccteam_core::ProjectState::load(&paths.project_state(slug)).ok())
+            .and_then(|state| state.owner)
     }
 
     /// One "switch project" button per project (`nav:cd:<slug>`), the current
@@ -2652,7 +2689,7 @@ impl Gateway {
     fn project_switch_options(&self, chat: &ChatKey) -> Vec<MessageOption> {
         let cur = self.current_project_for(chat);
         let mut options: Vec<MessageOption> = self
-            .project_slugs()
+            .visible_project_slugs(chat)
             .into_iter()
             .map(|slug| {
                 // A consistent leading glyph (✓ current / ▸ others) lines the
@@ -5457,6 +5494,39 @@ impl Gateway {
         owner_identity.starts_with("user:")
     }
 
+    /// Map an IM/web chat to the shared core ownership identity `(user_id,
+    /// is_admin)` that `ccteam_core::identity::can_see_owner` expects — the
+    /// IM-side twin of the web [`crate::auth::Identity`], so BOTH frontends
+    /// resolve PROJECT visibility through ONE policy (web/IM symmetry). A
+    /// per-tenant IM bot (`<platform>@<tenant>`) or a per-user web token is that
+    /// tenant (`user:<tenant>`, non-admin); every other chat — the owner's global
+    /// IM bot or the admin web console — is the operator/admin (`user:web-api`,
+    /// sees all non-tenant projects, never a tenant's private ones). HONEST
+    /// SCOPE: like the session ACL this is soft (UX) isolation under one OS uid;
+    /// treating every non-tenant-bot chat as the operator mirrors how the session
+    /// pool (`owner_identity_visible`) already grants the `user:` view.
+    fn project_acl_identity(chat: &ChatKey) -> (String, bool) {
+        if let Some(tid) = crate::transport::tenant_of_bot_channel(&chat.channel) {
+            return (tid.to_string(), false);
+        }
+        if chat.channel == "web" && chat.chat_id != ccteam_core::identity::ADMIN_WEB_ID {
+            return (chat.chat_id.clone(), false);
+        }
+        (ccteam_core::identity::ADMIN_WEB_ID.to_string(), true)
+    }
+
+    /// Whether `chat` may see/address a project whose persisted
+    /// `ProjectState.owner` is `owner`. Delegates to the SAME core policy the web
+    /// REST project ACL uses (`build_projects` / `can_see_project` →
+    /// `ccteam_core::identity::can_see_owner`), so a tenant's IM bot sees exactly
+    /// the projects its web console does: it never sees the admin's projects, and
+    /// the admin never peeks into a tenant's. Fixes the IM project-visibility
+    /// leak where `/projects` / the `/cd` picker showed every owner's projects.
+    fn chat_can_see_project_owner(chat: &ChatKey, owner: Option<&str>) -> bool {
+        let (user_id, is_admin) = Self::project_acl_identity(chat);
+        ccteam_core::identity::can_see_owner(&user_id, is_admin, owner)
+    }
+
     /// Point the chat's active session at an existing session owned by this
     /// chat in `project` (deterministic: smallest session index), returning its
     /// id. When none exists, clear the active session so the next message spawns
@@ -6165,18 +6235,21 @@ impl Gateway {
         }
         // Owner req — the last line points at the full project list (with a live
         // count), replacing the old cross-project `/sessions all` fleet pointer.
-        let nproj = self.project_slugs().len();
+        // Count only the projects THIS chat may see (same ACL as `/projects`), so
+        // the pointer never advertises another owner's projects.
+        let nproj = self.visible_project_slugs(chat).len();
         out.push_str(&format!("\n   ↓ 所有 {nproj} 个项目 → /projects"));
         out
     }
 
-    fn render_projects(&self) -> String {
-        // `project_slugs` reads the SAME source web / `ccteam status` use —
-        // `collect_projects` (config.yaml filtered to projects that have an
-        // on-disk `state.json`) — so IM `/projects` never diverges from the
-        // other surfaces: a half-registered project (in config, no state.json)
-        // shows in NEITHER, and a removed project disappears from BOTH at once.
-        self.project_slugs().join("\n")
+    fn render_projects(&self, chat: &ChatKey) -> String {
+        // `visible_project_slugs` reads the SAME source web / `ccteam status` use
+        // — `collect_projects` (config.yaml filtered to projects that have an
+        // on-disk `state.json`) — filtered by the SAME per-owner ACL web applies,
+        // so IM `/projects` never diverges from the other surfaces: a
+        // half-registered project (in config, no state.json) shows in NEITHER, a
+        // removed project disappears from BOTH, and each owner sees only its own.
+        self.visible_project_slugs(chat).join("\n")
     }
 
     /// Reconcile live `ccteam-chat-*` process names against tracked sessions.
@@ -13688,6 +13761,94 @@ mod tests {
         );
         // The admin/global bot oversees the shared web pool.
         assert!(Gateway::owner_identity_visible(&admin_tg, &web_a));
+    }
+
+    /// IM PROJECT ACL — the multi-user isolation the leaky unfiltered project
+    /// list broke: a tenant must NOT see the admin's projects (the reported
+    /// bug), and the operator must never peek into a tenant's — SYMMETRIC with
+    /// the web REST list (`build_projects` → `Identity::can_see_owner`) and the
+    /// MCP list (`visible_user_projects`), since all three now authorize off the
+    /// same `ProjectState.owner` through the same core policy
+    /// (`ccteam_core::identity::can_see_owner`). Pure-predicate twin of
+    /// `chat_owner_visible_converges_tenant_web_and_im` (the session rule),
+    /// keyed on PROJECT owners instead of session owners.
+    #[test]
+    fn project_acl_isolates_tenants_from_admin_and_each_other() {
+        // Project owner tags, as `/newproject` + web `POST /projects` stamp
+        // them: a tenant's project is `user:<id>`, the admin's is the shared web
+        // pool `user:web-api` or its own IM `telegram:<chat_id>`, a legacy
+        // `ccteam init` project is unowned (`None`).
+        let admin_web = Some("user:web-api");
+        let admin_im = Some("telegram:339");
+        let tenant_a = Some("user:ualice");
+        let tenant_b = Some("user:ubob");
+        let unowned: Option<&str> = None;
+
+        // A per-tenant IM bot (`telegram@ualice`) — the "user" in the bug report
+        // — and its own web console (channel "web", tenant id as chat_id) are ONE
+        // identity, so BOTH frontends see exactly the same projects (web/IM
+        // symmetry): ONLY the tenant's own, never the admin's (web OR IM), never
+        // another tenant's, never a legacy unowned one.
+        for viewer in [
+            ChatKey::new("telegram@ualice", "111", "alice"),
+            ChatKey::new("web", "ualice", "ualice"),
+        ] {
+            assert!(
+                Gateway::chat_can_see_project_owner(&viewer, tenant_a),
+                "a tenant sees its own project ({})",
+                viewer.channel
+            );
+            assert!(
+                !Gateway::chat_can_see_project_owner(&viewer, admin_web),
+                "a tenant must NOT see the admin's web project ({})",
+                viewer.channel
+            );
+            assert!(
+                !Gateway::chat_can_see_project_owner(&viewer, admin_im),
+                "a tenant must NOT see the admin's IM project ({})",
+                viewer.channel
+            );
+            assert!(
+                !Gateway::chat_can_see_project_owner(&viewer, tenant_b),
+                "a tenant must NOT see another tenant's project ({})",
+                viewer.channel
+            );
+            assert!(
+                !Gateway::chat_can_see_project_owner(&viewer, unowned),
+                "a tenant must NOT see a legacy unowned project ({})",
+                viewer.channel
+            );
+        }
+
+        // The operator (owner's global IM bot ≡ admin web console) sees every
+        // NON-tenant project — its own web pool, its own IM projects, and legacy
+        // unowned — but NEVER a per-user tenant's private project (exactly what
+        // web admin sees via `can_see_owner`).
+        for op in [
+            ChatKey::new("telegram", "339", "rob"),
+            ChatKey::new("web", "web-api", "web-api"),
+        ] {
+            assert!(
+                Gateway::chat_can_see_project_owner(&op, admin_web),
+                "operator sees its own web pool ({})",
+                op.channel
+            );
+            assert!(
+                Gateway::chat_can_see_project_owner(&op, admin_im),
+                "operator sees its own IM project ({})",
+                op.channel
+            );
+            assert!(
+                Gateway::chat_can_see_project_owner(&op, unowned),
+                "operator sees legacy unowned projects ({})",
+                op.channel
+            );
+            assert!(
+                !Gateway::chat_can_see_project_owner(&op, tenant_a),
+                "operator must NOT peek into a tenant's project ({})",
+                op.channel
+            );
+        }
     }
 
     /// v0.8.21 cold-resume ACL (web path) — `resume_stopped_session` resolves a


### PR DESCRIPTION
## The bug

On IM, multi-user isolation for **projects** failed: a tenant user's IM bot could see — and `/cd` into — the **admin's** projects. The web console was correct; only IM leaked. (`/projects`, the `/cd` picker, and the `/status` project count were all affected.)

## Root cause

Session-level ACLs on IM were all correctly owner-filtered (`chat_can_access` / `owner_identity_visible`), but the **project** list was not. The project-slug source read `ccteam_core::collect_projects` with **no per-owner filter**, so every chat saw every owner's projects — whereas the web REST list (`build_projects` → `Identity::can_see_owner`) and the MCP path (`visible_user_projects`) already filter off `ProjectState.owner`.

## The fix — one canonical policy, web/IM symmetric

Route IM project visibility through the **same** core policy the other two surfaces use, so all three authorize off `ProjectState.owner` via `ccteam_core::identity::can_see_owner`:

- **`project_acl_identity(chat)`** maps an IM/web chat to the shared `(user_id, is_admin)` — the IM-side twin of the web `Identity`. A per-tenant IM bot (`<platform>@<tenant>`) or per-user web token → that tenant; the owner's global bot / admin console → the operator.
- **`chat_can_see_project_owner`** = `can_see_owner` applied to that identity.
- **`visible_project_slugs(chat)`** filters the list; `render_projects`, the `/status` count, and the `/cd` picker all use it.
- **`change_project`** gates `/cd <slug>` on `can_see_project` as well, so a tenant can't switch into (then spawn sessions in) the admin's project by typing its slug — a hidden slug reads as `unknown project`, identical to a nonexistent one (no existence disclosure).

Net: a tenant sees **only** its own `user:<id>` projects; the operator sees non-tenant projects (its web pool + legacy CLI) but never a tenant's private ones — exactly what web admin sees.

### Scope / honesty
Like the existing session ACL, this is soft (UX) multi-user isolation under one OS uid, **not** a security boundary. The admin↔tenant *session*-pool semantics are unchanged (owner-gated red line); this PR only closes the project-list leak.

## Tests
`project_acl_isolates_tenants_from_admin_and_each_other` locks the policy across tenant-bot / tenant-web / global-bot / admin-console viewers × every owner tag (own, admin web, admin IM, other tenant, legacy unowned).

- `cargo test -p ccteam-im --lib`: **484 passed, 0 failed**
- `cargo clippy -p ccteam-im --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

> Note: also committed on `dev` (`ee316ee`). This PR is branched off `main` so the diff is just this fix, not the already-squash-merged v0.9.8 history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)