### PR TITLE
Docs: point Pi at pi.dev in the install cards

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ ccteam is a resident daemon (IM gateway + web console + MCP) that drives the sto
   | Grok Build | [docs.x.ai/build/overview](https://docs.x.ai/build/overview) | `grok login` |
   | OpenCode | [opencode.ai](https://opencode.ai) | `opencode auth login` |
   | Kimi Code | [moonshotai.github.io/kimi-code](https://moonshotai.github.io/kimi-code/) | `kimi login` |
-  | Pi | `npm i -g @earendil-works/pi-coding-agent` | provider API key, checked with `pi auth check --provider <provider>` |
+  | Pi | [pi.dev](https://pi.dev/) | provider API key, checked with `pi auth check --provider <provider>` |
 
   Verify with `<bin> --version`; after install, `ccteam status` reports which vendors this machine has and whether each is authenticated.
 - For `make install`: **Rust + Node.js**. No toolchain? Use the prebuilt `install.sh` instead (see below).

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Runs on **macOS**, **Linux**, and **Windows (via WSL)**.
 > - **Grok Build** — install [Grok CLI](https://docs.x.ai/build/overview), then `grok login`
 > - **OpenCode** — install [OpenCode](https://opencode.ai), then `opencode auth login`
 > - **Kimi Code** — install [Kimi Code](https://moonshotai.github.io/kimi-code/), then `kimi login`
-> - **Pi** — `npm i -g @earendil-works/pi-coding-agent`, then set your provider key and check it with `pi auth check --provider <provider>`
+> - **Pi** — install [Pi](https://pi.dev/), then set your provider key and check it with `pi auth check --provider <provider>`
 >
 > Any one of them is enough to start. Afterwards `ccteam status` and **Settings → Hosts** report, per machine, which vendors are installed, their versions, and whether each is actually authenticated — sitting on `PATH` never counts as logged in.
 

--- a/docs/usage-cn.md
+++ b/docs/usage-cn.md
@@ -40,7 +40,7 @@ ccteam 调用你机器上**已装好并登录的** Claude Code / Codex / Grok Bu
 | Grok Build | [docs.x.ai/build/overview](https://docs.x.ai/build/overview) | `grok login` |
 | OpenCode | [opencode.ai](https://opencode.ai) | `opencode auth login` |
 | Kimi Code | [moonshotai.github.io/kimi-code](https://moonshotai.github.io/kimi-code/) | `kimi login` |
-| Pi | `npm i -g @earendil-works/pi-coding-agent` | 配好 provider API key,用 `pi auth check --provider <provider>` 验证 |
+| Pi | [pi.dev](https://pi.dev/) | 配好 provider API key,用 `pi auth check --provider <provider>` 验证 |
 
 **1 · 让 agent 装**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,7 +40,7 @@ ccteam calls the Claude Code, Codex, Grok Build, OpenCode, Kimi Code, and Pi CLI
 | Grok Build | [docs.x.ai/build/overview](https://docs.x.ai/build/overview) | `grok login` |
 | OpenCode | [opencode.ai](https://opencode.ai) | `opencode auth login` |
 | Kimi Code | [moonshotai.github.io/kimi-code](https://moonshotai.github.io/kimi-code/) | `kimi login` |
-| Pi | `npm i -g @earendil-works/pi-coding-agent` | provider API key, verified with `pi auth check --provider <provider>` |
+| Pi | [pi.dev](https://pi.dev/) | provider API key, verified with `pi auth check --provider <provider>` |
 
 **1 · Let an agent do it**
 


### PR DESCRIPTION
Follow-up to #177, docs only (4 files, 4 lines): the Pi row of the "bring your own coding CLI" card named the npm package that ships it instead of the vendor's own page — the only one of the six not pointing at its vendor. Owner's call: https://pi.dev/.

Carried to `main` so the README on the repo front page matches `dev`. Cannot affect the v0.9.14 artifacts — those are built from the `v0.9.14` tag at `fb2a9540`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)